### PR TITLE
perf(comm): route generic MNNVL AR patterns to upstream flashinfer

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
@@ -110,11 +110,19 @@ class TrtllmAllReduceBackend(CommBackend):
                     )
                 )
 
-            # NVLS variant for the plain one-shot path (capability-gated,
+            # NVLS variants for the plain one-shot path (capability-gated,
             # collective, symmetric fallback): the fused-pattern wrappers in
-            # the kernel package arm their own copy; this one serves the
+            # the kernel package arm their own copy; these serve the
             # backend-level all_reduce (post-restructure attention ARs).
+            # Two workspaces, split by token count like _ar_fusion_workspace:
+            # the private kernel keeps decode-sized calls, upstream flashinfer
+            # takes M >= MNNVL_FLASHINFER_MIN_TOKENS and cross-node. The
+            # flashinfer workspace is a process-lifetime block shared with the
+            # kernel-package manager (group-keyed cache), so arming it here
+            # costs no extra memory. Both arming attempts are collectively
+            # voted, so every rank creates the same set.
             from tokenspeed_kernel.ops.communication.trtllm import (
+                _try_create_mnnvl_fi_workspace,
                 _try_create_mnnvl_workspace,
             )
 
@@ -125,16 +133,28 @@ class TrtllmAllReduceBackend(CommBackend):
                 hidden_dim,
                 device_group,
             )
+            mnnvl_fi_workspace = _try_create_mnnvl_fi_workspace(
+                rank,
+                len(group),
+                max_token_num,
+                hidden_dim,
+                device_group,
+            )
 
             # Nothing usable -> report failure so the backend keeps routing
             # this group through NCCL.
-            if workspace_tensor is None and mnnvl_workspace is None:
+            if (
+                workspace_tensor is None
+                and mnnvl_workspace is None
+                and mnnvl_fi_workspace is None
+            ):
                 return False
 
             self._resources[group] = {
                 "ipc_handles": ipc_handles,
                 "workspace": workspace_tensor,
                 "mnnvl": mnnvl_workspace,
+                "mnnvl_fi": mnnvl_fi_workspace,
                 "rank": rank,
                 "world_size": len(group),
                 "max_token_num": max_token_num,
@@ -256,6 +276,7 @@ class TrtllmAllReduceBackend(CommBackend):
             return None
 
         from tokenspeed_kernel.ops.communication.trtllm import (
+            MNNVL_FLASHINFER_MIN_TOKENS,
             MNNVL_PREFER_IPC_BYTES,
         )
 
@@ -265,26 +286,31 @@ class TrtllmAllReduceBackend(CommBackend):
 
         workspace = res["workspace"]
         mnnvl = res.get("mnnvl")
+        mnnvl_fi = res.get("mnnvl_fi")
         # Same Tier-2 split as _ar_fusion_workspace: prefer the IPC lamport
         # workspace (single-node only; cross-node it is None) once the payload
-        # reaches MNNVL_PREFER_IPC_BYTES, mnnvl below it. Unreachable while
-        # _MAX_ONESHOT_BYTES stays under the threshold, but keeps this path
-        # consistent with the kernel-side dispatch if either bound moves.
+        # reaches MNNVL_PREFER_IPC_BYTES; below it the private mnnvl kernel
+        # keeps decode-sized calls and upstream flashinfer takes M >=
+        # MNNVL_FLASHINFER_MIN_TOKENS (and cross-node), each falling back to
+        # the other when its supports() rejects the shape. Unreachable while
+        # _MAX_ONESHOT_BYTES stays under the IPC threshold, but keeps this
+        # path consistent with the kernel-side dispatch if either bound moves.
         payload_bytes = token_num * hidden_dim * tensor_2d.dtype.itemsize
         prefer_ipc = workspace is not None and payload_bytes >= MNNVL_PREFER_IPC_BYTES
-        if (
-            not prefer_ipc
-            and mnnvl is not None
-            and mnnvl.supports(
-                token_num,
-                hidden_dim,
-                tensor_2d.dtype,
-                res["world_size"],
-                AllReduceFusionPattern.kAllReduce,
-                use_oneshot=True,
-            )
-        ):
-            workspace = mnnvl
+        prefer_fi = token_num >= MNNVL_FLASHINFER_MIN_TOKENS or res["workspace"] is None
+        if not prefer_ipc:
+            candidates = (mnnvl_fi, mnnvl) if prefer_fi else (mnnvl, mnnvl_fi)
+            for candidate in candidates:
+                if candidate is not None and candidate.supports(
+                    token_num,
+                    hidden_dim,
+                    tensor_2d.dtype,
+                    res["world_size"],
+                    AllReduceFusionPattern.kAllReduce,
+                    use_oneshot=True,
+                ):
+                    workspace = candidate
+                    break
 
         # Shape not covered by mnnvl and no IPC fallback -> let the caller
         # fall back to NCCL (this function's None contract).

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/trtllm.py
@@ -60,6 +60,7 @@ if current_platform().is_nvidia:
     from tokenspeed_kernel.ops.communication.fabric import fabric_allocation_supported
     from tokenspeed_kernel.thirdparty.cuda.trtllm import (
         _MNNVL_SUPPORTED_WORLD_SIZES,
+        MNNVL_FLASHINFER_MIN_TOKENS,
         MNNVL_ONESHOT_MAX_TOKEN,
         MNNVL_PREFER_IPC_BYTES,
         AllGatherFusionPattern,
@@ -67,9 +68,11 @@ if current_platform().is_nvidia:
         ReduceScatterFusionPattern,
         _ar_should_use_oneshot,
         _load_trtllm_comm_module,
+        flashinfer_mnnvl_module_available,
         minimax_allreduce_rms_qk,
         trtllm_allgather_fusion,
         trtllm_allreduce_fusion,
+        trtllm_create_flashinfer_mnnvl_workspace_for_all_reduce_fusion,
         trtllm_create_ipc_workspace_for_all_reduce_fusion,
         trtllm_create_ipc_workspace_for_minimax,
         trtllm_create_mnnvl_workspace_for_all_reduce_fusion,
@@ -168,6 +171,105 @@ if current_platform().is_nvidia:
         )
         return workspace
 
+    def _mnnvl_fi_locally_available(world_size: int) -> bool:
+        """Non-collective capability probe for the upstream flashinfer MNNVL AR.
+
+        Same hardware requirements as the private kernel (NVLS multicast,
+        fabric-handle memory for cross-host groups) minus the world-size
+        whitelist: the upstream kernels serve arbitrary group sizes. Purely
+        local: safe to call before any collective.
+        """
+        if world_size <= 1 or not flashinfer_mnnvl_module_available():
+            return False
+        try:
+            if torch.cuda.get_device_capability()[0] < 9:
+                return False
+            from torch._C._autograd import DeviceType
+            from torch._C._distributed_c10d import _SymmetricMemory
+
+            if not _SymmetricMemory.has_multicast_support(
+                DeviceType.CUDA, torch.cuda.current_device()
+            ):
+                return False
+            # Cross-host groups need fabric-handle memory; the multicast
+            # capability alone is advertised even where the IMEX stack is
+            # absent and the handle exchange would then hang.
+            if world_size > torch.cuda.device_count() and not (
+                fabric_allocation_supported(torch.cuda.current_device())
+            ):
+                return False
+            return True
+        except Exception as exc:  # noqa: BLE001 - capability probe must not raise
+            logger.debug("flashinfer mnnvl capability probe failed: %s", exc)
+            return False
+
+    # One flashinfer workspace per process group, shared by every arming site
+    # (comm_backend per-group managers and the fused-pattern manager here).
+    # The multicast allocation granularity (hundreds of MB) dwarfs any
+    # requested size, so the first allocation has capacity for all callers;
+    # per-call sufficiency is still checked in supports(). Keyed by the
+    # group's global ranks -- distinct ProcessGroup objects over the same
+    # ranks share one workspace. Process-lifetime, like symm_mem allocations.
+    # Sharing requires all users of a group to issue their AR calls in a
+    # single total order (one compute stream), which the engine guarantees.
+    _mnnvl_fi_workspace_cache: dict = {}
+
+    def _try_create_mnnvl_fi_workspace(
+        rank: int,
+        world_size: int,
+        max_token_num: int,
+        hidden_dim: int,
+        group,
+    ):
+        """Collectively arm (or reuse) the upstream flashinfer MNNVL workspace.
+
+        Same two-phase agreement as :func:`_try_create_mnnvl_workspace`:
+        (1) all-reduce the local capability probe before the multicast handle
+        exchange, (2) all-reduce the creation result. Returns None on fallback
+        so every rank takes the same path. The cache lookup key is local
+        metadata computed identically on every rank, so hits and misses are
+        rank-uniform too.
+        """
+        cache_key = tuple(dist.get_process_group_ranks(group))
+        cached = _mnnvl_fi_workspace_cache.get(cache_key)
+        if cached is not None:
+            return cached
+        device = torch.device("cuda", torch.cuda.current_device())
+        ok = torch.tensor(
+            [1 if _mnnvl_fi_locally_available(world_size) else 0],
+            dtype=torch.int32,
+            device=device,
+        )
+        dist.all_reduce(ok, op=dist.ReduceOp.MIN, group=group)
+        if ok.item() == 0:
+            return None
+
+        workspace = None
+        try:
+            workspace = trtllm_create_flashinfer_mnnvl_workspace_for_all_reduce_fusion(
+                rank, world_size, max_token_num, hidden_dim, group=group
+            )
+        except Exception as exc:  # noqa: BLE001 - fall back to private/IPC
+            logger.warning("flashinfer mnnvl workspace creation failed: %s", exc)
+
+        ok = torch.tensor(
+            [1 if workspace is not None else 0], dtype=torch.int32, device=device
+        )
+        dist.all_reduce(ok, op=dist.ReduceOp.MIN, group=group)
+        if ok.item() == 0:
+            return None
+        logger.info(
+            "flashinfer MNNVL AR workspace armed: rank=%s world_size=%s "
+            "max_token_num=%s hidden_dim=%s buffer=%s bytes",
+            rank,
+            world_size,
+            workspace.max_token_num,
+            hidden_dim,
+            workspace.buffer_size_bytes,
+        )
+        _mnnvl_fi_workspace_cache[cache_key] = workspace
+        return workspace
+
     def _group_spans_nodes(group) -> bool:
         """True when the process group spans hosts.
 
@@ -206,6 +308,7 @@ if current_platform().is_nvidia:
             self.workspace_tensor = None
             self.ipc_handles = None
             self.mnnvl_workspace = None
+            self.mnnvl_fi_workspace = None
             self.world_size = None
             self.rank = None
             self.max_token_num = None
@@ -263,12 +366,23 @@ if current_platform().is_nvidia:
             self.mnnvl_workspace = _try_create_mnnvl_workspace(
                 rank, world_size, max_token_num, hidden_dim, group
             )
+            # Upstream flashinfer MNNVL workspace: preferred provider for the
+            # generic kAllReduce / kARResidualRMSNorm patterns (faster kernels,
+            # maintained upstream). The private mnnvl workspace above remains
+            # for the K3-specific epilogue patterns upstream does not have.
+            self.mnnvl_fi_workspace = _try_create_mnnvl_fi_workspace(
+                rank, world_size, max_token_num, hidden_dim, group
+            )
 
             # With IPC skipped, mnnvl is the only workspace; if it failed to
             # arm there is nothing to fuse with -- stay uninitialized so
             # prepare_allreduce_fusion() returns False and the model layer
             # keeps the plain NCCL path.
-            if self.workspace_tensor is None and self.mnnvl_workspace is None:
+            if (
+                self.workspace_tensor is None
+                and self.mnnvl_workspace is None
+                and self.mnnvl_fi_workspace is None
+            ):
                 logger.warning(
                     "trtllm AR: no workspace available (ipc skipped, mnnvl "
                     "failed); fusion disabled for this group"
@@ -314,6 +428,10 @@ if current_platform().is_nvidia:
                     # symm_mem allocations are process-lifetime; dropping the
                     # reference is all we can (and need to) do here.
                     self.mnnvl_workspace = None
+                    # The flashinfer workspace is shared across arming sites
+                    # via the process-lifetime cache; drop the reference only,
+                    # never destroy() it out from under other users.
+                    self.mnnvl_fi_workspace = None
                     self.initialized = False
                     self.world_size = None
                     self.rank = None
@@ -400,16 +518,21 @@ if current_platform().is_nvidia:
         Decision, first match wins:
           1. IPC exists (single-node) AND (payload >= MNNVL_PREFER_IPC_BYTES
              OR pattern == kAllReduceLatentNorm) ....... IPC lamport/twoshot
-          2. mnnvl supports this shape ................. mnnvl (one-shot <=128
-             tokens, two-shot 129..2048; device picks by token count)
+          2. between the mnnvl workspaces: upstream flashinfer when
+             token_num >= MNNVL_FLASHINFER_MIN_TOKENS or cross-node (generic
+             patterns only), the private kernel otherwise (and always for the
+             K3-specific epilogue patterns); whichever was not preferred is
+             the fallback when the preferred one rejects the shape
           3. no IPC fallback (cross-node) ............. None (caller degrades:
              the rmsnorm family runs unfused NCCL + torch epilogue, the rest
              raise loudly -- never a null workspace into the kernel)
           4. otherwise ................................ IPC
-        Cross-node, workspace_tensor is None so only 2/3 apply -- mnnvl serves
-        the whole range (it beats NCCL everywhere there).
+        Cross-node, workspace_tensor is None so only 2-3 apply -- the two
+        mnnvl workspaces together serve the whole range (they beat NCCL
+        everywhere there).
         """
         mnnvl = _workspace_manager.mnnvl_workspace
+        mnnvl_fi = _workspace_manager.mnnvl_fi_workspace
         # Byte-based split between the two fused workspaces: multicast (mnnvl)
         # for small payloads, IPC lamport once bandwidth dominates. Only bites
         # single-node -- cross-node workspace_tensor is None and mnnvl is the
@@ -425,6 +548,31 @@ if current_platform().is_nvidia:
         )
         if _workspace_manager.workspace_tensor is not None and prefer_ipc:
             return _workspace_manager.workspace_tensor
+        # Between the two mnnvl workspaces, prefer upstream flashinfer from
+        # MNNVL_FLASHINFER_MIN_TOKENS up and cross-node (no IPC): that is
+        # where it decisively wins (1.8-3.2x by M=64-128). Decode-sized calls
+        # stay on the private kernel -- in-situ the two are equals there and
+        # flashinfer's multicast traffic slows overlapped neighbors (see the
+        # constant's note). Either serves as the other's fallback when its
+        # supports() rejects a shape.
+        prefer_fi = (
+            token_num >= MNNVL_FLASHINFER_MIN_TOKENS
+            or _workspace_manager.workspace_tensor is None
+        )
+        if (
+            prefer_fi
+            and mnnvl_fi is not None
+            and mnnvl_fi.supports(
+                token_num,
+                hidden_dim,
+                dtype,
+                _workspace_manager.world_size,
+                pattern_code,
+                use_oneshot=use_oneshot,
+                residual_reduce_scattered=residual_reduce_scattered,
+            )
+        ):
+            return mnnvl_fi
         if mnnvl is not None and mnnvl.supports(
             token_num,
             hidden_dim,
@@ -435,6 +583,20 @@ if current_platform().is_nvidia:
             residual_reduce_scattered=residual_reduce_scattered,
         ):
             return mnnvl
+        if (
+            not prefer_fi
+            and mnnvl_fi is not None
+            and mnnvl_fi.supports(
+                token_num,
+                hidden_dim,
+                dtype,
+                _workspace_manager.world_size,
+                pattern_code,
+                use_oneshot=use_oneshot,
+                residual_reduce_scattered=residual_reduce_scattered,
+            )
+        ):
+            return mnnvl_fi
         # Cross-node there is no IPC workspace, so a shape/pattern mnnvl rejects
         # has no fused home. Return None and let the caller decide: the rmsnorm
         # family degrades to the unfused NCCL path, the rest raise loudly. Never

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm.py
@@ -42,6 +42,30 @@ from tokenspeed_kernel.thirdparty.cuda.cuda_ipc import (
 )
 from torch.distributed import ProcessGroup
 
+# Upstream flashinfer MNNVL AR (multi-node NVLink fabric). Serves the generic
+# kAllReduce / kARResidualRMSNorm patterns in place of the private mnnvl
+# kernel below; on installs without it the sentinels stay None, the wrapper
+# workspace never arms, and routing keeps the private path -- importing this
+# module never fails on their account.
+try:
+    from flashinfer.comm.comm_backend import TorchDistBackend as _FIDistBackend
+    from flashinfer.comm.mapping import Mapping as _FIMapping
+    from flashinfer.comm.trtllm_mnnvl_ar import (
+        MNNVLAllReduceFusionWorkspace as _FIMnnvlWorkspace,
+    )
+    from flashinfer.comm.trtllm_mnnvl_ar import (
+        trtllm_mnnvl_allreduce as _fi_mnnvl_allreduce,
+    )
+    from flashinfer.comm.trtllm_mnnvl_ar import (
+        trtllm_mnnvl_fused_allreduce_add_rmsnorm as _fi_mnnvl_ar_add_rmsnorm,
+    )
+except ImportError:  # pragma: no cover - flashinfer without the mnnvl module
+    _FIDistBackend = None
+    _FIMapping = None
+    _FIMnnvlWorkspace = None
+    _fi_mnnvl_allreduce = None
+    _fi_mnnvl_ar_add_rmsnorm = None
+
 # ---------------------------------------------------------------------------
 # Utility
 # ---------------------------------------------------------------------------
@@ -259,6 +283,21 @@ MNNVL_TWOSHOT_MAX_TOKEN = 2048
 # workspace, and there mnnvl beats NCCL across the whole supported range.
 MNNVL_PREFER_IPC_BYTES = int(
     os.environ.get("TOKENSPEED_MNNVL_PREFER_IPC_BYTES", 12 * 1024 * 1024)
+)
+
+# Below this token count the private mnnvl kernel keeps the generic patterns
+# on a single node; from here up (until MNNVL_PREFER_IPC_BYTES hands over to
+# IPC) the upstream flashinfer kernel takes them. Isolated graph-replay favors
+# flashinfer at every M, but in-situ (nsys over steady decode, 8x B300) the
+# two are wait-inclusive equals at decode M while flashinfer's multicast
+# traffic slows overlapped neighbor kernels (~+75 us GPU / +30 us wall per
+# step) -- so decode-sized calls stay private. From M=32 flashinfer's
+# advantage is decisive (1.8-3.2x by M=64-128, both hidden widths), well past
+# any neighbor effect. Cross-node there is no IPC and no measured small-M
+# in-situ data; flashinfer takes the whole range there (it beats the private
+# two-shot 1.5-2.1x at every measured M and is the maintained implementation).
+MNNVL_FLASHINFER_MIN_TOKENS = int(
+    os.environ.get("TOKENSPEED_MNNVL_FLASHINFER_MIN_TOKENS", 32)
 )
 
 _MNNVL_SUPPORTED_PATTERNS = frozenset(
@@ -499,6 +538,132 @@ def trtllm_create_mnnvl_workspace_for_all_reduce_fusion(
     )
 
 
+def flashinfer_mnnvl_module_available() -> bool:
+    """Whether the upstream flashinfer MNNVL AR module imported successfully."""
+    return _FIMnnvlWorkspace is not None
+
+
+class FlashinferMnnvlAllReduceFusionWorkspace:
+    """Upstream flashinfer MNNVL workspace behind the local dispatch contract.
+
+    Passing an instance as ``workspace_ptrs`` to :func:`trtllm_allreduce_fusion`
+    routes the call onto flashinfer's ``trtllm_mnnvl_ar`` kernels (McastGPUBuffer
+    over the NVLink fabric, one-shot/two-shot picked device-consistently from
+    the payload size). Covers only the generic patterns -- the K3-specific
+    epilogues (``kARResidualAttnResCombine``, ``kAllReduceLatentNorm``) stay on
+    the private mnnvl kernel until upstream grows them.
+    """
+
+    backend = "mnnvl-flashinfer"
+
+    _SUPPORTED_PATTERNS = frozenset(
+        {
+            AllReduceFusionPattern.kAllReduce,
+            AllReduceFusionPattern.kARResidualRMSNorm,
+        }
+    )
+
+    def __init__(self, workspace, max_token_num: int):
+        self.workspace = workspace
+        self.tp_rank = workspace.rank
+        self.tp_size = workspace.tp_size
+        self.max_token_num = max_token_num
+        self.buffer_size_bytes = workspace.buffer_size_bytes
+
+    def supports(
+        self,
+        token_num: int,
+        hidden_dim: int,
+        dtype: torch.dtype,
+        world_size: int,
+        pattern_code: int,
+        use_oneshot: bool = True,
+        residual_reduce_scattered: bool = False,
+    ) -> bool:
+        """Whether this call shape can run on the upstream mnnvl kernel.
+
+        Args:
+            token_num: number of tokens in this call.
+            hidden_dim: hidden width of this call.
+            dtype: payload dtype (fp16/bf16 only).
+            world_size: TP world size of this call.
+            pattern_code: AllReduceFusionPattern value.
+            use_oneshot: advisory only; the strategy is picked from the
+                payload size (AUTO), identically on every rank.
+            residual_reduce_scattered: RS-residual mode (unsupported).
+
+        Returns:
+            True when the upstream path can serve the call; callers fall back
+            to the private mnnvl or IPC lamport workspace otherwise.
+        """
+        if residual_reduce_scattered:
+            return False
+        if pattern_code not in self._SUPPORTED_PATTERNS:
+            return False
+        if world_size != self.tp_size:
+            return False
+        if dtype not in (torch.bfloat16, torch.float16):
+            return False
+        # token_num <= 0 would reach the kernel launch with an empty grid;
+        # reject here like the private workspace does. No cap on
+        # self.max_token_num: the multicast allocation granularity is far
+        # larger than any requested size, so capacity is judged by the actual
+        # buffer bytes below -- this lets one workspace serve every caller of
+        # its group regardless of who created it first.
+        if token_num <= 0:
+            return False
+        # AUTO strategy: sufficiency is checked against whichever kernel the
+        # payload size actually selects, mirroring the call-time dispatch.
+        return self.workspace.is_buffer_size_sufficient(
+            self.tp_size, token_num, hidden_dim, dtype
+        )
+
+
+def trtllm_create_flashinfer_mnnvl_workspace_for_all_reduce_fusion(
+    tp_rank: int,
+    tp_size: int,
+    max_token_num: int,
+    hidden_dim: int,
+    group: Optional[ProcessGroup] = None,
+    dtype: torch.dtype = torch.bfloat16,
+) -> "FlashinferMnnvlAllReduceFusionWorkspace":
+    """Create the upstream flashinfer MNNVL workspace.
+
+    Collective: every rank of ``group`` must call this in lockstep (multicast
+    handle exchange over the group). Raises when the flashinfer module or
+    NVLink multicast is unavailable; callers should probe capabilities first
+    (see ops/communication/trtllm.py).
+
+    Args:
+        tp_rank: this rank within the group.
+        tp_size: group world size.
+        max_token_num: maximum tokens per call the workspace must serve.
+        hidden_dim: maximum hidden width the workspace must hold.
+        group: the process group to exchange handles over.
+        dtype: payload dtype used for sizing (2-byte fp16/bf16).
+
+    Returns:
+        FlashinferMnnvlAllReduceFusionWorkspace bound to this group.
+    """
+    if _FIMnnvlWorkspace is None:
+        raise RuntimeError(
+            "flashinfer.comm.trtllm_mnnvl_ar is unavailable in this install"
+        )
+    workspace = _FIMnnvlWorkspace(
+        _FIMapping(
+            world_size=tp_size,
+            rank=tp_rank,
+            gpus_per_node=min(tp_size, torch.cuda.device_count()),
+            tp_size=tp_size,
+        ),
+        max_num_tokens=max_token_num,
+        hidden_dim=hidden_dim,
+        dtype=dtype,
+        comm_backend=_FIDistBackend(group),
+    )
+    return FlashinferMnnvlAllReduceFusionWorkspace(workspace, max_token_num)
+
+
 # ---------------------------------------------------------------------------
 # AllReduce fusion
 # ---------------------------------------------------------------------------
@@ -607,6 +772,47 @@ def trtllm_allreduce_fusion(
         use_oneshot = _ar_should_use_oneshot(
             token_num, hidden_dim, allreduce_in.dtype, world_size
         )
+
+    if isinstance(workspace_ptrs, FlashinferMnnvlAllReduceFusionWorkspace):
+        # Upstream flashinfer MNNVL path. Strategy is left to the upstream
+        # AUTO heuristic (host-side, deterministic from the shape, so every
+        # rank picks the same kernel). ``fp32_acc`` and
+        # ``trigger_completion_at_end`` have no upstream equivalent: the
+        # kernels accumulate in fp32 internally and manage the Lamport buffer
+        # rotation themselves.
+        if not workspace_ptrs.supports(
+            token_num,
+            hidden_dim,
+            allreduce_in.dtype,
+            world_size,
+            pattern_code,
+            use_oneshot=use_oneshot,
+            residual_reduce_scattered=residual_reduce_scattered,
+        ):
+            raise RuntimeError(
+                "flashinfer mnnvl workspace does not support this call "
+                f"(token_num={token_num}, hidden_dim={hidden_dim}, "
+                f"dtype={allreduce_in.dtype}, pattern={pattern_code})"
+            )
+        if pattern_code == AllReduceFusionPattern.kAllReduce:
+            _fi_mnnvl_allreduce(
+                allreduce_in,
+                workspace_ptrs.workspace,
+                launch_with_pdl,
+                output=allreduce_out,
+            )
+        else:  # kARResidualRMSNorm (the only other supported pattern)
+            _fi_mnnvl_ar_add_rmsnorm(
+                allreduce_in,
+                residual_in,
+                rms_gamma,
+                workspace_ptrs.workspace,
+                epsilon=rms_eps,
+                output=norm_out,
+                residual_out=residual_out,
+                launch_with_pdl=launch_with_pdl,
+            )
+        return
 
     if isinstance(workspace_ptrs, MnnvlAllReduceFusionWorkspace):
         # MNNVL-structured one-shot path: single NVLS multicast payload store,

--- a/tokenspeed-kernel/test/test_trtllm_mnnvl_fi_routing.py
+++ b/tokenspeed-kernel/test/test_trtllm_mnnvl_fi_routing.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for AR-fusion routing between the upstream flashinfer MNNVL workspace
+and the private mnnvl kernel (which now only backs the K3-specific epilogues)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.platform import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not (current_platform().is_nvidia and torch.cuda.is_available()),
+    reason="trtllm MNNVL routing is NVIDIA/CUDA only",
+)
+
+WORLD = 8
+HIDDEN = 7168
+DTYPE = torch.bfloat16
+
+
+class _FakeUpstreamWorkspace:
+    """Stands in for flashinfer's MNNVLAllReduceFusionWorkspace: only the
+    attributes the wrapper reads, with an always-sufficient buffer."""
+
+    rank = 0
+    tp_size = WORLD
+    buffer_size_bytes = 1 << 62
+
+    def is_buffer_size_sufficient(self, tp_size, num_tokens, hidden_dim, dtype):
+        return True
+
+
+def _fi_wrapper(max_token_num: int = 2048):
+    from tokenspeed_kernel.thirdparty.cuda.trtllm import (
+        FlashinferMnnvlAllReduceFusionWorkspace,
+    )
+
+    return FlashinferMnnvlAllReduceFusionWorkspace(
+        _FakeUpstreamWorkspace(), max_token_num
+    )
+
+
+def test_fi_supports_generic_patterns_only():
+    from tokenspeed_kernel.thirdparty.cuda.trtllm import AllReduceFusionPattern as P
+
+    ws = _fi_wrapper()
+    assert ws.supports(16, HIDDEN, DTYPE, WORLD, P.kAllReduce)
+    assert ws.supports(16, HIDDEN, DTYPE, WORLD, P.kARResidualRMSNorm)
+    # K3-specific epilogues stay on the private kernel.
+    assert not ws.supports(16, HIDDEN, DTYPE, WORLD, P.kARResidualAttnResCombine)
+    assert not ws.supports(16, HIDDEN + 3584, DTYPE, WORLD, P.kAllReduceLatentNorm)
+    # Quant/partial epilogues have no mnnvl home at all.
+    assert not ws.supports(
+        16, HIDDEN, DTYPE, WORLD, P.kARResidualRMSNormFP8BlockWiseQuant
+    )
+
+
+def test_fi_supports_shape_gates():
+    from tokenspeed_kernel.thirdparty.cuda.trtllm import AllReduceFusionPattern as P
+
+    ws = _fi_wrapper(max_token_num=2048)
+    assert not ws.supports(0, HIDDEN, DTYPE, WORLD, P.kAllReduce)
+    assert not ws.supports(16, HIDDEN, torch.float32, WORLD, P.kAllReduce)
+    assert not ws.supports(16, HIDDEN, DTYPE, WORLD - 4, P.kAllReduce)
+    assert not ws.supports(
+        16, HIDDEN, DTYPE, WORLD, P.kAllReduce, residual_reduce_scattered=True
+    )
+    # Capacity is judged by the actual buffer bytes, not the creation-time
+    # max_token_num (the multicast allocation granularity dwarfs any request,
+    # so one workspace serves every caller of its group).
+    ws.workspace.is_buffer_size_sufficient = (
+        lambda tp_size, num_tokens, hidden_dim, dtype: False
+    )
+    assert not ws.supports(16, HIDDEN, DTYPE, WORLD, P.kAllReduce)
+
+
+def test_routing_token_threshold_between_mnnvl_workspaces(monkeypatch):
+    """Single-node: decode-sized generic calls stay private, mid-M generic
+    calls go to fi, K3 epilogues stay private, IPC takes latent-norm and
+    large payloads. Each mnnvl workspace is the other's shape fallback."""
+    import tokenspeed_kernel.ops.communication.trtllm as trtllm_mod
+    from tokenspeed_kernel.thirdparty.cuda.trtllm import AllReduceFusionPattern as P
+
+    class _FakePrivate:
+        backend = "mnnvl"
+
+        def __init__(self, ok=True):
+            self.ok = ok
+
+        def supports(self, *args, **kwargs):
+            return self.ok
+
+    fi = _fi_wrapper()
+    priv = _FakePrivate()
+    ipc = torch.empty(1, dtype=torch.int64)
+    mgr = trtllm_mod._workspace_manager
+    monkeypatch.setattr(mgr, "mnnvl_fi_workspace", fi)
+    monkeypatch.setattr(mgr, "mnnvl_workspace", priv)
+    monkeypatch.setattr(mgr, "workspace_tensor", ipc)
+    monkeypatch.setattr(mgr, "world_size", WORLD)
+
+    route = trtllm_mod._ar_fusion_workspace
+    small = trtllm_mod.MNNVL_FLASHINFER_MIN_TOKENS - 1
+    mid = trtllm_mod.MNNVL_FLASHINFER_MIN_TOKENS
+    big = trtllm_mod.MNNVL_PREFER_IPC_BYTES // (HIDDEN * DTYPE.itemsize) + 8
+
+    assert route(small, HIDDEN, DTYPE, P.kAllReduce, True) is priv
+    assert route(mid, HIDDEN, DTYPE, P.kAllReduce, True) is fi
+    assert route(mid, HIDDEN, DTYPE, P.kARResidualRMSNorm, True) is fi
+    assert route(small, HIDDEN, DTYPE, P.kARResidualAttnResCombine, True) is priv
+    assert route(mid, HIDDEN, DTYPE, P.kARResidualAttnResCombine, True) is priv
+    assert route(small, HIDDEN + 3584, DTYPE, P.kAllReduceLatentNorm, True) is ipc
+    assert route(big, HIDDEN, DTYPE, P.kARResidualRMSNorm, True) is ipc
+    # Shape fallback: private rejects a small generic call -> fi takes it.
+    monkeypatch.setattr(mgr, "mnnvl_workspace", _FakePrivate(ok=False))
+    assert route(small, HIDDEN, DTYPE, P.kAllReduce, True) is fi
+
+
+def test_routing_cross_node_without_fi_falls_back_to_private(monkeypatch):
+    """No IPC (cross-node) and no fi (old flashinfer): the private kernel must
+    keep serving the generic patterns as before."""
+    import tokenspeed_kernel.ops.communication.trtllm as trtllm_mod
+    from tokenspeed_kernel.thirdparty.cuda.trtllm import AllReduceFusionPattern as P
+
+    class _FakePrivate:
+        backend = "mnnvl"
+
+        def supports(self, *args, **kwargs):
+            return True
+
+    priv = _FakePrivate()
+    mgr = trtllm_mod._workspace_manager
+    monkeypatch.setattr(mgr, "mnnvl_fi_workspace", None)
+    monkeypatch.setattr(mgr, "mnnvl_workspace", priv)
+    monkeypatch.setattr(mgr, "workspace_tensor", None)
+    monkeypatch.setattr(mgr, "world_size", WORLD)
+
+    route = trtllm_mod._ar_fusion_workspace
+    assert route(16, HIDDEN, DTYPE, P.kAllReduce, True) is priv
+    assert route(16, HIDDEN, DTYPE, P.kARResidualRMSNorm, True) is priv
+    # With fi armed, cross-node prefers it at every M (no IPC, no in-situ
+    # small-M data; fi wins everywhere measured).
+    monkeypatch.setattr(mgr, "mnnvl_fi_workspace", _fi_wrapper())
+    assert route(16, HIDDEN, DTYPE, P.kAllReduce, True) is mgr.mnnvl_fi_workspace


### PR DESCRIPTION
## Summary

Replaces the private MNNVL AR kernel with flashinfer upstream `trtllm_mnnvl_ar` for the two generic fusion patterns (`kAllReduce`, `kARResidualRMSNorm`), keeping the private kernel only for the K3-specific epilogues upstream does not implement (`kARResidualAttnResCombine`, `kAllReduceLatentNorm`).

### Routing (single node, hidden 7168, per-pattern)

| M range | generic AR / AR+RMSNorm | K3 epilogues |
|---|---|---|
| < 32 (decode) | private mnnvl (unchanged) | private / IPC |
| 32 – IPC crossover (~877) | **flashinfer** (1.8–3.2x at M=64–128) | private / IPC |
| above (to 2048) | IPC lamport (unchanged) | IPC |
| **cross-node** | **flashinfer, full range** (1.5–2.1x) | private mnnvl |

Threshold is `MNNVL_FLASHINFER_MIN_TOKENS` (default 32, env-overridable). Each mnnvl workspace is the other's shape fallback.

### Why not a full swap

Isolated graph-replay favors flashinfer at every M, but in-situ (nsys over steady decode, 8x B300 TP8) the two are wait-inclusive equals at decode M, and flashinfer's multicast traffic slows overlapped neighbor kernels (~+75 us GPU / +30 us wall per step → +0.27% TPOT). With the threshold, decode runs the exact same kernel stream as before.

### Memory

One multicast allocation per process group, shared across all arming sites via a group-keyed cache (McastGPUBuffer granularity is 512 MB regardless of requested size; per-site copies measured 2 GB/rank). `supports()` judges capacity by actual buffer bytes.

### Validation

- 8-rank numerics: both swapped patterns match NCCL+torch reference at bf16-rounding level, M=1..2048
- private kernel suite: 20 tests x 8 ranks unaffected; +8 new routing unit tests
- e2e (K3 TP8, differential TPOT, 9 trials): 10.794 ms vs 10.779 ms same-day baseline (noise band)
- sentinel-guarded imports: flashinfer 0.6.16 (current pin) verified to carry the full API; older installs keep the private path

### Not in this PR

The private `.cuh` stays: the two K3 epilogues have no upstream home. Upstreaming them (or a prefix-norm/custom-epilogue interface) would allow full retirement. Cross-node numbers are from single-node standalone benchmarks; true multi-node validation pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)