### PR TITLE
perf(kernel): accelerate GFX1250 FP8 DSA attention

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
@@ -21,9 +21,9 @@
 """GFX1250 Gluon kernels for DSA sparse attention.
 
 The kernels consume padded global KV slots (``topk_slots`` and
-``topk_lens``) and support dense BF16/FP8 or packed FP8 KV cache rows.
-Packed rows contain FP8 latent values, one FP32 scale per 128 latent
-elements, and BF16 RoPE values.
+``topk_lens``) and support dense BF16/E4M3/E5M2 or packed E4M3 KV cache
+rows. Dense FP8 rows use native Wave32 WMMA, while packed rows contain E4M3
+latent values, one FP32 scale per 128 latent elements, and BF16 RoPE values.
 
 The Wave32 WMMA and TDM gather design is adapted from ROCm/AITER commit
 00b271b.
@@ -41,6 +41,7 @@ __all__ = [
 ]
 
 _REGISTERED_TOPK_WIDTHS = (512, 1024, 2048)
+_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 
 
 @gluon.jit
@@ -66,41 +67,51 @@ def _dsa_selected_dense_wmma_kernel(
     SOFTMAX_SCALE: gl.constexpr,
     BLOCK_H: gl.constexpr,
     BLOCK_K: gl.constexpr,
+    IS_FP8: gl.constexpr,
 ):
     """Wave32 WMMA attention with a two-stage selected-row TDM pipeline."""
 
     WARP_SIZE: gl.constexpr = 32
     NUM_WARPS: gl.constexpr = gl.num_warps()
-    K_WIDTH: gl.constexpr = 8
+    K_WIDTH: gl.constexpr = 16 if IS_FP8 else 8
+    INSTR_K: gl.constexpr = 64 if IS_FP8 else 32
     qk_layout: gl.constexpr = gl.amd.AMDWMMALayout(
         version=3,
         transposed=True,
         warp_bases=[[1, 0], [2, 0]],
         reg_bases=[],
-        instr_shape=[16, 16, 32],
+        instr_shape=[16, 16, INSTR_K],
     )
     pv_layout: gl.constexpr = gl.amd.AMDWMMALayout(
         version=3,
         transposed=True,
         warp_bases=[[0, 1], [0, 2]],
         reg_bases=[],
-        instr_shape=[16, 16, 32],
+        instr_shape=[16, 16, INSTR_K],
     )
     q_dot_layout: gl.constexpr = gl.DotOperandLayout(0, qk_layout, K_WIDTH)
     k_dot_layout: gl.constexpr = gl.DotOperandLayout(1, qk_layout, K_WIDTH)
-    p_dot_layout: gl.constexpr = gl.DotOperandLayout(0, pv_layout, K_WIDTH)
-    v_dot_layout: gl.constexpr = gl.DotOperandLayout(1, pv_layout, K_WIDTH)
+    p_dot_layout: gl.constexpr = gl.DotOperandLayout(0, pv_layout, 8)
+    v_dot_layout: gl.constexpr = gl.DotOperandLayout(1, pv_layout, 8)
+    lora_threads: gl.constexpr = min(max(KV_LORA_RANK // K_WIDTH, 1), WARP_SIZE)
     q_lora_load_layout: gl.constexpr = gl.BlockedLayout(
-        [1, 8], [1, WARP_SIZE], [NUM_WARPS, 1], [1, 0]
+        [1, K_WIDTH],
+        [WARP_SIZE // lora_threads, lora_threads],
+        [NUM_WARPS, 1],
+        [1, 0],
     )
+    rope_threads: gl.constexpr = min(max(QK_ROPE_HEAD_DIM // K_WIDTH, 1), WARP_SIZE)
     q_rope_load_layout: gl.constexpr = gl.BlockedLayout(
-        [1, 8], [4, 8], [NUM_WARPS, 1], [1, 0]
+        [1, K_WIDTH],
+        [WARP_SIZE // rope_threads, rope_threads],
+        [NUM_WARPS, 1],
+        [1, 0],
     )
     kv_lora_shared_layout: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
-        [[KV_LORA_RANK, 8]], [BLOCK_K, KV_LORA_RANK], [1, 0]
+        [[KV_LORA_RANK, K_WIDTH]], [BLOCK_K, KV_LORA_RANK], [1, 0]
     )
     k_rope_shared_layout: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
-        [[QK_ROPE_HEAD_DIM, 8]], [BLOCK_K, QK_ROPE_HEAD_DIM], [1, 0]
+        [[QK_ROPE_HEAD_DIM, K_WIDTH]], [BLOCK_K, QK_ROPE_HEAD_DIM], [1, 0]
     )
     slot_layout: gl.constexpr = gl.BlockedLayout(
         [BLOCK_K], [WARP_SIZE], [NUM_WARPS], [0]
@@ -148,12 +159,13 @@ def _dsa_selected_dense_wmma_kernel(
     )
     q_lora_dot = gl.convert_layout(q_lora_val, q_dot_layout)
     q_rope_dot = gl.convert_layout(q_rope_val, q_dot_layout)
-    q_lora_dot = (q_lora_dot.to(gl.float32) * (SOFTMAX_SCALE * _INV_LN2)).to(
-        gl.bfloat16
-    )
-    q_rope_dot = (q_rope_dot.to(gl.float32) * (SOFTMAX_SCALE * _INV_LN2)).to(
-        gl.bfloat16
-    )
+    if not IS_FP8:
+        q_lora_dot = (q_lora_dot.to(gl.float32) * (SOFTMAX_SCALE * _INV_LN2)).to(
+            gl.bfloat16
+        )
+        q_rope_dot = (q_rope_dot.to(gl.float32) * (SOFTMAX_SCALE * _INV_LN2)).to(
+            gl.bfloat16
+        )
 
     lora_buffers = gl.allocate_shared_memory(
         kv_lora.dtype.element_ty,
@@ -238,14 +250,17 @@ def _dsa_selected_dense_wmma_kernel(
 
             k_lora = lora_buffers.index(buffer_index).permute([1, 0]).load(k_dot_layout)
             k_rope = rope_buffers.index(buffer_index).permute([1, 0]).load(k_dot_layout)
-            k_lora = k_lora.to(gl.bfloat16)
-            k_rope = k_rope.to(gl.bfloat16)
+            if not IS_FP8:
+                k_lora = k_lora.to(gl.bfloat16)
+                k_rope = k_rope.to(gl.bfloat16)
             scores = gl.amd.gfx1250.wmma(
                 q_lora_dot,
                 k_lora,
                 gl.zeros([BLOCK_H, BLOCK_K], gl.float32, layout=qk_layout),
             )
             scores = gl.amd.gfx1250.wmma(q_rope_dot, k_rope, scores)
+            if IS_FP8:
+                scores *= SOFTMAX_SCALE * _INV_LN2
             valid_col = gl.convert_layout(cur_valid, valid_col_layout)
             scores = gl.where(valid_col[None, :], scores, -float("inf"))
             m_new = gl.maximum(m_i, gl.max(scores, axis=1))
@@ -254,8 +269,18 @@ def _dsa_selected_dense_wmma_kernel(
             probs = gl.where(valid_col[None, :], probs, 0.0)
             l_i = l_i * alpha + gl.sum(probs, axis=1)
             acc = acc * gl.convert_layout(alpha[:, None], pv_layout)
-            p_dot = gl.convert_layout(probs.to(gl.bfloat16), p_dot_layout)
-            v_lora = lora_buffers.index(buffer_index).load(v_dot_layout).to(gl.bfloat16)
+            if IS_FP8:
+                probs = probs.to(
+                    kv_lora.dtype.element_ty,
+                    fp_downcast_rounding="rtne",
+                )
+                v_lora = lora_buffers.index(buffer_index).load(v_dot_layout)
+            else:
+                probs = probs.to(gl.bfloat16)
+                v_lora = (
+                    lora_buffers.index(buffer_index).load(v_dot_layout).to(gl.bfloat16)
+                )
+            p_dot = gl.convert_layout(probs, p_dot_layout)
             acc = gl.amd.gfx1250.wmma(p_dot, v_lora, acc)
             m_i = m_new
             cur_valid = next_valid
@@ -265,14 +290,17 @@ def _dsa_selected_dense_wmma_kernel(
         final_valid = ((num_tiles - 1) * BLOCK_K + slot_offsets < valid_len) & cur_valid
         k_lora = lora_buffers.index(buffer_index).permute([1, 0]).load(k_dot_layout)
         k_rope = rope_buffers.index(buffer_index).permute([1, 0]).load(k_dot_layout)
-        k_lora = k_lora.to(gl.bfloat16)
-        k_rope = k_rope.to(gl.bfloat16)
+        if not IS_FP8:
+            k_lora = k_lora.to(gl.bfloat16)
+            k_rope = k_rope.to(gl.bfloat16)
         scores = gl.amd.gfx1250.wmma(
             q_lora_dot,
             k_lora,
             gl.zeros([BLOCK_H, BLOCK_K], gl.float32, layout=qk_layout),
         )
         scores = gl.amd.gfx1250.wmma(q_rope_dot, k_rope, scores)
+        if IS_FP8:
+            scores *= SOFTMAX_SCALE * _INV_LN2
         valid_col = gl.convert_layout(final_valid, valid_col_layout)
         scores = gl.where(valid_col[None, :], scores, -float("inf"))
         m_new = gl.maximum(m_i, gl.max(scores, axis=1))
@@ -281,8 +309,16 @@ def _dsa_selected_dense_wmma_kernel(
         probs = gl.where(valid_col[None, :], probs, 0.0)
         l_i = l_i * alpha + gl.sum(probs, axis=1)
         acc = acc * gl.convert_layout(alpha[:, None], pv_layout)
-        p_dot = gl.convert_layout(probs.to(gl.bfloat16), p_dot_layout)
-        v_lora = lora_buffers.index(buffer_index).load(v_dot_layout).to(gl.bfloat16)
+        if IS_FP8:
+            probs = probs.to(
+                kv_lora.dtype.element_ty,
+                fp_downcast_rounding="rtne",
+            )
+            v_lora = lora_buffers.index(buffer_index).load(v_dot_layout)
+        else:
+            probs = probs.to(gl.bfloat16)
+            v_lora = lora_buffers.index(buffer_index).load(v_dot_layout).to(gl.bfloat16)
+        p_dot = gl.convert_layout(probs, p_dot_layout)
         acc = gl.amd.gfx1250.wmma(p_dot, v_lora, acc)
 
     denom = gl.convert_layout(l_i, gl.SliceLayout(1, pv_layout))
@@ -822,7 +858,7 @@ def _check_inputs(
     qk_rope_head_dim: int,
     page_size: int,
 ) -> None:
-    if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+    if q.dtype != torch.bfloat16 and q.dtype not in _FP8_DTYPES:
         raise TypeError(f"Gluon DSA supports BF16/FP8 q, got {q.dtype}")
     if page_size != 64:
         raise ValueError(f"Gluon DSA supports page_size=64, got {page_size}")
@@ -863,7 +899,7 @@ def _trim_topk_slots(topk_slots: torch.Tensor, max_seqlen_k: int) -> torch.Tenso
 
 
 def _allocate_output(q: torch.Tensor, kv_lora_rank: int) -> torch.Tensor:
-    dtype = torch.bfloat16 if q.dtype == torch.float8_e4m3fn else q.dtype
+    dtype = torch.bfloat16 if q.dtype in _FP8_DTYPES else q.dtype
     return torch.empty(
         (q.shape[0], q.shape[1], kv_lora_rank), dtype=dtype, device=q.device
     )
@@ -883,9 +919,8 @@ def _run_dense(
     dense = _flatten_dense_cache(kv_cache)
     expected_dim = kv_lora_rank + qk_rope_head_dim
     if (
-        dense.dtype not in (torch.bfloat16, torch.float8_e4m3fn)
-        or dense.shape[1] != expected_dim
-    ):
+        dense.dtype != torch.bfloat16 and dense.dtype not in _FP8_DTYPES
+    ) or dense.shape[1] != expected_dim:
         raise ValueError(
             "dense DSA cache must be BF16/FP8 with trailing dimension "
             f"{expected_dim}, got dtype={dense.dtype}, shape={tuple(dense.shape)}"
@@ -893,6 +928,7 @@ def _run_dense(
     dense = dense.contiguous()
     q = q.contiguous()
     out = _allocate_output(q, kv_lora_rank)
+    is_fp8 = q.dtype == dense.dtype and q.dtype in _FP8_DTYPES
     grid = (q.shape[0], triton.cdiv(q.shape[1], block_h))
     _dsa_selected_dense_wmma_kernel[grid](
         q,
@@ -915,7 +951,8 @@ def _run_dense(
         QK_ROPE_HEAD_DIM=qk_rope_head_dim,
         SOFTMAX_SCALE=float(softmax_scale),
         BLOCK_H=block_h,
-        BLOCK_K=32,
+        BLOCK_K=64 if is_fp8 else 32,
+        IS_FP8=is_fp8,
         num_warps=4,
     )
     return out
@@ -938,14 +975,12 @@ def _run_packed(
     expected_bytes = kv_lora_rank + scale_bytes + qk_rope_head_dim * 2
     if packed.shape[1] != expected_bytes:
         raise ValueError(
-            f"packed DSA row must contain {expected_bytes} bytes, got "
-            f"{packed.shape[1]}"
+            f"packed DSA row must contain {expected_bytes} bytes, got {packed.shape[1]}"
         )
     q = q.contiguous()
     out = _allocate_output(q, kv_lora_rank)
-    if kv_lora_rank in (128, 512) and q.dtype in (
-        torch.bfloat16,
-        torch.float8_e4m3fn,
+    if kv_lora_rank in (128, 512) and (
+        q.dtype == torch.bfloat16 or q.dtype in _FP8_DTYPES
     ):
         kv_splits = 16
         partial_m = torch.empty(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -1075,6 +1075,7 @@ if current_platform().is_amd:
             {
                 format_signature(q=dense_tensor_format(torch.bfloat16)),
                 format_signature(q=dense_tensor_format(torch.float8_e4m3fn)),
+                format_signature(q=dense_tensor_format(torch.float8_e5m2)),
             }
         ),
         priority=Priority.SPECIALIZED,
@@ -1128,6 +1129,41 @@ if current_platform().is_amd:
         tags={"amd", "gfx1250"},
     )
     def gluon_dsa_prefill_gfx1250(*args, **kwargs):
+        return _dsa_prefill_gfx1250_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "dsa_prefill",
+        name="gluon_dsa_prefill_fp8_dense_gfx1250",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(12, 5),
+            max_arch_version=ArchVersion(12, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=frozenset(
+            {
+                format_signature(q=dense_tensor_format(torch.float8_e4m3fn)),
+                format_signature(q=dense_tensor_format(torch.float8_e5m2)),
+            }
+        ),
+        priority=Priority.SPECIALIZED,
+        traits={
+            "page_size": frozenset({64}),
+            "q_len_per_req": frozenset({1}),
+            "qk_nope_head_dim": frozenset({128, 192}),
+            "kv_lora_rank": frozenset({512}),
+            "qk_rope_head_dim": frozenset({64}),
+            "topk": _DSA_PREFILL_TOPK_WIDTHS,
+            "kv_cache_available": frozenset({True}),
+            "sparse_kv_cache_available": frozenset({False}),
+            "topk_layout": frozenset({"global_slots"}),
+            "support_logit_cap": frozenset({False}),
+            "return_lse": frozenset({False}),
+        },
+        tags={"amd", "gfx1250"},
+    )
+    def gluon_dsa_prefill_fp8_dense_gfx1250(*args, **kwargs):
         return _dsa_prefill_gfx1250_impl(*args, **kwargs)
 
     @register_kernel(

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
@@ -1100,14 +1100,7 @@ def _assert_slots_visible(
     [
         pytest.param(torch.bfloat16, id="q_bf16"),
         pytest.param(torch.float8_e4m3fn, id="q_e4m3"),
-        pytest.param(
-            torch.float8_e5m2,
-            id="q_e5m2",
-            marks=pytest.mark.skipif(
-                not is_cdna4(),
-                reason="E5M2 DSA support is specific to gfx950",
-            ),
-        ),
+        pytest.param(torch.float8_e5m2, id="q_e5m2"),
     ],
 )
 def test_dsa_with_sparse_kvcache(mode: str, api, q_dtype: torch.dtype) -> None:
@@ -1176,14 +1169,7 @@ def test_dsa_with_sparse_kvcache(mode: str, api, q_dtype: torch.dtype) -> None:
     [
         pytest.param(torch.bfloat16, id="q_bf16"),
         pytest.param(torch.float8_e4m3fn, id="q_e4m3"),
-        pytest.param(
-            torch.float8_e5m2,
-            id="q_e5m2",
-            marks=pytest.mark.skipif(
-                not is_cdna4(),
-                reason="E5M2 DSA support is specific to gfx950",
-            ),
-        ),
+        pytest.param(torch.float8_e5m2, id="q_e5m2"),
     ],
 )
 @pytest.mark.parametrize(
@@ -1253,10 +1239,6 @@ def test_dsa_dense_kvcache(
     torch.testing.assert_close(out.float(), ref.float(), rtol=8e-2, atol=8e-2)
 
 
-@pytest.mark.skipif(
-    not is_cdna4(),
-    reason="dense FP8 specialization is specific to the gfx950 implementation",
-)
 @pytest.mark.parametrize(
     "api",
     [
@@ -1267,8 +1249,16 @@ def test_dsa_dense_kvcache(
 @pytest.mark.parametrize(
     ("valid_lengths", "max_seqlen_k"),
     [
-        pytest.param((0, 1, 33, 2048), 2112, id="static-full-width"),
-        pytest.param((0, 1, 31, 33), 33, id="dynamic-short-list"),
+        pytest.param(
+            (0, 1, 31, 32, 33, 63, 64, 65, 2048),
+            2112,
+            id="static-full-width",
+        ),
+        pytest.param(
+            (0, 1, 31, 32, 33, 63, 64, 65),
+            65,
+            id="dynamic-short-list",
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -1285,7 +1275,7 @@ def test_dsa_dense_fp8_glm52_production_shape(
     fp8_dtype: torch.dtype,
 ) -> None:
     device = "cuda"
-    tokens = 4
+    tokens = len(valid_lengths)
     num_heads = 16
     num_slots = 2112
     topk = 2048
@@ -1337,6 +1327,8 @@ def test_dsa_dense_fp8_glm52_production_shape(
     )
     assert out.shape == (tokens, num_heads, kv_lora_rank)
     assert out.dtype == torch.bfloat16
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out[0], torch.zeros_like(out[0]))
     torch.testing.assert_close(out.float(), ref.float(), rtol=8e-2, atol=8e-2)
 
 

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1234,6 +1234,46 @@ def _attention_dsa_prefill_bf16_dense_rank128() -> object:
     )
 
 
+def _attention_dsa_prefill_fp8_dense_rank128() -> object:
+    q = torch.empty((2, 8, 192), dtype=torch.float8_e4m3fn)
+    kv_cache = torch.empty((64, 192), dtype=torch.float8_e4m3fn)
+    topk_slots = torch.empty((2, 1024), dtype=torch.int32)
+    topk_lens = torch.empty((2,), dtype=torch.int32)
+    return tokenspeed_kernel.dsa_prefill(
+        q=q,
+        kv_cache=kv_cache,
+        sparse_kv_cache=None,
+        topk_slots=topk_slots,
+        topk_lens=topk_lens,
+        max_seqlen_k=1024,
+        qk_nope_head_dim=128,
+        kv_lora_rank=128,
+        qk_rope_head_dim=64,
+        softmax_scale=1.0,
+        page_size=64,
+    )
+
+
+def _attention_dsa_prefill_fp8_packed_rank512() -> object:
+    q = torch.empty((2, 8, 576), dtype=torch.float8_e4m3fn)
+    sparse_kv_cache = torch.empty((64, 656), dtype=torch.uint8)
+    topk_slots = torch.empty((2, 1024), dtype=torch.int32)
+    topk_lens = torch.empty((2,), dtype=torch.int32)
+    return tokenspeed_kernel.dsa_prefill(
+        q=q,
+        kv_cache=None,
+        sparse_kv_cache=sparse_kv_cache,
+        topk_slots=topk_slots,
+        topk_lens=topk_lens,
+        max_seqlen_k=1024,
+        qk_nope_head_dim=192,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        softmax_scale=1.0,
+        page_size=64,
+    )
+
+
 def _attention_dsa_decode_topk(*, weights_dtype: torch.dtype = torch.float32) -> object:
     q = torch.empty((2, 2, 128), dtype=torch.bfloat16)
     weights = torch.empty((2, 2), dtype=weights_dtype)
@@ -2572,6 +2612,46 @@ _CASES = [
         _is_cdna5,
         "cdna5",
         "attention",
+        "dsa_decode_fp8_e5m2_dense_rank128",
+        "gluon_dsa_decode_gfx1250",
+        _attention_dsa_decode_fp8_e5m2_dense_rank128_q4,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "dsa_decode_fp8_dense_rank512",
+        "gluon_dsa_decode_gfx1250",
+        _attention_dsa_decode_fp8_dense_rank512,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "dsa_decode_fp8_e5m2_dense_rank512",
+        "gluon_dsa_decode_gfx1250",
+        _attention_dsa_decode_fp8_e5m2_dense_rank512,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "dsa_decode_fp8_sparse_rank512",
+        "gluon_dsa_decode_gfx1250",
+        _attention_dsa_decode_fp8_sparse_rank512,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "dsa_decode_fp8_e5m2_sparse_rank512",
+        "gluon_dsa_decode_gfx1250",
+        _attention_dsa_decode_fp8_e5m2_sparse_rank512,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
         "dsa_prefill",
         "gluon_dsa_prefill_gfx1250",
         _attention_dsa_prefill_bf16_dense_rank128,
@@ -2581,8 +2661,32 @@ _CASES = [
         "cdna5",
         "attention",
         "dsa_prefill",
-        "triton_dsa_prefill",
+        "gluon_dsa_prefill_fp8_dense_gfx1250",
         _attention_dsa_prefill_fp8_dense,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "dsa_prefill_fp8_e5m2_dense_rank512",
+        "gluon_dsa_prefill_fp8_dense_gfx1250",
+        _attention_dsa_prefill_fp8_e5m2_dense,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "dsa_prefill_fp8_dense_rank128",
+        "triton_dsa_prefill",
+        _attention_dsa_prefill_fp8_dense_rank128,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "dsa_prefill_fp8_packed_rank512",
+        "triton_dsa_prefill",
+        _attention_dsa_prefill_fp8_packed_rank512,
     ),
     _case(
         _is_cdna5,


### PR DESCRIPTION
Port the implementation from https://github.com/lightseekorg/tokenspeed/pull/1054 to GFX1250.

### Performance
Measurements were collected on a physical GFX1250 using GPU-event medians
of 15 measurements after two warmups.

#### Decode
Shape: one query token attending to 2,048 selected KV positions.
| | BF16 | FP8 |
|---|---:|---:|
| Triton | 305.337 µs | 292.438 µs |
| Gluon | 114.331 µs | 89.975 µs |

#### Prefill
Shape: 4,096 query tokens, each attending to 2,048 selected KV positions.
| | BF16 | FP8 |
|---|---:|---:|
| Triton | 90.958 ms | 79.318 ms |
| Gluon | 1.508 ms | 0.906 ms |

These measurements isolate selected attention and do not include top-k
selection
