### PR TITLE
fix(layers): pass a 0-token batch through SiluAndMul without a launch

### DIFF
--- a/python/tokenspeed/runtime/layers/activation.py
+++ b/python/tokenspeed/runtime/layers/activation.py
@@ -52,6 +52,29 @@ logger = get_colorful_logger(__name__)
 class SiluAndMul(torch.nn.Module):
 
     def forward(self, x: torch.Tensor, fp8_out: bool = False) -> torch.Tensor:
+        # A DP rank's idle forward (ForwardMode.IDLE) runs the model over a
+        # 0-token batch to stay in the group's collectives. The activation
+        # kernels cannot launch over 0 rows (flashinfer's silu_and_mul dies
+        # with cudaErrorInvalidValue on an empty grid), and an empty input
+        # fully determines the output — return it without launching.
+        if x.shape[-2] == 0:
+            d = x.shape[-1] // 2
+            out = torch.empty(
+                x.shape[:-1] + (d,),
+                dtype=torch.float8_e4m3fn if fp8_out else x.dtype,
+                device=x.device,
+            )
+            if fp8_out:
+                # Same 0-row shape the fused path's TMA-aligned scale
+                # collapses to: (rows=0, d // 128).
+                scale = torch.empty(
+                    x.shape[:-2] + (0, d // 128),
+                    device=x.device,
+                    dtype=torch.float32,
+                )
+                return out, scale
+            return out
+
         if not _is_amd:
 
             def get_tma_aligned_scale(x):

--- a/test/runtime/layers/test_activation_empty_batch.py
+++ b/test/runtime/layers/test_activation_empty_batch.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""A DP rank's idle forward runs the model over a 0-token batch; the gated
+activations must pass it through instead of launching a kernel over an empty
+grid (flashinfer's silu_and_mul fails the launch with cudaErrorInvalidValue,
+killing the scheduler mid-lockstep)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.layers.activation import SiluAndMul
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="SiluAndMul kernels need CUDA"
+)
+
+
+def test_silu_and_mul_passes_through_empty_batch():
+    layer = SiluAndMul()
+    x = torch.empty(0, 512, dtype=torch.bfloat16, device="cuda")
+    out = layer(x)
+    assert out.shape == (0, 256)
+    assert out.dtype == x.dtype
+    assert out.device == x.device
+
+
+def test_silu_and_mul_fp8_passes_through_empty_batch():
+    layer = SiluAndMul()
+    x = torch.empty(0, 512, dtype=torch.bfloat16, device="cuda")
+    out, scale = layer(x, fp8_out=True)
+    assert out.shape == (0, 256)
+    assert out.dtype == torch.float8_e4m3fn
+    # Mirrors the fused path's TMA-aligned scale collapsed to zero rows.
+    assert scale.shape == (0, 256 // 128)
+    assert scale.dtype == torch.float32
+
+
+def test_silu_and_mul_nonempty_still_computes():
+    # The guard must not change the computed path: check a 1-token batch
+    # against the eager reference.
+    layer = SiluAndMul()
+    x = torch.randn(1, 512, dtype=torch.bfloat16, device="cuda")
+    out = layer(x)
+    gate, up = x.chunk(2, dim=-1)
+    expected = torch.nn.functional.silu(gate) * up
+    torch.testing.assert_close(out, expected, rtol=2e-2, atol=2e-2)


### PR DESCRIPTION
## Problem

A DP rank's idle forward (`ForwardMode.IDLE`) runs the model over a 0-token batch so the rank stays in the group's collectives. Any model whose MLP uses the fused `SiluAndMul` then launches flashinfer's `silu_and_mul` over an empty grid, and the launch itself fails:

```
RuntimeError: Check failed: (err == cudaSuccess) is false: Failed to launch kernel: invalid argument
```

killing the scheduler mid-lockstep; the sibling rank then dies on the broken collective (gloo "connection closed by peer"). Reproduced deterministically with Qwen3-4B at `dp=2` under an external ZMQ frontend on H100 — four out of four group starts died at the first idle forward. Llama passes only because its path never enters this kernel with zero rows.

## Solution

An empty input fully determines the output, so `SiluAndMul.forward` returns the empty output (and, for `fp8_out`, the zero-row TMA-aligned scale the fused path would collapse to) before any kernel launch. The non-empty path is unchanged.

## Tests

- `test_silu_and_mul_passes_through_empty_batch` / `..._fp8_...`: empty-batch passthrough for both forms — shape, dtype, device, and the scale shape mirroring the fused path's zero-row collapse. Both pass on GB300.
- `test_silu_and_mul_nonempty_still_computes`: a 1-token batch against the eager reference, guarding that the guard did not disturb the computed path.
