### PR TITLE
perf(kimi3): fold the MoE finalize into the multicast latent tail (+ extract the K3 comm layer)

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from enum import IntEnum
 from functools import partial
 
 import tokenspeed_kernel
@@ -61,49 +60,6 @@ InputProjector = Callable[
     tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None,
 ]
 _SUPPORTED_EP_SIZES = {1, 2, 4, 8}
-
-
-class K3MoETailTier(IntEnum):
-    """How the K3 MoE tail combines routed/shared partials, best first."""
-
-    TAIL_FUSION = 0  # fused decode kernel (aka the multicast latent tail)
-    MULTIMEM_AR = 1  # in-switch (ld_reduce) reduces, then the replicated tail
-    FUSED_LANE_AR = 2  # join tier: lane one-shot / cat+one-shot / grouped NCCL
-    SEPARATE_REDUCE = 3  # portable: reduce each partial on its own
-
-
-# Speculative decode may enter this prefill-tuned multimem window.
-MULTIMEM_AR_MIN_TOKENS = 256
-MULTIMEM_AR_MAX_TOKENS = 8192
-
-
-def select_k3_moe_tail_tier(
-    *,
-    num_tokens: int,
-    graph_phase: bool,
-    tail_fusion_max_tokens: int,
-    fused_moe_ar: bool,
-    multimem_ok: bool,
-) -> K3MoETailTier:
-    """Pick the tail tier; every input must be rank-uniform.
-
-    Args:
-        num_tokens: Tokens in this forward (identical on every rank).
-        graph_phase: Whether the forward runs under the CUDA-graph phase.
-        tail_fusion_max_tokens: Fused decode kernel capacity, 0 when absent.
-        fused_moe_ar: Whether the fused-AR execution plan is armed.
-        multimem_ok: Collectively-agreed multimem availability.
-
-    Returns:
-        The best applicable ``K3MoETailTier``.
-    """
-    if graph_phase and 1 <= num_tokens <= tail_fusion_max_tokens:
-        return K3MoETailTier.TAIL_FUSION
-    if not fused_moe_ar:
-        return K3MoETailTier.SEPARATE_REDUCE
-    if multimem_ok and MULTIMEM_AR_MIN_TOKENS <= num_tokens <= MULTIMEM_AR_MAX_TOKENS:
-        return K3MoETailTier.MULTIMEM_AR
-    return K3MoETailTier.FUSED_LANE_AR
 
 
 def _marlin_moe_available() -> bool:
@@ -792,11 +748,9 @@ class LatentMoELayer(nn.Module):
 
 
 __all__ = [
-    "K3MoETailTier",
     "Kimi3LatentProjection",
     "Kimi3MoEExecutionPlan",
     "LatentMoELayer",
     "kimi3_join_reduce_moe",
     "latent_moe_expert_shared_all_reduce",
-    "select_k3_moe_tail_tier",
 ]

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1354,6 +1354,7 @@ class KimiLinearMoE(nn.Module):
         topk_output: TopKOutput,
         num_global_tokens: int,
         max_num_tokens_per_gpu: int,
+        do_finalize: bool = True,
     ) -> torch.Tensor:
         """Run the precomputed-TopK SiTU MoE (TRT-LLM cubin or Hopper Marlin)."""
         plan = self.execution_plan
@@ -1367,6 +1368,7 @@ class KimiLinearMoE(nn.Module):
             topk_output=topk_output,
             num_global_tokens=num_global_tokens,
             max_num_tokens_per_gpu=max_num_tokens_per_gpu,
+            do_finalize=do_finalize,
         )
         # The kernel returns this rank's pre-reduce partial; the selected
         # tail tier owns the combining reduction.
@@ -1536,6 +1538,7 @@ class KimiLinearMoE(nn.Module):
                 topk_output,
                 num_global_tokens,
                 max_num_tokens_per_gpu,
+                do_finalize=not plan.defer_finalize,
             )
             if plan.routed_in_fork:
                 # No fused collective to hide behind: reduce and project here

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -61,7 +61,6 @@ from typing import TYPE_CHECKING
 
 import torch
 from tokenspeed_kernel.ops.activation.triton import (
-    add3,
     attnres_combine,
     attnres_partial,
     attnres_partial_dual,
@@ -70,14 +69,6 @@ from tokenspeed_kernel.ops.activation.triton import (
 )
 from tokenspeed_kernel.ops.attention import mla_normalize_project_query
 from tokenspeed_kernel.ops.attn_res import attn_res_fwd, attn_res_fwd_available
-from tokenspeed_kernel.ops.communication import allreduce_fusion_lane
-from tokenspeed_kernel.ops.communication.fabric import fabric_allocation_supported
-from tokenspeed_kernel.ops.communication.multimem import (
-    multimem_all_reduce_staged,
-    multimem_available,
-    multimem_prealloc,
-    multimem_stage,
-)
 from tokenspeed_kernel.ops.gemm import (
     kimi3_mla_qkv_gate_projection,
     kimi3_qkvfab_projection,
@@ -105,19 +96,15 @@ from tokenspeed.runtime.configs.kimi_k3_config import KimiK3Config, KimiLinearCo
 from tokenspeed.runtime.distributed.comm_manager import CommManager
 from tokenspeed.runtime.distributed.comm_ops import (
     all_reduce,
-    prepare_all_reduce_fusion,
-    prepare_all_reduce_lane,
     token_all_gather,
 )
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.cuda_graph_wrapper import (
     get_is_capture_mode,
-    get_is_cuda_graph_phase,
 )
 from tokenspeed.runtime.layers.activation import SituAndMul
 from tokenspeed.runtime.layers.layernorm import (
     RMSNorm,
-    _get_process_group,
 )
 from tokenspeed.runtime.layers.linear import (
     ColumnParallelLinear,
@@ -127,14 +114,10 @@ from tokenspeed.runtime.layers.linear import (
 )
 from tokenspeed.runtime.layers.moe.expert import MoELayer
 from tokenspeed.runtime.layers.moe.latent import (
-    MULTIMEM_AR_MAX_TOKENS,
-    K3MoETailTier,
     Kimi3LatentProjection,
     Kimi3MoEExecutionPlan,
     LatentMoELayer,
-    kimi3_join_reduce_moe,
     latent_moe_expert_shared_all_reduce,
-    select_k3_moe_tail_tier,
 )
 from tokenspeed.runtime.layers.moe.loader import build_moe_checkpoint_loader
 from tokenspeed.runtime.layers.moe.schema import ExpertCheckpointSchema
@@ -151,6 +134,11 @@ from tokenspeed.runtime.models.deepseek_v3 import (
     DeepseekV3AttentionMLA,
     DeepseekV3FusedQkvAProjWithMqa,
     _prepare_mla_kv_b_proj_weights,
+)
+from tokenspeed.runtime.models.kimi_k3_comm import (
+    K3AttnComm,
+    K3AttnCommState,
+    K3MoeTailComm,
 )
 from tokenspeed.runtime.models.moonvit import MoonViTVisionPath
 from tokenspeed.runtime.multimodal.embedder import (
@@ -1287,93 +1275,20 @@ class KimiLinearMoE(nn.Module):
             )
         )
 
-        self._initialize_tail_capabilities(
-            config, mapping, prefix, layer_index, model_scope
+        # Communication capability negotiation and tail routing live in
+        # K3MoeTailComm (one MIN-vote per process; see kimi_k3_comm.py).
+        self.comm = K3MoeTailComm(
+            mapping=mapping,
+            hidden_size=config.hidden_size,
+            prefix=prefix,
+            layer_index=layer_index,
+            model_scope=model_scope,
+            routed_hidden=self.routed_hidden,
+            top_k=self.top_k,
+            routed_norm=self.routed_expert_norm,
+            up_proj=self.routed_expert_up_proj,
+            execution_plan=self.execution_plan,
         )
-
-    def _initialize_tail_capabilities(
-        self,
-        config: KimiLinearConfig,
-        mapping: Mapping,
-        prefix: str,
-        layer_index: int,
-        model_scope: str,
-    ) -> None:
-        """Probe locally, cast one collective vote, then allocate collectively."""
-        # All ranks must agree on eligibility before either collective allocator runs.
-        multimem_local = (
-            torch.distributed.is_initialized()
-            and mapping.moe.tp_ep_size > 1
-            and mapping.moe.tp_ep_size == torch.distributed.get_world_size()
-            and mapping.attn.dp_size == 1
-            and mapping.attn.cp_size == 1
-            # Equal widths would alias the two per-width staging buffers.
-            and self.routed_hidden != config.hidden_size
-            and multimem_available()
-            # Cross-node symmetric-memory rendezvous requires fabric/IMEX.
-            and (
-                torch.distributed.get_world_size() <= torch.cuda.device_count()
-                or fabric_allocation_supported(torch.cuda.current_device())
-            )
-        )
-        tail_local = False
-        if (
-            not self.execution_plan.use_native
-            and self.routed_expert_norm is not None
-            and torch.distributed.is_initialized()
-            # The fused tail requires tp_ep to span WORLD.
-            and mapping.moe.tp_ep_size == torch.distributed.get_world_size()
-            and mapping.attn.dp_size == 1
-            and mapping.attn.cp_size == 1
-        ):
-            from tokenspeed_kernel.ops.moe.latent_tail import latent_tail_supported
-
-            tail_local = latent_tail_supported(
-                tp_size=mapping.moe.tp_ep_size,
-                hidden_size=config.hidden_size,
-                latent_size=self.routed_hidden,
-                dtype=torch.bfloat16,
-                group=torch.distributed.group.WORLD,
-            )
-
-        self._multimem_ar_ok = False
-        self._latent_tail = None
-        if torch.distributed.is_initialized():
-            votes = torch.tensor(
-                [int(multimem_local), int(tail_local)],
-                dtype=torch.int32,
-                device="cuda",
-            )
-            torch.distributed.all_reduce(votes, op=torch.distributed.ReduceOp.MIN)
-            multimem_ok, tail_ok = (bool(v) for v in votes.tolist())
-
-            if multimem_ok:
-                # Collective buffers must reach peak size before serving.
-                self._multimem_ar_ok = multimem_prealloc(
-                    MULTIMEM_AR_MAX_TOKENS,
-                    (self.routed_hidden, config.hidden_size),
-                    torch.distributed.group.WORLD.group_name,
-                )
-            if tail_ok:
-                from tokenspeed_kernel.ops.moe.latent_tail import KimiK3LatentTailOp
-
-                # Constructor failures must propagate because peers are already rendezvousing.
-                from tokenspeed.runtime.execution.workspace import workspace_pool
-
-                _device = torch.device("cuda", torch.cuda.current_device())
-                self._latent_tail = KimiK3LatentTailOp.initialize(
-                    group=torch.distributed.group.WORLD,
-                    hidden_size=config.hidden_size,
-                    latent_size=self.routed_hidden,
-                    rms_eps=self.routed_expert_norm.variance_epsilon,
-                    device=_device,
-                    layer_index=layer_index,
-                    model_scope=model_scope,
-                    # Staging may alias the workspace pool; each barrier-free mailbox must remain private.
-                    scratch_allocator=workspace_pool(_device).allocate,
-                )
-
-                logger.info("multicast latent tail engaged")
 
     def pack_input_projection_weights(self) -> None:
         """Back the router, routed-down, and shared gate/up weights with one tensor.
@@ -1595,17 +1510,9 @@ class KimiLinearMoE(nn.Module):
         # under concurrent GEMMs). Topk is a single small CTA, so it overlaps
         # down_proj from the aux stream, followed by the shared chain.
         router_logits = self.gate(hidden_states)
-        tier = self._select_tail_tier(num_tokens)
-        # Shard mode splits the joined reduction, so it cannot use the packed lane.
-        lane = allreduce_fusion_lane(
-            hidden_states,
-            self.routed_hidden + hidden_size,
-            enabled=(
-                tier is K3MoETailTier.FUSED_LANE_AR and not self._shard_up_projection
-            ),
-        )
-        if lane is not None:
-            self.experts._situ_output_buffer = lane[:, : self.routed_hidden]
+        plan = self.comm.plan(num_tokens, hidden_states)
+        if plan.lane is not None:
+            self.experts._situ_output_buffer = plan.lane[:, : self.routed_hidden]
         else:
             self.experts._situ_output_buffer = None
         with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
@@ -1616,7 +1523,9 @@ class KimiLinearMoE(nn.Module):
                 shared_partial = self.shared_experts(
                     hidden_states,
                     down_out=(
-                        lane[:, self.routed_hidden :] if lane is not None else None
+                        plan.lane[:, self.routed_hidden :]
+                        if plan.lane is not None
+                        else None
                     ),
                 )
             routed_in = decode_gemv(hidden_states, self.routed_expert_down_proj.weight)
@@ -1628,17 +1537,17 @@ class KimiLinearMoE(nn.Module):
                 num_global_tokens,
                 max_num_tokens_per_gpu,
             )
-            if tier is K3MoETailTier.SEPARATE_REDUCE:
-                routed_projected = self._reduce_project_routed(routed_partial)
-                routed_tail_input = routed_projected
+            if plan.routed_in_fork:
+                # No fused collective to hide behind: reduce and project here
+                # so the work overlaps the shared branch inside the fork.
+                routed_tail_input = self.comm.reduce_project_routed(routed_partial)
             else:
                 routed_tail_input = routed_partial
-        output = self._moe_tail(
-            tier,
+        output = self.comm.run(
+            plan,
             routed_tail_input,
             shared_partial,
             prefix_sum,
-            lane,
             num_tokens,
             hidden_size,
         )
@@ -1646,329 +1555,9 @@ class KimiLinearMoE(nn.Module):
         # keeps only its slice (a no-op view when no gather happened).
         return output[local_offset : local_offset + local_num_tokens]
 
-    def _select_tail_tier(self, num_tokens: int) -> K3MoETailTier:
-        # Graph warmup, capture, and replay must select the same tier.
-        return select_k3_moe_tail_tier(
-            num_tokens=num_tokens,
-            graph_phase=get_is_cuda_graph_phase(),
-            tail_fusion_max_tokens=(
-                self._latent_tail.max_num_tokens if self._latent_tail is not None else 0
-            ),
-            fused_moe_ar=self.execution_plan.fused_moe_ar,
-            multimem_ok=self._multimem_ar_ok,
-        )
-
-    def _moe_tail(
-        self,
-        tier: K3MoETailTier,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        lane: torch.Tensor | None,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        """Dispatch the selected tier over the partials.
-
-        Raw partials everywhere except SEPARATE_REDUCE, whose routed side
-        already ran inside the fork scope to overlap the shared branch.
-        """
-        if tier is K3MoETailTier.TAIL_FUSION:
-            return self._tail_fusion(routed_out, shared_partial, prefix_sum)
-        if tier is K3MoETailTier.MULTIMEM_AR:
-            return self._tail_multimem_ar(
-                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
-            )
-        if tier is K3MoETailTier.FUSED_LANE_AR:
-            return self._tail_fused_lane_ar(
-                routed_out, shared_partial, prefix_sum, lane, num_tokens, hidden_size
-            )
-        return self._tail_separate_reduce(
-            routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
-        )
-
-    def _tail_fusion(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-    ) -> torch.Tensor:
-        return self._latent_tail(
-            routed_out,
-            shared_partial,
-            self.routed_expert_norm.weight,
-            self.routed_expert_up_proj.weight,
-            prefix=prefix_sum,
-        )
-
-    def _tail_multimem_ar(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        if self._shard_up_projection:
-            return self._tail_multimem_ar_sharded(
-                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
-            )
-        return self._tail_multimem_ar_replicated(
-            routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
-        )
-
-    def _tail_multimem_ar_sharded(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        # Eligibility guarantees tp_ep spans WORLD for these symmetric reductions.
-        group_name = torch.distributed.group.WORLD.group_name
-        routed_stage = multimem_stage(routed_out, group_name, MULTIMEM_AR_MAX_TOKENS)
-        shared_stage = (
-            multimem_stage(shared_partial, group_name, MULTIMEM_AR_MAX_TOKENS)
-            if routed_stage is not None
-            else None
-        )
-        # Eligibility guarantees both stages exist; a miss is a contract violation.
-        if routed_stage is None or shared_stage is None:
-            raise RuntimeError(
-                "multimem staging failed after the tier was selected; the "
-                "init-time capability vote and the runtime shapes disagree"
-            )
-        routed_reduced = multimem_all_reduce_staged(routed_stage, group_name)
-        # Disjoint projection shards concatenate when injected into the shared sum.
-        routed_reduced = (
-            self.routed_expert_norm(routed_reduced)
-            if self.routed_expert_norm is not None
-            else routed_reduced
-        )
-        start, width = self.routed_expert_up_proj.shard_slice
-        target = shared_stage[:, start : start + width]
-        target += prefix_sum.view(num_tokens, hidden_size).narrow(-1, start, width)
-        target.addmm_(routed_reduced, self.routed_expert_up_proj.weight.t())
-        shared_reduced = multimem_all_reduce_staged(shared_stage, group_name)
-        # Clone: the staging buffer is recycled by the next layer's stage copy.
-        return shared_reduced.view(num_tokens, hidden_size).clone()
-
-    def _tail_multimem_ar_replicated(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        # Eligibility guarantees tp_ep spans WORLD for these symmetric reductions.
-        group_name = torch.distributed.group.WORLD.group_name
-        routed_stage = multimem_stage(routed_out, group_name, MULTIMEM_AR_MAX_TOKENS)
-        shared_stage = (
-            multimem_stage(shared_partial, group_name, MULTIMEM_AR_MAX_TOKENS)
-            if routed_stage is not None
-            else None
-        )
-        # Eligibility guarantees both stages exist; a miss is a contract violation.
-        if routed_stage is None or shared_stage is None:
-            raise RuntimeError(
-                "multimem staging failed after the tier was selected; the "
-                "init-time capability vote and the runtime shapes disagree"
-            )
-        routed_reduced = multimem_all_reduce_staged(routed_stage, group_name)
-        shared_reduced = multimem_all_reduce_staged(shared_stage, group_name)
-        if self.routed_expert_norm is not None:
-            routed_reduced = self.routed_expert_norm(routed_reduced)
-        return self._projection_tail(
-            routed_reduced, shared_reduced, prefix_sum, num_tokens, hidden_size
-        )
-
-    def _projection_tail(
-        self,
-        routed_reduced: torch.Tensor,
-        shared_reduced: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        return self.routed_expert_up_proj.forward_add3(
-            routed_reduced,
-            prefix_sum,
-            shared_reduced,
-        ).view(num_tokens, hidden_size)
-
-    def _project_and_inject_local_block(
-        self,
-        routed_reduced: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        start, width = self.routed_expert_up_proj.shard_slice
-        shared_partial = shared_partial.view(num_tokens, hidden_size)
-        target = shared_partial[:, start : start + width]
-        target += prefix_sum.view(num_tokens, hidden_size)[:, start : start + width]
-        target.addmm_(routed_reduced, self.routed_expert_up_proj.weight.t())
-        return shared_partial
-
-    def _inject_local_block(
-        self,
-        routed_projected_shard: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        """Add this rank's projection block into its columns of the shared
-        partial, in place, so the shared reduction also gathers the projection.
-
-        The column blocks are disjoint across ranks, so summing the partials
-        concatenates the blocks and adds ``prefix`` exactly once per column.
-        Works with any sum all-reduce; the caller runs it right after this.
-        """
-        # One extra bf16 rounding vs the joined tiers; measured nil on GPQA, not bitwise.
-        start, width = self.routed_expert_up_proj.shard_slice
-        shared_partial = shared_partial.view(num_tokens, hidden_size)
-        shared_partial[
-            :, start : start + width
-        ] += routed_projected_shard + prefix_sum.view(num_tokens, hidden_size).narrow(
-            -1, start, width
-        )
-        return shared_partial
-
-    def _tail_fused_lane_ar(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        lane: torch.Tensor | None,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        if self._shard_up_projection:
-            return self._tail_fused_lane_ar_sharded(
-                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
-            )
-        return self._tail_fused_lane_ar_replicated(
-            routed_out, shared_partial, prefix_sum, lane, num_tokens, hidden_size
-        )
-
-    def _tail_fused_lane_ar_sharded(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        # Sharded projection folds into the shared reduction; the packed lane is disabled here.
-        routed_reduced = all_reduce(routed_out, self.mapping.moe.tp_ep_group)
-        if self.routed_expert_norm is not None:
-            routed_reduced = self.routed_expert_norm(routed_reduced)
-        shared_partial = self._project_and_inject_local_block(
-            routed_reduced, shared_partial, prefix_sum, num_tokens, hidden_size
-        )
-        return all_reduce(shared_partial, self.mapping.moe.tp_ep_group)
-
-    def _tail_fused_lane_ar_replicated(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        lane: torch.Tensor | None,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        routed_reduced, shared_reduced = kimi3_join_reduce_moe(
-            routed_out,
-            shared_partial,
-            lane=lane,
-            routed_hidden=self.routed_hidden,
-            routed_norm=self.routed_expert_norm,
-            group=self.mapping.moe.tp_ep_group,
-            enable_lane_norm=self.execution_plan.lane_latent_norm_ar,
-            max_token_num=self.execution_plan.comm_fusion_max_num_tokens,
-        )
-        return self._projection_tail(
-            routed_reduced, shared_reduced, prefix_sum, num_tokens, hidden_size
-        )
-
-    def _reduce_project_routed(self, routed_out: torch.Tensor) -> torch.Tensor:
-        """Reduce, norm and up-project the routed partial (SEPARATE_REDUCE).
-
-        Runs in ``forward`` inside the stream fork so it overlaps the
-        shared-expert branch; the tier method then receives an
-        already-projected routed output, unlike the other tiers.
-        """
-        routed_reduced = routed_out
-        if self.mapping.moe.has_tp_ep:
-            routed_reduced = all_reduce(routed_reduced, self.mapping.moe.tp_ep_group)
-        if self.routed_expert_norm is not None:
-            routed_reduced = self.routed_expert_norm(routed_reduced)
-        if self._shard_up_projection:
-            # This block must wait for the fork before folding into the shared reduction.
-            return self.routed_expert_up_proj.project_shard(routed_reduced)
-        return self.routed_expert_up_proj(routed_reduced)[0]
-
-    def _tail_separate_reduce(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        if self._shard_up_projection:
-            return self._tail_separate_reduce_sharded(
-                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
-            )
-        return self._tail_separate_reduce_replicated(
-            routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
-        )
-
-    def _tail_separate_reduce_sharded(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        routed_projected_shard = routed_out
-        shared_partial = self._inject_local_block(
-            routed_projected_shard,
-            shared_partial,
-            prefix_sum,
-            num_tokens,
-            hidden_size,
-        )
-        shared_reduced = self._reduce_shared(shared_partial)
-        return shared_reduced.view(num_tokens, hidden_size)
-
-    def _tail_separate_reduce_replicated(
-        self,
-        routed_out: torch.Tensor,
-        shared_partial: torch.Tensor,
-        prefix_sum: torch.Tensor,
-        num_tokens: int,
-        hidden_size: int,
-    ) -> torch.Tensor:
-        routed_projected = routed_out
-        shared_reduced = self._reduce_shared(shared_partial)
-        # routed_scaling_factor already applied in TopK (matches reference).
-        return add3(
-            prefix_sum,
-            routed_projected.view(num_tokens, hidden_size),
-            shared_reduced.view(num_tokens, hidden_size),
-        )
-
     def _reduce_shared(self, shared_partial: torch.Tensor) -> torch.Tensor:
-        """Reduce the shared experts' TP partial on the current (default) stream."""
-        if self.mapping.moe.tp_ep_size > 1:
-            return all_reduce(shared_partial, self.mapping.moe.tp_ep_group)
-        return shared_partial
+        """Reduce the shared experts' TP partial (delegates to K3MoeTailComm)."""
+        return self.comm.reduce_shared(shared_partial)
 
 
 class KimiLinearDecoderLayer(nn.Module):
@@ -2080,26 +1669,11 @@ class KimiLinearDecoderLayer(nn.Module):
 
         # K3 AttnRes bypasses CommManager's fused residual, but the MLA attention
         # still uses it for the (no-op in AllReduce mode) pre_attn_comm.
-        # Fused AR+residual for the attention reduce: ones-weight RMSNorm rides
-        # the one-shot pattern; its norm output is discarded. Enabled when the
-        # attention TP group's one-shot lane is armed.
-        self._attn_ar_residual_fusion = (
-            mapping.attn.tp_size > 1
-            and prepare_all_reduce_lane(mapping.attn.tp_group, config.hidden_size)
-            and prepare_all_reduce_fusion(
-                mapping.attn.tp_group,
-                config.hidden_size,
-                max(
-                    int(global_server_args_dict["comm_fusion_max_num_tokens"]),
-                    1,
-                ),
-            )
+        # AR+residual fusion arming and the dummy-norm ride live in
+        # K3AttnCommState (armed once per process).
+        self.k3_comm = K3AttnComm(
+            K3AttnCommState.get(mapping=mapping, hidden_size=config.hidden_size)
         )
-        self._dummy_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self._dummy_norm.weight.data = torch.ones(
-            config.hidden_size, dtype=torch.bfloat16
-        )
-        self._dummy_norm.weight.requires_grad_(False)
 
         self.attn_fork = StreamFork(alt_stream)
         # (proj_w_getter, norm, valid_blocks) for the NEXT layer's attn-side
@@ -2135,97 +1709,13 @@ class KimiLinearDecoderLayer(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """All-reduce the attention partial and accumulate the residual.
 
-        Small batches fold the residual add into the one-shot AR kernel;
-        with ``combine = (scratch, res_w, rms_w, out_norm_w, eps)`` the
-        mlp-side AttnRes prefix combine also rides its epilogue and the mixed
-        hidden comes back as the second return (else None -- block-write
-        layers, large batches and the plain-reduce fallback).
+        Delegates to :meth:`K3AttnComm.attn_reduce`; see kimi_k3_comm.py for
+        the branch semantics (AttnRes-combine epilogue / fused AR+residual /
+        B1 combine / plain reduce).
         """
-        num_tokens = attn_partial.shape[0]
-        if (
-            prefix_sum is not None
-            and self._attn_ar_residual_fusion
-            and 0 < num_tokens
-            and num_tokens <= global_server_args_dict["comm_fusion_max_num_tokens"]
-        ):
-            if combine is not None:
-                from tokenspeed_kernel.ops.communication.trtllm import (
-                    allreduce_residual_attnres_combine,
-                )
-
-                from tokenspeed.runtime.utils.pdl import pdl_enabled
-
-                scratch, res_w, rms_w, out_norm_w, eps = combine
-                h, residual_out = allreduce_residual_attnres_combine(
-                    attn_partial,
-                    prefix_sum,
-                    res_w,
-                    rms_w,
-                    out_norm_w,
-                    scratch=scratch,
-                    rank=self.mapping.attn.tp_rank,
-                    group=_get_process_group(self.mapping.attn.tp_group),
-                    eps=eps,
-                    max_token_num=global_server_args_dict["comm_fusion_max_num_tokens"],
-                    launch_with_pdl=pdl_enabled(),
-                )
-                return residual_out, h
-            _, residual_out, *_ = self._dummy_norm.forward_with_allreduce_fusion(
-                self.mapping.attn.tp_rank,
-                self.mapping.attn.tp_group,
-                attn_partial,
-                prefix_sum,
-            )
-            if residual_out is not None:
-                return residual_out, None
-        if combine is not None and prefix_sum is not None and num_tokens == 1:
-            scratch, _, _, out_norm_w, eps = combine
-            if out_norm_w is not None:
-                from tokenspeed_kernel.ops.communication.triton import (
-                    allreduce_residual_attnres_combine,
-                    allreduce_residual_attnres_combine_supported,
-                )
-
-                group = _get_process_group(self.mapping.attn.tp_group)
-                fused_supported = not global_server_args_dict.get(
-                    "force_deterministic_rsag", False
-                ) and allreduce_residual_attnres_combine_supported(
-                    attn_partial,
-                    prefix_sum,
-                    self._mlp_wp,
-                    out_norm_w,
-                    scratch,
-                    rank=self.mapping.attn.tp_rank,
-                    group=group,
-                    local_world_size=self.mapping.nprocs_per_node,
-                )
-                if fused_supported:
-                    h, residual_out = allreduce_residual_attnres_combine(
-                        attn_partial,
-                        prefix_sum,
-                        self._mlp_wp,
-                        out_norm_w,
-                        scratch,
-                        rank=self.mapping.attn.tp_rank,
-                        group=group,
-                        local_world_size=self.mapping.nprocs_per_node,
-                        eps=eps,
-                    )
-                else:
-                    residual_out = prefix_sum + all_reduce(
-                        attn_partial, self.mapping.attn.tp_group
-                    )
-                    h = attnres_combine(
-                        residual_out,
-                        self._mlp_wp,
-                        out_norm_w,
-                        eps,
-                        scratch,
-                        torch.empty_like(residual_out),
-                    )
-                return residual_out, h
-        reduced = all_reduce(attn_partial, self.mapping.attn.tp_group)
-        return (reduced if prefix_sum is None else prefix_sum + reduced), None
+        return self.k3_comm.attn_reduce(
+            attn_partial, prefix_sum, combine, mlp_wp=self._mlp_wp
+        )
 
     def _mix_into_attention(
         self, hidden_states: torch.Tensor, block_residual: torch.Tensor
@@ -2357,6 +1847,8 @@ class KimiLinearDecoderLayer(nn.Module):
                 prefix_sum,
                 num_global_tokens=num_global_tokens,
                 max_num_tokens_per_gpu=max_num_tokens_per_gpu,
+                # ctx is required by the cross-DP-EP token gather (was missing).
+                ctx=ctx,
             )
         else:
             prefix_sum = prefix_sum + self.mlp(h)
@@ -2469,7 +1961,7 @@ class KimiLinearDecoderLayer(nn.Module):
             and (
                 num_tokens == 1
                 or (
-                    self._attn_ar_residual_fusion
+                    self.k3_comm.state.attn_ar_fusion_ok
                     and num_tokens
                     <= global_server_args_dict["comm_fusion_max_num_tokens"]
                 )

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -466,6 +466,10 @@ class TailPlan:
 
     Attributes:
         tier: The negotiated tail tier for this token count.
+        defer_finalize: The experts kernel must run with
+            ``do_finalize=False`` (the tail owns finalize). Set for
+            TAIL_FUSION when the multicast tail was armed to inline
+            finalize (trtllm fused-AR deployments).
         lane: Pre-materialized fused-lane buffer, or None; when set the
             experts kernel writes its routed partial into
             ``lane[:, :routed_hidden]`` and the shared experts into the rest.
@@ -474,6 +478,7 @@ class TailPlan:
     """
 
     tier: "K3MoETailTier"
+    defer_finalize: bool = False
     lane: torch.Tensor | None = None
     routed_in_fork: bool = False
 
@@ -521,6 +526,27 @@ class K3MoeTailComm:
         self._shard_up_projection = up_proj.shard_group is not None
         self.latent_tail = None
         if self.state.latent_tail_ok:
+            # Deferred-finalize arming (rank-uniform: execution_plan and the
+            # negotiated state agree on every rank). fused_moe_ar already
+            # implies use_trtllm at construction, and only the trtllm SiTU
+            # kernel emits the deferred triple; the explicit use_trtllm check
+            # keeps that assumption visible.
+            # NOTE: use_trtllm is a *proxy* for "the producer echoes bf16
+            # expert scales" — this comm layer never sees the experts module,
+            # so it cannot assert the kernel's supports_deferred_finalize
+            # trait or weight dtype here. The backstops are explicit: the
+            # experts layer raises on do_finalize=False without the trait,
+            # and KimiK3LatentTailOp.call_deferred raises on non-BF16 scales
+            # (no silent down-cast), so a future fp32-scale producer fails
+            # loudly instead of silently degrading precision.
+            tail_finalize_top_k = (
+                top_k
+                if (
+                    execution_plan.fused_moe_ar
+                    and getattr(execution_plan, "use_trtllm", False)
+                )
+                else None
+            )
             # Per-module mailbox. Constructor failures must propagate because
             # peers are already rendezvousing: a rank that failed mid-way has
             # stranded them, and killing the whole job is the good outcome.
@@ -536,8 +562,13 @@ class K3MoeTailComm:
                 # Staging may alias the workspace pool; each barrier-free
                 # mailbox must remain private.
                 scratch_allocator=workspace_pool(_device).allocate,
+                finalize_top_k=tail_finalize_top_k,
             )
-            logger.info("multicast latent tail engaged (%s)", prefix)
+            logger.info(
+                "multicast latent tail engaged (%s, deferred_finalize=%s)",
+                prefix,
+                tail_finalize_top_k is not None,
+            )
 
     # ------------------------------------------------------------------
     # Routing
@@ -558,6 +589,20 @@ class K3MoeTailComm:
             fused_moe_ar=self.execution_plan.fused_moe_ar,
             multimem_ok=self.state.multimem_ar_ok,
         )
+        if tier is K3MoETailTier.TAIL_FUSION:
+            # Full fusion: with the trtllm fused-AR plan armed and a
+            # deferred-capable tail op, the multicast tail consumes the
+            # experts kernel's deferred-finalize triple directly — no
+            # standalone finalize kernel, no [M, latent] intermediate.
+            # Otherwise the materialized-input mode remains.
+            return TailPlan(
+                tier=tier,
+                defer_finalize=(
+                    self.execution_plan.fused_moe_ar
+                    and self.latent_tail is not None
+                    and self.latent_tail.supports_deferred_finalize
+                ),
+            )
         # Shard mode splits the joined reduction, so it cannot use the packed lane.
         lane = allreduce_fusion_lane(
             hidden_states,
@@ -614,10 +659,22 @@ class K3MoeTailComm:
         """Dispatch the selected tier over the partials.
 
         Raw partials everywhere except SEPARATE_REDUCE, whose routed side
-        already ran inside the fork scope to overlap the shared branch.
+        already ran inside the fork scope to overlap the shared branch, and
+        deferred-finalize TAIL_FUSION (``plan.defer_finalize``), whose
+        ``routed_out`` is the experts kernel's deferred-finalize triple.
         """
         tier = plan.tier
         if tier is K3MoETailTier.TAIL_FUSION:
+            if plan.defer_finalize:
+                gemm2_out, expert_weights, expanded_idx = routed_out
+                return self._tail_fusion_deferred(
+                    gemm2_out,
+                    expert_weights,
+                    expanded_idx,
+                    shared_partial,
+                    prefix_sum,
+                    num_tokens,
+                )
             return self._tail_fusion(routed_out, shared_partial, prefix_sum)
         if tier is K3MoETailTier.MULTIMEM_AR:
             return self._tail_multimem_ar(
@@ -647,6 +704,27 @@ class K3MoeTailComm:
             shared_partial,
             self.routed_norm.weight,
             self.up_proj.weight,
+            prefix=prefix_sum,
+        )
+
+    def _tail_fusion_deferred(
+        self,
+        gemm2_out: torch.Tensor,
+        expert_weights: torch.Tensor,
+        expanded_idx: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+    ) -> torch.Tensor:
+        """TAIL_FUSION over the deferred-finalize triple (finalize in-kernel)."""
+        return self.latent_tail.call_deferred(
+            gemm2_out,
+            expert_weights,
+            expanded_idx,
+            shared_partial,
+            self.routed_norm.weight,
+            self.up_proj.weight,
+            num_tokens=num_tokens,
             prefix=prefix_sum,
         )
 

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -1,0 +1,910 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Kimi-K3 communication layer: capability negotiation and fused-reduction
+routing for the sites where K3's AttnRes/latent-lane semantics bypass the
+generic ``CommManager`` (decision D4).
+
+Layering: this module owns *which backend runs where* (votes, workspace
+lifecycle, M-window routing); the kernels themselves stay behind
+``tokenspeed_kernel.ops.communication`` / ``ops.moe``. Model code
+(``kimi_k3.py``) states semantics only and never names a backend.
+
+All M thresholds for the K3 tail live here (single source of truth):
+
+======================  =========================================
+decode fused tail       ``1 <= M <= latent-tail capacity``
+                        (multicast tail, tp_ep spanning WORLD) — see
+                        ``select_k3_moe_tail_tier``
+multimem AR window      ``MULTIMEM_AR_MIN_TOKENS..MAX`` (prefill)
+fused-lane one-shot     everything else with a fused plan
+======================  =========================================
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import IntEnum
+
+import torch
+import torch.distributed as dist
+from tokenspeed_kernel.ops.activation.triton import add3, attnres_combine
+from tokenspeed_kernel.ops.communication import allreduce_fusion_lane
+from tokenspeed_kernel.ops.communication.fabric import fabric_allocation_supported
+from tokenspeed_kernel.ops.communication.multimem import (
+    multimem_all_reduce_staged,
+    multimem_available,
+    multimem_prealloc,
+    multimem_stage,
+)
+from tokenspeed_kernel.ops.moe.latent_tail import (
+    KimiK3LatentTailOp,
+    latent_tail_supported,
+)
+
+from tokenspeed.runtime.distributed.comm_ops import (
+    all_reduce,
+    prepare_all_reduce_fusion,
+    prepare_all_reduce_lane,
+)
+from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_cuda_graph_phase
+from tokenspeed.runtime.execution.workspace import workspace_pool
+from tokenspeed.runtime.layers.layernorm import RMSNorm, _get_process_group
+from tokenspeed.runtime.layers.moe.latent import kimi3_join_reduce_moe
+from tokenspeed.runtime.utils.env import global_server_args_dict
+from tokenspeed.runtime.utils.pdl import pdl_enabled
+
+logger = logging.getLogger(__name__)
+
+
+class K3MoETailTier(IntEnum):
+    """How the K3 MoE tail combines routed/shared partials, best first.
+
+    Declaration order *is* the priority order (mirrors the selector's
+    branch order). Values never escape the process (identity comparisons
+    only, no serialization), so inserting mid-list is safe — keep new
+    tiers at their semantic rank rather than appending.
+    """
+
+    TAIL_FUSION = 0  # fused decode kernel (aka the multicast latent tail)
+    MULTIMEM_AR = 1  # in-switch (ld_reduce) reduces, then the replicated tail
+    FUSED_LANE_AR = 2  # join tier: lane one-shot / cat+one-shot / grouped NCCL
+    SEPARATE_REDUCE = 3  # portable: reduce each partial on its own
+
+
+# Above plain decode-graph buckets: at decode sizes the two staged reduces
+# lose ~4% TPOT to the single fused-lane AR; the ld_reduce win is prefill's.
+# Caveat: spec-decode buckets reach bs*q tokens and can re-enter this window
+# in-graph (correct, but decode-suboptimal) — a follow-up should add an
+# is_decode axis rather than gate on the graph phase, which prefill graphs
+# legitimately share.
+MULTIMEM_AR_MIN_TOKENS = 256
+# Upper edge of the measured window; larger batches take the join's grouped path.
+MULTIMEM_AR_MAX_TOKENS = 8192
+
+
+def select_k3_moe_tail_tier(
+    *,
+    num_tokens: int,
+    graph_phase: bool,
+    tail_fusion_max_tokens: int,
+    fused_moe_ar: bool,
+    multimem_ok: bool,
+) -> K3MoETailTier:
+    """Pick the tail tier; every input must be rank-uniform.
+
+    Args:
+        num_tokens: Tokens in this forward (identical on every rank).
+        graph_phase: Whether the forward runs under the CUDA-graph phase.
+        tail_fusion_max_tokens: Fused decode kernel capacity, 0 when absent.
+        fused_moe_ar: Whether the fused-AR execution plan is armed.
+        multimem_ok: Collectively-agreed multimem availability.
+
+    Returns:
+        The best applicable ``K3MoETailTier``.
+    """
+    # Tested first, so a fused-tail capacity that ever reached into the
+    # multimem window would still resolve here rather than overlap.
+    if graph_phase and 1 <= num_tokens <= tail_fusion_max_tokens:
+        return K3MoETailTier.TAIL_FUSION
+    if not fused_moe_ar:
+        return K3MoETailTier.SEPARATE_REDUCE
+    if multimem_ok and MULTIMEM_AR_MIN_TOKENS <= num_tokens <= MULTIMEM_AR_MAX_TOKENS:
+        return K3MoETailTier.MULTIMEM_AR
+    return K3MoETailTier.FUSED_LANE_AR
+
+
+class K3AttnCommState:
+    """Process-wide attention-AR fusion arming for Kimi-K3 (attn TP group).
+
+    Construction is collective: every rank must call :meth:`get` with
+    identical arguments, in lockstep, before any forward (model ``__init__``
+    satisfies this). The first call runs the collective allocators exactly
+    once per process — per-layer callers reuse the singleton. Splitting the
+    arming per layer is what previously left several independent ways to
+    strand a peer inside a rendezvous.
+
+    Collective constructors are deliberately unguarded: a rank that fails
+    mid-build has already stranded its peers, so propagating the exception
+    and killing the whole job is the good outcome.
+    """
+
+    _instance: "K3AttnCommState | None" = None
+
+    @classmethod
+    def get(cls, *, mapping, hidden_size: int) -> "K3AttnCommState":
+        """Return the singleton, constructing it on first use (any decoder
+        layer; construction is per-process, the collective prepares inside
+        run lockstep on the attention TP group).
+
+        Args:
+            mapping: Parallel mapping (attn/moe groups) — rank-uniform.
+            hidden_size: Model hidden width.
+        """
+        if cls._instance is None:
+            cls._instance = cls(mapping=mapping, hidden_size=hidden_size)
+        elif cls._instance.hidden_size != hidden_size:
+            # The singleton would otherwise silently hand a second model
+            # (e.g. an MTP draft sharing the process with its base) arming
+            # done for the wrong width.
+            raise ValueError(
+                "K3AttnCommState is armed once per process for "
+                f"hidden_size={cls._instance.hidden_size}, but a later caller "
+                f"asked for hidden_size={hidden_size}; the current "
+                "implementation assumes every model in the process (base + "
+                "draft) shares this width."
+            )
+        return cls._instance
+
+    def __init__(self, *, mapping, hidden_size: int):
+        self.mapping = mapping
+        self.hidden_size = hidden_size
+        hidden = hidden_size
+        # --- attention AR+residual fusion arming (was per decoder layer) ---
+        # Fused AR+residual for the attention reduce: a ones-weight RMSNorm
+        # rides the one-shot pattern and its norm output is discarded.
+        self.attn_ar_fusion_ok = dist.is_initialized() and (
+            mapping.attn.tp_size > 1
+            and prepare_all_reduce_lane(mapping.attn.tp_group, hidden)
+            and prepare_all_reduce_fusion(
+                mapping.attn.tp_group,
+                hidden,
+                max(int(global_server_args_dict["comm_fusion_max_num_tokens"]), 1),
+            )
+        )
+        # Plain attribute (not a registered submodule): the model loader
+        # never migrates it, so the device must be pinned explicitly here.
+        # The eps only shapes the discarded ones-weight norm output.
+        self.dummy_norm = RMSNorm(hidden, eps=1e-6)
+        self.dummy_norm.weight.data = torch.ones(
+            hidden,
+            dtype=torch.bfloat16,
+            device=torch.device("cuda", torch.cuda.current_device()),
+        )
+        self.dummy_norm.weight.requires_grad_(False)
+
+
+class K3MoeTailCommState:
+    """Process-wide negotiated MoE-tail backends for Kimi-K3 (moe tp_ep group).
+
+    Constructed by the first ``K3MoeTailComm`` — every rank builds MoE layers
+    in the same order, so the single MIN all-reduce and the collective
+    allocators below stay lockstep. Collective constructors are deliberately
+    unguarded: a failed rank has already stranded its peers, so killing the
+    whole job is the good outcome.
+    """
+
+    _instance: "K3MoeTailCommState | None" = None
+
+    @classmethod
+    def get(
+        cls,
+        *,
+        mapping,
+        hidden_size: int,
+        latent_size: int,
+        top_k: int,
+        rms_eps: float,
+        allow_latent_tail: bool,
+    ) -> "K3MoeTailCommState":
+        if cls._instance is None:
+            cls._instance = cls(
+                mapping=mapping,
+                hidden_size=hidden_size,
+                latent_size=latent_size,
+                top_k=top_k,
+                rms_eps=rms_eps,
+                allow_latent_tail=allow_latent_tail,
+            )
+        else:
+            inst = cls._instance
+            if (
+                inst.hidden_size != hidden_size
+                or inst.latent_size != latent_size
+                or inst.top_k != top_k
+                or inst.rms_eps != float(rms_eps)
+                or inst.allow_latent_tail != allow_latent_tail
+            ):
+                # The singleton would otherwise silently hand a second model
+                # (e.g. an MTP draft sharing the process with its base) a
+                # negotiation done for the wrong shapes.
+                raise ValueError(
+                    "K3MoeTailCommState is negotiated once per process for "
+                    f"hidden={inst.hidden_size} latent={inst.latent_size} "
+                    f"top_k={inst.top_k} rms_eps={inst.rms_eps} "
+                    f"allow_latent_tail={inst.allow_latent_tail}, but a later "
+                    f"caller asked for hidden={hidden_size} "
+                    f"latent={latent_size} top_k={top_k} "
+                    f"rms_eps={float(rms_eps)} "
+                    f"allow_latent_tail={allow_latent_tail}; the current "
+                    "implementation assumes every model in the process "
+                    "(base + draft) shares these parameters."
+                )
+        return cls._instance
+
+    def __init__(
+        self,
+        *,
+        mapping,
+        hidden_size,
+        latent_size,
+        top_k,
+        rms_eps,
+        allow_latent_tail,
+    ):
+        self.hidden_size = hidden_size
+        self.latent_size = latent_size
+        self.top_k = top_k
+        self.rms_eps = float(rms_eps)
+        self.allow_latent_tail = allow_latent_tail
+        self.multimem_ar_ok = False
+        self.latent_tail_ok = False  # per-layer ops built by K3MoeTailComm
+        if not dist.is_initialized():
+            return
+
+        world = dist.get_world_size()
+        hidden, latent = hidden_size, latent_size
+
+        # --- local probes (pure local; failures just vote False) ---
+        # All ranks must agree on eligibility before any collective
+        # allocator runs.
+        multimem_local = (
+            mapping.moe.tp_ep_size > 1
+            and mapping.moe.tp_ep_size == world
+            and mapping.attn.dp_size == 1
+            and mapping.attn.cp_size == 1
+            # Equal widths would alias the two per-width staging buffers.
+            and latent != hidden
+            and multimem_available()
+            # Cross-node symmetric-memory rendezvous requires fabric/IMEX.
+            and (
+                world <= torch.cuda.device_count()
+                or fabric_allocation_supported(torch.cuda.current_device())
+            )
+        )
+        tail_local = False
+        if (
+            allow_latent_tail
+            # The fused tail requires tp_ep to span WORLD.
+            and mapping.moe.tp_ep_size == world
+            and mapping.attn.dp_size == 1
+            and mapping.attn.cp_size == 1
+        ):
+            tail_local = latent_tail_supported(
+                tp_size=mapping.moe.tp_ep_size,
+                hidden_size=hidden,
+                latent_size=latent,
+                dtype=torch.bfloat16,
+                group=dist.group.WORLD,
+            )
+        # --- the single agreement point: every rank executes unconditionally ---
+        votes = torch.tensor(
+            [int(multimem_local), int(tail_local)],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        dist.all_reduce(votes, op=dist.ReduceOp.MIN)
+        multimem_ok, tail_ok = (bool(v) for v in votes.tolist())
+
+        # --- collective builds, fixed order, unguarded ---
+        if multimem_ok:
+            # Collective buffers must reach peak size before serving.
+            self.multimem_ar_ok = multimem_prealloc(
+                MULTIMEM_AR_MAX_TOKENS,
+                (latent, hidden),
+                dist.group.WORLD.group_name,
+            )
+        self.latent_tail_ok = tail_ok
+        logger.info(
+            "K3 comm negotiated: multimem=%s latent_tail=%s",
+            self.multimem_ar_ok,
+            self.latent_tail_ok,
+        )
+
+
+class K3AttnComm:
+    """Per-decoder-layer handle over the negotiated K3 communication state.
+
+    Model code states semantics (``attn_reduce``); backend choice,
+    thresholds and workspace access all live behind this class.
+    """
+
+    def __init__(self, state: K3AttnCommState) -> None:
+        self.state = state
+        self.mapping = state.mapping
+
+    # ------------------------------------------------------------------
+    # Attention-side reduction (moved verbatim from
+    # KimiLinearDecoderLayer._reduce_attn_accumulate; behavior unchanged).
+    # ------------------------------------------------------------------
+    def attn_reduce(
+        self,
+        attn_partial: torch.Tensor,
+        prefix_sum: torch.Tensor | None,
+        combine: tuple | None = None,
+        *,
+        mlp_wp: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """All-reduce the attention partial and accumulate the residual.
+
+        Small batches fold the residual add into the one-shot AR kernel;
+        with ``combine = (scratch, res_w, rms_w, out_norm_w, eps)`` the
+        mlp-side AttnRes prefix combine also rides its epilogue and the mixed
+        hidden comes back as the second return (else None -- block-write
+        layers, large batches and the plain-reduce fallback).
+
+        ``mlp_wp`` is the calling layer's precomputed ``rms_w * res_w``
+        product (per-layer state, filled in post_load_weights); the B1
+        combine kernels consume it in place of the separate weights.
+        """
+        num_tokens = attn_partial.shape[0]
+        if (
+            prefix_sum is not None
+            and self.state.attn_ar_fusion_ok
+            and 0 < num_tokens
+            and num_tokens <= global_server_args_dict["comm_fusion_max_num_tokens"]
+        ):
+            if combine is not None:
+                from tokenspeed_kernel.ops.communication.trtllm import (
+                    allreduce_residual_attnres_combine,
+                )
+
+                scratch, res_w, rms_w, out_norm_w, eps = combine
+                h, residual_out = allreduce_residual_attnres_combine(
+                    attn_partial,
+                    prefix_sum,
+                    res_w,
+                    rms_w,
+                    out_norm_w,
+                    scratch=scratch,
+                    rank=self.mapping.attn.tp_rank,
+                    group=_get_process_group(self.mapping.attn.tp_group),
+                    eps=eps,
+                    max_token_num=global_server_args_dict["comm_fusion_max_num_tokens"],
+                    launch_with_pdl=pdl_enabled(),
+                )
+                return residual_out, h
+            _, residual_out, *_ = self.state.dummy_norm.forward_with_allreduce_fusion(
+                self.mapping.attn.tp_rank,
+                self.mapping.attn.tp_group,
+                attn_partial,
+                prefix_sum,
+            )
+            if residual_out is not None:
+                return residual_out, None
+        if combine is not None and prefix_sum is not None and num_tokens == 1:
+            scratch, _, _, out_norm_w, eps = combine
+            if out_norm_w is not None:
+                from tokenspeed_kernel.ops.communication.triton import (
+                    allreduce_residual_attnres_combine,
+                    allreduce_residual_attnres_combine_supported,
+                )
+
+                group = _get_process_group(self.mapping.attn.tp_group)
+                fused_supported = not global_server_args_dict.get(
+                    "force_deterministic_rsag", False
+                ) and allreduce_residual_attnres_combine_supported(
+                    attn_partial,
+                    prefix_sum,
+                    mlp_wp,
+                    out_norm_w,
+                    scratch,
+                    rank=self.mapping.attn.tp_rank,
+                    group=group,
+                    local_world_size=self.mapping.nprocs_per_node,
+                )
+                if fused_supported:
+                    h, residual_out = allreduce_residual_attnres_combine(
+                        attn_partial,
+                        prefix_sum,
+                        mlp_wp,
+                        out_norm_w,
+                        scratch,
+                        rank=self.mapping.attn.tp_rank,
+                        group=group,
+                        local_world_size=self.mapping.nprocs_per_node,
+                        eps=eps,
+                    )
+                else:
+                    residual_out = prefix_sum + all_reduce(
+                        attn_partial, self.mapping.attn.tp_group
+                    )
+                    h = attnres_combine(
+                        residual_out,
+                        mlp_wp,
+                        out_norm_w,
+                        eps,
+                        scratch,
+                        torch.empty_like(residual_out),
+                    )
+                return residual_out, h
+        reduced = all_reduce(attn_partial, self.mapping.attn.tp_group)
+        return (reduced if prefix_sum is None else prefix_sum + reduced), None
+
+
+@dataclass
+class TailPlan:
+    """Per-forward contract between the model and the MoE tail.
+
+    Attributes:
+        tier: The negotiated tail tier for this token count.
+        lane: Pre-materialized fused-lane buffer, or None; when set the
+            experts kernel writes its routed partial into
+            ``lane[:, :routed_hidden]`` and the shared experts into the rest.
+        routed_in_fork: Whether the routed partial must be reduced and
+            projected inside the fork (SEPARATE_REDUCE overlap).
+    """
+
+    tier: "K3MoETailTier"
+    lane: torch.Tensor | None = None
+    routed_in_fork: bool = False
+
+
+class K3MoeTailComm:
+    """MoE-tail routing and execution for one KimiLinearMoE module.
+
+    Holds the negotiated ``K3MoeTailCommState`` plus this module's own
+    resources (per-module multicast mailbox, norm/up-proj weights).
+    """
+
+    def __init__(
+        self,
+        *,
+        mapping,
+        hidden_size: int,
+        prefix: str,
+        layer_index: int,
+        model_scope: str,
+        routed_hidden: int,
+        top_k: int,
+        routed_norm,
+        up_proj,
+        execution_plan,
+    ) -> None:
+        self.state = K3MoeTailCommState.get(
+            mapping=mapping,
+            hidden_size=hidden_size,
+            latent_size=routed_hidden,
+            top_k=top_k,
+            rms_eps=(routed_norm.variance_epsilon if routed_norm is not None else 1e-6),
+            allow_latent_tail=(
+                not execution_plan.use_native and routed_norm is not None
+            ),
+        )
+        self.mapping = mapping
+        self.hidden_size = hidden_size
+        self.routed_hidden = routed_hidden
+        self.top_k = top_k
+        self.routed_norm = routed_norm
+        self.up_proj = up_proj
+        self.execution_plan = execution_plan
+        # Derived from the projection itself (built with a shard group iff
+        # _shard_k3_up_projection held), so comm and module cannot disagree.
+        self._shard_up_projection = up_proj.shard_group is not None
+        self.latent_tail = None
+        if self.state.latent_tail_ok:
+            # Per-module mailbox. Constructor failures must propagate because
+            # peers are already rendezvousing: a rank that failed mid-way has
+            # stranded them, and killing the whole job is the good outcome.
+            _device = torch.device("cuda", torch.cuda.current_device())
+            self.latent_tail = KimiK3LatentTailOp.initialize(
+                group=dist.group.WORLD,
+                hidden_size=hidden_size,
+                latent_size=routed_hidden,
+                rms_eps=self.state.rms_eps,
+                device=_device,
+                layer_index=layer_index,
+                model_scope=model_scope,
+                # Staging may alias the workspace pool; each barrier-free
+                # mailbox must remain private.
+                scratch_allocator=workspace_pool(_device).allocate,
+            )
+            logger.info("multicast latent tail engaged (%s)", prefix)
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+    def plan(self, num_tokens: int, hidden_states: torch.Tensor) -> TailPlan:
+        """Pick the tail tier and its forward-side obligations.
+
+        Every input must be rank-uniform (token count, graph phase and the
+        negotiated capabilities) so all ranks take identical branches.
+        """
+        # Graph warmup, capture, and replay must select the same tier.
+        tier = select_k3_moe_tail_tier(
+            num_tokens=num_tokens,
+            graph_phase=get_is_cuda_graph_phase(),
+            tail_fusion_max_tokens=(
+                self.latent_tail.max_num_tokens if self.latent_tail is not None else 0
+            ),
+            fused_moe_ar=self.execution_plan.fused_moe_ar,
+            multimem_ok=self.state.multimem_ar_ok,
+        )
+        # Shard mode splits the joined reduction, so it cannot use the packed lane.
+        lane = allreduce_fusion_lane(
+            hidden_states,
+            self.routed_hidden + self.hidden_size,
+            enabled=(
+                tier is K3MoETailTier.FUSED_LANE_AR and not self._shard_up_projection
+            ),
+        )
+        return TailPlan(
+            tier=tier,
+            lane=lane,
+            routed_in_fork=tier is K3MoETailTier.SEPARATE_REDUCE,
+        )
+
+    # ------------------------------------------------------------------
+    # Fork-side helpers (called by the model inside its stream fork)
+    # ------------------------------------------------------------------
+    def reduce_shared(self, shared_partial: torch.Tensor) -> torch.Tensor:
+        """Reduce the shared experts' TP partial on the current stream."""
+        if self.mapping.moe.tp_ep_size > 1:
+            return all_reduce(shared_partial, self.mapping.moe.tp_ep_group)
+        return shared_partial
+
+    def reduce_project_routed(self, routed_out: torch.Tensor) -> torch.Tensor:
+        """Reduce, norm and up-project the routed partial (SEPARATE_REDUCE).
+
+        Runs in the model's ``forward`` inside the stream fork so it overlaps
+        the shared-expert branch; the tier method then receives an
+        already-projected routed output, unlike the other tiers.
+        """
+        routed_reduced = routed_out
+        if self.mapping.moe.has_tp_ep:
+            routed_reduced = all_reduce(routed_reduced, self.mapping.moe.tp_ep_group)
+        if self.routed_norm is not None:
+            routed_reduced = self.routed_norm(routed_reduced)
+        if self._shard_up_projection:
+            # This block must wait for the fork before folding into the shared reduction.
+            return self.up_proj.project_shard(routed_reduced)
+        return self.up_proj(routed_reduced)[0]
+
+    # ------------------------------------------------------------------
+    # Tail dispatch (moved verbatim from KimiLinearMoE._moe_tail and the
+    # tier methods)
+    # ------------------------------------------------------------------
+    def run(
+        self,
+        plan: TailPlan,
+        routed_out,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        """Dispatch the selected tier over the partials.
+
+        Raw partials everywhere except SEPARATE_REDUCE, whose routed side
+        already ran inside the fork scope to overlap the shared branch.
+        """
+        tier = plan.tier
+        if tier is K3MoETailTier.TAIL_FUSION:
+            return self._tail_fusion(routed_out, shared_partial, prefix_sum)
+        if tier is K3MoETailTier.MULTIMEM_AR:
+            return self._tail_multimem_ar(
+                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
+            )
+        if tier is K3MoETailTier.FUSED_LANE_AR:
+            return self._tail_fused_lane_ar(
+                routed_out,
+                shared_partial,
+                prefix_sum,
+                plan.lane,
+                num_tokens,
+                hidden_size,
+            )
+        return self._tail_separate_reduce(
+            routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
+        )
+
+    def _tail_fusion(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.latent_tail(
+            routed_out,
+            shared_partial,
+            self.routed_norm.weight,
+            self.up_proj.weight,
+            prefix=prefix_sum,
+        )
+
+    def _tail_multimem_ar(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        if self._shard_up_projection:
+            return self._tail_multimem_ar_sharded(
+                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
+            )
+        return self._tail_multimem_ar_replicated(
+            routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
+        )
+
+    def _tail_multimem_ar_sharded(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        # Eligibility guarantees tp_ep spans WORLD for these symmetric reductions.
+        group_name = dist.group.WORLD.group_name
+        routed_stage = multimem_stage(routed_out, group_name, MULTIMEM_AR_MAX_TOKENS)
+        shared_stage = (
+            multimem_stage(shared_partial, group_name, MULTIMEM_AR_MAX_TOKENS)
+            if routed_stage is not None
+            else None
+        )
+        # Eligibility guarantees both stages exist; a miss is a contract violation.
+        if routed_stage is None or shared_stage is None:
+            raise RuntimeError(
+                "multimem staging failed after the tier was selected; the "
+                "init-time capability vote and the runtime shapes disagree"
+            )
+        routed_reduced = multimem_all_reduce_staged(routed_stage, group_name)
+        # Disjoint projection shards concatenate when injected into the shared sum.
+        routed_reduced = (
+            self.routed_norm(routed_reduced)
+            if self.routed_norm is not None
+            else routed_reduced
+        )
+        start, width = self.up_proj.shard_slice
+        target = shared_stage[:, start : start + width]
+        target += prefix_sum.view(num_tokens, hidden_size).narrow(-1, start, width)
+        target.addmm_(routed_reduced, self.up_proj.weight.t())
+        shared_reduced = multimem_all_reduce_staged(shared_stage, group_name)
+        # Clone: the staging buffer is recycled by the next layer's stage copy.
+        return shared_reduced.view(num_tokens, hidden_size).clone()
+
+    def _tail_multimem_ar_replicated(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        # Eligibility guarantees tp_ep spans WORLD for these symmetric reductions.
+        group_name = dist.group.WORLD.group_name
+        routed_stage = multimem_stage(routed_out, group_name, MULTIMEM_AR_MAX_TOKENS)
+        shared_stage = (
+            multimem_stage(shared_partial, group_name, MULTIMEM_AR_MAX_TOKENS)
+            if routed_stage is not None
+            else None
+        )
+        # Eligibility guarantees both stages exist; a miss is a contract violation.
+        if routed_stage is None or shared_stage is None:
+            raise RuntimeError(
+                "multimem staging failed after the tier was selected; the "
+                "init-time capability vote and the runtime shapes disagree"
+            )
+        routed_reduced = multimem_all_reduce_staged(routed_stage, group_name)
+        shared_reduced = multimem_all_reduce_staged(shared_stage, group_name)
+        if self.routed_norm is not None:
+            routed_reduced = self.routed_norm(routed_reduced)
+        return self._projection_tail(
+            routed_reduced, shared_reduced, prefix_sum, num_tokens, hidden_size
+        )
+
+    def _projection_tail(
+        self,
+        routed_reduced: torch.Tensor,
+        shared_reduced: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        return self.up_proj.forward_add3(
+            routed_reduced,
+            prefix_sum,
+            shared_reduced,
+        ).view(num_tokens, hidden_size)
+
+    def _project_and_inject_local_block(
+        self,
+        routed_reduced: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        start, width = self.up_proj.shard_slice
+        shared_partial = shared_partial.view(num_tokens, hidden_size)
+        target = shared_partial[:, start : start + width]
+        target += prefix_sum.view(num_tokens, hidden_size)[:, start : start + width]
+        target.addmm_(routed_reduced, self.up_proj.weight.t())
+        return shared_partial
+
+    def _inject_local_block(
+        self,
+        routed_projected_shard: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        """Add this rank's projection block into its columns of the shared
+        partial, in place, so the shared reduction also gathers the projection.
+
+        The column blocks are disjoint across ranks, so summing the partials
+        concatenates the blocks and adds ``prefix`` exactly once per column.
+        Works with any sum all-reduce; the caller runs it right after this.
+        """
+        # One extra bf16 rounding vs the joined tiers; measured nil on GPQA, not bitwise.
+        start, width = self.up_proj.shard_slice
+        shared_partial = shared_partial.view(num_tokens, hidden_size)
+        shared_partial[
+            :, start : start + width
+        ] += routed_projected_shard + prefix_sum.view(num_tokens, hidden_size).narrow(
+            -1, start, width
+        )
+        return shared_partial
+
+    def _tail_fused_lane_ar(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        lane: torch.Tensor | None,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        if self._shard_up_projection:
+            return self._tail_fused_lane_ar_sharded(
+                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
+            )
+        return self._tail_fused_lane_ar_replicated(
+            routed_out, shared_partial, prefix_sum, lane, num_tokens, hidden_size
+        )
+
+    def _tail_fused_lane_ar_sharded(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        # Sharded projection folds into the shared reduction; the packed lane is disabled here.
+        routed_reduced = all_reduce(routed_out, self.mapping.moe.tp_ep_group)
+        if self.routed_norm is not None:
+            routed_reduced = self.routed_norm(routed_reduced)
+        shared_partial = self._project_and_inject_local_block(
+            routed_reduced, shared_partial, prefix_sum, num_tokens, hidden_size
+        )
+        return all_reduce(shared_partial, self.mapping.moe.tp_ep_group)
+
+    def _tail_fused_lane_ar_replicated(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        lane: torch.Tensor | None,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        routed_reduced, shared_reduced = kimi3_join_reduce_moe(
+            routed_out,
+            shared_partial,
+            lane=lane,
+            routed_hidden=self.routed_hidden,
+            routed_norm=self.routed_norm,
+            group=self.mapping.moe.tp_ep_group,
+            enable_lane_norm=self.execution_plan.lane_latent_norm_ar,
+            max_token_num=self.execution_plan.comm_fusion_max_num_tokens,
+        )
+        return self._projection_tail(
+            routed_reduced, shared_reduced, prefix_sum, num_tokens, hidden_size
+        )
+
+    def _tail_separate_reduce(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        if self._shard_up_projection:
+            return self._tail_separate_reduce_sharded(
+                routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
+            )
+        return self._tail_separate_reduce_replicated(
+            routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
+        )
+
+    def _tail_separate_reduce_sharded(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        routed_projected_shard = routed_out
+        shared_partial = self._inject_local_block(
+            routed_projected_shard,
+            shared_partial,
+            prefix_sum,
+            num_tokens,
+            hidden_size,
+        )
+        shared_reduced = self.reduce_shared(shared_partial)
+        return shared_reduced.view(num_tokens, hidden_size)
+
+    def _tail_separate_reduce_replicated(
+        self,
+        routed_out: torch.Tensor,
+        shared_partial: torch.Tensor,
+        prefix_sum: torch.Tensor,
+        num_tokens: int,
+        hidden_size: int,
+    ) -> torch.Tensor:
+        routed_projected = routed_out
+        shared_reduced = self.reduce_shared(shared_partial)
+        # routed_scaling_factor already applied in TopK (matches reference).
+        return add3(
+            prefix_sum,
+            routed_projected.view(num_tokens, hidden_size),
+            shared_reduced.view(num_tokens, hidden_size),
+        )
+
+
+__all__ = [
+    "K3AttnComm",
+    "K3AttnCommState",
+    "K3MoETailTier",
+    "K3MoeTailComm",
+    "K3MoeTailCommState",
+    "MULTIMEM_AR_MAX_TOKENS",
+    "MULTIMEM_AR_MIN_TOKENS",
+    "TailPlan",
+    "select_k3_moe_tail_tier",
+]

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -20,21 +20,23 @@
 
 """Every K3 MoE tail tier must produce the same answer.
 
-The selector routes a forward to one of four tiers by token count and graph
-phase, so which arithmetic runs depends on batch size and whether a CUDA graph
-is replaying. An end-to-end eval only ever exercises the tiers its own shapes
+The selector routes a forward to one of the tail tiers by token count and
+graph phase, so which arithmetic runs depends on batch size and whether a CUDA
+graph is replaying. An end-to-end eval only ever exercises the tiers its own shapes
 happen to select — GPQA at ebs8 never reaches SEPARATE_REDUCE, and nothing in
 the decode path reaches MULTIMEM_AR. This file compares the tiers against each
 other directly on identical inputs, which is what makes a tier-specific
 numerical defect visible at all.
 
-The tiers are driven through ``KimiLinearMoE``'s own ``_tail_*`` methods, on an
-instance built by ``__new__`` with only the attributes those methods read. That
-matters: a test that re-derived norm+projection in torch would agree with
-itself no matter what ``routed_expert_norm``, ``kimi3_latent_projection_add3``,
-``kimi3_join_reduce_moe`` or the fused kernel's epilogue actually computed.
-Only ``mapping`` and ``execution_plan`` are stand-ins — they carry group and
-policy configuration, no arithmetic.
+The tiers are driven through ``K3MoeTailComm``'s own ``_tail_*`` methods, on an
+instance built by ``__new__`` with only the attributes those methods read
+(the collective negotiation in ``K3MoeTailCommState`` is deliberately
+bypassed). That matters: a test that re-derived norm+projection in torch
+would agree with itself no matter what ``routed_norm``,
+``kimi3_latent_projection_add3``, ``kimi3_join_reduce_moe`` or the fused
+kernel's epilogue actually computed. Only ``mapping``, ``execution_plan`` and
+``state`` are stand-ins — they carry group and policy configuration, no
+arithmetic.
 
 The tolerance is deliberately loose, and not because any tier accumulates in
 bf16 — none does; every dot product runs in fp32. The paths differ in the
@@ -95,24 +97,24 @@ def _agreed(ok: bool) -> bool:
     return bool(flag.item())
 
 
-def _build_moe(device: torch.device, *, latent_tail=None):
-    """A ``KimiLinearMoE`` carrying just what the tail methods touch.
+def _build_comm(device: torch.device, *, latent_tail=None):
+    """A ``K3MoeTailComm`` carrying just what the tail methods touch.
 
-    Constructing the real module needs a config, loaded expert weights and a
-    parallel state this test has no use for, so the instance is built by
-    ``__new__`` and populated directly. The norm and projection are the
-    production modules with random weights; ``mapping`` and ``execution_plan``
-    are namespaces because the tail reads only group handles and policy flags
-    off them.
+    Constructing it for real runs the process-wide MIN-vote and the
+    collective allocators this test has no use for, so the instance is built
+    by ``__new__`` and populated directly. The norm and projection are the
+    production modules with random weights; ``mapping``, ``execution_plan``
+    and ``state`` are namespaces because the tail reads only group handles
+    and policy flags off them.
     """
     from tokenspeed.runtime.layers.layernorm import RMSNorm
     from tokenspeed.runtime.layers.moe.latent import Kimi3LatentProjection
-    from tokenspeed.runtime.models.kimi_k3 import KimiLinearMoE
+    from tokenspeed.runtime.models.kimi_k3_comm import K3MoeTailComm
 
     world = _world_size()
-    moe = object.__new__(KimiLinearMoE)
-    torch.nn.Module.__init__(moe)
-    moe.routed_hidden = L
+    comm = object.__new__(K3MoeTailComm)
+    comm.hidden_size = H
+    comm.routed_hidden = L
 
     with torch.device(device):
         up_proj = Kimi3LatentProjection(L, H, params_dtype=torch.bfloat16)
@@ -124,10 +126,13 @@ def _build_moe(device: torch.device, *, latent_tail=None):
     gw = torch.Generator(device="cpu").manual_seed(7)
     up_proj.weight.data.copy_((torch.randn(H, L, generator=gw) * 0.02).to(device))
     norm.weight.data.copy_((torch.randn(L, generator=gw) * 0.1).to(device))
-    moe.routed_expert_up_proj = up_proj
-    moe.routed_expert_norm = norm
+    comm.up_proj = up_proj
+    comm.routed_norm = norm
+    # Replicated projection (no shard group): the tiers take their
+    # _replicated variants, matching the full-width reference below.
+    comm._shard_up_projection = up_proj.shard_group is not None
 
-    moe.mapping = SimpleNamespace(
+    comm.mapping = SimpleNamespace(
         moe=SimpleNamespace(
             # tokenspeed groups are tuples of global ranks, not ProcessGroups.
             tp_ep_group=tuple(range(world)),
@@ -135,14 +140,19 @@ def _build_moe(device: torch.device, *, latent_tail=None):
             has_tp_ep=world > 1,
         )
     )
-    moe.execution_plan = SimpleNamespace(
+    comm.execution_plan = SimpleNamespace(
         fused_moe_ar=True,
         lane_latent_norm_ar=False,
         comm_fusion_max_num_tokens=8192,
     )
-    moe._latent_tail = latent_tail
-    moe._multimem_ar_ok = True
-    return moe
+    # Negotiated state stand-in.
+    comm.state = SimpleNamespace(
+        rms_eps=EPS,
+        multimem_ar_ok=True,
+        latent_tail_ok=latent_tail is not None,
+    )
+    comm.latent_tail = latent_tail
+    return comm
 
 
 def _inputs(rank: int, device: torch.device, m: int, seed: int):
@@ -155,7 +165,7 @@ def _inputs(rank: int, device: torch.device, m: int, seed: int):
     return routed, shared, prefix
 
 
-def _reference(moe, routed, shared, prefix):
+def _reference(comm, routed, shared, prefix):
     """All-reduce both partials, RMS-norm the latent, up-project, accumulate.
 
     Computed in fp32 from the same weights the tiers use, so it is a fixed
@@ -166,8 +176,8 @@ def _reference(moe, routed, shared, prefix):
     dist.all_reduce(routed_sum)
     dist.all_reduce(shared_sum)
     var = routed_sum.pow(2).mean(dim=-1, keepdim=True)
-    normed = routed_sum * torch.rsqrt(var + EPS) * moe.routed_expert_norm.weight.float()
-    up_w = moe.routed_expert_up_proj.weight.float()
+    normed = routed_sum * torch.rsqrt(var + EPS) * comm.routed_norm.weight.float()
+    up_w = comm.up_proj.weight.float()
     return prefix.float() + normed @ up_w.T + shared_sum
 
 
@@ -176,16 +186,16 @@ def _rel_err(out: torch.Tensor, ref: torch.Tensor) -> float:
     return (out.float() - ref).abs().max().item() / max(scale, 1e-6)
 
 
-def _run_separate_reduce(moe, routed, shared, prefix, m):
+def _run_separate_reduce(comm, routed, shared, prefix, m):
     # The fork scope reduces and projects the routed side before the tier
     # method sees it; serving does that on a side stream, order unchanged.
-    routed_proj = moe._reduce_project_routed(routed)
-    return moe._tail_separate_reduce(routed_proj, shared, prefix, m, H)
+    routed_proj = comm.reduce_project_routed(routed)
+    return comm._tail_separate_reduce(routed_proj, shared, prefix, m, H)
 
 
 def test_selector_boundaries():
     """The tier map itself, with no GPU or collective involved."""
-    from tokenspeed.runtime.layers.moe.latent import (
+    from tokenspeed.runtime.models.kimi_k3_comm import (
         K3MoETailTier,
         select_k3_moe_tail_tier,
     )
@@ -253,10 +263,10 @@ def test_fused_tail_matches_reference(m):
         layer_index=0,
         model_scope="test",
     )
-    moe = _build_moe(dev, latent_tail=tail)
+    comm = _build_comm(dev, latent_tail=tail)
     routed, shared, prefix = _inputs(rank, dev, m, seed=11)
-    ref = _reference(moe, routed, shared, prefix)
-    out = moe._tail_fusion(routed, shared, prefix)
+    ref = _reference(comm, routed, shared, prefix)
+    out = comm._tail_fusion(routed, shared, prefix)
     torch.cuda.synchronize()
     assert _rel_err(out, ref) < 0.05
 
@@ -271,10 +281,10 @@ def test_multimem_ar_matches_reference(m):
     if not _agreed(multimem_available()):
         pytest.skip("multimem unavailable here")
 
-    moe = _build_moe(dev)
+    comm = _build_comm(dev)
     routed, shared, prefix = _inputs(rank, dev, m, seed=22)
-    ref = _reference(moe, routed, shared, prefix)
-    out = moe._tail_multimem_ar(routed, shared, prefix, m, H)
+    ref = _reference(comm, routed, shared, prefix)
+    out = comm._tail_multimem_ar(routed, shared, prefix, m, H)
     torch.cuda.synchronize()
     assert _rel_err(out, ref) < 0.05
 
@@ -288,10 +298,10 @@ def test_fused_lane_ar_matches_reference(m):
     a captured graph, and the join's no-lane path is what eager traffic takes.
     """
     rank, dev = _setup()
-    moe = _build_moe(dev)
+    comm = _build_comm(dev)
     routed, shared, prefix = _inputs(rank, dev, m, seed=55)
-    ref = _reference(moe, routed, shared, prefix)
-    out = moe._tail_fused_lane_ar(routed, shared, prefix, None, m, H)
+    ref = _reference(comm, routed, shared, prefix)
+    out = comm._tail_fused_lane_ar(routed, shared, prefix, None, m, H)
     torch.cuda.synchronize()
     assert _rel_err(out, ref) < 0.05
 
@@ -304,10 +314,10 @@ def test_separate_reduce_matches_reference(m):
     No end-to-end eval in this repo selects it, so this is its only coverage.
     """
     rank, dev = _setup()
-    moe = _build_moe(dev)
+    comm = _build_comm(dev)
     routed, shared, prefix = _inputs(rank, dev, m, seed=33)
-    ref = _reference(moe, routed, shared, prefix)
-    out = _run_separate_reduce(moe, routed, shared, prefix, m)
+    ref = _reference(comm, routed, shared, prefix)
+    out = _run_separate_reduce(comm, routed, shared, prefix, m)
     torch.cuda.synchronize()
     assert _rel_err(out, ref) < 0.05
 
@@ -345,7 +355,7 @@ def test_tiers_agree_with_each_other():
             layer_index=0,
             model_scope="test",
         )
-    moe = _build_moe(dev, latent_tail=tail)
+    comm = _build_comm(dev, latent_tail=tail)
     routed, shared, prefix = _inputs(rank, dev, m, seed=44)
 
     # Every tier reduces its partials in place, so each gets its own copies;
@@ -354,13 +364,13 @@ def test_tiers_agree_with_each_other():
     def fresh():
         return routed.clone(), shared.clone(), prefix.clone()
 
-    outs = {"separate_reduce": _run_separate_reduce(moe, *fresh(), m)}
+    outs = {"separate_reduce": _run_separate_reduce(comm, *fresh(), m)}
     r, s, p = fresh()
-    outs["fused_lane_ar"] = moe._tail_fused_lane_ar(r, s, p, None, m, H)
+    outs["fused_lane_ar"] = comm._tail_fused_lane_ar(r, s, p, None, m, H)
     if _agreed(multimem_available()):
-        outs["multimem_ar"] = moe._tail_multimem_ar(*fresh(), m, H)
+        outs["multimem_ar"] = comm._tail_multimem_ar(*fresh(), m, H)
     if tail is not None:
-        outs["tail_fusion"] = moe._tail_fusion(*fresh())
+        outs["tail_fusion"] = comm._tail_fusion(*fresh())
     torch.cuda.synchronize()
 
     base_name, base = next(iter(outs.items()))

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -193,6 +193,130 @@ def _run_separate_reduce(comm, routed, shared, prefix, m):
     return comm._tail_separate_reduce(routed_proj, shared, prefix, m, H)
 
 
+TOP_K = 8  # K3's num_experts_per_token; any value in [1, 64] compiles.
+
+
+def _deferred_triple(rank: int, device: torch.device, m: int, seed: int):
+    """Synthesize a per-rank deferred-finalize triple with EP-style -1 slots.
+
+    Mirrors the trtllm ``do_finalize=False`` contract: permuted gemm2 rows
+    (with a few never-referenced padded rows poisoned with NaN, so any
+    out-of-contract read turns the output NaN and fails the tolerance
+    assertions), bf16 expert scales, and an int32 expanded->permuted map
+    where ``-1`` marks slots whose expert lives on another rank.
+    """
+    g = torch.Generator(device="cpu").manual_seed(seed * 1009 + rank)
+    slots = m * TOP_K
+    # ~30% of slots dropped, mimicking EP routing away from this rank.
+    keep = torch.rand(slots, generator=g) < 0.7
+    kept = int(keep.sum().item())
+    num_rows = kept + 3  # padded rows must never leak into the output
+    idx = torch.full((slots,), -1, dtype=torch.int32)
+    idx[keep] = torch.randperm(num_rows, generator=g)[:kept].to(torch.int32)
+    gemm2 = (torch.randn(num_rows, L, generator=g) * 0.1).to(device, torch.bfloat16)
+    referenced = torch.zeros(num_rows, dtype=torch.bool, device=device)
+    referenced[idx[keep].to(device).long()] = True
+    gemm2[~referenced] = float("nan")
+    weights = (torch.rand(m, TOP_K, generator=g) * 0.5).to(device, torch.bfloat16)
+    return gemm2, weights, idx.to(device)
+
+
+def _manual_finalize(gemm2, weights, idx, m):
+    """Torch reference finalize: fp32 accumulate in k order, one bf16 round.
+
+    Semantically equivalent to the standalone finalize kernel
+    (moe_finalize_fuse_shared.cu) that the deferred TAIL_FUSION mode inlines;
+    bitwise identity is not expected (FMA contraction differs).
+    """
+    acc = torch.zeros(m, L, dtype=torch.float32, device=gemm2.device)
+    idx2 = idx.view(m, TOP_K).long()
+    w2 = weights.view(m, TOP_K).float()
+    for k in range(TOP_K):
+        rows = idx2[:, k]
+        valid = rows >= 0
+        if valid.any():
+            acc[valid] += w2[valid, k, None] * gemm2[rows[valid]].float()
+    return acc.to(torch.bfloat16)
+
+
+def test_call_deferred_shape_hardening():
+    """Host-op contract checks that need no collective (F1/F2 hardening).
+
+    A stubbed collective records what the launch would receive: a zero-row
+    gemm2 (EP routed everything away) must take the safe one-row placeholder
+    path — never an early return, which would strand peers — and fp32 expert
+    scales must be refused rather than silently down-cast to bf16.
+    """
+    from tokenspeed_kernel.ops.moe import latent_tail as lt
+
+    m = 2
+    op = object.__new__(lt.KimiK3LatentTailOp)
+    op.contract = lt._Contract(
+        group_name="test-group",
+        tp_size=8,
+        device=torch.device("cpu"),
+        hidden_size=H,
+        latent_size=L,
+        rms_eps=EPS,
+        finalize_top_k=TOP_K,
+    )
+    op.rank = 0
+    seen = {}
+
+    class FakeCollective:
+        def call_deferred(self, gemm2, weights, idx, shared, gamma, num_tokens):
+            seen.update(gemm2=gemm2, weights=weights, idx=idx, m=num_tokens)
+            return "LATENT", "SHARD"
+
+    class FakeUpProj:
+        # Special methods resolve on the type, so a class (not a namespace)
+        # stands in for the callable up-projection kernel.
+        def is_compiled(self, m):
+            return True
+
+        def ensure_compiled(self, m):
+            return None
+
+        def __call__(self, latent, weight, shard):
+            return "MAILBOX"
+
+    op._collective = FakeCollective()
+    op._up_projection = FakeUpProj()
+    op._lamport_copy = lambda mailbox, m, residual: torch.zeros(1, m, H)
+
+    weights = torch.zeros(m, TOP_K, dtype=torch.bfloat16)
+    idx = torch.full((m * TOP_K,), -1, dtype=torch.int32)
+    shared = torch.zeros(m, H, dtype=torch.bfloat16)
+    rms_w = torch.zeros(L, dtype=torch.bfloat16)
+    up_w = torch.zeros(H, L, dtype=torch.bfloat16)
+
+    out = op.call_deferred(
+        torch.empty(0, L, dtype=torch.bfloat16),
+        weights,
+        idx,
+        shared,
+        rms_w,
+        up_w,
+        num_tokens=m,
+    )
+    assert out.shape == (m, H)
+    # The zero-row input was replaced by the never-read one-row placeholder.
+    assert seen["gemm2"].shape == (1, L)
+    assert (seen["gemm2"] == 0).all()
+    assert seen["weights"].shape == (m * TOP_K,) and seen["m"] == m
+
+    with pytest.raises(ValueError, match="BF16"):
+        op.call_deferred(
+            torch.zeros(4, L, dtype=torch.bfloat16),
+            weights.float(),  # fp32 scales must be refused, not down-cast
+            idx,
+            shared,
+            rms_w,
+            up_w,
+            num_tokens=m,
+        )
+
+
 def test_selector_boundaries():
     """The tier map itself, with no GPU or collective involved."""
     from tokenspeed.runtime.models.kimi_k3_comm import (
@@ -227,6 +351,52 @@ def test_selector_boundaries():
     assert pick(1, fused_ar=False) is K3MoETailTier.TAIL_FUSION
     for n in (17, 64, 256, 100_000):
         assert pick(n, fused_ar=False) is K3MoETailTier.SEPARATE_REDUCE
+
+
+def test_tail_fusion_plan_defer_decision(monkeypatch):
+    """TAIL_FUSION defers finalize iff the tail op and the fused-AR plan agree.
+
+    Pure Python: the plan() early return for TAIL_FUSION never touches the
+    lane machinery or hidden_states, so stubs carry the whole decision.
+    """
+    from tokenspeed.runtime.models import kimi_k3_comm as mod
+
+    monkeypatch.setattr(mod, "get_is_cuda_graph_phase", lambda: True)
+
+    def build(*, supports_deferred, fused_ar):
+        comm = object.__new__(mod.K3MoeTailComm)
+        comm.latent_tail = SimpleNamespace(
+            max_num_tokens=16,
+            supports_deferred_finalize=supports_deferred,
+        )
+        comm.execution_plan = SimpleNamespace(fused_moe_ar=fused_ar)
+        comm.state = SimpleNamespace(multimem_ar_ok=False)
+        comm._shard_up_projection = False
+        comm.routed_hidden, comm.hidden_size = L, H
+        return comm
+
+    plan = build(supports_deferred=True, fused_ar=True).plan(1, None)
+    assert plan.tier is mod.K3MoETailTier.TAIL_FUSION
+    assert plan.defer_finalize
+    assert plan.lane is None and not plan.routed_in_fork
+
+    # A tail op without the deferred variant must keep the materialized mode.
+    plan = build(supports_deferred=False, fused_ar=True).plan(16, None)
+    assert plan.tier is mod.K3MoETailTier.TAIL_FUSION
+    assert not plan.defer_finalize
+
+    # Without the fused-AR (trtllm) plan the experts kernel cannot defer.
+    plan = build(supports_deferred=True, fused_ar=False).plan(1, None)
+    assert plan.tier is mod.K3MoETailTier.TAIL_FUSION
+    assert not plan.defer_finalize
+
+    # No tail op at all: the tier is unreachable, nothing defers.
+    comm = build(supports_deferred=True, fused_ar=True)
+    comm.latent_tail = None
+    hidden = torch.zeros(17, H)
+    plan = comm.plan(17, hidden)
+    assert plan.tier is not mod.K3MoETailTier.TAIL_FUSION
+    assert not plan.defer_finalize
 
 
 # 4 is included so a single node can cover the tiers; the fused tail itself
@@ -269,6 +439,60 @@ def test_fused_tail_matches_reference(m):
     out = comm._tail_fusion(routed, shared, prefix)
     torch.cuda.synchronize()
     assert _rel_err(out, ref) < 0.05
+
+
+@collective
+@pytest.mark.parametrize("m", [1, 4, 16])
+def test_fused_tail_deferred_finalize_matches_reference(m):
+    """TAIL_FUSION with the MoE finalize inlined into the publish phase.
+
+    The triple is synthetic (random permuted rows, scales, and an index map
+    with EP-style ``-1`` holes); the reference materializes the finalize with
+    the torch mirror of the standalone kernel's math and then runs the same
+    fp32 tail reference as every other tier. A second assertion pins the
+    deferred output to the materialized TAIL_FUSION path on identical inputs,
+    which isolates the in-kernel finalize from the rest of the tail.
+    """
+    from tokenspeed_kernel.ops.moe.latent_tail import (
+        KimiK3LatentTailOp,
+        latent_tail_supported,
+    )
+
+    rank, dev = _setup()
+    if not _agreed(
+        latent_tail_supported(
+            tp_size=_world_size(), hidden_size=H, latent_size=L, dtype=torch.bfloat16
+        )
+    ):
+        pytest.skip("fused latent tail unsupported here")
+
+    tail = KimiK3LatentTailOp.initialize(
+        group=dist.group.WORLD,
+        hidden_size=H,
+        latent_size=L,
+        rms_eps=EPS,
+        device=dev,
+        layer_index=0,
+        model_scope="test-deferred",
+        finalize_top_k=TOP_K,
+    )
+    assert tail.supports_deferred_finalize
+    comm = _build_comm(dev, latent_tail=tail)
+    gemm2, weights, idx = _deferred_triple(rank, dev, m, seed=66)
+    routed_manual = _manual_finalize(gemm2, weights, idx, m)
+    _, shared, prefix = _inputs(rank, dev, m, seed=66)
+    ref = _reference(comm, routed_manual, shared, prefix)
+
+    out = comm._tail_fusion_deferred(gemm2, weights, idx, shared, prefix, m)
+    torch.cuda.synchronize()
+    assert _rel_err(out, ref) < 0.05
+
+    # Same tail, materialized finalize: only the in-kernel finalize differs.
+    out_materialized = comm._tail_fusion(routed_manual, shared, prefix)
+    torch.cuda.synchronize()
+    scale = out_materialized.float().abs().max().item()
+    diff = (out.float() - out_materialized.float()).abs().max().item()
+    assert diff / max(scale, 1e-6) < 0.02
 
 
 @collective

--- a/test/runtime/test_k3_moe_tail_tier.py
+++ b/test/runtime/test_k3_moe_tail_tier.py
@@ -22,7 +22,7 @@
 
 import pytest
 
-from tokenspeed.runtime.layers.moe.latent import (
+from tokenspeed.runtime.models.kimi_k3_comm import (
     K3MoETailTier,
     select_k3_moe_tail_tier,
 )

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -329,6 +329,7 @@ class KimiK3RegistrationTests(unittest.TestCase):
             def __init__(self, *args, **kwargs):
                 super().__init__()
                 self.weight = torch.empty(0)
+                self.shard_group = kwargs.get("shard_group")
 
         class FakeExperts(torch.nn.Module):
             def __init__(self, *args, **kwargs):
@@ -386,11 +387,7 @@ class KimiK3RegistrationTests(unittest.TestCase):
 
         with (
             mock.patch.object(kimi_k3, "ReplicatedLinear", FakeLinear),
-            mock.patch.object(
-                kimi_k3,
-                "Kimi3LatentProjection",
-                side_effect=lambda *args, **kwargs: FakeLinear(),
-            ),
+            mock.patch.object(kimi_k3, "Kimi3LatentProjection", FakeLinear),
             mock.patch.object(kimi_k3, "MoELayer", FakeExperts),
             mock.patch.object(kimi_k3, "KimiLinearMLP", FakeSharedExperts),
             mock.patch.object(kimi_k3, "LatentMoELayer", FakeLatentMoE),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxfp4.py
@@ -439,6 +439,7 @@ if platform.is_nvidia:
         output: torch.Tensor,
         enable_pdl: bool,
         hidden_states_scale: torch.Tensor | None = None,
+        do_finalize: bool = True,
     ) -> torch.Tensor:
         local_experts = getattr(w, "num_local_experts", w.w13_weight.shape[0])
         if local_experts != w.w13_weight.shape[0]:
@@ -461,7 +462,7 @@ if platform.is_nvidia:
         # format; expert IDs stay global and the kernel filters to the local
         # range. routing_method_type=1 (Renormalize) matches K3's
         # pre-normalized topk weights, which the kernel consumes as-is.
-        _fi_fp4_routed_moe(
+        result = _fi_fp4_routed_moe(
             topk_ids=topk,
             routing_bias=None,
             hidden_states=x,
@@ -487,12 +488,15 @@ if platform.is_nvidia:
             local_num_experts=local_experts,
             routed_scaling_factor=None,
             routing_method_type=1,
-            do_finalize=True,
+            do_finalize=do_finalize,
             enable_pdl=enable_pdl,
             activation_type=_SITU_ACTIVATION_TYPE,
             tune_max_num_tokens=get_autotune_max_num_tokens(),
-            output=output,
+            output=output if do_finalize else None,
         )
+        if not do_finalize:
+            # [gemm2_output, expert_weights, expanded_idx_to_permuted_idx]
+            return result
         return output
 
     @register_kernel(
@@ -611,7 +615,7 @@ if platform.is_nvidia:
                 "weight_dtype": frozenset({"mxfp4"}),
                 "activation": frozenset({"situ"}),
                 "routing_mode": frozenset({"precomputed_topk"}),
-                "supports_deferred_finalize": frozenset({False}),
+                "supports_deferred_finalize": frozenset({True, False}),
                 "supports_ep": frozenset({True}),
                 "supports_all_to_all_ep": frozenset({False}),
                 "ispp_alignment": frozenset({1}),
@@ -637,8 +641,6 @@ if platform.is_nvidia:
     ):
         if topk_weights is None or topk_ids is None:
             raise ValueError("precomputed_topk plan requires topk_weights and topk_ids")
-        if not do_finalize:
-            raise NotImplementedError("FlashInfer MXFP4 SiTU requires finalization")
         if x.dtype != torch.bfloat16:
             raise TypeError("FlashInfer MXFP4 SiTU requires bf16 input")
 
@@ -666,18 +668,22 @@ if platform.is_nvidia:
         )
         hidden_states_scale = x_scale.view(torch.float8_e4m3fn).reshape(x.shape[0], -1)
 
-        out_buf = getattr(w, "_situ_output_buffer", None)
-        if (
-            out_buf is not None
-            and out_buf.shape == (x.shape[0], hidden_padded)
-            and out_buf.is_contiguous()
-        ):
-            # Caller-owned destination (e.g. a fused all-reduce lane slice).
-            output = out_buf
-        else:
-            output = torch.empty(
-                x.shape[0], hidden_padded, dtype=torch.bfloat16, device=x.device
-            )
+        # Deferred finalize returns the raw triple, so it needs no
+        # [tokens, hidden] destination at all — skip the allocation.
+        output = None
+        if do_finalize:
+            out_buf = getattr(w, "_situ_output_buffer", None)
+            if (
+                out_buf is not None
+                and out_buf.shape == (x.shape[0], hidden_padded)
+                and out_buf.is_contiguous()
+            ):
+                # Caller-owned destination (e.g. a fused all-reduce lane slice).
+                output = out_buf
+            else:
+                output = torch.empty(
+                    x.shape[0], hidden_padded, dtype=torch.bfloat16, device=x.device
+                )
         # Tactics come from the autotuner cache, seeded by a pre-swept table
         # and/or the runtime's startup autotune window (which exercises this
         # op via the dummy prefill); uncovered shapes take the heuristic
@@ -690,7 +696,13 @@ if platform.is_nvidia:
             output,
             enable_pdl,
             hidden_states_scale=hidden_states_scale,
+            do_finalize=do_finalize,
         )
+        if not do_finalize:
+            # Deferred: [gemm2_output(permuted), expert_weights,
+            # expanded_idx_to_permuted_idx]; padded width is the caller's
+            # concern (K3 latent 3584 needs no pad on this path).
+            return result
         if hidden_original != hidden_padded:
             result = result[:, :hidden_original].contiguous()
         return result

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
@@ -145,6 +145,10 @@ class _Contract:
     hidden_size: int
     latent_size: int
     rms_eps: float
+    # Non-None arms the deferred-finalize input mode (the collective kernel
+    # inlines the MoE finalize); part of the pool identity because it selects
+    # which kernel variants the pooled slot compiles.
+    finalize_top_k: int | None = None
 
 
 @dataclass
@@ -165,7 +169,7 @@ class KimiK3LatentTailOp:
     """
 
     _symmetric_pools: dict[
-        tuple[str, int, torch.device, int, int, float, str, int],
+        tuple[str, int, torch.device, int, int, float, int | None, str, int],
         _SymmetricPoolSlot,
     ] = {}
 
@@ -181,6 +185,7 @@ class KimiK3LatentTailOp:
         layer_index: int,
         model_scope: str,
         scratch_allocator: _ScratchAllocator | None = None,
+        finalize_top_k: int | None = None,
     ) -> "KimiK3LatentTailOp":
         """Construct this caller's tail op with a statically bound pool slot.
 
@@ -197,6 +202,12 @@ class KimiK3LatentTailOp:
                 per-call staging views from a shared block (the runtime's
                 workspace pool). The views are re-fetched on every collective
                 call per that pool's contract; None keeps private buffers.
+            finalize_top_k: When set (rank-uniform), additionally compiles the
+                deferred-finalize input mode so :meth:`call_deferred` can
+                consume the MoE kernel's ``(gemm2 permuted rows, expert
+                weights, expanded->permuted index)`` triple directly, skipping
+                the standalone finalize kernel and its ``[M, latent]``
+                intermediate. The standard mode stays available.
         """
         contract = _Contract(
             group_name=group.group_name,
@@ -205,6 +216,7 @@ class KimiK3LatentTailOp:
             hidden_size=hidden_size,
             latent_size=latent_size,
             rms_eps=float(rms_eps),
+            finalize_top_k=finalize_top_k,
         )
         return cls(
             contract,
@@ -238,6 +250,7 @@ class KimiK3LatentTailOp:
             contract.hidden_size,
             contract.latent_size,
             contract.rms_eps,
+            contract.finalize_top_k,
             model_scope,
             slot_index,
         )
@@ -259,6 +272,7 @@ class KimiK3LatentTailOp:
                         rms_eps=contract.rms_eps,
                         fp32_internal=True,
                         scratch_allocator=scratch_allocator,
+                        finalize_top_k=contract.finalize_top_k,
                     ),
                     up_projection=AdaptiveUpProjectionKernel(
                         group=group,
@@ -293,6 +307,11 @@ class KimiK3LatentTailOp:
     def max_num_tokens(self) -> int:
         return _MAX_NUM_TOKENS
 
+    @property
+    def supports_deferred_finalize(self) -> bool:
+        """Whether :meth:`call_deferred` may consume the deferred triple."""
+        return self.contract.finalize_top_k is not None
+
     def __call__(
         self,
         routed_partial: torch.Tensor,
@@ -323,17 +342,127 @@ class KimiK3LatentTailOp:
         """
         # Same-slot calls are stream-ordered, preserving Lamport buffer rotation.
         m = routed_partial.shape[0]
+        self._assert_capture_compiled(m)
+        latent, shared_shard = self._collective(
+            routed_partial,
+            shared_partial,
+            rms_weight,
+        )
+        return self._project_and_gather(latent, shared_shard, m, up_weight, prefix)
+
+    def call_deferred(
+        self,
+        gemm2_output: torch.Tensor,
+        expert_weights: torch.Tensor,
+        expanded_idx_to_permuted_idx: torch.Tensor,
+        shared_partial: torch.Tensor,
+        rms_weight: torch.Tensor,
+        up_weight: torch.Tensor,
+        *,
+        num_tokens: int,
+        prefix: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Fused tail consuming the MoE kernel's deferred-finalize triple.
+
+        The collective kernel inlines the finalize (FP32 accumulate over the
+        fixed top-k order, semantically equivalent to the standalone finalize
+        kernel; bitwise identity is not guaranteed across compilers) into its
+        publish phase, so no ``[M, latent]`` routed partial is materialized.
+
+        Args:
+            gemm2_output: Permuted expert rows ``[total_padded_rows, >=3584]``
+                BF16 from the MoE kernel's ``do_finalize=False`` path; extra
+                padded width is sliced off.
+            expert_weights: Per-slot scales, ``[M, top_k]`` or flat
+                ``[M * top_k]`` (coerced to contiguous BF16).
+            expanded_idx_to_permuted_idx: Expanded->permuted row map,
+                ``[M, top_k]`` or flat ``[M * top_k]`` (coerced to contiguous
+                int32); ``-1`` drops the slot (EP non-local expert / padding).
+            shared_partial: This rank's shared-expert partial ``[M, 7168]``.
+            rms_weight: Latent RMSNorm weight ``[3584]``.
+            up_weight: Up-projection weight, as in :meth:`__call__`.
+            num_tokens: Token count M for this step.
+            prefix: Optional residual stream ``[M, 7168]``, as in
+                :meth:`__call__`.
+
+        Returns:
+            ``[M, 7168]`` post-communication hidden, as in :meth:`__call__`.
+        """
+        if not self.supports_deferred_finalize:
+            raise RuntimeError(
+                "KimiK3LatentTailOp was initialized without finalize_top_k; "
+                "the deferred-finalize mode is unavailable"
+            )
+        m = int(num_tokens)
+        top_k = self.contract.finalize_top_k
+        self._assert_capture_compiled(m)
+        # The deferred trtllm MoE returns scale/index tensors as either
+        # [m, top_k] or flat [m * top_k]; both are memory-identical when
+        # contiguous, and the fused kernel indexes the flat form. Reshape is
+        # a view and contiguous() a no-op on the K3 SiTU path.
+        if expert_weights.dtype != torch.bfloat16:
+            # No silent cast: the collective kernel scalar-loads raw BF16
+            # bits, so a .to(bfloat16) here would quietly halve the scale
+            # precision of a producer emitting fp32 weights (e.g. a routing
+            # path with _routing_logits_dtype=float32). Refuse instead.
+            raise ValueError(
+                "deferred-finalize expert_weights must be BF16 (the trtllm "
+                "SiTU path echoes the caller's bf16 topk weights); got "
+                f"{expert_weights.dtype}. An fp32-scale producer needs an "
+                "fp32 weight-load variant of the latent-tail kernel first."
+            )
+        if expert_weights.shape != (m * top_k,) or not expert_weights.is_contiguous():
+            expert_weights = expert_weights.reshape(m * top_k).contiguous()
+        if (
+            expanded_idx_to_permuted_idx.dtype != torch.int32
+            or expanded_idx_to_permuted_idx.shape != (m * top_k,)
+            or not expanded_idx_to_permuted_idx.is_contiguous()
+        ):
+            expanded_idx_to_permuted_idx = (
+                expanded_idx_to_permuted_idx.reshape(m * top_k)
+                .to(torch.int32)
+                .contiguous()
+            )
+        if gemm2_output.shape[-1] != self.contract.latent_size:
+            gemm2_output = gemm2_output[:, : self.contract.latent_size].contiguous()
+        if gemm2_output.shape[0] == 0:
+            # EP corner: every slot routed away from this rank (idx all -1).
+            # This rank must still publish zeros and join the collective, so
+            # substitute a one-row zero placeholder rather than early-return
+            # (which would strand peers in the AR poll). The kernel only
+            # dereferences rows named by non-negative indices, and a zero row
+            # contributes nothing even if a contract-violating index reads it.
+            gemm2_output = torch.zeros(
+                (1, self.contract.latent_size),
+                dtype=torch.bfloat16,
+                device=gemm2_output.device,
+            )
+        latent, shared_shard = self._collective.call_deferred(
+            gemm2_output,
+            expert_weights,
+            expanded_idx_to_permuted_idx,
+            shared_partial,
+            rms_weight,
+            num_tokens=m,
+        )
+        return self._project_and_gather(latent, shared_shard, m, up_weight, prefix)
+
+    def _assert_capture_compiled(self, m: int) -> None:
         # JIT compilation launches kernels; under capture they would be
         # recorded into the graph. Warmup must have compiled this m already.
         assert not torch.cuda.is_current_stream_capturing() or (
             self._up_projection.is_compiled(m)
         ), f"latent-tail up-projection for M={m} must compile in warmup, not capture"
         self._up_projection.ensure_compiled(m)
-        latent, shared_shard = self._collective(
-            routed_partial,
-            shared_partial,
-            rms_weight,
-        )
+
+    def _project_and_gather(
+        self,
+        latent: torch.Tensor,
+        shared_shard: torch.Tensor,
+        m: int,
+        up_weight: torch.Tensor,
+        prefix: torch.Tensor | None,
+    ) -> torch.Tensor:
         local_hidden = self.contract.hidden_size // self.contract.tp_size
         if up_weight.shape[0] == local_hidden:
             local_up_weight = up_weight

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
@@ -24,6 +24,8 @@ from .primitives import (
     bf16x8_to_packed_u32x4,
     block_sum_specialized,
     fragment_is_dirty,
+    load_global_bf16_as_f32,
+    load_global_s32,
     load_global_u32x4,
     load_volatile_u32,
     map_shared_to_peer,
@@ -106,6 +108,7 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
         include_reduce_scatter: bool = True,
         include_routed: bool = True,
         use_pdl: bool | None = None,
+        finalize_top_k: int | None = None,
     ):
         # Bind in host Python; the JIT resolves names from self, not module globals.
         if use_pdl is None:
@@ -121,6 +124,17 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
             raise ValueError(f"rank must be in [0,{tp_size}), got {rank}")
         if not include_routed and not include_reduce_scatter:
             raise ValueError("at least one collective role must be enabled")
+        if finalize_top_k is not None and not 1 <= finalize_top_k <= 64:
+            raise ValueError(f"finalize_top_k must be in [1, 64], got {finalize_top_k}")
+        # Deferred-finalize input mode: the routed publish phase consumes the
+        # MoE kernel's (gemm2 permuted rows, expert weights, expanded->permuted
+        # index) triple instead of a materialized [M, latent] partial. The
+        # finalize math is semantically equivalent to moe_finalize_fuse_shared
+        # (FP32 accumulate in ascending fixed k order — rank-deterministic —
+        # skip idx == -1 slots for EP non-local / padding, one final round to
+        # BF16); bitwise identity is not guaranteed across compilers.
+        self.finalize_input = finalize_top_k is not None
+        self.finalize_top_k = finalize_top_k if finalize_top_k is not None else 0
         self.rank = rank
         self.tp_size = tp_size
         self.latent_dim = latent_dim
@@ -170,10 +184,16 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
         shared_workspace: cute.Tensor,
         shared_flags: cute.Tensor,
         shared_peer_ptrs: cute.Tensor,
+        finalize_weights: cute.Tensor,
+        finalize_idx: cute.Tensor,
         m: Int32,
         epsilon: Float32,
         stream: cuda.CUstream,
     ):
+        # In finalize-input mode ``latent_source`` carries the gemm2 permuted
+        # rows [total_padded_rows, latent_dim]; ``finalize_weights`` /
+        # ``finalize_idx`` are the flat [m * top_k] expert scales and
+        # expanded->permuted map. Otherwise the last two are unused dummies.
         self.kernel(
             latent_source,
             gamma,
@@ -186,6 +206,8 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
             shared_workspace,
             shared_flags,
             shared_peer_ptrs,
+            finalize_weights,
+            finalize_idx,
             m,
             epsilon,
         ).launch(
@@ -211,6 +233,8 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
         shared_workspace: cute.Tensor,
         shared_flags: cute.Tensor,
         shared_peer_ptrs: cute.Tensor,
+        finalize_weights: cute.Tensor,
+        finalize_idx: cute.Tensor,
         m: Int32,
         epsilon: Float32,
     ):
@@ -237,6 +261,8 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
                 shared_workspace,
                 shared_flags,
                 shared_peer_ptrs,
+                finalize_weights,
+                finalize_idx,
                 m,
                 epsilon,
                 token,
@@ -264,6 +290,8 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
         shared_workspace: cute.Tensor,
         shared_flags: cute.Tensor,
         shared_peer_ptrs: cute.Tensor,
+        finalize_weights: cute.Tensor,
+        finalize_idx: cute.Tensor,
         m: Int32,
         epsilon: Float32,
         token: Int32,
@@ -294,15 +322,56 @@ class AllReduceRMSNormWithReduceScatterEarlyExit:
             )
             dirty_elements = Int64(dirty_index) * (Int64(bytes_per_buffer) // Int64(2))
 
-            local_ptr = cute.make_ptr(
-                BFloat16,
-                (latent_source.iterator + element_offset).llvm_ptr,
-                cute.AddressSpace.gmem,
-                assumed_align=16,
-            )
-            local_packed = sanitize_negative_zero(
-                load_global_u32x4(local_ptr, volatile=False)
-            )
+            if cutlass.const_expr(self.finalize_input):
+                # Inline MoE finalize: gather this fragment from every routed
+                # expert's gemm2 row and combine with the expert scales.
+                # Semantically equivalent to the standalone finalize kernel
+                # (FP32 ascending-k accumulate, single BF16 round); bitwise
+                # identity is not guaranteed across compilers. idx == -1
+                # slots are EP non-local / padded entries: they contribute
+                # nothing.
+                finalize_accum = cute.make_rmem_tensor(
+                    cute.make_layout((VEC_BF16,)), Float32
+                )
+                for element in cutlass.range_constexpr(VEC_BF16):
+                    finalize_accum[element] = Float32(0.0)
+                for k in cutlass.range_constexpr(self.finalize_top_k):
+                    slot = Int64(token) * self.finalize_top_k + k
+                    permuted_row = load_global_s32(finalize_idx.iterator + slot)
+                    if permuted_row >= Int32(0):
+                        scale = load_global_bf16_as_f32(
+                            finalize_weights.iterator + slot
+                        )
+                        row_ptr = cute.make_ptr(
+                            BFloat16,
+                            (
+                                latent_source.iterator
+                                + Int64(permuted_row) * self.latent_dim
+                                + Int64(packed_idx) * VEC_BF16
+                            ).llvm_ptr,
+                            cute.AddressSpace.gmem,
+                            assumed_align=16,
+                        )
+                        expert_values = packed_u32x4_to_bf16x8(
+                            load_global_u32x4(row_ptr, volatile=False)
+                        ).to(Float32)
+                        for element in cutlass.range_constexpr(VEC_BF16):
+                            finalize_accum[element] = (
+                                finalize_accum[element] + scale * expert_values[element]
+                            )
+                local_packed = sanitize_negative_zero(
+                    bf16x8_to_packed_u32x4(finalize_accum.load().to(BFloat16))
+                )
+            else:
+                local_ptr = cute.make_ptr(
+                    BFloat16,
+                    (latent_source.iterator + element_offset).llvm_ptr,
+                    cute.AddressSpace.gmem,
+                    assumed_align=16,
+                )
+                local_packed = sanitize_negative_zero(
+                    load_global_u32x4(local_ptr, volatile=False)
+                )
             multicast_offset = (
                 Int64(current_index) * Int64(bytes_per_buffer)
                 + (
@@ -636,6 +705,7 @@ def _compile_key(
     fp32_internal: bool,
     include_reduce_scatter: bool,
     include_routed: bool,
+    finalize_top_k: int | None = None,
 ):
     return (
         torch.accelerator.current_device_index(),
@@ -648,6 +718,7 @@ def _compile_key(
         fp32_internal,
         include_reduce_scatter,
         include_routed,
+        finalize_top_k,
     )
 
 
@@ -663,8 +734,16 @@ def _runtime_args(
     shared_workspace: torch.Tensor,
     shared_flags: torch.Tensor,
     shared_peer_ptrs: torch.Tensor,
+    finalize_weights: torch.Tensor,
+    finalize_idx: torch.Tensor,
+    num_tokens: int,
     rms_eps: float,
 ):
+    # ``latent_source`` is [M, latent] in the standard mode and the gemm2
+    # permuted rows [P, latent] in finalize-input mode; both are dynamic in
+    # mode 0 so one compiled kernel serves every token count. The finalize
+    # scale/index tensors are flat [M * top_k] (dummies otherwise) and only
+    # ever scalar-loaded, so 4-byte alignment suffices.
     return (
         to_cute_dynamic_m(latent_source, mode=0, assumed_align=16),
         to_cute(gamma, 16),
@@ -677,7 +756,9 @@ def _runtime_args(
         to_cute(shared_workspace, 16),
         to_cute(shared_flags, 16),
         to_cute(shared_peer_ptrs, 16),
-        Int32(latent_source.shape[0]),
+        to_cute_dynamic_m(finalize_weights, mode=0, assumed_align=4),
+        to_cute_dynamic_m(finalize_idx, mode=0, assumed_align=4),
+        Int32(num_tokens),
         Float32(rms_eps),
         cuda.CUstream(torch.cuda.current_stream(latent_source.device).cuda_stream),
     )
@@ -703,6 +784,7 @@ def compile_kernel(
     fp32_internal: bool,
     include_reduce_scatter: bool = True,
     include_routed: bool = True,
+    finalize_top_k: int | None = None,
 ) -> None:
     """Compile the rank/M specialization without retaining caller tensors."""
 
@@ -716,13 +798,20 @@ def compile_kernel(
         fp32_internal,
         include_reduce_scatter,
         include_routed,
+        finalize_top_k,
     )
     if key in _COMPILED:
         return
     device = latent_output.device
-    latent = torch.empty((max_m, latent_dim), dtype=torch.bfloat16, device=device)
+    latent_rows = max_m if finalize_top_k is None else max_m * finalize_top_k
+    finalize_slots = 8 if finalize_top_k is None else max_m * finalize_top_k
+    latent = torch.empty((latent_rows, latent_dim), dtype=torch.bfloat16, device=device)
     gamma = torch.empty((latent_dim,), dtype=torch.bfloat16, device=device)
     shared = torch.empty((max_m, hidden_dim), dtype=torch.bfloat16, device=device)
+    finalize_weights = torch.zeros(
+        (finalize_slots,), dtype=torch.bfloat16, device=device
+    )
+    finalize_idx = torch.full((finalize_slots,), -1, dtype=torch.int32, device=device)
     kernel = AllReduceRMSNormWithReduceScatterEarlyExit(
         rank=rank,
         tp_size=tp_size,
@@ -733,6 +822,7 @@ def compile_kernel(
         fp32_internal=fp32_internal,
         include_reduce_scatter=include_reduce_scatter,
         include_routed=include_routed,
+        finalize_top_k=finalize_top_k,
     )
     _COMPILED[key] = cute.compile(
         kernel,
@@ -748,6 +838,9 @@ def compile_kernel(
             shared_workspace,
             shared_flags,
             shared_peer_ptrs,
+            finalize_weights,
+            finalize_idx,
+            max_m,
             rms_eps,
         ),
     )
@@ -765,6 +858,9 @@ def launch(
     shared_workspace: torch.Tensor,
     shared_flags: torch.Tensor,
     shared_peer_ptrs: torch.Tensor,
+    finalize_weights: torch.Tensor,
+    finalize_idx: torch.Tensor,
+    num_tokens: int,
     rms_eps: float,
     *,
     rank: int,
@@ -776,6 +872,7 @@ def launch(
     fp32_internal: bool,
     include_reduce_scatter: bool = True,
     include_routed: bool = True,
+    finalize_top_k: int | None = None,
 ) -> None:
     compile_kernel(
         rank=rank,
@@ -796,6 +893,7 @@ def launch(
         fp32_internal=fp32_internal,
         include_reduce_scatter=include_reduce_scatter,
         include_routed=include_routed,
+        finalize_top_k=finalize_top_k,
     )
     _COMPILED[
         _compile_key(
@@ -808,6 +906,7 @@ def launch(
             fp32_internal,
             include_reduce_scatter,
             include_routed,
+            finalize_top_k,
         )
     ](
         *_runtime_args(
@@ -822,6 +921,9 @@ def launch(
             shared_workspace,
             shared_flags,
             shared_peer_ptrs,
+            finalize_weights,
+            finalize_idx,
+            num_tokens,
             rms_eps,
         )
     )
@@ -843,12 +945,15 @@ class CollectiveKernel:
         rms_eps: float,
         fp32_internal: bool,
         scratch_allocator=None,
+        finalize_top_k: int | None = None,
     ) -> None:
         validate_shape(
             tp_size=tp_size,
             latent_dim=latent_dim,
             hidden_dim=hidden_dim,
         )
+        if finalize_top_k is not None and not 1 <= finalize_top_k <= 64:
+            raise ValueError(f"finalize_top_k must be in [1, 64], got {finalize_top_k}")
         self.rank = rank
         self.tp_size = tp_size
         self.latent_dim = latent_dim
@@ -858,7 +963,19 @@ class CollectiveKernel:
         self.max_token_ctas = max_token_ctas
         self.rms_eps = float(rms_eps)
         self.fp32_internal = fp32_internal
+        # When set, ``call_deferred`` additionally accepts the MoE kernel's
+        # deferred-finalize triple; the standard materialized-input mode
+        # stays available on the same instance.
+        self.finalize_top_k = finalize_top_k
         device = torch.device("cuda", torch.accelerator.current_device_index())
+        # Placeholders for the finalize operand slots of the standard-mode
+        # kernel signature (never dereferenced when finalize is compiled out).
+        self._finalize_dummy_weights = torch.zeros(
+            (8,), dtype=torch.bfloat16, device=device
+        )
+        self._finalize_dummy_idx = torch.full(
+            (8,), -1, dtype=torch.int32, device=device
+        )
 
         bytes_per_routed_buffer = max_m * tp_size * latent_dim * 2
         routed_bytes = NUM_LAMPORT_BUFFERS * bytes_per_routed_buffer
@@ -934,24 +1051,30 @@ class CollectiveKernel:
         dist.barrier(group=group, device_ids=[device.index])
         for owner in range(tp_size):
             if rank == owner:
-                compile_kernel(
-                    rank=rank,
-                    tp_size=tp_size,
-                    latent_dim=latent_dim,
-                    hidden_dim=hidden_dim,
-                    max_m=max_m,
-                    max_token_ctas=max_token_ctas,
-                    latent_output=self._latent_output,
-                    routed_workspace=self._routed_workspace,
-                    routed_flags=self._routed_flags,
-                    routed_multicast_ptr=self._routed_multicast_ptr,
-                    shared_output=self._shared_output,
-                    shared_workspace=self._shared_workspace,
-                    shared_flags=self._shared_flags,
-                    shared_peer_ptrs=self._shared_peer_ptrs,
-                    rms_eps=self.rms_eps,
-                    fp32_internal=fp32_internal,
-                )
+                # Compile the standard variant always and the deferred-input
+                # variant when armed; both must exist before graph capture.
+                for variant_top_k in (
+                    (None,) if finalize_top_k is None else (None, finalize_top_k)
+                ):
+                    compile_kernel(
+                        rank=rank,
+                        tp_size=tp_size,
+                        latent_dim=latent_dim,
+                        hidden_dim=hidden_dim,
+                        max_m=max_m,
+                        max_token_ctas=max_token_ctas,
+                        latent_output=self._latent_output,
+                        routed_workspace=self._routed_workspace,
+                        routed_flags=self._routed_flags,
+                        routed_multicast_ptr=self._routed_multicast_ptr,
+                        shared_output=self._shared_output,
+                        shared_workspace=self._shared_workspace,
+                        shared_flags=self._shared_flags,
+                        shared_peer_ptrs=self._shared_peer_ptrs,
+                        rms_eps=self.rms_eps,
+                        fp32_internal=fp32_internal,
+                        finalize_top_k=variant_top_k,
+                    )
             dist.barrier(group=group, device_ids=[device.index])
 
     def __call__(
@@ -979,7 +1102,112 @@ class CollectiveKernel:
                 raise ValueError(f"{name} must be contiguous CUDA BF16 {list(shape)}")
         if not 1 <= m <= self.max_m:
             raise ValueError(f"runtime M={m} must be in [1, {self.max_m}]")
+        return self._dispatch(
+            latent_source,
+            shared_source,
+            gamma,
+            m,
+            finalize_weights=self._finalize_dummy_weights,
+            finalize_idx=self._finalize_dummy_idx,
+            finalize_top_k=None,
+        )
 
+    def call_deferred(
+        self,
+        gemm2_output: torch.Tensor,
+        expert_weights: torch.Tensor,
+        expanded_idx_to_permuted_idx: torch.Tensor,
+        shared_source: torch.Tensor,
+        gamma: torch.Tensor,
+        num_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Fused collective over the MoE kernel's deferred-finalize triple.
+
+        Args:
+            gemm2_output: Permuted expert rows ``[total_padded_rows,
+                latent_dim]`` (contiguous BF16); rows not referenced by the
+                index map are never read.
+            expert_weights: Flat per-slot scales ``[num_tokens * top_k]``
+                (contiguous BF16).
+            expanded_idx_to_permuted_idx: Flat expanded->permuted map
+                ``[num_tokens * top_k]`` (contiguous int32); ``-1`` drops the
+                slot (EP non-local expert or padding).
+            shared_source: This rank's shared partial ``[num_tokens, hidden]``.
+            gamma: Latent RMSNorm weight ``[latent_dim]``.
+            num_tokens: Token count M for this launch.
+
+        Returns:
+            ``(latent_output[:M], shared_shard)`` exactly like ``__call__``.
+        """
+        if self.finalize_top_k is None:
+            raise RuntimeError(
+                "CollectiveKernel was constructed without finalize_top_k; "
+                "the deferred-finalize variant is not compiled"
+            )
+        m = int(num_tokens)
+        if not 1 <= m <= self.max_m:
+            raise ValueError(f"runtime M={m} must be in [1, {self.max_m}]")
+        device = self._routed_workspace.device
+        slots = m * self.finalize_top_k
+        if (
+            gemm2_output.ndim != 2
+            or gemm2_output.shape[1] != self.latent_dim
+            or gemm2_output.dtype != torch.bfloat16
+            or gemm2_output.device != device
+            or not gemm2_output.is_contiguous()
+        ):
+            raise ValueError(
+                f"gemm2_output must be contiguous CUDA BF16 [*, {self.latent_dim}]"
+            )
+        for tensor, dtype, name in (
+            (expert_weights, torch.bfloat16, "expert_weights"),
+            (expanded_idx_to_permuted_idx, torch.int32, "expanded_idx_to_permuted_idx"),
+        ):
+            if (
+                tensor.shape != (slots,)
+                or tensor.dtype != dtype
+                or tensor.device != device
+                or not tensor.is_contiguous()
+            ):
+                raise ValueError(f"{name} must be contiguous CUDA {dtype} [{slots}]")
+        if (
+            shared_source.shape != (m, self.hidden_dim)
+            or shared_source.dtype != torch.bfloat16
+            or shared_source.device != device
+            or not shared_source.is_contiguous()
+        ):
+            raise ValueError(
+                f"shared_source must be contiguous CUDA BF16 [{m}, {self.hidden_dim}]"
+            )
+        if (
+            gamma.shape != (self.latent_dim,)
+            or gamma.dtype != torch.bfloat16
+            or gamma.device != device
+            or not gamma.is_contiguous()
+        ):
+            raise ValueError(f"gamma must be contiguous CUDA BF16 [{self.latent_dim}]")
+        return self._dispatch(
+            gemm2_output,
+            shared_source,
+            gamma,
+            m,
+            finalize_weights=expert_weights,
+            finalize_idx=expanded_idx_to_permuted_idx,
+            finalize_top_k=self.finalize_top_k,
+        )
+
+    def _dispatch(
+        self,
+        latent_source: torch.Tensor,
+        shared_source: torch.Tensor,
+        gamma: torch.Tensor,
+        m: int,
+        *,
+        finalize_weights: torch.Tensor,
+        finalize_idx: torch.Tensor,
+        finalize_top_k: int | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        device = self._routed_workspace.device
         if self._scratch_allocator is not None:
             # Pool views cannot survive another allocation, which may move the block.
             self._latent_output, self._shared_output = self._scratch_allocator(
@@ -1003,6 +1231,9 @@ class CollectiveKernel:
                 self._shared_workspace,
                 self._shared_flags,
                 self._shared_peer_ptrs,
+                finalize_weights,
+                finalize_idx,
+                m,
                 self.rms_eps,
                 rank=self.rank,
                 tp_size=self.tp_size,
@@ -1011,6 +1242,7 @@ class CollectiveKernel:
                 max_m=self.max_m,
                 max_token_ctas=self.max_token_ctas,
                 fp32_internal=self.fp32_internal,
+                finalize_top_k=finalize_top_k,
             )
         return (
             self._latent_output[:m],

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/primitives.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/primitives.py
@@ -216,6 +216,50 @@ def red_async_release_gpu_add_u32(
 
 
 @dsl_user_op
+def load_global_bf16_as_f32(pointer: cute.Pointer, *, loc=None, ip=None) -> Float32:
+    """Load one BF16 scalar and widen it exactly to FP32.
+
+    BF16 is the high half of FP32, so the widen is a zero-extended 16-bit
+    load shifted into the high halfword and reinterpreted — no rounding.
+    Used by the deferred-finalize publish phase to read expert scales.
+    """
+
+    address = pointer.toint(loc=loc, ip=ip)
+    widened = llvm.inline_asm(
+        T.i32(),
+        [address.ir_value(loc=loc, ip=ip)],
+        "ld.global.u16 $0, [$1]; shl.b32 $0, $0, 16;",
+        "=r,l",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Float32(llvm.bitcast(T.f32(), widened, loc=loc, ip=ip))
+
+
+@dsl_user_op
+def load_global_s32(pointer: cute.Pointer, *, loc=None, ip=None) -> Int32:
+    """Load one signed 32-bit scalar from global memory."""
+
+    address = pointer.toint(loc=loc, ip=ip)
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [address.ir_value(loc=loc, ip=ip)],
+            "ld.global.s32 $0, [$1];",
+            "=r,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
 def load_volatile_u32(pointer: cute.Pointer, *, loc=None, ip=None) -> Uint32:
     address = pointer.toint(loc=loc, ip=ip)
     return Uint32(


### PR DESCRIPTION
## What

Two commits:

1. **`refactor(kimi3): extract the K3 communication layer into kimi_k3_comm`** — pure refactor, behavior-equivalent to main. K3's attention-AR strategy dispatch and the MoE-tail tier table (TAIL_FUSION / MULTIMEM_AR / FUSED_LANE_AR / SEPARATE_REDUCE) move behind `K3AttnComm` / `K3MoeTailComm` with one MIN-vote per process instead of one per layer; `kimi_k3.py` states semantics only. Tier bodies are taken verbatim from current main (post-#1038 sharded variants, post-#1102 workspace pooling, post-#1060 ctx plumbing). Also folds in singleton-state parameter guards and a ctx-forwarding fix in `_forward_fused_attnres_graph` (pre-existing gap: the cross-DP-EP token gather requires a ForwardContext).

2. **`perf(kimi3): fold the MoE finalize into the multicast latent tail`** — a `FINALIZE_INPUT` variant of the tail's publish phase consumes the experts kernel's deferred-finalize triple (permuted gemm2 rows, bf16 expert scales, expanded-to-permuted indices with `-1` padding) and performs gather + fp32 ascending-k weighted accumulation + a single bf16 round in-register before the multicast store. One fewer kernel launch and no `[M, latent]` round-trip per MoE layer per step. Pure local CuTe-DSL: no new dependencies, no env switches, no topology limits beyond the tail's own; capability-negotiated with automatic fallback to the materialized-finalize path (Marlin / native / eager unaffected).

## Validation (4x GB200, TP16 cross-node NVLS)

- Numerical equivalence suite: 18 cases x 2 PDL modes (default and `--disable-pdl`), against an independent fp32 torch reference, with NaN-poisoned padding rows to prove the `-1`-skip logic never reads a dropped slot.
- Tier truth table: 19 cases.
- E2E serving: negotiation log shows `deferred_finalize=True` engaged; GSM8K within the established baseline band.
- Two rounds of multi-lens adversarial review; all confirmed findings addressed.

## Known items

- Upstream (unrelated, also fails on main): `test_latent_tail_accepts_sharded_weight[1]` fails at world=16; will be reported separately.
- Decode-TPOT gain measurement on 8x B300 is follow-up.
- pre-commit hooks could not run in the validation environment (config pins python3.12); black/isort of the same major version report clean.

## Note

This replaces the earlier MNNVL CuTe-DSL finalize-tail approach on this branch: the in-tail fusion covers the same work without the flashinfer-nightly dependency, the world==8 restriction, or a new tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)