### PR TITLE
[wip] fix(amd): warm up auxiliary streams before graph capture

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -74,6 +74,26 @@ def get_is_cuda_graph_phase() -> bool:
     return _is_cuda_graph_phase
 
 
+@contextmanager
+def _capture_execution_path():
+    """Select graph-capture branches for warmup and graph recording.
+
+    Capture-only branches may use streams and library handles that eager
+    execution never touches. Running warmups under the same mode ensures all
+    of that per-stream state is initialized before recording starts.
+    """
+    global _is_capture_mode, _is_cuda_graph_phase
+    old_capture_mode = _is_capture_mode
+    old_cuda_graph_phase = _is_cuda_graph_phase
+    _is_capture_mode = True
+    _is_cuda_graph_phase = True
+    try:
+        yield
+    finally:
+        _is_capture_mode = old_capture_mode
+        _is_cuda_graph_phase = old_cuda_graph_phase
+
+
 def _should_update_mamba_state_after_mtp_verify(
     drafter, attn_backend, forward_mode: ForwardMode
 ) -> bool:
@@ -119,9 +139,6 @@ def get_batch_sizes_to_capture(config: ModelExecutorConfig):
     effective_max = min(config.max_cudagraph_capture_size, max_bs)
     capture_bs = [bs for bs in capture_bs if 0 < bs <= effective_max]
     return capture_bs
-
-
-global_graph_memory_pool = None
 
 
 class DeepEPCudaGraphRunnerAdapter:
@@ -298,6 +315,7 @@ class CudaGraphWrapper:
         )
         self.graphs: dict[tuple[str, int], torch.cuda.CUDAGraph] = {}
         self.output_buffers: dict[tuple[str, int], tuple] = {}
+        self._graph_memory_pool = None
 
         self._forward_func: Callable | None = forward_func
         self.deepep_adapter = DeepEPCudaGraphRunnerAdapter()
@@ -473,51 +491,50 @@ class CudaGraphWrapper:
                 )
             return self._forward_func(bs=bs, ctx=ctx, sampling_info=sampling_info)
 
-        global _is_cuda_graph_phase
-        _is_cuda_graph_phase = True
+        with _capture_execution_path():
+            # Warm up the exact execution topology that will be recorded. In
+            # particular, PyTorch 2.13 keys ROCm hipBLASLt handles by stream;
+            # both the graph stream and capture-only auxiliary streams must be
+            # touched before hipMalloc becomes illegal inside capture.
+            for _ in range(4):
+                torch.cuda.synchronize()
+                dist.barrier()
+                self._prepare_sampling_capture(bs=bs, variant=variant)
+                # Keep warmup seq_lens >= q_len_per_req so no query row gets an
+                # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
+                self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
+                self._init_capture_metadata(bs)
+                with torch.cuda.stream(self.stream):
+                    run_once()
 
-        # Warm up before capture.
-        for _ in range(4):
+            # Clear any per-pool state that warm-up dirtied at pool row 0,
+            # so the graph captures reads against a clean baseline.
+            if self.sampling_backend is not None:
+                self.sampling_backend.reset_capture_state()
+
             torch.cuda.synchronize()
             dist.barrier()
-            self._prepare_sampling_capture(bs=bs, variant=variant)
-            # Keep warmup seq_lens >= q_len_per_req so no query row gets an
-            # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
-            self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
+
+            # Warmups can switch a backend back to eager metadata objects. Restore
+            # the graph-backed metadata immediately before capture so replay-time
+            # metadata refreshes update the same tensors recorded by the graph.
             self._init_capture_metadata(bs)
-            run_once()
 
-        # Clear any per-pool state that warm-up dirtied at pool row 0,
-        # so the graph captures reads against a clean baseline.
-        if self.sampling_backend is not None:
-            self.sampling_backend.reset_capture_state()
+            # Fill sampler buffers OUTSIDE the capture so RNG ops aren't recorded.
+            self._prepare_sampling_capture(bs=bs, variant=variant)
+            # Warmup forwards can mutate aliased metadata buffers, so refresh
+            # them again immediately before graph capture records the final views.
+            self._init_capture_metadata(bs)
 
-        torch.cuda.synchronize()
-        dist.barrier()
+            self.deepep_adapter.capture()
 
-        # Warmups can switch a backend back to eager metadata objects. Restore
-        # the graph-backed metadata immediately before capture so replay-time
-        # metadata refreshes update the same tensors recorded by the graph.
-        self._init_capture_metadata(bs)
+            with torch.cuda.graph(
+                graph, pool=self._graph_memory_pool, stream=self.stream
+            ):
+                out = run_once()
 
-        # Fill sampler buffers OUTSIDE the capture so RNG ops aren't recorded.
-        self._prepare_sampling_capture(bs=bs, variant=variant)
-        # Warmup forwards can mutate aliased metadata buffers, so refresh
-        # them again immediately before graph capture records the final views.
-        self._init_capture_metadata(bs)
-
-        self.deepep_adapter.capture()
-
-        global _is_capture_mode
-        _is_capture_mode = True
-        global global_graph_memory_pool
-        with torch.cuda.graph(graph, pool=global_graph_memory_pool, stream=self.stream):
-            out = run_once()
-
-        torch.cuda.synchronize()
-        dist.barrier()
-        _is_capture_mode = False
-        _is_cuda_graph_phase = False
+            torch.cuda.synchronize()
+            dist.barrier()
 
         # Graph capture records the hostfunc launches without invoking
         # them, so the dummy run_once pushed stays queued — drain it, and
@@ -531,7 +548,7 @@ class CudaGraphWrapper:
                     break
             self.capturable_grammar.reset_state()
 
-        global_graph_memory_pool = graph.pool()
+        self._graph_memory_pool = graph.pool()
 
         return graph, out
 

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -492,10 +492,6 @@ class CudaGraphWrapper:
             return self._forward_func(bs=bs, ctx=ctx, sampling_info=sampling_info)
 
         with _capture_execution_path():
-            # Warm up the exact execution topology that will be recorded. In
-            # particular, PyTorch 2.13 keys ROCm hipBLASLt handles by stream;
-            # both the graph stream and capture-only auxiliary streams must be
-            # touched before hipMalloc becomes illegal inside capture.
             for _ in range(4):
                 torch.cuda.synchronize()
                 dist.barrier()

--- a/test/runtime/execution/test_cuda_graph_capture_path.py
+++ b/test/runtime/execution/test_cuda_graph_capture_path.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression tests for capture-only auxiliary-stream initialization."""
+
+import multiprocessing
+import os
+import sys
+import unittest
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=20, suite="runtime-1gpu")
+
+import torch  # noqa: E402
+from torch.nn import functional as F  # noqa: E402
+
+
+def _run_rocm_aux_stream_capture() -> None:
+    """Run in a child so a capture-time HIP failure cannot hang pytest."""
+    from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+        _capture_execution_path,
+        get_is_capture_mode,
+    )
+    from tokenspeed.runtime.utils.cuda_stream import StreamFork
+
+    torch.backends.cuda.preferred_blas_library("hipblaslt")
+
+    # Qwen3.5-397B shared-expert gate/up projection at decode batch size 1.
+    x = torch.randn((1, 4096), device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn((2048, 4096), device="cuda", dtype=torch.bfloat16)
+    graph_stream = torch.cuda.Stream()
+    stream_fork = StreamFork(torch.cuda.Stream())
+    torch.cuda.synchronize()
+
+    def run_once() -> torch.Tensor:
+        with stream_fork.scope(enable=get_is_capture_mode()) as fork:
+            with fork.branch():
+                return F.linear(x, weight)
+
+    graph = torch.cuda.CUDAGraph()
+    with _capture_execution_path():
+        for _ in range(4):
+            with torch.cuda.stream(graph_stream):
+                output = run_once()
+        torch.cuda.synchronize()
+
+        with torch.cuda.graph(graph, stream=graph_stream):
+            output = run_once()
+
+    graph.replay()
+    torch.cuda.synchronize()
+    if not torch.isfinite(output).all().item():
+        raise AssertionError("captured hipBLASLt output is not finite")
+
+
+class CaptureExecutionPathTest(unittest.TestCase):
+    def setUp(self):
+        from tokenspeed.runtime.execution import cuda_graph_wrapper
+
+        self.wrapper_module = cuda_graph_wrapper
+        self.old_capture_mode = cuda_graph_wrapper._is_capture_mode
+        self.old_cuda_graph_phase = cuda_graph_wrapper._is_cuda_graph_phase
+        cuda_graph_wrapper._is_capture_mode = False
+        cuda_graph_wrapper._is_cuda_graph_phase = False
+
+    def tearDown(self):
+        self.wrapper_module._is_capture_mode = self.old_capture_mode
+        self.wrapper_module._is_cuda_graph_phase = self.old_cuda_graph_phase
+
+    def test_selects_capture_branches_and_restores_state(self):
+        wrapper = self.wrapper_module
+
+        with wrapper._capture_execution_path():
+            self.assertTrue(wrapper.get_is_capture_mode())
+            self.assertTrue(wrapper.get_is_cuda_graph_phase())
+
+        self.assertFalse(wrapper.get_is_capture_mode())
+        self.assertFalse(wrapper.get_is_cuda_graph_phase())
+
+    def test_restores_state_after_failure(self):
+        wrapper = self.wrapper_module
+
+        with self.assertRaisesRegex(RuntimeError, "warmup failed"):
+            with wrapper._capture_execution_path():
+                raise RuntimeError("warmup failed")
+
+        self.assertFalse(wrapper.get_is_capture_mode())
+        self.assertFalse(wrapper.get_is_cuda_graph_phase())
+
+
+@unittest.skipUnless(
+    torch.version.hip is not None and torch.cuda.is_available(),
+    "requires a ROCm GPU",
+)
+class RocmAuxStreamCaptureTest(unittest.TestCase):
+    def test_capture_path_prewarms_aux_stream_hipblaslt_handle(self):
+        process = multiprocessing.get_context("spawn").Process(
+            target=_run_rocm_aux_stream_capture
+        )
+        process.start()
+        process.join(timeout=60)
+
+        if process.is_alive():
+            process.kill()
+            process.join()
+            self.fail("ROCm auxiliary-stream graph capture timed out")
+
+        self.assertEqual(process.exitcode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This patch resolves an issue exposed when we updated to torch 2.13. PyTorch PR [#179053](https://github.com/pytorch/pytorch/pull/179053) explains that hipBLASLt cannot safely share one handle across multiple streams, so the implementation was changed to return a handle for each (device, stream) pair. Conceptually, the handle cache changed from:

```
handle = cache[device]
```

to:

```
handle = cache[(device, stream)]
```

These handles are created lazily when an operation on a stream first selects hipBLASLt. Creating a handle may allocate memory, which is not permitted after stream capture has started. During the existing graph warmup, we did not select the capture execution path and did not run the forward on the final graph stream. In Qwen3.5 MoE, `get_is_capture_mode()` was therefore false, disabling the StreamFork used by the shared expert https://github.com/lightseekorg/tokenspeed/blob/34da97fc1228e3a0c5477aaa05bb0baa0b1f0cae/python/tokenspeed/runtime/models/qwen3_5_moe.py#L350-L354

So the shared expert ran on the current warmup stream instead of the auxiliary stream, leaving the auxiliary stream’s hipBLASLt handle uninitialized now that they are not shared. 

When graph recording started, the stream fork was enabled for the first time. The shared expert then ran on the
auxiliary stream, and its first hipBLASLt operation attempted to create the stream-local handle during capture, resulting in HIP error 900.

Fix by running warmup on the final graph stream while selecting the same execution path used during graph recording. This activates the Qwen shared-expert stream fork during warmup and initializes the required stream-local hipBLASLt state before capture begins.


## Test Plan

<!-- How was this validated? -->

- Full Qwen3.5-397B MXFP4 TP4 run:
- All decode graphs [1, 2, 4, 8, 15, 16] captured.
- All 40 prefill buckets captured.
- All four ranks initialized.
- Warmup generation succeeded.
- gRPC reached SERVING.
- No HIP 900 errors.
