### PR TITLE
fix(runtime): warm graph auxiliary streams before capture

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -476,16 +476,20 @@ class CudaGraphWrapper:
         global _is_cuda_graph_phase
         _is_cuda_graph_phase = True
 
-        # Warm up before capture.
-        for _ in range(4):
+        # Warm the same primary stream used by capture. Capture-only auxiliary
+        # branches use this graph phase to warm their own streams serially.
+        with torch.cuda.stream(self.stream):
+            for _ in range(4):
+                torch.cuda.synchronize()
+                dist.barrier()
+                self._prepare_sampling_capture(bs=bs, variant=variant)
+                # Keep warmup seq_lens >= q_len_per_req so no query row gets an
+                # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
+                self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
+                self._init_capture_metadata(bs)
+                run_once()
+            # Order the reset below after the last warmup's stateful kernels.
             torch.cuda.synchronize()
-            dist.barrier()
-            self._prepare_sampling_capture(bs=bs, variant=variant)
-            # Keep warmup seq_lens >= q_len_per_req so no query row gets an
-            # empty causal span; a stale seq_len of 1 overflows to non-finite KV.
-            self.input_buffers.seq_lens_buf[:bs].fill_(self.max_tokens_per_req)
-            self._init_capture_metadata(bs)
-            run_once()
 
         # Clear any per-pool state that warm-up dirtied at pool row 0,
         # so the graph captures reads against a clean baseline.

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -100,7 +100,10 @@ from tokenspeed.runtime.configs.inkling_config import (
 from tokenspeed.runtime.distributed.comm_manager import CommManager
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
-from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
+from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+    get_is_capture_mode,
+    get_is_cuda_graph_phase,
+)
 from tokenspeed.runtime.layers.activation import SiluAndMul
 from tokenspeed.runtime.layers.layernorm import RMSNorm
 from tokenspeed.runtime.layers.linear import (
@@ -581,10 +584,11 @@ class InklingAttention(nn.Module):
         qkvr, _ = self.qkvr(hidden_states)
         q, kv, r = qkvr.split([self.q_size, 2 * self.kv_size, self.r_size], dim=-1)
 
-        # Fork the R-slice-only rel projection onto the aux stream (capture
-        # only; joins before attention). INKLING_ATTN_RELFORK=0 = serial.
+        # Warm the R-slice projection serially on the capture topology, then
+        # overlap it during capture. INKLING_ATTN_RELFORK=0 stays serial.
         with self.stream_fork.scope(
-            enable=_ATTN_RELFORK and get_is_capture_mode()
+            enable=_ATTN_RELFORK and get_is_cuda_graph_phase(),
+            overlap=get_is_capture_mode(),
         ) as fork:
             with fork.branch():
                 rel_logits = self.rel_logits_proj(
@@ -932,8 +936,11 @@ class InklingSparseMoeBlock(nn.Module):
             num_global_tokens, max_tokens_per_gpu = self.comm_manager.get_num_tokens(
                 ctx
             )
-            # Shared experts depend only on x: fork before the gate (capture-only, allocator stream safety).
-            with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
+            # Warm this branch serially on the aux stream, then overlap it with
+            # the gate during capture.
+            with self.stream_fork.scope(
+                enable=get_is_cuda_graph_phase(), overlap=get_is_capture_mode()
+            ) as fork:
                 with fork.branch():
                     shared_out = self.shared_experts(x, do_finalize=False)
                 weights, topk_ids, router_logits = self.gate(x)
@@ -975,7 +982,9 @@ class InklingSparseMoeBlock(nn.Module):
                     topk_ids=topk_ids,
                     router_logits=router_logits,
                 )
-                with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
+                with self.stream_fork.scope(
+                    enable=get_is_cuda_graph_phase(), overlap=get_is_capture_mode()
+                ) as fork:
                     routed_out = self.experts(
                         hidden_states=x,
                         topk_output=topk_output,

--- a/python/tokenspeed/runtime/models/qwen3_5_moe.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_moe.py
@@ -39,7 +39,10 @@ from tokenspeed.runtime.configs.qwen3_5_text_base_config import Qwen3_5BaseTextC
 from tokenspeed.runtime.distributed.comm_manager import CommManager
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
-from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_capture_mode
+from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+    get_is_capture_mode,
+    get_is_cuda_graph_phase,
+)
 from tokenspeed.runtime.layers.activation import SiluAndMul
 from tokenspeed.runtime.layers.dense.nvfp4 import Nvfp4LinearMethod
 from tokenspeed.runtime.layers.linear import (
@@ -351,8 +354,9 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
             enable=(
                 self.shared_expert is not None
                 and hidden_states.shape[0] > 0
-                and get_is_capture_mode()
-            )
+                and get_is_cuda_graph_phase()
+            ),
+            overlap=get_is_capture_mode(),
         ) as fork:
             with fork.branch():
                 if self.shared_expert is not None:

--- a/python/tokenspeed/runtime/utils/cuda_stream.py
+++ b/python/tokenspeed/runtime/utils/cuda_stream.py
@@ -29,11 +29,23 @@ class StreamFork:
         self.fork_event = torch.cuda.Event() if aux_stream is not None else None
         self.join_event = torch.cuda.Event() if aux_stream is not None else None
         self._active = False
+        self._overlap = True
         self._current: torch.cuda.Stream | None = None
 
     @contextmanager
-    def scope(self, *, enable: bool):
+    def scope(self, *, enable: bool, overlap: bool = True):
+        """Configure auxiliary-stream execution for work in this scope.
+
+        Args:
+            enable: Whether calls to ``branch()`` use the auxiliary stream.
+            overlap: Whether the main stream may overlap with auxiliary-stream
+                work. If false, the main stream waits after each branch.
+
+        Yields:
+            This stream fork, ready to create branches with ``branch()``.
+        """
         self._active = enable and self.aux_stream is not None
+        self._overlap = overlap
         if self._active:
             self._current = torch.cuda.current_stream()
             self.fork_event.record(self._current)
@@ -43,6 +55,7 @@ class StreamFork:
             if self._active:
                 self.join_event.wait(self._current)
                 self._active = False
+                self._overlap = True
                 self._current = None
 
     @contextmanager
@@ -54,3 +67,5 @@ class StreamFork:
             self.fork_event.wait(self.aux_stream)
             yield
             self.join_event.record(self.aux_stream)
+        if not self._overlap:
+            self.join_event.wait(self._current)


### PR DESCRIPTION
## Problem

PyTorch 2.13 lazily creates a stream-local hipBLASLt handle when Qwen3.5 or Inkling first enters its auxiliary GEMM stream during global graph capture, and ROCm 7.2.4 consequently attempts a forbidden `hipMalloc` and exits with HIP error 900.

## Key changes

- Think of warmup as a rehearsal for graph capture: `python/tokenspeed/runtime/execution/cuda_graph_wrapper.py::_capture_one` now rehearses on the exact primary stream that capture will use and waits for the rehearsal to finish before resetting state.
- `python/tokenspeed/runtime/utils/cuda_stream.py::StreamFork.scope` adds an `overlap=False` rehearsal mode that runs work on the real auxiliary stream but makes the primary stream wait immediately, so stream-local libraries initialize safely without introducing warmup-time concurrency.
- The Qwen shared-expert path in `python/tokenspeed/runtime/models/qwen3_5_moe.py` and the attention/shared-expert paths in `python/tokenspeed/runtime/models/inkling.py` now use that serialized rehearsal mode during warmup and keep their existing parallel execution during graph capture.

`get_is_cuda_graph_phase()` is true during both warmup and capture, so it makes the auxiliary branch run early enough to initialize its stream-local state before capture begins. `overlap=get_is_capture_mode()` keeps that branch serialized during warmup (`False`) but restores parallel execution during actual capture (`True`), preserving performance while avoiding unsafe initialization.

## Validation

- Exact ROCm 7.2.4 / PyTorch 2.13 runner image: serialized auxiliary warmup followed by multi-stream graph capture and replay completed without HIP error 900.
- `python -m pytest -q test/runtime/models/test_qwen3_5_shared_expert_dp.py test/runtime/models/test_inkling_models.py` (`4 passed, 1 skipped`).
- `pre-commit run --all-files`.
