### PR TITLE
chore(cudagraph): capture decode graphs largest batch size first

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -317,12 +317,6 @@ class CudaGraphWrapper:
         with freeze_gc(self.enable_cudagraph_gc):
             self.stream = torch.cuda.Stream()
             # Capture backend-declared sampler variants explicitly.
-            # Capture largest-first. The graph pool can only reuse a freed
-            # block when a later capture fits inside it, so ascending order
-            # forces a fresh allocation for every bucket and the pool ends up
-            # holding the SUM of all buckets; descending order lets the first
-            # (largest) capture set the high-water mark and every smaller
-            # bucket reuse it.
             capture_items = [
                 (variant, bs)
                 for variant in self._cuda_graph_capture_variants()

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -317,10 +317,16 @@ class CudaGraphWrapper:
         with freeze_gc(self.enable_cudagraph_gc):
             self.stream = torch.cuda.Stream()
             # Capture backend-declared sampler variants explicitly.
+            # Capture largest-first. The graph pool can only reuse a freed
+            # block when a later capture fits inside it, so ascending order
+            # forces a fresh allocation for every bucket and the pool ends up
+            # holding the SUM of all buckets; descending order lets the first
+            # (largest) capture set the high-water mark and every smaller
+            # bucket reuse it.
             capture_items = [
                 (variant, bs)
                 for variant in self._cuda_graph_capture_variants()
-                for bs in self.capture_bs
+                for bs in sorted(self.capture_bs, reverse=True)
             ]
             capture_range = tqdm.tqdm(capture_items) if rank == 0 else capture_items
             if rank == 0:


### PR DESCRIPTION
## Summary

The graph memory pool can only reuse a freed block when a later capture fits inside it. Capturing ascending never gives it that chance -- each larger batch size needs more than anything the smaller ones released -- so the pool ends up holding the sum of every bucket instead of just the largest.

Reversing the order lets the first capture set the high-water mark and every smaller bucket reuse it. Bucket coverage is unchanged; only the order differs.

## Test Plan

<!-- How was this validated? -->
