### PR TITLE
feat(spec): frontier-anchored multi-layered MTP

### DIFF
--- a/python/tokenspeed/runtime/configs/inkling_config.py
+++ b/python/tokenspeed/runtime/configs/inkling_config.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 
 import copy
 import enum
-import os
 from typing import Any, Literal
 
 from transformers.configuration_utils import PretrainedConfig
@@ -174,22 +173,6 @@ def inkling_conv_total_dim(config: "InklingModelConfig", attn_tp_size: int) -> i
     layout = inkling_conv_stream_layout(config, attn_tp_size)
     last_offset, last_dim = layout[InklingConvStream.MLP]
     return last_offset + last_dim
-
-
-def inkling_mtp_decode_lookback_mode() -> int:
-    """Parse the ``INKLING_MTP_DECODE_LOOKBACK`` MTP decode-window A/B knob.
-
-    Returns:
-        0: verify-anchored window only — stale per-depth KV/sconv entries
-           from rejected drafts are never repaired.
-        1: verify-anchored window plus steps-1 lookback repair rows.
-        2: frontier-anchored window (default) — the k rows end at the last
-           committed position, repairing in place with zero garbage rows.
-    """
-    mode = int(os.environ.get("INKLING_MTP_DECODE_LOOKBACK", "2"))
-    if mode not in (0, 1, 2):
-        raise ValueError(f"INKLING_MTP_DECODE_LOOKBACK must be 0, 1 or 2, got {mode}")
-    return mode
 
 
 class InklingModelConfig(PretrainedConfig):

--- a/python/tokenspeed/runtime/configs/inkling_config.py
+++ b/python/tokenspeed/runtime/configs/inkling_config.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import copy
 import enum
+import os
 from typing import Any, Literal
 
 from transformers.configuration_utils import PretrainedConfig
@@ -173,6 +174,22 @@ def inkling_conv_total_dim(config: "InklingModelConfig", attn_tp_size: int) -> i
     layout = inkling_conv_stream_layout(config, attn_tp_size)
     last_offset, last_dim = layout[InklingConvStream.MLP]
     return last_offset + last_dim
+
+
+def inkling_mtp_decode_lookback_mode() -> int:
+    """Parse the ``INKLING_MTP_DECODE_LOOKBACK`` MTP decode-window A/B knob.
+
+    Returns:
+        0: verify-anchored window only — stale per-depth KV/sconv entries
+           from rejected drafts are never repaired.
+        1: verify-anchored window plus steps-1 lookback repair rows.
+        2: frontier-anchored window (default) — the k rows end at the last
+           committed position, repairing in place with zero garbage rows.
+    """
+    mode = int(os.environ.get("INKLING_MTP_DECODE_LOOKBACK", "2"))
+    if mode not in (0, 1, 2):
+        raise ValueError(f"INKLING_MTP_DECODE_LOOKBACK must be 0, 1 or 2, got {mode}")
+    return mode
 
 
 class InklingModelConfig(PretrainedConfig):

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -864,10 +864,9 @@ class DFlash(BaseDrafter):
                 - 1
                 + num_extends
             )
-            safe_accept_lengths = (
-                accept_lengths[num_extends:].to(torch.int64).clamp(1, spec_num_tokens)
-            )
-            current[num_extends:] = output_tokens[offsets + safe_accept_lengths]
+            current[num_extends:] = output_tokens[
+                offsets + accept_lengths[num_extends:]
+            ]
         return current
 
     def get_candidates(self, base_ctx: ForwardContext) -> torch.Tensor | None:

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -140,30 +140,6 @@ class Eagle(BaseDrafter):
             getattr(hf_config, "index_share_for_mtp_iteration", False)
         )
 
-    def _accepted_output_indices(
-        self,
-        accept_lengths: torch.Tensor,
-        row_count: int,
-        *,
-        base_offset: int = 0,
-    ) -> torch.Tensor:
-        """Return safe flat output-token indices for each decode request.
-
-        ``accept_lengths`` is the number of tokens that may be committed.  When
-        the context-length cap reduces a row to 0 there is no real newly
-        committed output token, but the drafter still runs to preserve graph
-        shape.  Use the row's first verify output as a valid dummy source rather
-        than producing ``row * N - 1``.
-        """
-        safe_accept_lengths = (
-            accept_lengths[:row_count].to(torch.int64).clamp(1, self.spec_num_tokens)
-        )
-        return (
-            self.padded_gather_ids_offsets_buf[:row_count]
-            + safe_accept_lengths
-            + base_offset
-        )
-
     def set_mm_pad_substitute_id(self, token_id: int) -> None:
         """Legacy one-token substitution used by single-modality callers."""
         self.set_mm_pad_substitute_ids({modality: token_id for modality in Modality})
@@ -255,18 +231,15 @@ class Eagle(BaseDrafter):
                 gather_ids = torch.cat(
                     [
                         gather_ids,
-                        self._accepted_output_indices(
-                            draft_input.accept_lengths[num_extends:],
-                            num_decodes,
-                            base_offset=num_prefill_tokens,
-                        ),
+                        self.padded_gather_ids_offsets_buf[:num_decodes]
+                        + draft_input.accept_lengths[num_extends:]
+                        + num_prefill_tokens,
                     ]
                 )
         else:
             input_ids = draft_input.base_model_output
-            gather_ids = self._accepted_output_indices(
-                draft_input.accept_lengths,
-                bs,
+            gather_ids = (
+                self.padded_gather_ids_offsets_buf[:bs] + draft_input.accept_lengths
             )
 
         return input_ids, gather_ids
@@ -474,9 +447,9 @@ class Eagle(BaseDrafter):
         if num_extends > 0:
             next_tokens[:num_extends, 0] = draft_input.base_model_output[:num_extends]
         if num_decodes > 0:
-            indices = self._accepted_output_indices(
-                draft_input.accept_lengths[num_extends:],
-                num_decodes,
+            indices = (
+                self.padded_gather_ids_offsets_buf[:num_decodes]
+                + draft_input.accept_lengths[num_extends:]
             )
             if num_extends > 0:
                 indices.add_(num_extends)

--- a/python/tokenspeed/runtime/execution/drafter/eagle.py
+++ b/python/tokenspeed/runtime/execution/drafter/eagle.py
@@ -33,7 +33,6 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
-from tokenspeed.runtime.multimodal.inputs import Modality, maybe_substitute_mm_pad
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 
 DsaTopKState = tuple[Any | None, Any | None]
@@ -133,36 +132,10 @@ class Eagle(BaseDrafter):
             - 1
         )
 
-        # VLM placeholder ids plumbed by ModelExecutor; empty for text-only targets.
-        self.mm_pad_substitute_ids: dict[Modality, int] = {}
         hf_config = getattr(draft_model_runner.model_config, "hf_config", None)
         self._dsa_reuse_mtp_topk = bool(
             getattr(hf_config, "index_share_for_mtp_iteration", False)
         )
-
-    def set_mm_pad_substitute_id(self, token_id: int) -> None:
-        """Legacy one-token substitution used by single-modality callers."""
-        self.set_mm_pad_substitute_ids({modality: token_id for modality in Modality})
-
-    def set_mm_pad_substitute_ids(self, substitute_ids: dict[Modality, int]) -> None:
-        if self.vocab_size is None:
-            raise ValueError("MM draft substitution requires a known vocabulary size")
-        invalid = {
-            modality: token_id
-            for modality, token_id in substitute_ids.items()
-            if token_id < 0 or token_id >= self.vocab_size
-        }
-        if invalid:
-            raise ValueError(
-                "MM draft substitute token IDs must be inside the target vocabulary: "
-                f"{invalid} (vocab_size={self.vocab_size})"
-            )
-        self.mm_pad_substitute_ids = dict(substitute_ids)
-
-    def _prepare_draft_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        """Restore tagged media pads, then guard the draft embedding lookup."""
-        input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_ids)
-        return input_ids.clamp(0, self.vocab_size - 1)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -257,7 +230,6 @@ class Eagle(BaseDrafter):
         input_ids, gather_ids = self._get_first_step_input(
             draft_input, bs, draft_input.input_num_tokens
         )
-        input_ids = self._prepare_draft_input_ids(input_ids)
         draft_model = self.draft_model_runner.model
         input_num_tokens = draft_input.input_num_tokens
 

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -47,7 +47,6 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
-from tokenspeed.runtime.multimodal.inputs import Modality, maybe_substitute_mm_pad
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 
 if TYPE_CHECKING:
@@ -57,42 +56,6 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
     from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
-
-
-def _decode_shifted_ids(
-    v: torch.Tensor,
-    accept: torch.Tensor,
-    next_tokens: torch.Tensor,
-    depth: int,
-    src: torch.Tensor,
-) -> torch.Tensor:
-    """Depth-``depth`` input ids over a decode verify window.
-
-    Row ``j`` consumes the token at source position ``p_j + depth``; in
-    verify-output coordinates that is ``src[j]``: ``src < accept`` reads
-    this round's verify output ``v[:, src]``, else the round's own draft
-    ``d_m`` (m = src - accept + 1 <= depth) from ``next_tokens`` columns
-    1..depth. Negative ``src`` rows come out as ``v[:, 0]``; the caller
-    overlays them from its stash (see ``_frontier_shifted_ids``).
-
-    Args:
-        v: [bs, k] verify outputs.
-        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
-        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
-            this round's drafts.
-        depth: draft depth d >= 1.
-        src: [1, n] (or [bs, n]) int64 source coordinates.
-
-    Returns:
-        [bs, n] input ids.
-    """
-    bs, k = v.shape
-    n = src.shape[-1]
-    from_verify = torch.gather(v, 1, src.clamp(0, k - 1).expand(bs, n))
-    drafts = next_tokens[:, 1 : depth + 1]
-    m = (src - accept).clamp_min(0)  # draft index - 1; never exceeds depth - 1
-    from_draft = torch.gather(drafts, 1, m.expand(bs, n))
-    return torch.where(src < accept, from_verify, from_draft)
 
 
 def _extend_depth_precompute(
@@ -162,43 +125,34 @@ def _extend_depth_shifted_ids_from(
 def _frontier_shifted_ids(
     v: torch.Tensor,
     accept: torch.Tensor,
-    next_tokens: torch.Tensor,
     stash_tokens: torch.Tensor,
-    depth: int,
 ) -> torch.Tensor:
-    """Depth-``depth`` input ids over a frontier-anchored decode window.
+    """Depth-0 input ids over a frontier-anchored decode window.
 
     The window's k rows end at the last committed position: row ``j`` sits
     at source position ``frontier - k + j`` (frontier = vc + accept) and
-    consumes the token at source + depth + 1; in verify-output coordinates
-    that is ``src = accept - k + depth + j`` — per-request, unlike the
-    verify-anchored windows' static shifts. ``src < 0`` reads the stash of
-    the last k-1 committed tokens (entry ``src + k - 1``), ``src < accept``
-    this round's verify output ``v[src]``, else this round's own draft
-    ``d_m`` (m = src - accept + 1 <= depth) — every row holds a committed
-    token or a fresh draft, never garbage. Depth 0 never reaches past the
-    accepted prefix (``src <= accept - 1``).
+    consumes the token one past it; in verify-output coordinates that is
+    ``src = accept - k + j`` — per-request, unlike the verify-anchored
+    windows' static shifts. ``src < 0`` reads the stash of the last k-1
+    committed tokens (entry ``src + k - 1``), else this round's verify
+    output ``v[src]`` — depth 0 never reaches past the accepted prefix
+    (``src <= accept - 1``). Deeper depths need no re-splice: they are
+    static slices of [window || drafts], built by the caller.
 
     Args:
         v: [bs, k] verify outputs (token at position vc+j+1 = v[:, j]);
             entries at or past ``accept`` are never read.
-        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
-        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
-            this round's drafts.
+        accept: [bs, 1] accepted lengths in [1, k].
         stash_tokens: [bs, k-1] committed tokens at positions
             vc-k+2 .. vc.
-        depth: draft depth d >= 0.
 
     Returns:
         [bs * k] input ids.
     """
     bs, k = v.shape
     col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
-    src = accept - k + depth + col
-    if depth == 0:
-        ids = torch.gather(v, 1, src.clamp_min(0))
-    else:
-        ids = _decode_shifted_ids(v, accept, next_tokens, depth, src=src)
+    src = accept - k + col
+    ids = torch.gather(v, 1, src.clamp_min(0))
     from_stash = stash_tokens.gather(1, (src + k - 1).clamp_max(k - 2))
     return torch.where(src < 0, from_stash, ids).reshape(-1)
 
@@ -222,7 +176,7 @@ def _frontier_hidden_splice(
         fresh_hidden: [bs, k, H] this round's verify hiddens (row j = the
             hidden at position vc+j); rows at or past ``accept`` are never
             read.
-        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
+        accept: [bs, 1] accepted lengths in [1, k].
 
     Returns:
         [bs * k, H] chain hidden rows for the depth-0 pass.
@@ -232,37 +186,6 @@ def _frontier_hidden_splice(
     col = torch.arange(k, dtype=torch.int64, device=h.device).view(1, k)
     idx = (accept - 1 + col).view(bs, k, 1).expand(bs, k, h.shape[-1])
     return h.gather(1, idx).reshape(bs * k, -1)
-
-
-def _committed_tail_update(
-    stash: torch.Tensor,
-    fresh: torch.Tensor,
-    valid: torch.Tensor,
-    width: int,
-) -> torch.Tensor:
-    """Roll a committed-tail stash: last ``width`` of [stash || fresh[:valid]].
-
-    ``stash``: [bs, width, ...] previous tail; ``fresh``: [bs, k, ...]
-    this round's per-row values whose committed prefix is the first
-    ``valid`` rows (``fresh`` row 0 must directly follow the stash's last
-    entry); ``valid``: [bs] int64 in [1, k].
-
-    Returns:
-        The updated [bs, width, ...] tail.
-    """
-    bs = fresh.shape[0]
-    rows = (
-        valid.view(bs, 1)
-        - width
-        + torch.arange(width, dtype=torch.int64, device=fresh.device).view(1, width)
-    )
-    idx_shape = (bs, width) + (1,) * (fresh.dim() - 2)
-    expand = (bs, width) + fresh.shape[2:]
-    new_rows = fresh.gather(1, rows.clamp_min(0).view(idx_shape).expand(expand))
-    old_rows = stash.gather(
-        1, (rows + width).clamp_max(width - 1).view(idx_shape).expand(expand)
-    )
-    return torch.where((rows >= 0).view(idx_shape), new_rows, old_rows)
 
 
 def _ragged_tail_rows(
@@ -375,11 +298,6 @@ class Mtp(BaseDrafter):
             - 1
         )
 
-        # In-vocab media tokens plumbed by ModelExecutor. The content-derived
-        # prefix-cache pad IDs retain a modality tag and are restored here before
-        # the text-only speculative draft performs its embedding lookup.
-        self.mm_pad_substitute_ids: dict[Modality, int] = {}
-
         # Multi-depth drafting has no DP support: idle rounds (a DP rank
         # keeping collectives in sync with no work of its own) have no
         # window to run.
@@ -410,26 +328,6 @@ class Mtp(BaseDrafter):
             device=self.device,
         )
 
-    def set_mm_pad_substitute_ids(self, substitute_ids: dict[Modality, int]) -> None:
-        if self.vocab_size is None:
-            raise ValueError("MM draft substitution requires a known vocabulary size")
-        invalid = {
-            modality: token_id
-            for modality, token_id in substitute_ids.items()
-            if token_id < 0 or token_id >= self.vocab_size
-        }
-        if invalid:
-            raise ValueError(
-                "MM draft substitute token IDs must be inside the target vocabulary: "
-                f"{invalid} (vocab_size={self.vocab_size})"
-            )
-        self.mm_pad_substitute_ids = dict(substitute_ids)
-
-    def _prepare_draft_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        """Restore tagged media pads, then guard the draft embedding lookup."""
-        input_ids = maybe_substitute_mm_pad(input_ids, self.mm_pad_substitute_ids)
-        return input_ids.clamp(0, self.vocab_size - 1)
-
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -441,15 +339,12 @@ class Mtp(BaseDrafter):
             return logits_output.next_token_ids
         return sampling_argmax(logits_output.next_token_logits)
 
-    @nvtx_range("run_frontier_window", color="purple")
-    def _run_frontier_window(
+    @nvtx_range("run_decode_depths", color="purple")
+    def _run_decode_depths(
         self,
         bs: int,
         next_tokens: torch.Tensor,
         draft_input: MtpDraftInput,
-        slot: torch.Tensor,
-        v: torch.Tensor,
-        accept: torch.Tensor,
     ) -> None:
         """Frontier-anchored decode window: every depth 0..steps-1 runs the
         SAME k rows per request, ending at the last committed position
@@ -478,6 +373,9 @@ class Mtp(BaseDrafter):
         """
         k = self.spec_num_tokens
         buffers = self.input_buffers
+        slot = buffers.req_pool_indices_buf[:bs]
+        v = draft_input.base_model_output.view(bs, k)
+        accept = draft_input.accept_lengths[:bs].view(bs, 1)
         positions = buffers.positions_buf[: bs * k].view(bs, k)
         # positions[:, 0] is vc, the position before the verify window.
         frontier = (positions[:, 0] + accept.view(-1).to(positions.dtype)).to(
@@ -496,16 +394,27 @@ class Mtp(BaseDrafter):
         # Static sample gather: the last window row sits at frontier-1 for
         # every depth (row at position p and depth d predicts p + d + 2).
         gather_ids = self.padded_gather_ids_offsets_buf[:bs] + k
-        stash_tokens = self._stash_tokens_buf[slot]
-        prev_hidden = _frontier_hidden_splice(
+        # Depth-0 window = the last k committed (token, hidden) pairs; its
+        # tail [:, 1:] is exactly the next round's stash, rolled at the end.
+        # Depth d+1's ids roll the window one left, appending depth d's
+        # draft: only depth 0 is accept-dependent.
+        window_ids = _frontier_shifted_ids(
+            v, accept, self._stash_tokens_buf[slot]
+        ).view(bs, k)
+        spliced_hidden = _frontier_hidden_splice(
             self._stash_hidden_buf[slot],
             draft_input.base_out_hidden_states.view(bs, k, -1),
             accept,
         )
         for d in range(self.spec_num_steps):
-            input_ids = self._prepare_draft_input_ids(
-                _frontier_shifted_ids(v, accept, next_tokens, stash_tokens, d)
-            )
+            if d == 0:
+                input_ids = window_ids
+                prev_hidden = spliced_hidden
+            else:
+                input_ids = torch.cat(
+                    [input_ids[:, 1:], next_tokens[:, d : d + 1]], dim=1
+                )
+                prev_hidden = logits_output.hidden_states
 
             ctx = ForwardContext(
                 bs=bs,
@@ -525,51 +434,18 @@ class Mtp(BaseDrafter):
             with nvtx_range("draft_frontier_forward", color="red"):
                 logits_output = self.draft_model_runner.forward(
                     ctx=ctx,
-                    input_ids=input_ids,
+                    input_ids=input_ids.view(-1),
                     positions=step_positions,
                     out_cache_loc=out_cache_loc,
                     captured_hidden_states=prev_hidden,
                     spec_step_idx=d,
                 )
-            prev_hidden = logits_output.hidden_states
 
             with nvtx_range("draft_sample", color="yellow"):
                 next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
 
-    def _decode_slices(
-        self, bs: int, draft_input: MtpDraftInput
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """``(slot, v, accept)`` shared by the frontier window pass and the
-        decode stash roll: [bs] int64 stash slots, [bs, k] int64 verify
-        outputs, [bs, 1] int64 accepted lengths clamped to [1, k]."""
-        k = self.spec_num_tokens
-        slot = self.input_buffers.req_pool_indices_buf[:bs]
-        v = draft_input.base_model_output.view(bs, k)
-        accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
-        return slot, v, accept
-
-    def _update_stash_decode(
-        self,
-        slot: torch.Tensor,
-        accept: torch.Tensor,
-        v: torch.Tensor,
-        hidden_rows: torch.Tensor,
-    ) -> None:
-        """Roll the cross-round drafter stash past a round's decode-row
-        commits.
-
-        Args come pre-sliced per decode row: ``slot`` [n] int64 stash slots,
-        ``accept`` [n]-viewable int64 accepts clamped to [1, k], ``v`` [n, k]
-        int64 verify outputs, ``hidden_rows`` [n, k, H] this round's target
-        verify hiddens (verify hidden row j sits one position behind verify
-        token j, which is why the hidden stash ends one position before the
-        token stash).
-        """
-        width = self._stash_width
-        tokens = self._stash_tokens_buf
-        tokens[slot] = _committed_tail_update(tokens[slot], v, accept, width)
-        hidden = self._stash_hidden_buf
-        hidden[slot] = _committed_tail_update(hidden[slot], hidden_rows, accept, width)
+        self._stash_tokens_buf[slot] = window_ids[:, 1:]
+        self._stash_hidden_buf[slot] = spliced_hidden.view(bs, k, -1)[:, 1:]
 
     def _update_stash_extend(self, draft_input: MtpDraftInput) -> None:
         """Roll the stash across an EXTEND round's chunk rows: the last
@@ -657,7 +533,6 @@ class Mtp(BaseDrafter):
                 if d == 0
                 else _extend_depth_shifted_ids_from(extend_pre, next_tokens, d)
             )
-            step_ids = self._prepare_draft_input_ids(step_ids)
 
             ctx = ForwardContext(
                 bs=bs,
@@ -719,7 +594,12 @@ class Mtp(BaseDrafter):
             device=self.device,
         )
 
-        if draft_input.num_extends == 0:
+        if draft_input.num_extends > 0:
+            # EXTEND round (MIXED batches are rejected at the backend's metadata
+            # init): every depth runs the prompt chunk's ragged rows.
+            next_tokens[:, 0] = draft_input.base_model_output[:bs]
+            self._run_extend_depths(bs, next_tokens, draft_input)
+        else:
             # Pure-decode round: every depth (0 included) runs inside the
             # frontier window loop.
             indices = (
@@ -728,20 +608,8 @@ class Mtp(BaseDrafter):
             torch.index_select(
                 draft_input.base_model_output, 0, indices, out=next_tokens[:, 0]
             )
-            slot, v, accept = self._decode_slices(bs, draft_input)
-            self._run_frontier_window(bs, next_tokens, draft_input, slot, v, accept)
-            self._update_stash_decode(
-                slot,
-                accept,
-                v,
-                draft_input.base_out_hidden_states.view(bs, self.spec_num_tokens, -1),
-            )
-            return next_tokens
+            self._run_decode_depths(bs, next_tokens, draft_input)
 
-        # EXTEND round (MIXED batches are rejected at the backend's metadata
-        # init): every depth runs the prompt chunk's ragged rows.
-        next_tokens[:, 0] = draft_input.base_model_output[:bs]
-        self._run_extend_depths(bs, next_tokens, draft_input)
         return next_tokens
 
     @override

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -76,7 +76,7 @@ def _decode_shifted_ids(
     overlays them from its stash (see ``_frontier_shifted_ids``).
 
     Args:
-        v: [bs, k] int64 verify outputs.
+        v: [bs, k] verify outputs.
         accept: [bs, 1] int64 accepted lengths clamped to [1, k].
         next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
             this round's drafts.
@@ -84,13 +84,13 @@ def _decode_shifted_ids(
         src: [1, n] (or [bs, n]) int64 source coordinates.
 
     Returns:
-        [bs, n] int64 input ids.
+        [bs, n] input ids.
     """
     bs, k = v.shape
     n = src.shape[-1]
     from_verify = torch.gather(v, 1, src.clamp(0, k - 1).expand(bs, n))
-    drafts = next_tokens[:, 1 : depth + 1].to(torch.int64)
-    m = (src - accept).clamp(0, depth - 1)  # draft index - 1
+    drafts = next_tokens[:, 1 : depth + 1]
+    m = (src - accept).clamp_min(0)  # draft index - 1; never exceeds depth - 1
     from_draft = torch.gather(drafts, 1, m.expand(bs, n))
     return torch.where(src < accept, from_verify, from_draft)
 
@@ -107,7 +107,7 @@ def _extend_depth_precompute(
     computed it.
 
     Returns:
-        ``(shift1_i64, base, req_of_row, row_last)``: the int64 shift-1 ids,
+        ``(shift1_ids, base, req_of_row, row_last)``: the shift-1 ids,
         ``arange(num_rows)``, each row's request index, and the global index
         of each row's request-final row.
     """
@@ -117,10 +117,10 @@ def _extend_depth_precompute(
     if last_row is None:
         last_row = lengths.cumsum(0) - 1
     cu_seqlens = torch.nn.functional.pad(last_row + 1, (1, 0))
-    # Sync-free repeat_interleave(arange(ne), lengths) equivalent.
+    # Sync-free repeat_interleave(arange(num_extends), lengths) equivalent.
     req_of_row = seq_idx_from_cu_seqlens(cu_seqlens, num_rows).to(torch.int64)
     base = torch.arange(num_rows, dtype=torch.int64, device=device)
-    return shift1_ids.to(torch.int64), base, req_of_row, last_row[req_of_row]
+    return shift1_ids, base, req_of_row, last_row[req_of_row]
 
 
 def _extend_depth_shifted_ids_from(
@@ -148,14 +148,14 @@ def _extend_depth_shifted_ids_from(
         depth: draft depth d >= 1.
 
     Returns:
-        [num_prefill_rows] int64 input ids for the depth-``depth`` pass.
+        [num_prefill_rows] input ids for the depth-``depth`` pass.
     """
-    shift1_i64, base, req_of_row, row_last = pre
-    num_rows = shift1_i64.shape[0]
+    shift1_ids, base, req_of_row, row_last = pre
+    num_rows = shift1_ids.shape[0]
     src = base + depth
-    from_prompt = shift1_i64[src.clamp(max=num_rows - 1)]
-    overshoot = (src - row_last).clamp(1, depth)
-    from_draft = next_tokens.to(torch.int64)[req_of_row, overshoot]
+    from_prompt = shift1_ids[src.clamp(max=num_rows - 1)]
+    overshoot = (src - row_last).clamp_min(1)  # never exceeds depth
+    from_draft = next_tokens[req_of_row, overshoot]
     return torch.where(src <= row_last, from_prompt, from_draft)
 
 
@@ -180,26 +180,26 @@ def _frontier_shifted_ids(
     accepted prefix (``src <= accept - 1``).
 
     Args:
-        v: [bs, k] int64 verify outputs (token at position vc+j+1 = v[:, j]);
+        v: [bs, k] verify outputs (token at position vc+j+1 = v[:, j]);
             entries at or past ``accept`` are never read.
         accept: [bs, 1] int64 accepted lengths clamped to [1, k].
         next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
             this round's drafts.
-        stash_tokens: [bs, k-1] int64 committed tokens at positions
+        stash_tokens: [bs, k-1] committed tokens at positions
             vc-k+2 .. vc.
         depth: draft depth d >= 0.
 
     Returns:
-        [bs * k] int64 input ids.
+        [bs * k] input ids.
     """
     bs, k = v.shape
     col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
     src = accept - k + depth + col
     if depth == 0:
-        ids = torch.gather(v, 1, src.clamp(0, k - 1))
+        ids = torch.gather(v, 1, src.clamp_min(0))
     else:
         ids = _decode_shifted_ids(v, accept, next_tokens, depth, src=src)
-    from_stash = stash_tokens.gather(1, (src + k - 1).clamp(0, k - 2))
+    from_stash = stash_tokens.gather(1, (src + k - 1).clamp_max(k - 2))
     return torch.where(src < 0, from_stash, ids).reshape(-1)
 
 
@@ -260,7 +260,7 @@ def _committed_tail_update(
     expand = (bs, width) + fresh.shape[2:]
     new_rows = fresh.gather(1, rows.clamp_min(0).view(idx_shape).expand(expand))
     old_rows = stash.gather(
-        1, (rows + width).clamp(0, width - 1).view(idx_shape).expand(expand)
+        1, (rows + width).clamp_max(width - 1).view(idx_shape).expand(expand)
     )
     return torch.where((rows >= 0).view(idx_shape), new_rows, old_rows)
 
@@ -293,12 +293,12 @@ def _ragged_tail_rows(
         - width
         + torch.arange(width, dtype=torch.int64, device=flat.device).view(1, width)
     )
-    rows = (starts.view(n, 1) + offs.clamp_min(0)).clamp(max=max(flat.shape[0] - 1, 0))
+    rows = starts.view(n, 1) + offs.clamp_min(0)
     new_rows = flat[rows.reshape(-1)].reshape((n, width) + flat.shape[1:])
     idx_shape = (n, width) + (1,) * (old_tail.dim() - 2)
     expand = (n, width) + old_tail.shape[2:]
     old_rows = old_tail.gather(
-        1, (offs + width).clamp(0, width - 1).view(idx_shape).expand(expand)
+        1, (offs + width).clamp_max(width - 1).view(idx_shape).expand(expand)
     )
     return torch.where((offs >= 0).view(idx_shape), new_rows, old_rows)
 
@@ -389,11 +389,11 @@ class Mtp(BaseDrafter):
                 f"(dp_size={self.dp_size})"
             )
 
-        # Cross-round drafter stash keyed by req_pool_indices (PAD rows clamp
-        # to the reserved slot 0): the last k-1 committed tokens and the
-        # target hiddens one position behind them. Allocated eagerly — the
-        # decode rounds that fill it run inside CUDA graph capture, where
-        # allocation is off-limits.
+        # Cross-round drafter stash keyed by req_pool_indices (graph-padded
+        # rows arrive as the reserved slot 0): the last k-1 committed tokens
+        # and the target hiddens one position behind them. Allocated eagerly
+        # — the decode rounds that fill it run inside CUDA graph capture,
+        # where allocation is off-limits.
         self._stash_width = spec_num_tokens - 1
         model_config = draft_model_runner.model_config
         # page_table is batch-ordered and may have fewer rows than the
@@ -401,37 +401,13 @@ class Mtp(BaseDrafter):
         request_pool_rows = self.runtime_states.valid_cache_lengths.shape[0]
         self._stash_tokens_buf = torch.zeros(
             (request_pool_rows, self._stash_width),
-            dtype=torch.int64,
+            dtype=torch.int32,
             device=self.device,
         )
         self._stash_hidden_buf = torch.zeros(
             (request_pool_rows, self._stash_width, model_config.hidden_size),
             dtype=model_config.dtype,
             device=self.device,
-        )
-
-    def _accepted_output_indices(
-        self,
-        accept_lengths: torch.Tensor,
-        row_count: int,
-        *,
-        base_offset: int = 0,
-    ) -> torch.Tensor:
-        """Return safe flat output-token indices for each decode request.
-
-        ``accept_lengths`` is the number of tokens that may be committed.  When
-        the context-length cap reduces a row to 0 there is no real newly
-        committed output token, but the drafter still runs to preserve graph
-        shape.  Use the row's first verify output as a valid dummy source rather
-        than producing ``row * N - 1``.
-        """
-        safe_accept_lengths = (
-            accept_lengths[:row_count].to(torch.int64).clamp(1, self.spec_num_tokens)
-        )
-        return (
-            self.padded_gather_ids_offsets_buf[:row_count]
-            + safe_accept_lengths
-            + base_offset
         )
 
     def set_mm_pad_substitute_ids(self, substitute_ids: dict[Modality, int]) -> None:
@@ -465,114 +441,7 @@ class Mtp(BaseDrafter):
             return logits_output.next_token_ids
         return sampling_argmax(logits_output.next_token_logits)
 
-    def _get_first_step_input(
-        self,
-        draft_input: MtpDraftInput,
-        bs: int,
-        input_num_tokens: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Returns (input_ids, gather_ids) for the first draft step.
-
-        The first-step input shape matches the base model's: ragged
-        ``[prefill_part || decode_part]`` under MIXED, full prefill chunks
-        under EXTEND, ``base_model_output`` directly under DECODE.
-        """
-        num_extends = draft_input.num_extends
-        num_decodes = bs - num_extends
-        if num_extends > 0:
-            num_decode_tokens = num_decodes * self.spec_num_tokens
-            num_prefill_tokens = input_num_tokens - num_decode_tokens
-
-            input_ids = self.input_buffers.shifted_prefill_ids_buf[:input_num_tokens]
-            unpadded_input_lengths = self.input_buffers.input_lengths_buf[:bs]
-            if num_decodes > 0:
-                input_ids[num_prefill_tokens:].copy_(
-                    draft_input.base_model_output[num_extends:]
-                )
-                unpadded_input_lengths[num_extends:].copy_(
-                    draft_input.accept_lengths[num_extends:]
-                )
-
-            last_indices = unpadded_input_lengths[:num_extends].cumsum(0) - 1
-            last_input_ids = input_ids[last_indices]
-            input_ids[last_indices] = torch.where(
-                last_input_ids == -1,
-                draft_input.base_model_output[:num_extends],
-                last_input_ids,
-            )
-
-            gather_ids = last_indices
-            if num_decodes > 0:
-                gather_ids = torch.cat(
-                    [
-                        gather_ids,
-                        self._accepted_output_indices(
-                            draft_input.accept_lengths[num_extends:],
-                            num_decodes,
-                            base_offset=num_prefill_tokens,
-                        ),
-                    ]
-                )
-        else:
-            input_ids = draft_input.base_model_output
-            gather_ids = self._accepted_output_indices(
-                draft_input.accept_lengths,
-                bs,
-            )
-
-        return input_ids, gather_ids
-
-    @nvtx_range("draft_first_step", color="purple")
-    def _run_first_step(
-        self,
-        bs: int,
-        draft_input: MtpDraftInput,
-    ) -> LogitsProcessorOutput:
-
-        buffers = self.input_buffers
-        forward_mode = draft_input.forward_mode
-
-        input_ids, gather_ids = self._get_first_step_input(
-            draft_input, bs, draft_input.input_num_tokens
-        )
-        input_ids = self._prepare_draft_input_ids(input_ids)
-        input_num_tokens = draft_input.input_num_tokens
-
-        # Multi-depth window mode and extend catch-up chain FULL per-row
-        # hidden states between depths (see _run_frontier_window /
-        # _run_extend_depth_catchup); logits stay gathered.
-        capture_mode = (
-            CaptureHiddenMode.FULL
-            if self.spec_num_steps > 1
-            else CaptureHiddenMode.LAST
-        )
-
-        ctx = ForwardContext(
-            attn_backend=self.attn_backend,
-            token_to_kv_pool=self.token_to_kv_pool,
-            bs=bs,
-            num_extends=draft_input.num_extends,
-            input_num_tokens=input_num_tokens,
-            forward_mode=forward_mode,
-            capture_hidden_mode=capture_mode,
-            gather_ids=gather_ids,
-            global_num_tokens=draft_input.global_num_tokens,
-            global_bs=draft_input.global_bs,
-            all_decode_or_idle=draft_input.all_decode_or_idle,
-            accept_lengths=draft_input.accept_lengths,
-        )
-
-        logits_output = self.draft_model_runner.forward(
-            ctx=ctx,
-            input_ids=input_ids,
-            positions=buffers.positions_buf[:input_num_tokens],
-            out_cache_loc=buffers.out_cache_loc_buf[:input_num_tokens],
-            captured_hidden_states=draft_input.base_out_hidden_states,
-            spec_step_idx=0,
-        )
-        return logits_output
-
-    @nvtx_range("draft_frontier_window", color="purple")
+    @nvtx_range("run_frontier_window", color="purple")
     def _run_frontier_window(
         self,
         bs: int,
@@ -674,8 +543,8 @@ class Mtp(BaseDrafter):
         decode stash roll: [bs] int64 stash slots, [bs, k] int64 verify
         outputs, [bs, 1] int64 accepted lengths clamped to [1, k]."""
         k = self.spec_num_tokens
-        slot = self.input_buffers.req_pool_indices_buf[:bs].to(torch.int64).clamp_min(0)
-        v = draft_input.base_model_output.view(bs, k).to(torch.int64)
+        slot = self.input_buffers.req_pool_indices_buf[:bs]
+        v = draft_input.base_model_output.view(bs, k)
         accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
         return slot, v, accept
 
@@ -702,133 +571,102 @@ class Mtp(BaseDrafter):
         hidden = self._stash_hidden_buf
         hidden[slot] = _committed_tail_update(hidden[slot], hidden_rows, accept, width)
 
-    def _update_stash_extend(
-        self,
-        draft_input: MtpDraftInput,
-        hidden_full: torch.Tensor,
-    ) -> None:
-        """Roll the stash across an EXTEND/MIXED round's chunk rows.
-
-        Prefill requests stash the last stash-width shift-1 ids and target
-        hidden rows of their chunk (blending across chunk boundaries when a
-        chunk is shorter than the stash); MIXED decode rows roll the same
-        committed-tail update as pure decode, offset past the prefill rows.
+    def _update_stash_extend(self, draft_input: MtpDraftInput) -> None:
+        """Roll the stash across an EXTEND round's chunk rows: the last
+        stash-width shift-1 ids and target hidden rows of each request's
+        chunk (blending across chunk boundaries when a chunk is shorter
+        than the stash).
         """
         width = self._stash_width
-        k = self.spec_num_tokens
         buffers = self.input_buffers
-        ne = draft_input.num_extends
         bs = draft_input.accept_lengths.shape[0]
-        nd = bs - ne
-        num_prefill_tokens = draft_input.input_num_tokens - nd * k
-        slot = buffers.req_pool_indices_buf[:bs].to(torch.int64).clamp_min(0)
-        lengths = buffers.input_lengths_buf[:ne]
+        num_tokens = draft_input.input_num_tokens
+        slot = buffers.req_pool_indices_buf[:bs]
+        lengths = buffers.input_lengths_buf[:bs]
         tokens = self._stash_tokens_buf
         hidden = self._stash_hidden_buf
-        shift1 = buffers.shifted_prefill_ids_buf[:num_prefill_tokens].to(torch.int64)
-        extend_slot = slot[:ne]
-        tokens[extend_slot] = _ragged_tail_rows(
-            shift1, lengths, tokens[extend_slot], width
+        shift1 = buffers.shifted_prefill_ids_buf[:num_tokens]
+        tokens[slot] = _ragged_tail_rows(shift1, lengths, tokens[slot], width)
+        hidden[slot] = _ragged_tail_rows(
+            draft_input.base_out_hidden_states, lengths, hidden[slot], width
         )
-        hidden[extend_slot] = _ragged_tail_rows(
-            hidden_full[:num_prefill_tokens], lengths, hidden[extend_slot], width
-        )
-        if nd > 0:
-            self._update_stash_decode(
-                slot[ne:],
-                draft_input.accept_lengths[ne:bs].to(torch.int64).clamp(1, k),
-                draft_input.base_model_output[ne:].view(nd, k).to(torch.int64),
-                hidden_full[num_prefill_tokens:].view(nd, k, -1),
-            )
 
-    @nvtx_range("draft_extend_catchup", color="purple")
-    def _run_extend_depth_catchup(
+    @nvtx_range("run_extend_depths", color="purple")
+    def _run_extend_depths(
         self,
         bs: int,
         next_tokens: torch.Tensor,
-        logits_output: LogitsProcessorOutput,
         draft_input: MtpDraftInput,
     ) -> None:
-        """Per-depth prompt coverage at EXTEND rounds.
+        """Depths 0..steps-1 over an EXTEND round's ragged prompt rows.
 
-        The decode windows only repair pure-decode rounds, so without this
-        pass depths >= 1 would never write KV or sconv state over the prompt
-        region and their decode queries would attend over never-written
-        prompt keys forever.
+        Depth 0 is not special: every depth d runs the SAME ragged rows —
+        identical positions, out_cache_loc, and attention / conv metadata
+        (the KV and conv pools are layer-indexed, so depth d's writes land
+        in its own layer) — consuming inputs shifted d+1 within each request
+        and the previous stage's FULL rows as chained hiddens (the target's
+        rows at depth 0), and sampling its draft token at the request-last
+        rows. Without this pass depths >= 1 would never write KV or sconv
+        state over the prompt region and their decode queries would attend
+        over never-written prompt keys forever.
 
-        Each step d re-runs depth layer d over the SAME ragged rows the first
-        step processed — identical positions, out_cache_loc, and attention /
-        conv metadata (the KV and conv pools are layer-indexed, so depth d's
-        writes land in its own layer) — consuming the previous depth's FULL
-        rows as captured_hidden_states and inputs shifted d further:
-
-        - prefill rows: the request's own prompt tokens (all known), with the
-          trailing d rows taking the round's fresh drafts (final chunk) or
-          placeholder columns (mid-chunk; backfilled never — known
-          approximation, <= steps-1 rows per chunk boundary);
-        - decode rows (MIXED batches): the window-mode gather over verify
-          outputs and drafts, offset past the prefill rows.
-
-        Step d's draft token is sampled at the same rows as the first step
-        (request-last prefill row / accept-position decode row), so this also
-        replaces the classic loop's one-token steps for EXTEND rounds.
+        Mid-chunk EXTEND rounds are covered too — their drafts get discarded
+        (no verification completes after this forward), but the point is
+        per-depth KV/sconv coverage of THIS chunk's rows; the trailing d
+        rows per chunk consume placeholder ``next_tokens`` columns
+        (backfilled never — known approximation, <= steps-1 rows per chunk).
         """
-        k = self.spec_num_tokens
         buffers = self.input_buffers
-        ne = draft_input.num_extends
-        nd = bs - ne
         input_num_tokens = draft_input.input_num_tokens
-        num_prefill_tokens = input_num_tokens - nd * k
+
+        # Final chunks carry a -1 placeholder in their last shift-1 row;
+        # patch in the round's sampled token IN PLACE so the per-depth
+        # shifts and the stash roll below read the completed buffer.
+        input_ids = buffers.shifted_prefill_ids_buf[:input_num_tokens]
+        input_lengths = buffers.input_lengths_buf[:bs]
+        gather_ids = input_lengths.to(torch.int64).cumsum(0) - 1
+        last_input_ids = input_ids[gather_ids]
+        input_ids[gather_ids] = torch.where(
+            last_input_ids == -1,
+            draft_input.base_model_output[:bs],
+            last_input_ids,
+        )
 
         # This round's chunk tail (shift-1 ids + target rows) feeds the
         # next decode round's frontier window.
-        self._update_stash_extend(draft_input, draft_input.base_out_hidden_states)
+        self._update_stash_extend(draft_input)
 
-        shift1_ids = buffers.shifted_prefill_ids_buf[:num_prefill_tokens]
-        input_lengths = buffers.input_lengths_buf[:ne]
-        gather_ids = input_lengths.to(torch.int64).cumsum(0) - 1
         # Depth-invariant pieces of the per-depth shifted-id gathers
         # (gather_ids doubles as the precompute's per-request last row).
         extend_pre = _extend_depth_precompute(
-            shift1_ids, input_lengths, last_row=gather_ids
+            input_ids, input_lengths, last_row=gather_ids
         )
-        if nd > 0:
-            v = draft_input.base_model_output[ne:].view(nd, k).to(torch.int64)
-            accept = (
-                draft_input.accept_lengths[ne:].to(torch.int64).clamp(1, k).view(nd, 1)
-            )
-            col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
-            gather_ids = torch.cat(
-                [
-                    gather_ids,
-                    self._accepted_output_indices(
-                        draft_input.accept_lengths[ne:],
-                        nd,
-                        base_offset=num_prefill_tokens,
-                    ),
-                ]
-            )
         positions = buffers.positions_buf[:input_num_tokens]
         out_cache_loc = buffers.out_cache_loc_buf[:input_num_tokens]
+        # FULL per-row hiddens chain between depths; logits stay gathered.
+        capture_mode = (
+            CaptureHiddenMode.FULL
+            if self.spec_num_steps > 1
+            else CaptureHiddenMode.LAST
+        )
 
-        prev_hidden = logits_output.hidden_states  # [input_num_tokens, H]
-        for d in range(1, self.spec_num_steps):
-            input_ids = _extend_depth_shifted_ids_from(extend_pre, next_tokens[:ne], d)
-            if nd > 0:
-                decode_ids = _decode_shifted_ids(
-                    v, accept, next_tokens[ne:], d, src=col + d
-                )
-                input_ids = torch.cat([input_ids, decode_ids.reshape(-1)])
-            input_ids = self._prepare_draft_input_ids(input_ids)
+        prev_hidden = draft_input.base_out_hidden_states  # [input_num_tokens, H]
+        for d in range(self.spec_num_steps):
+            step_ids = (
+                input_ids
+                if d == 0
+                else _extend_depth_shifted_ids_from(extend_pre, next_tokens, d)
+            )
+            step_ids = self._prepare_draft_input_ids(step_ids)
 
             ctx = ForwardContext(
                 bs=bs,
-                num_extends=ne,
+                num_extends=bs,
                 attn_backend=self.attn_backend,
                 token_to_kv_pool=self.token_to_kv_pool,
                 input_num_tokens=input_num_tokens,
                 forward_mode=draft_input.forward_mode,
-                capture_hidden_mode=CaptureHiddenMode.FULL,
+                capture_hidden_mode=capture_mode,
                 gather_ids=gather_ids,
                 global_num_tokens=draft_input.global_num_tokens,
                 global_bs=draft_input.global_bs,
@@ -836,10 +674,10 @@ class Mtp(BaseDrafter):
                 accept_lengths=draft_input.accept_lengths,
             )
 
-            with nvtx_range("draft_extend_catchup_forward", color="red"):
+            with nvtx_range("draft_extend_forward", color="red"):
                 logits_output = self.draft_model_runner.forward(
                     ctx=ctx,
-                    input_ids=input_ids,
+                    input_ids=step_ids,
                     positions=positions,
                     out_cache_loc=out_cache_loc,
                     captured_hidden_states=prev_hidden,
@@ -859,16 +697,11 @@ class Mtp(BaseDrafter):
         self,
         base_ctx: ForwardContext,
     ) -> torch.Tensor | None:
-        num_extends = base_ctx.num_extends
-        num_decodes = base_ctx.bs - num_extends
-        if num_decodes == 0:
+        if base_ctx.num_extends > 0:
             return None
-
-        num_decode_tokens = num_decodes * self.spec_num_tokens
-        num_prefill_tokens = base_ctx.input_num_tokens - num_decode_tokens
-        return self.input_buffers.input_ids_buf[
-            num_prefill_tokens : base_ctx.input_num_tokens
-        ].reshape(num_decodes, self.spec_num_tokens)
+        return self.input_buffers.input_ids_buf[: base_ctx.input_num_tokens].reshape(
+            base_ctx.bs, self.spec_num_tokens
+        )
 
     @override
     def draft(
@@ -886,60 +719,29 @@ class Mtp(BaseDrafter):
             device=self.device,
         )
 
-        # Last verified id per request → next_tokens[:, 0].
-        num_extends = draft_input.num_extends
-        num_decodes = bs - num_extends
-        if num_extends > 0:
-            next_tokens[:num_extends, 0] = draft_input.base_model_output[:num_extends]
-        if num_decodes > 0:
-            indices = self._accepted_output_indices(
-                draft_input.accept_lengths[num_extends:],
-                num_decodes,
-            )
-            if num_extends > 0:
-                indices.add_(num_extends)
-            torch.index_select(
-                draft_input.base_model_output,
-                0,
-                indices,
-                out=next_tokens[num_extends:, 0],
-            )
-        next_tokens[:, 1:] = next_tokens[:, :1]
-
         if draft_input.num_extends == 0:
-            # Pure-decode round: no verify-anchored pass exists — depth 0
-            # runs inside the frontier window loop. override_num_extends
-            # drops any [num_extends:] slice a MIXED target set up; no-op on
-            # backends that fill separate prefill/decode metadata at init.
-            with self.attn_backend.override_num_extends(0):
-                slot, v, accept = self._decode_slices(bs, draft_input)
-                self._run_frontier_window(bs, next_tokens, draft_input, slot, v, accept)
-                self._update_stash_decode(
-                    slot,
-                    accept,
-                    v,
-                    draft_input.base_out_hidden_states.view(
-                        bs, self.spec_num_tokens, -1
-                    ),
-                )
+            # Pure-decode round: every depth (0 included) runs inside the
+            # frontier window loop.
+            indices = (
+                self.padded_gather_ids_offsets_buf[:bs] + draft_input.accept_lengths
+            )
+            torch.index_select(
+                draft_input.base_model_output, 0, indices, out=next_tokens[:, 0]
+            )
+            slot, v, accept = self._decode_slices(bs, draft_input)
+            self._run_frontier_window(bs, next_tokens, draft_input, slot, v, accept)
+            self._update_stash_decode(
+                slot,
+                accept,
+                v,
+                draft_input.base_out_hidden_states.view(bs, self.spec_num_tokens, -1),
+            )
             return next_tokens
 
-        # First draft step. LogitsProcessor prunes `[num_prefill_tokens + num_decodes * spec_num_tokens, ...]`
-        # down to `[bs, ...]`, so logits/hidden_states arrive here already aligned to one row per request.
-        logits_output = self._run_first_step(bs, draft_input)
-
-        draft_ids = self._sample_step_tokens(logits_output)
-        next_tokens[:, 1] = draft_ids
-
-        # EXTEND/MIXED with per-depth prompt coverage: reuses the first
-        # step's extend metadata as-is. This covers mid-chunk EXTEND
-        # rounds too — their drafts get discarded (no verification
-        # completes after this forward), but catch-up's point is
-        # per-depth KV/sconv coverage of THIS chunk's rows; skipping
-        # mid-chunks would leave every chunk but the last uncovered for
-        # depths >= 1 on long prompts. At spec_num_steps == 1 its depth
-        # loop is empty and only the stash priming runs.
-        self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
+        # EXTEND round (MIXED batches are rejected at the backend's metadata
+        # init): every depth runs the prompt chunk's ragged rows.
+        next_tokens[:, 0] = draft_input.base_model_output[:bs]
+        self._run_extend_depths(bs, next_tokens, draft_input)
         return next_tokens
 
     @override

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -23,7 +23,8 @@
 Hosts speculative drafting for MTP heads with multiple distinct depth
 layers, where speculative step ``d`` runs depth layer ``d`` over a shifted
 window and rejected drafts leave per-depth KV slots to repair (extend
-catch-up, decode windows, lookback stashes).
+catch-up, decode windows, lookback and frontier drafter stashes; the
+INKLING_MTP_DECODE_LOOKBACK knob selects the decode-window repair design).
 
 Eagle-like MTP (MTP-Eagle: a single MTP layer chained on its own hidden,
 e.g. DeepSeek) stays in ``eagle.py``. Both register under
@@ -212,6 +213,81 @@ def _lookback_shifted_ids(
     return ids.reshape(-1)
 
 
+def _frontier_shifted_ids(
+    v: torch.Tensor,
+    accept: torch.Tensor,
+    next_tokens: torch.Tensor,
+    stash_tokens: torch.Tensor,
+    depth: int,
+) -> torch.Tensor:
+    """Depth-``depth`` input ids over a frontier-anchored decode window.
+
+    The window's k rows end at the last committed position: row ``j`` sits
+    at source position ``frontier - k + j`` (frontier = vc + accept) and
+    consumes the token at source + depth + 1; in verify-output coordinates
+    that is ``src = accept - k + depth + j`` — per-request, unlike the
+    verify-anchored windows' static shifts. ``src < 0`` reads the stash of
+    the last k-1 committed tokens (entry ``src + k - 1``), ``src < accept``
+    this round's verify output ``v[src]``, else this round's own draft
+    ``d_m`` (m = src - accept + 1 <= depth) — every row holds a committed
+    token or a fresh draft, never garbage. Depth 0 never reaches past the
+    accepted prefix (``src <= accept - 1``).
+
+    Args:
+        v: [bs, k] int64 verify outputs (token at position vc+j+1 = v[:, j]);
+            entries at or past ``accept`` are never read.
+        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
+        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
+            this round's drafts.
+        stash_tokens: [bs, k-1] int64 committed tokens at positions
+            vc-k+2 .. vc.
+        depth: draft depth d >= 0.
+
+    Returns:
+        [bs * k] int64 input ids.
+    """
+    bs, k = v.shape
+    col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
+    src = accept - k + depth + col
+    if depth == 0:
+        ids = torch.gather(v, 1, src.clamp(0, k - 1))
+    else:
+        ids = _decode_shifted_ids(v, accept, next_tokens, depth, src=src)
+    from_stash = stash_tokens.gather(1, (src + k - 1).clamp(0, k - 2))
+    return torch.where(src < 0, from_stash, ids).reshape(-1)
+
+
+def _frontier_hidden_splice(
+    stash_hidden: torch.Tensor,
+    fresh_hidden: torch.Tensor,
+    accept: torch.Tensor,
+) -> torch.Tensor:
+    """Depth-0 chain hiddens for a frontier-anchored decode window.
+
+    Row ``j`` needs the target hidden of its source position
+    ``frontier - k + j``: the last ``accept`` window rows take this round's
+    verify hiddens (rows 0..accept-1, exactly the committed-input rows),
+    earlier rows the stash of the k-1 preceding target hiddens. Over the
+    concatenation [stash || fresh] both cases are one gather at
+    ``accept - 1 + j``.
+
+    Args:
+        stash_hidden: [bs, k-1, H] target hiddens at positions vc-k+1..vc-1.
+        fresh_hidden: [bs, k, H] this round's verify hiddens (row j = the
+            hidden at position vc+j); rows at or past ``accept`` are never
+            read.
+        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
+
+    Returns:
+        [bs * k, H] chain hidden rows for the depth-0 pass.
+    """
+    bs, k = fresh_hidden.shape[:2]
+    h = torch.cat([stash_hidden, fresh_hidden], 1)
+    col = torch.arange(k, dtype=torch.int64, device=h.device).view(1, k)
+    idx = (accept - 1 + col).view(bs, k, 1).expand(bs, k, h.shape[-1])
+    return h.gather(1, idx).reshape(bs * k, -1)
+
+
 def _committed_tail_update(
     stash: torch.Tensor,
     fresh: torch.Tensor,
@@ -338,9 +414,10 @@ class Mtp(BaseDrafter):
         # place during multi-step decode.
         self.draft_seq_lens_buf = torch.zeros_like(self.input_buffers.seq_lens_buf)
 
-        # Persistent output buffer for the draft step's compute_out_cache_loc.
+        # Persistent output buffer for the draft step's compute_out_cache_loc:
+        # D lookback rows per request, or the full k-row frontier window.
         self.draft_out_cache_loc_buf = torch.empty(
-            (self.input_buffers.max_bs * (spec_num_steps - 1),),
+            (self.input_buffers.max_bs * max(spec_num_steps - 1, spec_num_tokens),),
             dtype=torch.int32,
             device=self.device,
         )
@@ -369,23 +446,38 @@ class Mtp(BaseDrafter):
                 f"(dp_size={self.dp_size})"
             )
 
-        # Decode-window lookback (INKLING_MTP_DECODE_LOOKBACK A/B knob via
-        # the model's draft_decode_lookback); armed only when the backend
-        # supports the lagged-conv recurrence.
+        # Decode-window repair mode (INKLING_MTP_DECODE_LOOKBACK A/B knob via
+        # the model's draft_decode_lookback): 1 = verify-anchored window plus
+        # D lookback rows (armed only when the backend supports it), 2 =
+        # frontier-anchored k-row window (the backend MUST support it).
         model = draft_model_runner.model
+        mode = int(getattr(model, "draft_decode_lookback", 0) or 0)
         lookback = 0
-        if spec_num_steps > 1 and getattr(model, "draft_decode_lookback", False):
+        frontier = False
+        if spec_num_steps > 1 and mode == 1:
             lookback = spec_num_steps - 1
             configure = getattr(self.attn_backend, "configure_draft_lookback", None)
             if configure is None or not configure(lookback):
                 lookback = 0
+        elif spec_num_steps > 1 and mode == 2:
+            configure = getattr(self.attn_backend, "configure_draft_frontier", None)
+            if configure is None or not configure():
+                raise RuntimeError(
+                    "Inkling MTP frontier window: the draft attention backend "
+                    "cannot arm it (configure_draft_frontier missing or refused)"
+                )
+            frontier = True
         self.draft_lookback = lookback
-        # Cross-round stashes keyed by req_pool_indices (PAD rows clamp to the
-        # reserved slot 0): the last D committed tokens and depth-0 chain rows
-        # per request. Allocated eagerly — the decode rounds that fill them
-        # run inside CUDA graph capture, where allocation is off-limits.
+        self.draft_frontier = frontier
+        # Cross-round drafter stashes keyed by req_pool_indices (PAD rows
+        # clamp to the reserved slot 0). Lookback: the last D committed
+        # tokens and depth-0 chain rows. Frontier: the last k-1 committed
+        # tokens and the target hiddens one position behind them. Allocated
+        # eagerly — the decode rounds that fill them run inside CUDA graph
+        # capture, where allocation is off-limits.
+        self._stash_width = (spec_num_tokens - 1) if frontier else lookback
         self._lookback_hidden_buf: torch.Tensor | None = None
-        if lookback:
+        if self._stash_width:
             if self.runtime_states is None:
                 raise RuntimeError("MTP lookback requires request-pool runtime state")
             model_config = draft_model_runner.model_config
@@ -393,12 +485,12 @@ class Mtp(BaseDrafter):
             # request-pool indices used to address these persistent stashes.
             request_pool_rows = self.runtime_states.valid_cache_lengths.shape[0]
             self._lookback_tokens_buf = torch.zeros(
-                (request_pool_rows, lookback),
+                (request_pool_rows, self._stash_width),
                 dtype=torch.int64,
                 device=self.device,
             )
             self._lookback_hidden_buf = torch.zeros(
-                (request_pool_rows, lookback, model_config.hidden_size),
+                (request_pool_rows, self._stash_width, model_config.hidden_size),
                 dtype=model_config.dtype,
                 device=self.device,
             )
@@ -766,6 +858,108 @@ class Mtp(BaseDrafter):
                 next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
         return True
 
+    @nvtx_range("draft_frontier_window", color="purple")
+    def _run_frontier_window(
+        self,
+        bs: int,
+        next_tokens: torch.Tensor,
+        draft_input: MtpDraftInput,
+        slot: torch.Tensor,
+        v: torch.Tensor,
+        accept: torch.Tensor,
+    ) -> None:
+        """Frontier-anchored decode window: every depth 0..steps-1 runs the
+        SAME k rows per request, ending at the last committed position
+        (``frontier = vc + accept``, computed once before depth 0; nothing
+        advances between depths).
+
+        Every row's input token is committed or a fresh draft — rejected
+        drafts and garbage rows are structurally impossible — so re-running
+        a depth over the window rewrites its provisional tail slots (KV and
+        sconv ring rows written last round from then-unverified drafts) with
+        exact values in place, while accepted-region rows are exact-value
+        no-ops. Depth 0 re-runs purely to regenerate fresh chain hiddens for
+        depth 1: its inputs splice the drafter stash (pre-window history)
+        with this round's verify hiddens at the accept boundary.
+
+        The sample gather is static (always the last row, at position
+        frontier-1) and the row count stays bs*k, so the attention metadata
+        only needs its anchor moved: seq_lens, positions and cache write
+        locations shift back by ``k - accept`` (the backend hook re-anchors
+        the conv metadata and grouped write locations the same way; all of
+        it is plain tensor math, CUDA-graph-recorded and recomputed per
+        replay). Runs inside graph capture — no host syncs; sub-k prompts,
+        whose window would cross position 0, are clamped GPU-side (their
+        first positions get wrong-shift rewrites, bounded to prompts shorter
+        than k-1 tokens — below any real chat traffic).
+        """
+        k = self.spec_num_tokens
+        buffers = self.input_buffers
+        positions = buffers.positions_buf[: bs * k].view(bs, k)
+        # positions[:, 0] is vc, the position before the verify window.
+        frontier = (positions[:, 0] + accept.view(-1).to(positions.dtype)).to(
+            torch.int32
+        )
+        step_positions = (
+            (positions + (accept - k).to(positions.dtype)).clamp_min(0).reshape(-1)
+        )
+        out_cache_loc = self.draft_out_cache_loc_buf[: bs * k]
+        self.cache_view.out_cache_loc_uniform(
+            out=out_cache_loc,
+            cache_start=(frontier - k).clamp_min(0),
+            num_tokens=k,
+        )
+        enter = getattr(self.attn_backend, "enter_draft_frontier_window", None)
+        if enter is None:
+            raise RuntimeError(
+                "Inkling MTP frontier window: the draft attention backend "
+                "lacks enter_draft_frontier_window"
+            )
+        enter(bs, frontier)
+        # Static sample gather: the last window row sits at frontier-1 for
+        # every depth (row at position p and depth d predicts p + d + 2).
+        gather_ids = self.padded_gather_ids_offsets_buf[:bs] + k
+        stash_tokens = self._lookback_tokens_buf[slot]
+        prev_hidden = _frontier_hidden_splice(
+            self._lookback_hidden_buf[slot],
+            draft_input.base_out_hidden_states.view(bs, k, -1),
+            accept,
+        )
+        for d in range(self.spec_num_steps):
+            input_ids = self._prepare_draft_input_ids(
+                _frontier_shifted_ids(v, accept, next_tokens, stash_tokens, d)
+            )
+
+            ctx = ForwardContext(
+                bs=bs,
+                num_extends=0,
+                attn_backend=self.attn_backend,
+                token_to_kv_pool=self.token_to_kv_pool,
+                input_num_tokens=bs * k,
+                forward_mode=ForwardMode.DECODE,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+                gather_ids=gather_ids,
+                global_num_tokens=draft_input.global_num_tokens,
+                global_bs=draft_input.global_bs,
+                all_decode_or_idle=draft_input.all_decode_or_idle,
+                draft_seq_lens_buf=self.draft_seq_lens_buf,
+                accept_lengths=draft_input.accept_lengths,
+            )
+
+            with nvtx_range("draft_frontier_forward", color="red"):
+                logits_output = self.draft_model_runner.forward(
+                    ctx=ctx,
+                    input_ids=input_ids,
+                    positions=step_positions,
+                    out_cache_loc=out_cache_loc,
+                    captured_hidden_states=prev_hidden,
+                    spec_step_idx=d,
+                )
+            prev_hidden = logits_output.hidden_states
+
+            with nvtx_range("draft_sample", color="yellow"):
+                next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
+
     def _decode_slices(
         self, bs: int, draft_input: MtpDraftInput
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -785,13 +979,18 @@ class Mtp(BaseDrafter):
         v: torch.Tensor,
         h0: torch.Tensor,
     ) -> None:
-        """Roll the cross-round stashes past a round's decode-row commits.
+        """Roll the cross-round drafter stashes past a round's decode-row
+        commits.
 
         Args come pre-sliced per decode row: ``slot`` [n] int64 stash slots,
         ``accept`` [n]-viewable int64 accepts clamped to [1, k], ``v`` [n, k]
-        int64 verify outputs, ``h0`` [n, k, H] depth-0 hidden rows.
+        int64 verify outputs, ``h0`` [n, k, H] hidden rows — depth-0 chain
+        rows in lookback mode, this round's target verify hiddens in
+        frontier mode (verify hidden row j sits one position behind verify
+        token j, which is why the frontier hidden stash ends one position
+        before the token stash).
         """
-        lb = self.draft_lookback
+        lb = self._stash_width
         tokens = self._lookback_tokens_buf
         tokens[slot] = _committed_tail_update(tokens[slot], v, accept, lb)
         hidden = self._lookback_hidden_buf
@@ -804,12 +1003,14 @@ class Mtp(BaseDrafter):
     ) -> None:
         """Roll the stashes across an EXTEND/MIXED round's chunk rows.
 
-        Prefill requests stash the last D shift-1 ids and depth-0 rows of
-        their chunk (blending across chunk boundaries when a chunk is
-        shorter than D); MIXED decode rows roll the same committed-tail
-        update as pure decode, offset past the prefill rows.
+        Prefill requests stash the last stash-width shift-1 ids and hidden
+        rows of their chunk (blending across chunk boundaries when a chunk
+        is shorter than the stash); MIXED decode rows roll the same
+        committed-tail update as pure decode, offset past the prefill rows.
+        ``h0_full`` is the caller's per-mode hidden source: depth-0 chain
+        rows (lookback) or the target's full rows (frontier).
         """
-        lb = self.draft_lookback
+        lb = self._stash_width
         k = self.spec_num_tokens
         buffers = self.input_buffers
         ne = draft_input.num_extends
@@ -875,10 +1076,18 @@ class Mtp(BaseDrafter):
         input_num_tokens = draft_input.input_num_tokens
         num_prefill_tokens = input_num_tokens - nd * k
 
-        if self.draft_lookback:
+        if self._stash_width:
             # Before the loop rebinds logits_output: this round's chunk tail
-            # (tokens + depth-0 rows) feeds the next decode round's lookback.
-            self._update_lookback_stash_extend(draft_input, logits_output.hidden_states)
+            # feeds the next decode round's window (depth-0 rows for the
+            # lookback window, target rows for the frontier window).
+            self._update_lookback_stash_extend(
+                draft_input,
+                (
+                    draft_input.base_out_hidden_states
+                    if self.draft_frontier
+                    else logits_output.hidden_states
+                ),
+            )
 
         shift1_ids = buffers.shifted_prefill_ids_buf[:num_prefill_tokens]
         input_lengths = buffers.input_lengths_buf[:ne]
@@ -1005,6 +1214,22 @@ class Mtp(BaseDrafter):
 
         # Seed the draft attn backend's aliased seq_lens for the first step.
         self.draft_seq_lens_buf[:bs].copy_(self.input_buffers.seq_lens_buf[:bs])
+
+        if self.draft_frontier and draft_input.num_extends == 0:
+            # Frontier-anchored decode round: no verify-anchored pass exists
+            # in this mode — depth 0 runs inside the re-anchored window loop.
+            with self.attn_backend.override_num_extends(0):
+                slot, v, accept = self._decode_slices(bs, draft_input)
+                self._run_frontier_window(bs, next_tokens, draft_input, slot, v, accept)
+                self._update_lookback_stash_decode(
+                    slot,
+                    accept,
+                    v,
+                    draft_input.base_out_hidden_states.view(
+                        bs, self.spec_num_tokens, -1
+                    ),
+                )
+            return next_tokens
 
         # First draft step. LogitsProcessor prunes `[num_prefill_tokens + num_decodes * spec_num_tokens, ...]`
         # down to `[bs, ...]`, so logits/hidden_states arrive here already aligned to one row per request.

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -383,15 +383,14 @@ class Mtp(BaseDrafter):
             draft_input.base_out_hidden_states.view(bs, k, -1),
             accept_lengths,
         )
+        prev_hidden = spliced_hidden
         for d in range(self.spec_num_steps):
             if d == 0:
                 input_ids = window_ids
-                prev_hidden = spliced_hidden
             else:
                 input_ids = torch.cat(
                     [input_ids[:, 1:], next_tokens[:, d : d + 1]], dim=1
                 )
-                prev_hidden = logits_output.hidden_states
 
             ctx = ForwardContext(
                 bs=bs,
@@ -417,6 +416,7 @@ class Mtp(BaseDrafter):
                     captured_hidden_states=prev_hidden,
                     spec_step_idx=d,
                 )
+                prev_hidden = logits_output.hidden_states
 
             with nvtx_range("draft_sample", color="yellow"):
                 next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -91,27 +91,23 @@ def _extend_depth_shifted_ids_from(
     next_tokens: torch.Tensor,
     depth: int,
 ) -> torch.Tensor:
-    """Depth-``depth`` input ids for the ragged prefill rows of an EXTEND round.
+    """Depth-``depth`` input ids for an EXTEND round's ragged prefill rows.
 
-    ``pre`` is :func:`_extend_depth_precompute` output over the first draft
-    step's prefill inputs ``shift1_ids`` (prompt tokens shifted by one within
-    each request, last row already holding the round's sampled token on final
-    chunks). Depth ``d`` at local row ``i`` consumes the token ``d`` further
-    along: ``shift1_ids[row + d]`` while that stays inside the request, else
-    the request's own draft ``d_m`` (``m = overshoot``) from ``next_tokens``
-    — columns ``1..d`` are already filled when depth ``d`` runs. On mid-chunk
-    rows the overshoot tokens are not staged; those trailing ``d`` rows per
-    chunk consume the placeholder ``next_tokens`` columns (known
-    approximation, <= steps-1 rows per chunk).
+    Depth ``d`` at local row ``i`` consumes the token ``d`` further along:
+    ``shift1_ids[row + d]`` inside the request, else the request's own
+    draft ``d_m`` (``m = overshoot``) from ``next_tokens`` columns 1..d,
+    already filled when depth ``d`` runs. Mid-chunk rows' overshoot tokens
+    are not staged: the trailing ``d`` rows per chunk read placeholder
+    columns (known approximation, <= steps-1 rows per chunk).
 
     Args:
-        pre: :func:`_extend_depth_precompute` output.
-        next_tokens: [>=num_extends, >=depth+1] col 0 = last verified token,
-            cols 1.. = this round's drafts, per request.
+        pre: :func:`_extend_depth_precompute` output over the depth-0 ids.
+        next_tokens: [>=num_extends, >=depth+1] col 0 = last verified
+            token, cols 1.. = this round's drafts.
         depth: draft depth d >= 1.
 
     Returns:
-        [num_prefill_rows] input ids for the depth-``depth`` pass.
+        [num_prefill_rows] input ids.
     """
     shift1_ids, base, req_of_row, row_last = pre
     num_rows = shift1_ids.shape[0]
@@ -129,29 +125,24 @@ def _frontier_shifted_ids(
 ) -> torch.Tensor:
     """Depth-0 input ids over a frontier-anchored decode window.
 
-    The window's k rows end at the last committed position: row ``j`` sits
-    at source position ``frontier - k + j`` (frontier = vc + accept) and
-    consumes the token one past it; in verify-output coordinates that is
-    ``src = accept - k + j`` — per-request, unlike the verify-anchored
-    windows' static shifts. ``src < 0`` reads the stash of the last k-1
-    committed tokens (entry ``src + k - 1``), else this round's verify
-    output ``v[src]`` — depth 0 never reaches past the accepted prefix
-    (``src <= accept - 1``). Deeper depths need no re-splice: they are
-    static slices of [window || drafts], built by the caller.
+    Window row ``j`` sits at position ``frontier - k + j`` (frontier =
+    vc + accept) and consumes the token one past it; in verify coordinates
+    ``src = accept - k + j``: the stash entry ``src + k - 1`` when
+    ``src < 0``, else ``v[src]`` (depth 0 never reads past the accepted
+    prefix). Deeper depths are rolls of [window || drafts], built by the
+    caller.
 
     Args:
-        v: [bs, k] verify outputs (token at position vc+j+1 = v[:, j]);
-            entries at or past ``accept`` are never read.
-        accept: [bs, 1] accepted lengths in [1, k].
-        stash_tokens: [bs, k-1] committed tokens at positions
-            vc-k+2 .. vc.
+        v: [bs, k] verify outputs (token at position vc+j+1 = v[:, j]).
+        accept: [bs] accepted lengths in [1, k].
+        stash_tokens: [bs, k-1] committed tokens at positions vc-k+2..vc.
 
     Returns:
         [bs * k] input ids.
     """
     bs, k = v.shape
     col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
-    src = accept - k + col
+    src = accept.unsqueeze(-1) - k + col
     ids = torch.gather(v, 1, src.clamp_min(0))
     from_stash = stash_tokens.gather(1, (src + k - 1).clamp_max(k - 2))
     return torch.where(src < 0, from_stash, ids).reshape(-1)
@@ -164,27 +155,23 @@ def _frontier_hidden_splice(
 ) -> torch.Tensor:
     """Depth-0 chain hiddens for a frontier-anchored decode window.
 
-    Row ``j`` needs the target hidden of its source position
-    ``frontier - k + j``: the last ``accept`` window rows take this round's
-    verify hiddens (rows 0..accept-1, exactly the committed-input rows),
-    earlier rows the stash of the k-1 preceding target hiddens. Over the
-    concatenation [stash || fresh] both cases are one gather at
+    Row ``j`` needs the target hidden of position ``frontier - k + j``:
+    the last ``accept`` rows take this round's verify hiddens, earlier
+    rows the stash. Over [stash || fresh] both cases are one gather at
     ``accept - 1 + j``.
 
     Args:
         stash_hidden: [bs, k-1, H] target hiddens at positions vc-k+1..vc-1.
-        fresh_hidden: [bs, k, H] this round's verify hiddens (row j = the
-            hidden at position vc+j); rows at or past ``accept`` are never
-            read.
-        accept: [bs, 1] accepted lengths in [1, k].
+        fresh_hidden: [bs, k, H] verify hiddens (row j = position vc+j).
+        accept: [bs] accepted lengths in [1, k].
 
     Returns:
-        [bs * k, H] chain hidden rows for the depth-0 pass.
+        [bs * k, H] depth-0 chain hiddens.
     """
     bs, k = fresh_hidden.shape[:2]
     h = torch.cat([stash_hidden, fresh_hidden], 1)
     col = torch.arange(k, dtype=torch.int64, device=h.device).view(1, k)
-    idx = (accept - 1 + col).view(bs, k, 1).expand(bs, k, h.shape[-1])
+    idx = (accept.unsqueeze(-1) - 1 + col).view(bs, k, 1).expand(bs, k, h.shape[-1])
     return h.gather(1, idx).reshape(bs * k, -1)
 
 
@@ -231,7 +218,7 @@ class MtpDraftInput:
     input_num_tokens: int
     num_extends: int
     forward_mode: ForwardMode
-    base_model_output: torch.Tensor  # [bs]
+    base_model_output: torch.Tensor  # [bs] (extend) / [bs * k] (decode verify outputs)
     accept_lengths: torch.Tensor  # [bs]
     base_out_hidden_states: torch.Tensor
     global_num_tokens: list[int] | None = None
@@ -273,7 +260,15 @@ class Mtp(BaseDrafter):
 
         self.device = draft_model_runner.device
 
-        self.dp_size = draft_model_runner.mapping.attn.dp_size
+        # Multi-depth drafting has no DP support: idle rounds (a DP rank
+        # keeping collectives in sync with no work of its own) have no
+        # window to run.
+        dp_size = draft_model_runner.mapping.attn.dp_size
+        if dp_size > 1:
+            raise NotImplementedError(
+                "multi-depth MTP drafting does not support data parallelism "
+                f"(dp_size={dp_size})"
+            )
 
         # Drafter-owned seq_lens the CUDA-graph wrapper aliases into every
         # draft metadata init (it copies the round's live lengths in; on
@@ -297,21 +292,16 @@ class Mtp(BaseDrafter):
             * spec_num_tokens
             - 1
         )
-
-        # Multi-depth drafting has no DP support: idle rounds (a DP rank
-        # keeping collectives in sync with no work of its own) have no
-        # window to run.
-        if self.dp_size > 1:
-            raise NotImplementedError(
-                "multi-depth MTP drafting does not support data parallelism "
-                f"(dp_size={self.dp_size})"
-            )
+        # Static last-row sample gather (request r's window-final row,
+        # r*k + k-1): the row at frontier-1 predicts frontier+d+1 at depth d.
+        self.padded_gather_ids_buf = (
+            self.padded_gather_ids_offsets_buf + spec_num_tokens
+        )
 
         # Cross-round drafter stash keyed by req_pool_indices (graph-padded
         # rows arrive as the reserved slot 0): the last k-1 committed tokens
-        # and the target hiddens one position behind them. Allocated eagerly
-        # — the decode rounds that fill it run inside CUDA graph capture,
-        # where allocation is off-limits.
+        # and the target hiddens one position behind them. Allocated eagerly:
+        # the decode rounds that fill it run inside CUDA graph capture.
         self._stash_width = spec_num_tokens - 1
         model_config = draft_model_runner.model_config
         # page_table is batch-ordered and may have fewer rows than the
@@ -346,65 +336,52 @@ class Mtp(BaseDrafter):
         next_tokens: torch.Tensor,
         draft_input: MtpDraftInput,
     ) -> None:
-        """Frontier-anchored decode window: every depth 0..steps-1 runs the
-        SAME k rows per request, ending at the last committed position
-        (``frontier = vc + accept``, computed once before depth 0; nothing
-        advances between depths).
+        """Frontier-anchored decode window: every depth 0..steps-1 runs
+        the SAME k rows per request, ending at the committed frontier
+        (= vc + accept); nothing advances between depths.
 
-        Every row's input token is committed or a fresh draft — rejected
-        drafts and garbage rows are structurally impossible — so re-running
-        a depth over the window rewrites its provisional tail slots (KV and
-        sconv ring rows written last round from then-unverified drafts) with
-        exact values in place, while accepted-region rows are exact-value
-        no-ops. Depth 0 re-runs purely to regenerate fresh chain hiddens for
-        depth 1: its inputs splice the drafter stash (pre-window history)
-        with this round's verify hiddens at the accept boundary.
-
-        The sample gather is static (always the last row, at position
-        frontier-1) and the row count stays bs*k, so the attention metadata
-        only needs its anchor moved: seq_lens, positions and cache write
-        locations shift back by ``k - accept`` (the backend hook re-anchors
-        the conv metadata and grouped write locations the same way; all of
-        it is plain tensor math, CUDA-graph-recorded and recomputed per
-        replay). Runs inside graph capture — no host syncs; sub-k prompts,
-        whose window would cross position 0, are clamped GPU-side (their
-        first positions get wrong-shift rewrites, bounded to prompts shorter
-        than k-1 tokens — below any real chat traffic).
+        Every row's input is a committed token or a fresh draft, so each
+        depth rewrites its provisional tail slots (KV / sconv rows written
+        last round from since-rejected drafts) with exact values in place;
+        depth 0 re-runs purely to regenerate chain hiddens for depth 1.
+        Row count and sample gather are static — only the anchor moves
+        (positions, cache locs and backend metadata shift by accept - k),
+        all in-graph tensor math, no host syncs. Sub-k prompts clamp at
+        position 0: wrong-shift rewrites bounded to prompts shorter than
+        k-1 tokens, draft-quality-only.
         """
         k = self.spec_num_tokens
         buffers = self.input_buffers
         slot = buffers.req_pool_indices_buf[:bs]
-        v = draft_input.base_model_output.view(bs, k)
-        accept = draft_input.accept_lengths[:bs].view(bs, 1)
+
+        accept_lengths = draft_input.accept_lengths[:bs]
         positions = buffers.positions_buf[: bs * k].view(bs, k)
         # positions[:, 0] is vc, the position before the verify window.
-        frontier = (positions[:, 0] + accept.view(-1).to(positions.dtype)).to(
-            torch.int32
-        )
+        frontier = positions[:, 0].to(torch.int32) + accept_lengths
         step_positions = (
-            (positions + (accept - k).to(positions.dtype)).clamp_min(0).reshape(-1)
+            (positions + (accept_lengths.unsqueeze(-1) - k)).clamp_min(0).reshape(-1)
         )
+
         out_cache_loc = self.draft_out_cache_loc_buf[: bs * k]
         self.cache_view.out_cache_loc_uniform(
             out=out_cache_loc,
             cache_start=(frontier - k).clamp_min(0),
             num_tokens=k,
         )
-        self.attn_backend.enter_draft_frontier_window(bs, frontier)
-        # Static sample gather: the last window row sits at frontier-1 for
-        # every depth (row at position p and depth d predicts p + d + 2).
-        gather_ids = self.padded_gather_ids_offsets_buf[:bs] + k
+        self.attn_backend.update_draft_forward_metadata(frontier)
         # Depth-0 window = the last k committed (token, hidden) pairs; its
         # tail [:, 1:] is exactly the next round's stash, rolled at the end.
         # Depth d+1's ids roll the window one left, appending depth d's
         # draft: only depth 0 is accept-dependent.
         window_ids = _frontier_shifted_ids(
-            v, accept, self._stash_tokens_buf[slot]
+            draft_input.base_model_output.view(bs, k),
+            accept_lengths,
+            self._stash_tokens_buf[slot],
         ).view(bs, k)
         spliced_hidden = _frontier_hidden_splice(
             self._stash_hidden_buf[slot],
             draft_input.base_out_hidden_states.view(bs, k, -1),
-            accept,
+            accept_lengths,
         )
         for d in range(self.spec_num_steps):
             if d == 0:
@@ -424,7 +401,7 @@ class Mtp(BaseDrafter):
                 input_num_tokens=bs * k,
                 forward_mode=ForwardMode.DECODE,
                 capture_hidden_mode=CaptureHiddenMode.FULL,
-                gather_ids=gather_ids,
+                gather_ids=self.padded_gather_ids_buf[:bs],
                 global_num_tokens=draft_input.global_num_tokens,
                 global_bs=draft_input.global_bs,
                 all_decode_or_idle=draft_input.all_decode_or_idle,
@@ -476,21 +453,14 @@ class Mtp(BaseDrafter):
     ) -> None:
         """Depths 0..steps-1 over an EXTEND round's ragged prompt rows.
 
-        Depth 0 is not special: every depth d runs the SAME ragged rows —
-        identical positions, out_cache_loc, and attention / conv metadata
-        (the KV and conv pools are layer-indexed, so depth d's writes land
-        in its own layer) — consuming inputs shifted d+1 within each request
-        and the previous stage's FULL rows as chained hiddens (the target's
-        rows at depth 0), and sampling its draft token at the request-last
-        rows. Without this pass depths >= 1 would never write KV or sconv
-        state over the prompt region and their decode queries would attend
-        over never-written prompt keys forever.
-
-        Mid-chunk EXTEND rounds are covered too — their drafts get discarded
-        (no verification completes after this forward), but the point is
-        per-depth KV/sconv coverage of THIS chunk's rows; the trailing d
-        rows per chunk consume placeholder ``next_tokens`` columns
-        (backfilled never — known approximation, <= steps-1 rows per chunk).
+        Every depth d runs the SAME rows — same positions, out_cache_loc
+        and metadata (the KV and conv pools are layer-indexed) — consuming
+        inputs shifted d+1 within each request and the previous depth's
+        FULL rows as chain hiddens, sampling at the request-last rows.
+        Without this pass depths >= 1 would never write KV/sconv state
+        over the prompt region. Mid-chunk rounds run it too (their drafts
+        are discarded): the point is per-depth state coverage of THIS
+        chunk's rows.
         """
         buffers = self.input_buffers
         input_num_tokens = draft_input.input_num_tokens
@@ -508,8 +478,6 @@ class Mtp(BaseDrafter):
             last_input_ids,
         )
 
-        # This round's chunk tail (shift-1 ids + target rows) feeds the
-        # next decode round's frontier window.
         self._update_stash_extend(draft_input)
 
         # Depth-invariant pieces of the per-depth shifted-id gathers
@@ -634,5 +602,4 @@ class Mtp(BaseDrafter):
             all_decode_or_idle=base_ctx.all_decode_or_idle,
         )
 
-        # next_tokens layout: column 0 = last verified id, columns 1.. = drafter tokens.
         return self.draft(draft_input)

--- a/python/tokenspeed/runtime/execution/drafter/mtp.py
+++ b/python/tokenspeed/runtime/execution/drafter/mtp.py
@@ -23,8 +23,7 @@
 Hosts speculative drafting for MTP heads with multiple distinct depth
 layers, where speculative step ``d`` runs depth layer ``d`` over a shifted
 window and rejected drafts leave per-depth KV slots to repair (extend
-catch-up, decode windows, lookback and frontier drafter stashes; the
-INKLING_MTP_DECODE_LOOKBACK knob selects the decode-window repair design).
+catch-up, frontier-anchored decode windows, the cross-round drafter stash).
 
 Eagle-like MTP (MTP-Eagle: a single MTP layer chained on its own hidden,
 e.g. DeepSeek) stays in ``eagle.py``. Both register under
@@ -65,7 +64,7 @@ def _decode_shifted_ids(
     accept: torch.Tensor,
     next_tokens: torch.Tensor,
     depth: int,
-    src: torch.Tensor | None = None,
+    src: torch.Tensor,
 ) -> torch.Tensor:
     """Depth-``depth`` input ids over a decode verify window.
 
@@ -73,8 +72,8 @@ def _decode_shifted_ids(
     verify-output coordinates that is ``src[j]``: ``src < accept`` reads
     this round's verify output ``v[:, src]``, else the round's own draft
     ``d_m`` (m = src - accept + 1 <= depth) from ``next_tokens`` columns
-    1..depth. Negative ``src`` rows (lookback) come out as ``drafts[:, 0]``;
-    the caller overlays them (see ``_lookback_shifted_ids``).
+    1..depth. Negative ``src`` rows come out as ``v[:, 0]``; the caller
+    overlays them from its stash (see ``_frontier_shifted_ids``).
 
     Args:
         v: [bs, k] int64 verify outputs.
@@ -82,15 +81,12 @@ def _decode_shifted_ids(
         next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
             this round's drafts.
         depth: draft depth d >= 1.
-        src: optional [1, n] (or [bs, n]) int64 source coordinates; defaults
-            to ``arange(k) + depth`` (the plain forward window).
+        src: [1, n] (or [bs, n]) int64 source coordinates.
 
     Returns:
         [bs, n] int64 input ids.
     """
     bs, k = v.shape
-    if src is None:
-        src = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k) + depth
     n = src.shape[-1]
     from_verify = torch.gather(v, 1, src.clamp(0, k - 1).expand(bs, n))
     drafts = next_tokens[:, 1 : depth + 1].to(torch.int64)
@@ -161,56 +157,6 @@ def _extend_depth_shifted_ids_from(
     overshoot = (src - row_last).clamp(1, depth)
     from_draft = next_tokens.to(torch.int64)[req_of_row, overshoot]
     return torch.where(src <= row_last, from_prompt, from_draft)
-
-
-def _lookback_shifted_ids(
-    v: torch.Tensor,
-    accept: torch.Tensor,
-    next_tokens: torch.Tensor,
-    stash_tokens: torch.Tensor,
-    depth: int,
-    lookback: int,
-    src: torch.Tensor | None = None,
-) -> torch.Tensor:
-    """Depth-``depth`` input ids for a lookback decode window.
-
-    Row ``r`` of the ``lookback + k`` window sits at source position
-    ``vc - lookback + r`` and consumes the token at source + depth + 1;
-    in verify-output coordinates that is ``src = r - lookback + depth``:
-    ``src < 0`` reads the stash of the last ``lookback`` committed tokens
-    (entry ``lookback + src``), ``src < accept`` this round's verify output
-    ``v[src]``, else this round's own draft ``d_m`` (m = src - accept + 1
-    <= depth) — identical to the plain window for the trailing k rows.
-
-    Args:
-        v: [bs, k] int64 verify outputs (token at position vc+j+1 = v[:, j]).
-        accept: [bs, 1] int64 accepted lengths clamped to [1, k].
-        next_tokens: [bs, >= depth+1] col 0 = last verified id, cols 1.. =
-            this round's drafts.
-        stash_tokens: [bs, lookback] int64 committed tokens at positions
-            vc-lookback+1 .. vc (the pre-window tail).
-        depth: draft depth d >= 1.
-        lookback: D >= 1 lookback rows.
-        src: optional [1, lookback + k] precomputed source coordinates
-            (``arange(total) - lookback + depth``), hoistable per depth.
-
-    Returns:
-        [bs * (lookback + k)] int64 input ids.
-    """
-    bs, k = v.shape
-    total = lookback + k
-    if src is None:
-        src = (
-            torch.arange(total, dtype=torch.int64, device=v.device).view(1, total)
-            - lookback
-            + depth
-        )
-    ids = _decode_shifted_ids(v, accept, next_tokens, depth, src=src)
-    from_stash = stash_tokens.gather(
-        1, (src + lookback).clamp(0, lookback - 1).expand(bs, total)
-    )
-    ids = torch.where(src < 0, from_stash, ids)
-    return ids.reshape(-1)
 
 
 def _frontier_shifted_ids(
@@ -292,31 +238,29 @@ def _committed_tail_update(
     stash: torch.Tensor,
     fresh: torch.Tensor,
     valid: torch.Tensor,
-    lookback: int,
+    width: int,
 ) -> torch.Tensor:
-    """Roll a committed-tail stash: last ``lookback`` of [stash || fresh[:valid]].
+    """Roll a committed-tail stash: last ``width`` of [stash || fresh[:valid]].
 
-    ``stash``: [bs, lookback, ...] previous tail; ``fresh``: [bs, k, ...]
+    ``stash``: [bs, width, ...] previous tail; ``fresh``: [bs, k, ...]
     this round's per-row values whose committed prefix is the first
     ``valid`` rows (``fresh`` row 0 must directly follow the stash's last
     entry); ``valid``: [bs] int64 in [1, k].
 
     Returns:
-        The updated [bs, lookback, ...] tail.
+        The updated [bs, width, ...] tail.
     """
     bs = fresh.shape[0]
     rows = (
         valid.view(bs, 1)
-        - lookback
-        + torch.arange(lookback, dtype=torch.int64, device=fresh.device).view(
-            1, lookback
-        )
+        - width
+        + torch.arange(width, dtype=torch.int64, device=fresh.device).view(1, width)
     )
-    idx_shape = (bs, lookback) + (1,) * (fresh.dim() - 2)
-    expand = (bs, lookback) + fresh.shape[2:]
+    idx_shape = (bs, width) + (1,) * (fresh.dim() - 2)
+    expand = (bs, width) + fresh.shape[2:]
     new_rows = fresh.gather(1, rows.clamp_min(0).view(idx_shape).expand(expand))
     old_rows = stash.gather(
-        1, (rows + lookback).clamp(0, lookback - 1).view(idx_shape).expand(expand)
+        1, (rows + width).clamp(0, width - 1).view(idx_shape).expand(expand)
     )
     return torch.where((rows >= 0).view(idx_shape), new_rows, old_rows)
 
@@ -325,38 +269,36 @@ def _ragged_tail_rows(
     flat: torch.Tensor,
     lengths: torch.Tensor,
     old_tail: torch.Tensor,
-    lookback: int,
+    width: int,
 ) -> torch.Tensor:
-    """Per-request last ``lookback`` rows of ragged ``flat`` chunks.
+    """Per-request last ``width`` rows of ragged ``flat`` chunks.
 
-    Requests whose chunk is shorter than ``lookback`` borrow leading entries
+    Requests whose chunk is shorter than ``width`` borrow leading entries
     from ``old_tail`` (the previous chunk's tail, contiguous with this
     chunk's first row).
 
     Args:
         flat: [total, ...] ragged per-request rows.
         lengths: [n] per-request row counts.
-        old_tail: [n, lookback, ...] previous tail.
+        old_tail: [n, width, ...] previous tail.
 
     Returns:
-        The updated [n, lookback, ...] tail.
+        The updated [n, width, ...] tail.
     """
     n = lengths.shape[0]
     lens = lengths.to(torch.int64)
     starts = lens.cumsum(0) - lens
     offs = (
         lens.view(n, 1)
-        - lookback
-        + torch.arange(lookback, dtype=torch.int64, device=flat.device).view(
-            1, lookback
-        )
+        - width
+        + torch.arange(width, dtype=torch.int64, device=flat.device).view(1, width)
     )
     rows = (starts.view(n, 1) + offs.clamp_min(0)).clamp(max=max(flat.shape[0] - 1, 0))
-    new_rows = flat[rows.reshape(-1)].reshape((n, lookback) + flat.shape[1:])
-    idx_shape = (n, lookback) + (1,) * (old_tail.dim() - 2)
-    expand = (n, lookback) + old_tail.shape[2:]
+    new_rows = flat[rows.reshape(-1)].reshape((n, width) + flat.shape[1:])
+    idx_shape = (n, width) + (1,) * (old_tail.dim() - 2)
+    expand = (n, width) + old_tail.shape[2:]
     old_rows = old_tail.gather(
-        1, (offs + lookback).clamp(0, lookback - 1).view(idx_shape).expand(expand)
+        1, (offs + width).clamp(0, width - 1).view(idx_shape).expand(expand)
     )
     return torch.where((offs >= 0).view(idx_shape), new_rows, old_rows)
 
@@ -410,14 +352,15 @@ class Mtp(BaseDrafter):
 
         self.dp_size = draft_model_runner.mapping.attn.dp_size
 
-        # Drafter-owned alias source for the draft attn backend; advanced in
-        # place during multi-step decode.
+        # Drafter-owned seq_lens the CUDA-graph wrapper aliases into every
+        # draft metadata init (it copies the round's live lengths in; on
+        # EXTEND this buffer also serves as the draft prefill seq_lens).
         self.draft_seq_lens_buf = torch.zeros_like(self.input_buffers.seq_lens_buf)
 
-        # Persistent output buffer for the draft step's compute_out_cache_loc:
-        # D lookback rows per request, or the full k-row frontier window.
+        # Persistent output buffer for the frontier window's cache write
+        # locations (k rows per request).
         self.draft_out_cache_loc_buf = torch.empty(
-            (self.input_buffers.max_bs * max(spec_num_steps - 1, spec_num_tokens),),
+            (self.input_buffers.max_bs * spec_num_tokens,),
             dtype=torch.int32,
             device=self.device,
         )
@@ -439,61 +382,33 @@ class Mtp(BaseDrafter):
 
         # Multi-depth drafting has no DP support: idle rounds (a DP rank
         # keeping collectives in sync with no work of its own) have no
-        # window to run, and the lookback rows change per-rank token counts.
+        # window to run.
         if self.dp_size > 1:
             raise NotImplementedError(
                 "multi-depth MTP drafting does not support data parallelism "
                 f"(dp_size={self.dp_size})"
             )
 
-        # Decode-window repair mode (INKLING_MTP_DECODE_LOOKBACK A/B knob via
-        # the model's draft_decode_lookback): 1 = verify-anchored window plus
-        # D lookback rows (armed only when the backend supports it), 2 =
-        # frontier-anchored k-row window (the backend MUST support it).
-        model = draft_model_runner.model
-        mode = int(getattr(model, "draft_decode_lookback", 0) or 0)
-        lookback = 0
-        frontier = False
-        if spec_num_steps > 1 and mode == 1:
-            lookback = spec_num_steps - 1
-            configure = getattr(self.attn_backend, "configure_draft_lookback", None)
-            if configure is None or not configure(lookback):
-                lookback = 0
-        elif spec_num_steps > 1 and mode == 2:
-            configure = getattr(self.attn_backend, "configure_draft_frontier", None)
-            if configure is None or not configure():
-                raise RuntimeError(
-                    "Inkling MTP frontier window: the draft attention backend "
-                    "cannot arm it (configure_draft_frontier missing or refused)"
-                )
-            frontier = True
-        self.draft_lookback = lookback
-        self.draft_frontier = frontier
-        # Cross-round drafter stashes keyed by req_pool_indices (PAD rows
-        # clamp to the reserved slot 0). Lookback: the last D committed
-        # tokens and depth-0 chain rows. Frontier: the last k-1 committed
-        # tokens and the target hiddens one position behind them. Allocated
-        # eagerly — the decode rounds that fill them run inside CUDA graph
-        # capture, where allocation is off-limits.
-        self._stash_width = (spec_num_tokens - 1) if frontier else lookback
-        self._lookback_hidden_buf: torch.Tensor | None = None
-        if self._stash_width:
-            if self.runtime_states is None:
-                raise RuntimeError("MTP lookback requires request-pool runtime state")
-            model_config = draft_model_runner.model_config
-            # page_table is batch-ordered and may have fewer rows than the
-            # request-pool indices used to address these persistent stashes.
-            request_pool_rows = self.runtime_states.valid_cache_lengths.shape[0]
-            self._lookback_tokens_buf = torch.zeros(
-                (request_pool_rows, self._stash_width),
-                dtype=torch.int64,
-                device=self.device,
-            )
-            self._lookback_hidden_buf = torch.zeros(
-                (request_pool_rows, self._stash_width, model_config.hidden_size),
-                dtype=model_config.dtype,
-                device=self.device,
-            )
+        # Cross-round drafter stash keyed by req_pool_indices (PAD rows clamp
+        # to the reserved slot 0): the last k-1 committed tokens and the
+        # target hiddens one position behind them. Allocated eagerly — the
+        # decode rounds that fill it run inside CUDA graph capture, where
+        # allocation is off-limits.
+        self._stash_width = spec_num_tokens - 1
+        model_config = draft_model_runner.model_config
+        # page_table is batch-ordered and may have fewer rows than the
+        # request-pool indices used to address these persistent stashes.
+        request_pool_rows = self.runtime_states.valid_cache_lengths.shape[0]
+        self._stash_tokens_buf = torch.zeros(
+            (request_pool_rows, self._stash_width),
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self._stash_hidden_buf = torch.zeros(
+            (request_pool_rows, self._stash_width, model_config.hidden_size),
+            dtype=model_config.dtype,
+            device=self.device,
+        )
 
     def _accepted_output_indices(
         self,
@@ -624,7 +539,7 @@ class Mtp(BaseDrafter):
         input_num_tokens = draft_input.input_num_tokens
 
         # Multi-depth window mode and extend catch-up chain FULL per-row
-        # hidden states between depths (see _run_multi_step /
+        # hidden states between depths (see _run_frontier_window /
         # _run_extend_depth_catchup); logits stay gathered.
         capture_mode = (
             CaptureHiddenMode.FULL
@@ -644,7 +559,6 @@ class Mtp(BaseDrafter):
             global_num_tokens=draft_input.global_num_tokens,
             global_bs=draft_input.global_bs,
             all_decode_or_idle=draft_input.all_decode_or_idle,
-            draft_seq_lens_buf=self.draft_seq_lens_buf,
             accept_lengths=draft_input.accept_lengths,
         )
 
@@ -657,206 +571,6 @@ class Mtp(BaseDrafter):
             spec_step_idx=0,
         )
         return logits_output
-
-    @nvtx_range("draft_multi_step", color="purple")
-    def _run_multi_step(
-        self,
-        bs: int,
-        next_tokens: torch.Tensor,
-        logits_output: LogitsProcessorOutput,
-        draft_input: MtpDraftInput,
-    ) -> None:
-        """Multi-depth decode window passes.
-
-        Multi-depth MTP heads are trained as full-sequence layers: depth d's
-        attention at source position p runs over depth-d activations of ALL
-        positions <= p, so a one-row-per-step chain loop would leave its
-        queries attending over KV it mostly never wrote.
-
-        Every step d re-runs depth layer d over the SAME verify window the
-        first step processed (same positions and KV slot locations — the KV
-        pool write is layer-indexed), consuming:
-
-        - the previous depth's FULL chain-normed window rows as
-          captured_hidden_states (row j = source position p_j), and
-        - per-depth shifted input ids: row j of depth d needs the token at
-          source p_j + d, which is the verify output ``v[j + d]`` while it
-          lands inside the accepted prefix and the drafter's own token
-          ``d_m`` (m = j + d - accept + 1 <= d) at the accepted tail. Rows
-          past the accepted prefix are rejected-tail garbage; their KV is
-          rewritten by the next round's window, which starts at the first
-          uncommitted position.
-
-        The drafted token for step d is sampled at the accept-position row
-        (same gather as the first step). Nothing advances between steps: the
-        attention metadata, conv metadata (valid-length catch-up mode),
-        positions, and out_cache_loc of the first step are all reused.
-        """
-        k = self.spec_num_tokens
-        buffers = self.input_buffers
-        v = draft_input.base_model_output.view(bs, k).to(torch.int64)
-        accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
-        gather_ids = self._accepted_output_indices(draft_input.accept_lengths, bs)
-        positions = buffers.positions_buf[: bs * k]
-        out_cache_loc = buffers.out_cache_loc_buf[: bs * k]
-        col = torch.arange(k, dtype=torch.int64, device=v.device).view(1, k)
-
-        prev_hidden = logits_output.hidden_states  # [bs*k, H], depth d-1 rows
-        for d in range(1, self.spec_num_steps):
-            input_ids = _decode_shifted_ids(
-                v, accept, next_tokens, d, src=col + d
-            ).reshape(-1)
-
-            ctx = ForwardContext(
-                bs=bs,
-                num_extends=0,
-                attn_backend=self.attn_backend,
-                token_to_kv_pool=self.token_to_kv_pool,
-                input_num_tokens=bs * k,
-                forward_mode=ForwardMode.DECODE,
-                capture_hidden_mode=CaptureHiddenMode.FULL,
-                gather_ids=gather_ids,
-                global_num_tokens=draft_input.global_num_tokens,
-                global_bs=draft_input.global_bs,
-                all_decode_or_idle=draft_input.all_decode_or_idle,
-                draft_seq_lens_buf=self.draft_seq_lens_buf,
-                accept_lengths=draft_input.accept_lengths,
-            )
-
-            with nvtx_range("draft_step_forward", color="red"):
-                logits_output = self.draft_model_runner.forward(
-                    ctx=ctx,
-                    input_ids=input_ids,
-                    positions=positions,
-                    out_cache_loc=out_cache_loc,
-                    captured_hidden_states=prev_hidden,
-                    spec_step_idx=d,
-                )
-            prev_hidden = logits_output.hidden_states
-
-            with nvtx_range("draft_sample", color="yellow"):
-                next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
-
-    @nvtx_range("draft_multi_step_lookback", color="purple")
-    def _run_multi_step_lookback(
-        self,
-        bs: int,
-        next_tokens: torch.Tensor,
-        logits_output: LogitsProcessorOutput,
-        draft_input: MtpDraftInput,
-        slot: torch.Tensor,
-        v: torch.Tensor,
-        accept: torch.Tensor,
-    ) -> bool:
-        """Lookback variant of ``_run_multi_step``.
-
-        Every depth d >= 1 re-runs over ``D + k`` rows per request
-        (D = steps-1): the D leading rows re-cover the last D committed
-        positions — whose entries were first written while their input
-        tokens were still unverified drafts — from now-committed tokens,
-        overwriting the stale KV and conv contributions in place. Depth 1's
-        lookback rows chain the stashed depth-0 hidden (depth 0 has no
-        residue of its own, so it never re-runs); deeper depths chain the
-        previous pass's corrected full rows directly.
-
-        Attention rides the first step's decode metadata unchanged: the rel
-        decode kernel derives ``max_seqlen_q`` from the row count, and with
-        the round's ``seq_lens`` the D+k queries land at positions
-        ``vc-D .. vc+k-1`` — exactly the extended window. Conv metadata is
-        rebuilt by the backend hook (lagged-window recurrence).
-
-        ``slot``/``v``/``accept`` come pre-sliced from the caller (see
-        ``_decode_slices``), which also feeds them to the stash roll.
-
-        Returns False when the backend refuses the lookback metadata; the
-        caller then falls back to the plain window pass. This runs inside
-        CUDA graph capture (MTP decode rounds are graph-captured), so there
-        are no host syncs: sub-D prompts, whose lookback would cross
-        position 0, are clamped GPU-side instead — their first positions
-        get wrong-shift rewrites, bounded to prompts shorter than steps-1
-        tokens (below any real chat traffic).
-        """
-        k = self.spec_num_tokens
-        lb = self.draft_lookback
-        buffers = self.input_buffers
-        positions = buffers.positions_buf[: bs * k]
-        first_pos = positions.view(bs, k)[:, 0]
-        enter = getattr(self.attn_backend, "enter_draft_lookback_window", None)
-        if enter is None or not enter(bs):
-            return False
-        total = lb + k
-        gather_ids = (
-            torch.arange(bs, dtype=torch.int64, device=v.device) * total
-            + (lb - 1)
-            + accept.view(-1)
-        )
-        # The D lookback rows prepend the committed slots just before the
-        # verify window; their cache locs go through the paged mapping.
-        lb_positions = (
-            first_pos.view(bs, 1)
-            - lb
-            + torch.arange(lb, dtype=positions.dtype, device=v.device).view(1, lb)
-        ).clamp_min(0)
-        step_positions = torch.cat([lb_positions, positions.view(bs, k)], 1).reshape(-1)
-        lb_cache_loc = self.draft_out_cache_loc_buf[: bs * lb]
-        self.cache_view.out_cache_loc_uniform(
-            out=lb_cache_loc,
-            cache_start=(first_pos - lb).clamp_min(0).to(torch.int32),
-            num_tokens=lb,
-        )
-        out_cache_loc = torch.cat(
-            [
-                lb_cache_loc.view(bs, lb),
-                buffers.out_cache_loc_buf[: bs * k].view(bs, k),
-            ],
-            1,
-        ).reshape(-1)
-        stash_tokens = self._lookback_tokens_buf[slot]
-        hidden_stash = self._lookback_hidden_buf
-        h0 = logits_output.hidden_states  # [bs*k, H], depth-0 rows
-        prev_hidden = torch.cat([hidden_stash[slot], h0.view(bs, k, -1)], 1).reshape(
-            bs * total, -1
-        )
-        # Depth-invariant base of the per-depth source coordinates.
-        base_src = (
-            torch.arange(total, dtype=torch.int64, device=v.device).view(1, total) - lb
-        )
-        for d in range(1, self.spec_num_steps):
-            input_ids = _lookback_shifted_ids(
-                v, accept, next_tokens, stash_tokens, d, lb, src=base_src + d
-            )
-            input_ids = self._prepare_draft_input_ids(input_ids)
-
-            ctx = ForwardContext(
-                bs=bs,
-                num_extends=0,
-                attn_backend=self.attn_backend,
-                token_to_kv_pool=self.token_to_kv_pool,
-                input_num_tokens=bs * total,
-                forward_mode=ForwardMode.DECODE,
-                capture_hidden_mode=CaptureHiddenMode.FULL,
-                gather_ids=gather_ids,
-                global_num_tokens=draft_input.global_num_tokens,
-                global_bs=draft_input.global_bs,
-                all_decode_or_idle=draft_input.all_decode_or_idle,
-                draft_seq_lens_buf=self.draft_seq_lens_buf,
-                accept_lengths=draft_input.accept_lengths,
-            )
-
-            with nvtx_range("draft_lookback_forward", color="red"):
-                logits_output = self.draft_model_runner.forward(
-                    ctx=ctx,
-                    input_ids=input_ids,
-                    positions=step_positions,
-                    out_cache_loc=out_cache_loc,
-                    captured_hidden_states=prev_hidden,
-                    spec_step_idx=d,
-                )
-            prev_hidden = logits_output.hidden_states
-
-            with nvtx_range("draft_sample", color="yellow"):
-                next_tokens[:, d + 1] = self._sample_step_tokens(logits_output)
-        return True
 
     @nvtx_range("draft_frontier_window", color="purple")
     def _run_frontier_window(
@@ -909,19 +623,13 @@ class Mtp(BaseDrafter):
             cache_start=(frontier - k).clamp_min(0),
             num_tokens=k,
         )
-        enter = getattr(self.attn_backend, "enter_draft_frontier_window", None)
-        if enter is None:
-            raise RuntimeError(
-                "Inkling MTP frontier window: the draft attention backend "
-                "lacks enter_draft_frontier_window"
-            )
-        enter(bs, frontier)
+        self.attn_backend.enter_draft_frontier_window(bs, frontier)
         # Static sample gather: the last window row sits at frontier-1 for
         # every depth (row at position p and depth d predicts p + d + 2).
         gather_ids = self.padded_gather_ids_offsets_buf[:bs] + k
-        stash_tokens = self._lookback_tokens_buf[slot]
+        stash_tokens = self._stash_tokens_buf[slot]
         prev_hidden = _frontier_hidden_splice(
-            self._lookback_hidden_buf[slot],
+            self._stash_hidden_buf[slot],
             draft_input.base_out_hidden_states.view(bs, k, -1),
             accept,
         )
@@ -942,7 +650,6 @@ class Mtp(BaseDrafter):
                 global_num_tokens=draft_input.global_num_tokens,
                 global_bs=draft_input.global_bs,
                 all_decode_or_idle=draft_input.all_decode_or_idle,
-                draft_seq_lens_buf=self.draft_seq_lens_buf,
                 accept_lengths=draft_input.accept_lengths,
             )
 
@@ -963,7 +670,7 @@ class Mtp(BaseDrafter):
     def _decode_slices(
         self, bs: int, draft_input: MtpDraftInput
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """``(slot, v, accept)`` shared by the lookback window pass and the
+        """``(slot, v, accept)`` shared by the frontier window pass and the
         decode stash roll: [bs] int64 stash slots, [bs, k] int64 verify
         outputs, [bs, 1] int64 accepted lengths clamped to [1, k]."""
         k = self.spec_num_tokens
@@ -972,45 +679,42 @@ class Mtp(BaseDrafter):
         accept = draft_input.accept_lengths[:bs].to(torch.int64).clamp(1, k).view(bs, 1)
         return slot, v, accept
 
-    def _update_lookback_stash_decode(
+    def _update_stash_decode(
         self,
         slot: torch.Tensor,
         accept: torch.Tensor,
         v: torch.Tensor,
-        h0: torch.Tensor,
+        hidden_rows: torch.Tensor,
     ) -> None:
-        """Roll the cross-round drafter stashes past a round's decode-row
+        """Roll the cross-round drafter stash past a round's decode-row
         commits.
 
         Args come pre-sliced per decode row: ``slot`` [n] int64 stash slots,
         ``accept`` [n]-viewable int64 accepts clamped to [1, k], ``v`` [n, k]
-        int64 verify outputs, ``h0`` [n, k, H] hidden rows — depth-0 chain
-        rows in lookback mode, this round's target verify hiddens in
-        frontier mode (verify hidden row j sits one position behind verify
-        token j, which is why the frontier hidden stash ends one position
-        before the token stash).
+        int64 verify outputs, ``hidden_rows`` [n, k, H] this round's target
+        verify hiddens (verify hidden row j sits one position behind verify
+        token j, which is why the hidden stash ends one position before the
+        token stash).
         """
-        lb = self._stash_width
-        tokens = self._lookback_tokens_buf
-        tokens[slot] = _committed_tail_update(tokens[slot], v, accept, lb)
-        hidden = self._lookback_hidden_buf
-        hidden[slot] = _committed_tail_update(hidden[slot], h0, accept, lb)
+        width = self._stash_width
+        tokens = self._stash_tokens_buf
+        tokens[slot] = _committed_tail_update(tokens[slot], v, accept, width)
+        hidden = self._stash_hidden_buf
+        hidden[slot] = _committed_tail_update(hidden[slot], hidden_rows, accept, width)
 
-    def _update_lookback_stash_extend(
+    def _update_stash_extend(
         self,
         draft_input: MtpDraftInput,
-        h0_full: torch.Tensor,
+        hidden_full: torch.Tensor,
     ) -> None:
-        """Roll the stashes across an EXTEND/MIXED round's chunk rows.
+        """Roll the stash across an EXTEND/MIXED round's chunk rows.
 
-        Prefill requests stash the last stash-width shift-1 ids and hidden
-        rows of their chunk (blending across chunk boundaries when a chunk
-        is shorter than the stash); MIXED decode rows roll the same
+        Prefill requests stash the last stash-width shift-1 ids and target
+        hidden rows of their chunk (blending across chunk boundaries when a
+        chunk is shorter than the stash); MIXED decode rows roll the same
         committed-tail update as pure decode, offset past the prefill rows.
-        ``h0_full`` is the caller's per-mode hidden source: depth-0 chain
-        rows (lookback) or the target's full rows (frontier).
         """
-        lb = self._stash_width
+        width = self._stash_width
         k = self.spec_num_tokens
         buffers = self.input_buffers
         ne = draft_input.num_extends
@@ -1019,22 +723,22 @@ class Mtp(BaseDrafter):
         num_prefill_tokens = draft_input.input_num_tokens - nd * k
         slot = buffers.req_pool_indices_buf[:bs].to(torch.int64).clamp_min(0)
         lengths = buffers.input_lengths_buf[:ne]
-        tokens = self._lookback_tokens_buf
-        hidden = self._lookback_hidden_buf
+        tokens = self._stash_tokens_buf
+        hidden = self._stash_hidden_buf
         shift1 = buffers.shifted_prefill_ids_buf[:num_prefill_tokens].to(torch.int64)
         extend_slot = slot[:ne]
         tokens[extend_slot] = _ragged_tail_rows(
-            shift1, lengths, tokens[extend_slot], lb
+            shift1, lengths, tokens[extend_slot], width
         )
         hidden[extend_slot] = _ragged_tail_rows(
-            h0_full[:num_prefill_tokens], lengths, hidden[extend_slot], lb
+            hidden_full[:num_prefill_tokens], lengths, hidden[extend_slot], width
         )
         if nd > 0:
-            self._update_lookback_stash_decode(
+            self._update_stash_decode(
                 slot[ne:],
                 draft_input.accept_lengths[ne:bs].to(torch.int64).clamp(1, k),
                 draft_input.base_model_output[ne:].view(nd, k).to(torch.int64),
-                h0_full[num_prefill_tokens:].view(nd, k, -1),
+                hidden_full[num_prefill_tokens:].view(nd, k, -1),
             )
 
     @nvtx_range("draft_extend_catchup", color="purple")
@@ -1076,18 +780,9 @@ class Mtp(BaseDrafter):
         input_num_tokens = draft_input.input_num_tokens
         num_prefill_tokens = input_num_tokens - nd * k
 
-        if self._stash_width:
-            # Before the loop rebinds logits_output: this round's chunk tail
-            # feeds the next decode round's window (depth-0 rows for the
-            # lookback window, target rows for the frontier window).
-            self._update_lookback_stash_extend(
-                draft_input,
-                (
-                    draft_input.base_out_hidden_states
-                    if self.draft_frontier
-                    else logits_output.hidden_states
-                ),
-            )
+        # This round's chunk tail (shift-1 ids + target rows) feeds the
+        # next decode round's frontier window.
+        self._update_stash_extend(draft_input, draft_input.base_out_hidden_states)
 
         shift1_ids = buffers.shifted_prefill_ids_buf[:num_prefill_tokens]
         input_lengths = buffers.input_lengths_buf[:ne]
@@ -1138,7 +833,6 @@ class Mtp(BaseDrafter):
                 global_num_tokens=draft_input.global_num_tokens,
                 global_bs=draft_input.global_bs,
                 all_decode_or_idle=draft_input.all_decode_or_idle,
-                draft_seq_lens_buf=self.draft_seq_lens_buf,
                 accept_lengths=draft_input.accept_lengths,
             )
 
@@ -1212,16 +906,15 @@ class Mtp(BaseDrafter):
             )
         next_tokens[:, 1:] = next_tokens[:, :1]
 
-        # Seed the draft attn backend's aliased seq_lens for the first step.
-        self.draft_seq_lens_buf[:bs].copy_(self.input_buffers.seq_lens_buf[:bs])
-
-        if self.draft_frontier and draft_input.num_extends == 0:
-            # Frontier-anchored decode round: no verify-anchored pass exists
-            # in this mode — depth 0 runs inside the re-anchored window loop.
+        if draft_input.num_extends == 0:
+            # Pure-decode round: no verify-anchored pass exists — depth 0
+            # runs inside the frontier window loop. override_num_extends
+            # drops any [num_extends:] slice a MIXED target set up; no-op on
+            # backends that fill separate prefill/decode metadata at init.
             with self.attn_backend.override_num_extends(0):
                 slot, v, accept = self._decode_slices(bs, draft_input)
                 self._run_frontier_window(bs, next_tokens, draft_input, slot, v, accept)
-                self._update_lookback_stash_decode(
+                self._update_stash_decode(
                     slot,
                     accept,
                     v,
@@ -1238,56 +931,15 @@ class Mtp(BaseDrafter):
         draft_ids = self._sample_step_tokens(logits_output)
         next_tokens[:, 1] = draft_ids
 
-        if self.spec_num_steps <= 1:
-            return next_tokens
-
-        if draft_input.num_extends > 0:
-            # EXTEND/MIXED with per-depth prompt coverage: reuses the first
-            # step's extend metadata as-is, so it must run OUTSIDE the
-            # override_num_extends(0) below. This covers mid-chunk EXTEND
-            # rounds too — their drafts get discarded (no verification
-            # completes after this forward), but catch-up's point is
-            # per-depth KV/sconv coverage of THIS chunk's rows; skipping
-            # mid-chunks would leave every chunk but the last uncovered for
-            # depths >= 1 on long prompts.
-            self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
-            return next_tokens
-
-        # Draft steps 2+ (pure-decode window passes): operate on full bs;
-        # drop the [num_extends:] slice that step 0 may have set up for
-        # MIXED target. No-op on backends that fill separate prefill/decode
-        # metadata at init time.
-        with self.attn_backend.override_num_extends(0):
-            use_lookback = self.draft_lookback > 0
-            ran_lookback = False
-            if use_lookback:
-                slot, v, accept = self._decode_slices(bs, draft_input)
-                ran_lookback = self._run_multi_step_lookback(
-                    bs,
-                    next_tokens,
-                    logits_output,
-                    draft_input,
-                    slot,
-                    v,
-                    accept,
-                )
-            if not ran_lookback:
-                self._run_multi_step(
-                    bs,
-                    next_tokens,
-                    logits_output,
-                    draft_input,
-                )
-            if use_lookback:
-                # Keep the stashes fresh even on fallback rounds; the
-                # next round may look back. logits_output here is still
-                # the first step's FULL depth-0 capture.
-                self._update_lookback_stash_decode(
-                    slot,
-                    accept,
-                    v,
-                    logits_output.hidden_states.view(bs, self.spec_num_tokens, -1),
-                )
+        # EXTEND/MIXED with per-depth prompt coverage: reuses the first
+        # step's extend metadata as-is. This covers mid-chunk EXTEND
+        # rounds too — their drafts get discarded (no verification
+        # completes after this forward), but catch-up's point is
+        # per-depth KV/sconv coverage of THIS chunk's rows; skipping
+        # mid-chunks would leave every chunk but the last uncovered for
+        # depths >= 1 on long prompts. At spec_num_steps == 1 its depth
+        # loop is empty and only the stash priming runs.
+        self._run_extend_depth_catchup(bs, next_tokens, logits_output, draft_input)
         return next_tokens
 
     @override

--- a/python/tokenspeed/runtime/execution/input_buffer.py
+++ b/python/tokenspeed/runtime/execution/input_buffer.py
@@ -29,6 +29,7 @@ from tokenspeed.runtime.execution.cache_loc_kernel import (
     fused_decode_input_prep,
 )
 from tokenspeed.runtime.execution.forward_batch_info import compute_position_triton
+from tokenspeed.runtime.multimodal.inputs import Modality, substitute_mm_pad_
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 
@@ -63,6 +64,10 @@ class InputBuffers:
         self.state_write_padding_pool_index = state_write_padding_pool_index
         self.max_bs = max_bs
         self.all_extends_mid_chunk = False
+        # Per-modality in-vocab draft tokens; when set, fill rewrites the
+        # drafter-only shift-1 buffer's media pad ids in place so drafters
+        # only ever see embeddable input ids.
+        self.mm_pad_substitute_ids: dict[Modality, int] = {}
 
         with torch.device(device):
             # Initialise buffers to the *padding* values the captured graph
@@ -118,6 +123,27 @@ class InputBuffers:
             off += (nbytes + align - 1) // align * align
         bulk = torch.empty(off, dtype=torch.int8, pin_memory=True)
         return [bulk[o : o + n * dt.itemsize].view(dt) for o, n, dt in offsets]
+
+    def set_mm_pad_substitute_ids(
+        self, substitute_ids: dict[Modality, int], vocab_size: int
+    ) -> None:
+        """Install the per-modality draft substitutes applied at fill time.
+
+        Args:
+            substitute_ids: in-vocab token id per media modality.
+            vocab_size: target vocabulary size, for validation.
+        """
+        invalid = {
+            modality: token_id
+            for modality, token_id in substitute_ids.items()
+            if token_id < 0 or token_id >= vocab_size
+        }
+        if invalid:
+            raise ValueError(
+                "MM draft substitute token IDs must be inside the target "
+                f"vocabulary: {invalid} (vocab_size={vocab_size})"
+            )
+        self.mm_pad_substitute_ids = dict(substitute_ids)
 
     @nvtx_range("input_prep_fill", color="cyan")
     def fill_input_buffers(
@@ -314,6 +340,13 @@ class InputBuffers:
                 shifted_ids_cpu,
                 non_blocking=True,
             )
+            if self.mm_pad_substitute_ids:
+                # Media positions carry content-hash ids (prefix-cache keying);
+                # the draft embedding needs the modality's in-vocab token.
+                substitute_mm_pad_(
+                    self.shifted_prefill_ids_buf[:prefill_token_count],
+                    self.mm_pad_substitute_ids,
+                )
             if num_extends < batch_size:
                 decode_req_pool_indices = req_pool_indices_device[
                     num_extends:batch_size
@@ -357,15 +390,13 @@ class InputBuffers:
         # Defensive clamp of the target-model IDs into the valid vocab range.
         # Decode IDs come from future_input_map, written by the previous
         # sampler/drafter; a stale/corrupt value must not reach the captured
-        # graph's embedding gather. The shifted draft buffer is deliberately
-        # handled separately below because valid content-derived MM pads are
-        # out-of-vocab until Eagle/MTP restores their modality token.
+        # graph's embedding gather. The shift-1 draft buffer is not clamped:
+        # its prefill segment legitimately carries a -1 placeholder in each
+        # final chunk's last row (patched by the drafter with the round's
+        # sampled token), and every id the drafters consume is sampled or
+        # substituted in-vocab by construction.
         vocab_size = runtime_states.vocab_size
         self.input_ids_buf[:total_tokens].clamp_(0, vocab_size - 1)
-        # Do not clamp shifted_prefill_ids_buf here. Content-derived MM pad IDs
-        # intentionally exceed the vocabulary and retain a modality tag until
-        # Eagle/MTP replaces them with model-specific in-vocab tokens. The draft
-        # path performs its own defensive clamp immediately after substitution.
 
         if valid_cache_lengths is not None:
             torch.add(

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -427,7 +427,7 @@ class ModelExecutor:
             )
             self.drafter.wire_target(self.model_runner.model)
             MultimodalRuntime.wire_drafter(
-                self.drafter, self.model_runner.model_config.hf_config
+                self.input_buffers, self.model_runner.model_config
             )
         else:
             self.drafter = None

--- a/python/tokenspeed/runtime/execution/multimodal_runtime.py
+++ b/python/tokenspeed/runtime/execution/multimodal_runtime.py
@@ -293,11 +293,24 @@ class MultimodalRuntime:
         return active_wrappers
 
     @staticmethod
-    def wire_drafter(drafter, target_hf_config) -> None:
-        """Hand the drafter the pad-substitute token IDs for mm placeholders."""
-        mm_pad_substitute_ids = resolve_mm_pad_substitute_ids(target_hf_config)
-        if mm_pad_substitute_ids and hasattr(drafter, "set_mm_pad_substitute_ids"):
-            drafter.set_mm_pad_substitute_ids(mm_pad_substitute_ids)
+    def wire_drafter(input_buffers, target_model_config) -> None:
+        """Wire mm pad substitution for the draft path.
+
+        Substitution runs once at fill time on the drafter-only shift-1
+        buffer, so drafters only ever see in-vocab input ids. A multimodal
+        target with no resolvable substitutes must fail here, loudly —
+        otherwise the fill clamp would silently rewrite media positions.
+        """
+        substitute_ids = resolve_mm_pad_substitute_ids(target_model_config.hf_config)
+        if substitute_ids:
+            input_buffers.set_mm_pad_substitute_ids(
+                substitute_ids, target_model_config.vocab_size
+            )
+        elif target_model_config.is_multimodal_active:
+            raise ValueError(
+                "Speculative decoding on a multimodal target requires draft "
+                "substitute tokens, but none could be resolved from the HF config."
+            )
 
     # ------------------------------------------------------------------
     # Diagnostics

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -316,12 +316,11 @@ class CacheGroupsMixin:
         md = self.forward_decode_metadata
         fields = {"seq_lens": frontier[:bs]}
         if md.out_cache_locs is not None:
-            spec_n = max(int(getattr(self, "spec_num_tokens", 1) or 1), 1)
             fields["out_cache_locs"] = self._compute_decode_group_out_cache_locs(
                 md.page_tables,
                 frontier[:bs],
                 self.kernel_page_size,
-                spec_n,
+                self.spec_num_tokens,
             )
         self.forward_decode_metadata = replace(md, **fields)
 

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -345,6 +345,33 @@ class CacheGroupsMixin:
         self.forward_decode_metadata = replace(md, out_cache_locs=locs)
         return True
 
+    def enter_draft_frontier(self, bs: int, frontier: torch.Tensor) -> None:
+        """Drafter hook (via the Inkling conv wrapper): re-anchor the k-row
+        decode metadata to end at the committed frontier.
+
+        Replaces ``seq_lens`` with the per-request frontier and recomputes
+        the grouped write locs for k tokens ending there (positions
+        ``frontier-k..frontier-1``). The frontier depends on this round's
+        accept lengths, which are only known inside the captured graph, so
+        both replacements are plain tensor ops recorded at capture and
+        recomputed on every replay — unlike the lookback variant, whose
+        accept-independent locs are refilled host-side. The next round's
+        metadata init restores the plain metadata.
+        """
+        md = self.forward_decode_metadata
+        if md is None:
+            raise RuntimeError("frontier window: no decode metadata to re-anchor")
+        fields = {"seq_lens": frontier[:bs]}
+        if md.out_cache_locs is not None:
+            spec_n = max(int(getattr(self, "spec_num_tokens", 1) or 1), 1)
+            fields["out_cache_locs"] = self._compute_decode_group_out_cache_locs(
+                md.page_tables,
+                frontier[:bs],
+                self.page_size,
+                spec_n,
+            )
+        self.forward_decode_metadata = replace(md, **fields)
+
     def _maybe_check_group_write_locs(self, page_tables, out_cache_locs, page_size):
         """TOKENSPEED_CACHE_DEBUG=1 (eager only, GPU sync): write pages must
         be real and inside the group's table. Not for graph-padded batches —

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -77,11 +77,6 @@ class CacheGroupsMixin:
     # Wrapper-owned (Inkling conv) groups: mixin skips their write-loc math and capture buffers
     engine_owned_group_ids: frozenset[str] = frozenset()
 
-    # Draft decode-window lookback rows (Inkling MTP): armed by the conv
-    # wrapper's configure_draft_lookback BEFORE graph init, so the lookback
-    # loc stack below is sized alongside the main one.
-    draft_lookback: int = 0
-
     # Value for CUDA-graph buffer column tails past this replay's table
     # width. -1 is a debug tripwire (never read past cache_seqlens by the
     # MHA kernels); backends whose kernels assume a full-width table
@@ -306,45 +301,6 @@ class CacheGroupsMixin:
             for gid, chunks in out.items()
         }
 
-    def enter_draft_lookback(self, bs: int) -> bool:
-        """Drafter hook (via the Inkling conv wrapper): swap the decode
-        metadata's write locs to the lookback-window variant — N + D tokens
-        per request at positions ``seq-(N+D)..seq-1`` — so the lookback
-        pass's KV writes cover its extra leading rows.
-
-        Metadata without grouped locations needs no swap: the drafter's caller
-        locations are live there. Returns False when grouped locations cannot be
-        provided (lookback disarmed, or a captured metadata without the
-        lookback loc stack), so the caller falls back to the plain window
-        pass. The next round's metadata init restores the plain locs.
-        """
-        md = self.forward_decode_metadata
-        if md is None or md.out_cache_locs is None:
-            return True
-        lookback = int(getattr(self, "draft_lookback", 0) or 0)
-        if lookback <= 0:
-            return False
-        spec_n = max(int(getattr(self, "spec_num_tokens", 1) or 1), 1)
-        total = spec_n + lookback
-        captured = getattr(self, "cuda_graph_decode_metadata", None) or {}
-        if md is captured.get(bs):
-            if not self.cuda_graph_lookback_locs:
-                return False
-            locs = {
-                gid: buf[: bs * total]
-                for gid, buf in self.cuda_graph_lookback_locs.items()
-                if gid in md.out_cache_locs
-            }
-        else:
-            locs = self._compute_decode_group_out_cache_locs(
-                md.page_tables,
-                md.seq_lens,
-                self.kernel_page_size,
-                total,
-            )
-        self.forward_decode_metadata = replace(md, out_cache_locs=locs)
-        return True
-
     def enter_draft_frontier(self, bs: int, frontier: torch.Tensor) -> None:
         """Drafter hook (via the Inkling conv wrapper): re-anchor the k-row
         decode metadata to end at the committed frontier.
@@ -354,20 +310,17 @@ class CacheGroupsMixin:
         ``frontier-k..frontier-1``). The frontier depends on this round's
         accept lengths, which are only known inside the captured graph, so
         both replacements are plain tensor ops recorded at capture and
-        recomputed on every replay — unlike the lookback variant, whose
-        accept-independent locs are refilled host-side. The next round's
-        metadata init restores the plain metadata.
+        recomputed on every replay — a host-side fill could not serve them.
+        The next round's metadata init restores the plain metadata.
         """
         md = self.forward_decode_metadata
-        if md is None:
-            raise RuntimeError("frontier window: no decode metadata to re-anchor")
         fields = {"seq_lens": frontier[:bs]}
         if md.out_cache_locs is not None:
             spec_n = max(int(getattr(self, "spec_num_tokens", 1) or 1), 1)
             fields["out_cache_locs"] = self._compute_decode_group_out_cache_locs(
                 md.page_tables,
                 frontier[:bs],
-                self.page_size,
+                self.kernel_page_size,
                 spec_n,
             )
         self.forward_decode_metadata = replace(md, **fields)
@@ -408,10 +361,8 @@ class CacheGroupsMixin:
         are gone, on the spec-verify path too."""
         self.cuda_graph_page_tables: dict[str, torch.Tensor] = {}
         self.cuda_graph_out_cache_locs: dict[str, torch.Tensor] = {}
-        self.cuda_graph_lookback_locs: dict[str, torch.Tensor] = {}
         self._cuda_graph_max_bs = max_bs
         self._group_locs_stack = None
-        self._group_lookback_locs_stack = None
         self._group_tables_stack = None
         self._group_source_widths = {}
         self._group_grain_ratios = ()
@@ -478,18 +429,6 @@ class CacheGroupsMixin:
         self._group_locs_stack = torch.zeros(
             (len(att_gids), max_bs * spec_n), dtype=torch.int32, device=self.device
         )
-        lookback = int(getattr(self, "draft_lookback", 0) or 0)
-        if lookback > 0:
-            # Draft lookback window passes write N + D rows per request
-            # (positions seq-(N+D)..seq-1); their captured kernels read this
-            # second stack, refilled alongside the main one at replay.
-            self._group_lookback_locs_stack = torch.zeros(
-                (len(att_gids), max_bs * (spec_n + lookback)),
-                dtype=torch.int32,
-                device=self.device,
-            )
-            for i, gid in enumerate(att_gids):
-                self.cuda_graph_lookback_locs[gid] = self._group_lookback_locs_stack[i]
         self._group_source_widths = source_widths
         self._group_grain_ratios = tuple(ratios[gid] for gid in gids)
         self._group_block_granularities_tensor = torch.tensor(
@@ -694,14 +633,3 @@ class CacheGroupsMixin:
             bs,
             tokens_per_req,
         )
-        if self._group_lookback_locs_stack is not None:
-            # Second variant for the draft's lookback window passes: N + D
-            # rows per request ending at the same frontier.
-            compute_group_decode_locs(
-                self._group_tables_stack[: self._attention_group_count],
-                self._group_block_granularities_tensor,
-                seq_lens[:bs],
-                self._group_lookback_locs_stack,
-                bs,
-                tokens_per_req + self.draft_lookback,
-            )

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -301,24 +301,18 @@ class CacheGroupsMixin:
             for gid, chunks in out.items()
         }
 
-    def enter_draft_frontier(self, bs: int, frontier: torch.Tensor) -> None:
-        """Drafter hook (via the Inkling conv wrapper): re-anchor the k-row
-        decode metadata to end at the committed frontier.
-
-        Replaces ``seq_lens`` with the per-request frontier and recomputes
-        the grouped write locs for k tokens ending there (positions
-        ``frontier-k..frontier-1``). The frontier depends on this round's
-        accept lengths, which are only known inside the captured graph, so
-        both replacements are plain tensor ops recorded at capture and
-        recomputed on every replay — a host-side fill could not serve them.
-        The next round's metadata init restores the plain metadata.
-        """
+    def update_draft_forward_metadata(self, frontier: torch.Tensor) -> None:
+        """Re-anchor the k-row decode metadata to the committed frontier:
+        seq_lens becomes ``frontier`` and the grouped write locs cover
+        positions ``frontier-k..frontier-1``. Accept-dependent, so pure
+        tensor ops recomputed per graph replay; the next metadata init
+        resets."""
         md = self.forward_decode_metadata
-        fields = {"seq_lens": frontier[:bs]}
+        fields = {"seq_lens": frontier}
         if md.out_cache_locs is not None:
             fields["out_cache_locs"] = self._compute_decode_group_out_cache_locs(
                 md.page_tables,
-                frontier[:bs],
+                frontier,
                 self.kernel_page_size,
                 self.spec_num_tokens,
             )

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -117,7 +117,7 @@ class InklingConvStatePool:
 
     Memory layout: ``[num_layers, num_slots, R, conv_dim]`` — the feature dim
     is contiguous (the ``tokenspeed_kernel.ops.conv`` kernels' contract). Ring
-    row of absolute position ``p`` is ``p % R``; ``R >= (W-1) + K + lookback``
+    row of absolute position ``p`` is ``p % R``; ``R >= (W-1) + K``
     so a round's pre-chunk tap reads and chunk-row writes never alias. The
     four streams of a block live at fixed channel offsets given by
     ``inkling_conv_stream_layout``; modules take channel slices.
@@ -196,14 +196,6 @@ class InklingAttnBackend(AttentionBackend):
         self.conv_spec_num_tokens = max(1, int(spec_num_tokens))
         self.conv_is_draft = is_draft
         self.enable_layerwise_cache_ready = enable_layerwise_cache_ready
-        # Draft decode-window lookback: D > 0 makes the catch-up chunk carry
-        # D extra leading rows that re-run committed positions (ring reads go
-        # D deeper). Configured by the drafter via configure_draft_lookback.
-        self._draft_lookback = 0
-        # Draft frontier-anchored window: the k-row catch-up chunk is
-        # re-anchored to end at the committed frontier each decode round.
-        # Configured by the drafter via configure_draft_frontier.
-        self._draft_frontier = False
         # Persistent spec conv metadata buffers for CUDA graphs; sized in init_cuda_graph_state.
         self._graph_spec_qsl: torch.Tensor | None = None
         self._graph_spec_seq_idx: torch.Tensor | None = None
@@ -579,74 +571,6 @@ class InklingAttnBackend(AttentionBackend):
             ),
         )
 
-    def configure_draft_lookback(self, lookback: int) -> bool:
-        """Drafter hook (draft wrapper only): arm decode-window lookback.
-
-        Lookback rows are ring reads ``lookback`` positions behind the
-        committed frontier, so arming only widens the catch-up chunk; no
-        extra state is allocated. Paged conv columns coexist with it: the
-        ring stays the working store, the columns are only the
-        publish/restore bridge. Returns True when armed; False when this
-        backend cannot support it (target wrapper).
-        """
-        if not self.conv_is_draft or lookback <= 0:
-            return False
-        self._draft_lookback = int(lookback)
-        # Arm the inner backend's grouped lookback-location stack (sized at graph
-        # init, which runs after this): the lookback pass writes N + D rows
-        # per request, so its cache write locations need their own variant.
-        self.inner.draft_lookback = int(lookback)
-        return True
-
-    def enter_draft_lookback_window(self, bs: int) -> bool:
-        """Drafter hook before the lookback window loop: rebuild the
-        catch-up conv metadata for ``k + D`` rows per request. The next
-        round's ``init_forward_metadata`` restores the plain shape."""
-        lookback = self._draft_lookback
-        md = self.conv_metadata
-        if lookback <= 0 or md is None or md.is_decode or not self.conv_is_draft:
-            return False
-        # Cache write locations must widen to the lookback rows too; refusal falls
-        # back to the plain window pass before any metadata is mutated.
-        inner_enter = getattr(self.inner, "enter_draft_lookback", None)
-        if inner_enter is not None and not inner_enter(bs):
-            return False
-        tokens = self.conv_spec_num_tokens + lookback
-        device = md.cache_indices.device
-        qsl = torch.arange(
-            0, bs * tokens + 1, step=tokens, dtype=torch.int32, device=device
-        )
-        self.conv_metadata = InklingConvMetadata(
-            query_start_loc=qsl,
-            cache_indices=md.cache_indices[:bs],
-            has_initial_state=md.has_initial_state[:bs],
-            is_decode=False,
-            seq_idx=seq_idx_from_cu_seqlens(qsl, bs * tokens),
-            # Same through-chunk lengths: the wider chunk keeps its end, the
-            # lookback rows extend it backwards.
-            seq_lens=md.seq_lens[:bs] if md.seq_lens is not None else None,
-            # Paged draft conv rides through: the in-kernel publish resolves
-            # pages from the table by position, so a boundary rewritten by
-            # the lookback rows is re-published with committed content.
-            col_block_table=md.col_block_table,
-        )
-        return True
-
-    def configure_draft_frontier(self) -> bool:
-        """Drafter hook (draft wrapper only): arm the frontier-anchored
-        decode window.
-
-        The window keeps the plain k-row catch-up shape — only its anchor
-        (seq_lens) moves back to the committed frontier — so no extra state
-        or widened location stacks are needed; ring reads simply follow the
-        shifted positions. Returns True when armed; False when this backend
-        cannot support it (target wrapper).
-        """
-        if not self.conv_is_draft:
-            return False
-        self._draft_frontier = True
-        return True
-
     def enter_draft_frontier_window(self, bs: int, frontier: torch.Tensor) -> None:
         """Drafter hook before the frontier window loop (all depths): rebuild
         the k-row conv metadata to end at ``frontier`` and re-anchor the
@@ -654,26 +578,10 @@ class InklingAttnBackend(AttentionBackend):
         frontier is accept-dependent, so everything here must be (and is)
         plain tensor ops — recorded at capture, recomputed per replay. The
         next round's ``init_forward_metadata`` restores the plain shape.
-
-        Raises instead of falling back: with the frontier window armed, a
-        missing hook or wrong-shape metadata is a wiring bug, and a silent
-        plain-window round would leave stale per-depth KV unrepaired.
         """
-        if not self._draft_frontier or not self.conv_is_draft:
-            raise RuntimeError(
-                "frontier window pass on a backend without configure_draft_frontier"
-            )
         md = self.conv_metadata
-        if md is None or md.is_decode:
-            raise RuntimeError(
-                "frontier window needs the k-row catch-up conv metadata; got "
-                f"{'no metadata' if md is None else 'single-token decode metadata'}"
-            )
-        inner_enter = getattr(self.inner, "enter_draft_frontier", None)
-        if inner_enter is None:
-            raise RuntimeError("inner attention backend lacks enter_draft_frontier")
         frontier_i32 = frontier[:bs].to(torch.int32)
-        inner_enter(bs, frontier_i32)
+        self.inner.enter_draft_frontier(bs, frontier_i32)
         self.conv_metadata = InklingConvMetadata(
             query_start_loc=md.query_start_loc,
             cache_indices=md.cache_indices[:bs],
@@ -686,7 +594,7 @@ class InklingAttnBackend(AttentionBackend):
             # Paged draft conv rides through: the in-kernel publish resolves
             # pages from the table by position, so boundaries rewritten by
             # the re-anchored rows are re-published with committed content.
-            col_page_table=md.col_page_table,
+            col_block_table=md.col_block_table,
         )
 
     def register_shortconv_checkpoint_stream(
@@ -712,37 +620,6 @@ class InklingAttnBackend(AttentionBackend):
                 f"ShortConv checkpoint stream {key!r} changed storage buffer"
             )
 
-    def advance_draft_forward_metadata(self, seq_lens: torch.Tensor | None = None):
-        """Drafter hook before each multi-step decode step: the catch-up
-        (k tokens/request) metadata becomes single-token decode metadata."""
-        inner_advance = getattr(self.inner, "advance_draft_forward_metadata", None)
-        if inner_advance is not None:
-            inner_advance(seq_lens)
-        md = self.conv_metadata
-        if md is None or md.is_decode:
-            return
-        bs = md.cache_indices.shape[0]
-        if self._graph_has_initial_state is not None:
-            has_initial = self._graph_has_initial_state[:bs]
-        else:
-            has_initial = torch.ones(
-                bs, dtype=torch.bool, device=md.cache_indices.device
-            )
-        query_start_loc = self._decode_query_start_loc(bs, md.cache_indices.device)
-        self.conv_metadata = InklingConvMetadata(
-            query_start_loc=query_start_loc,
-            cache_indices=md.cache_indices,
-            has_initial_state=has_initial,
-            is_decode=True,
-            seq_idx=query_start_loc[:bs],
-            seq_lens=(
-                seq_lens[:bs].to(torch.int32) if seq_lens is not None else md.seq_lens
-            ),
-            # Paged conv rides through every per-step rebuild: dropping the
-            # table silently disables the T=1 landing publish for the step.
-            col_block_table=md.col_block_table,
-        )
-
     # ------------------------------------------------------------------
     # Attention delegation
     # ------------------------------------------------------------------
@@ -754,10 +631,11 @@ class InklingAttnBackend(AttentionBackend):
     ) -> torch.Tensor:
         """Cached ``arange(bs + 1) * max_seqlen_q`` for rel decode.
 
-        Cached PER ``max_seqlen_q``: under MTP the draft backend alternates
-        between the catch-up chunk (``spec_num_tokens``) and single-token
-        steps, and a single keyed-on-last-step buffer would be reallocated on
-        every switch — invalidating the pointer captured CUDA graphs hold.
+        Cached PER ``max_seqlen_q``: one wrapper instance can see several
+        row-per-request shapes (non-spec decode at 1, spec windows at
+        ``spec_num_tokens``), and a single keyed-on-last-step buffer would be
+        reallocated on every switch — invalidating the pointer captured CUDA
+        graphs hold.
         Grown buffers are retained (never freed): their static contents stay
         correct for any graph that recorded them.
         """
@@ -1114,7 +992,7 @@ class InklingAttnBackend(AttentionBackend):
         # unseeded (zero) length would address position -1 during capture.
         self._graph_seq_lens[:bs].copy_(seq_lens[:bs])
         if self.conv_spec_num_tokens > 1:
-            # k-token spec chunk; drafter capture swaps to 1-token steps via advance_draft_forward_metadata.
+            # k-token spec chunk (target verify / draft window).
             self.conv_metadata = self._spec_conv_metadata(bs)
             return
         if self.conv_columns.get("pd_endpoint_snapshots", False):

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -200,6 +200,10 @@ class InklingAttnBackend(AttentionBackend):
         # D extra leading rows that re-run committed positions (ring reads go
         # D deeper). Configured by the drafter via configure_draft_lookback.
         self._draft_lookback = 0
+        # Draft frontier-anchored window: the k-row catch-up chunk is
+        # re-anchored to end at the committed frontier each decode round.
+        # Configured by the drafter via configure_draft_frontier.
+        self._draft_frontier = False
         # Persistent spec conv metadata buffers for CUDA graphs; sized in init_cuda_graph_state.
         self._graph_spec_qsl: torch.Tensor | None = None
         self._graph_spec_seq_idx: torch.Tensor | None = None
@@ -627,6 +631,63 @@ class InklingAttnBackend(AttentionBackend):
             col_block_table=md.col_block_table,
         )
         return True
+
+    def configure_draft_frontier(self) -> bool:
+        """Drafter hook (draft wrapper only): arm the frontier-anchored
+        decode window.
+
+        The window keeps the plain k-row catch-up shape — only its anchor
+        (seq_lens) moves back to the committed frontier — so no extra state
+        or widened location stacks are needed; ring reads simply follow the
+        shifted positions. Returns True when armed; False when this backend
+        cannot support it (target wrapper).
+        """
+        if not self.conv_is_draft:
+            return False
+        self._draft_frontier = True
+        return True
+
+    def enter_draft_frontier_window(self, bs: int, frontier: torch.Tensor) -> None:
+        """Drafter hook before the frontier window loop (all depths): rebuild
+        the k-row conv metadata to end at ``frontier`` and re-anchor the
+        inner backend's seq_lens and grouped write locs the same way. The
+        frontier is accept-dependent, so everything here must be (and is)
+        plain tensor ops — recorded at capture, recomputed per replay. The
+        next round's ``init_forward_metadata`` restores the plain shape.
+
+        Raises instead of falling back: with the frontier window armed, a
+        missing hook or wrong-shape metadata is a wiring bug, and a silent
+        plain-window round would leave stale per-depth KV unrepaired.
+        """
+        if not self._draft_frontier or not self.conv_is_draft:
+            raise RuntimeError(
+                "frontier window pass on a backend without configure_draft_frontier"
+            )
+        md = self.conv_metadata
+        if md is None or md.is_decode:
+            raise RuntimeError(
+                "frontier window needs the k-row catch-up conv metadata; got "
+                f"{'no metadata' if md is None else 'single-token decode metadata'}"
+            )
+        inner_enter = getattr(self.inner, "enter_draft_frontier", None)
+        if inner_enter is None:
+            raise RuntimeError("inner attention backend lacks enter_draft_frontier")
+        frontier_i32 = frontier[:bs].to(torch.int32)
+        inner_enter(bs, frontier_i32)
+        self.conv_metadata = InklingConvMetadata(
+            query_start_loc=md.query_start_loc,
+            cache_indices=md.cache_indices[:bs],
+            has_initial_state=md.has_initial_state[:bs],
+            is_decode=False,
+            seq_idx=md.seq_idx,
+            # Chunk end moves to the committed frontier; the k rows re-run
+            # the last k committed positions in place.
+            seq_lens=frontier_i32,
+            # Paged draft conv rides through: the in-kernel publish resolves
+            # pages from the table by position, so boundaries rewritten by
+            # the re-anchored rows are re-published with committed content.
+            col_page_table=md.col_page_table,
+        )
 
     def register_shortconv_checkpoint_stream(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -45,7 +45,7 @@ and overwritten.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import torch
 from tokenspeed_kernel import (
@@ -85,7 +85,6 @@ class InklingConvMetadata:
             (``req_pool_indices``; ``PAD_SLOT_ID`` marks padded rows).
         has_initial_state: ``[bs]`` bool; False for fresh prefills so stale
             slot contents are ignored.
-        is_decode: True when this is a single-token-per-request decode batch.
         seq_idx: ``[total_tokens]`` int32 sequence id per token (decode:
             the cached arange — token t belongs to request t).
         seq_lens: ``[bs]`` int32 lengths THROUGH the chunk; the source of
@@ -96,7 +95,6 @@ class InklingConvMetadata:
     query_start_loc: torch.Tensor
     cache_indices: torch.Tensor
     has_initial_state: torch.Tensor
-    is_decode: bool
     seq_idx: torch.Tensor | None = None
     seq_lens: torch.Tensor | None = None
     # Extend rows in the batch: 0 (decode-family rounds) or the batch's
@@ -467,7 +465,6 @@ class InklingAttnBackend(AttentionBackend):
                     (1, 0),
                 )
             has_initial_state = extend_prefix_lens[:bs] > 0
-            is_decode = False
             if extend_total is not None:
                 seq_idx = seq_idx_from_cu_seqlens(query_start_loc, extend_total)
             if pfg_total >= 0:
@@ -498,7 +495,6 @@ class InklingAttnBackend(AttentionBackend):
             )
             seq_idx = seq_idx_from_cu_seqlens(query_start_loc, bs * k)
             has_initial_state = torch.ones(bs, dtype=torch.bool, device=device)
-            is_decode = False
         else:
             query_start_loc = self._decode_query_start_loc(bs, req_pool_indices.device)
             # Decode: token t belongs to request t, so seq_idx is the same
@@ -507,7 +503,6 @@ class InklingAttnBackend(AttentionBackend):
             has_initial_state = torch.ones(
                 bs, dtype=torch.bool, device=req_pool_indices.device
             )
-            is_decode = True
         remote_restore_mask = None
         if (
             forward_mode.is_decode()
@@ -519,7 +514,6 @@ class InklingAttnBackend(AttentionBackend):
             query_start_loc=query_start_loc,
             cache_indices=cache_indices,
             has_initial_state=has_initial_state,
-            is_decode=is_decode,
             seq_idx=seq_idx,
             seq_lens=(
                 self._pfg_seq_lens if pfg_total >= 0 else seq_lens[:bs].to(torch.int32)
@@ -545,7 +539,6 @@ class InklingAttnBackend(AttentionBackend):
             query_start_loc=self._graph_spec_qsl[: bs + 1],
             cache_indices=self._graph_cache_indices[:bs],
             has_initial_state=self._graph_has_initial_state[:bs],
-            is_decode=False,
             seq_idx=self._graph_spec_seq_idx[: bs * k],
             seq_lens=self._graph_seq_lens[:bs],
             col_block_table={
@@ -560,7 +553,6 @@ class InklingAttnBackend(AttentionBackend):
             query_start_loc=self._decode_qsl[: bs + 1],
             cache_indices=self._graph_cache_indices[:bs],
             has_initial_state=self._graph_has_initial_state[:bs],
-            is_decode=True,
             seq_idx=self._decode_qsl[:bs],
             seq_lens=self._graph_seq_lens[:bs],
             col_block_table={g: t[:bs] for g, t in self._graph_col_tables.items()},
@@ -571,31 +563,16 @@ class InklingAttnBackend(AttentionBackend):
             ),
         )
 
-    def enter_draft_frontier_window(self, bs: int, frontier: torch.Tensor) -> None:
-        """Drafter hook before the frontier window loop (all depths): rebuild
-        the k-row conv metadata to end at ``frontier`` and re-anchor the
-        inner backend's seq_lens and grouped write locs the same way. The
-        frontier is accept-dependent, so everything here must be (and is)
-        plain tensor ops — recorded at capture, recomputed per replay. The
-        next round's ``init_forward_metadata`` restores the plain shape.
-        """
-        md = self.conv_metadata
-        frontier_i32 = frontier[:bs].to(torch.int32)
-        self.inner.enter_draft_frontier(bs, frontier_i32)
-        self.conv_metadata = InklingConvMetadata(
-            query_start_loc=md.query_start_loc,
-            cache_indices=md.cache_indices[:bs],
-            has_initial_state=md.has_initial_state[:bs],
-            is_decode=False,
-            seq_idx=md.seq_idx,
-            # Chunk end moves to the committed frontier; the k rows re-run
-            # the last k committed positions in place.
-            seq_lens=frontier_i32,
-            # Paged draft conv rides through: the in-kernel publish resolves
-            # pages from the table by position, so boundaries rewritten by
-            # the re-anchored rows are re-published with committed content.
-            col_block_table=md.col_block_table,
-        )
+    def update_draft_forward_metadata(self, frontier: torch.Tensor) -> None:
+        """Re-anchor the k-row conv metadata and the inner backend's
+        seq_lens/write locs to end at ``frontier`` ([bs] int32). Accept-
+        dependent, so pure tensor ops — recomputed per graph replay; the
+        next round's ``init_forward_metadata`` resets."""
+        self.inner.update_draft_forward_metadata(frontier)
+        # Paged bridges ride through: the in-kernel publish resolves pages
+        # by position, so boundaries rewritten by the re-anchored rows are
+        # re-published with committed content.
+        self.conv_metadata = replace(self.conv_metadata, seq_lens=frontier)
 
     def register_shortconv_checkpoint_stream(
         self,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
@@ -210,15 +210,19 @@ def _workspace_bytes(
 ) -> int:
     import torch
 
-    from tokenspeed.runtime.configs.inkling_config import inkling_conv_total_dim
+    from tokenspeed.runtime.configs.inkling_config import (
+        inkling_conv_total_dim,
+        inkling_mtp_decode_lookback_mode,
+    )
 
     rows = int(attn_config.max_bs) + 2
-    # Must match _wrap_inkling_backend's ring sizing:
-    # (W-1) taps + K chunk rows + draft lookback depth (K-2).
+    # Must match _wrap_inkling_backend's ring sizing: (W-1) taps + K chunk
+    # rows, plus the draft lookback depth (K-2) in lookback mode only.
     spec_tokens = max(1, int(spec_tokens))
-    ring_rows = (
-        int(text_config.sconv_kernel_size) - 1 + spec_tokens + max(spec_tokens - 2, 0)
+    lookback_rows = (
+        max(spec_tokens - 2, 0) if inkling_mtp_decode_lookback_mode() == 1 else 0
     )
+    ring_rows = int(text_config.sconv_kernel_size) - 1 + spec_tokens + lookback_rows
     conv_dim = inkling_conv_total_dim(text_config, attn_config.attn_tp_size)
     element_size = torch.bfloat16.itemsize
     pending_bytes = rows * torch.bool.itemsize

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
@@ -210,19 +210,12 @@ def _workspace_bytes(
 ) -> int:
     import torch
 
-    from tokenspeed.runtime.configs.inkling_config import (
-        inkling_conv_total_dim,
-        inkling_mtp_decode_lookback_mode,
-    )
+    from tokenspeed.runtime.configs.inkling_config import inkling_conv_total_dim
 
     rows = int(attn_config.max_bs) + 2
-    # Must match _wrap_inkling_backend's ring sizing: (W-1) taps + K chunk
-    # rows, plus the draft lookback depth (K-2) in lookback mode only.
+    # Must match _wrap_inkling_backend's ring sizing: (W-1) taps + K chunk rows.
     spec_tokens = max(1, int(spec_tokens))
-    lookback_rows = (
-        max(spec_tokens - 2, 0) if inkling_mtp_decode_lookback_mode() == 1 else 0
-    )
-    ring_rows = int(text_config.sconv_kernel_size) - 1 + spec_tokens + lookback_rows
+    ring_rows = int(text_config.sconv_kernel_size) - 1 + spec_tokens
     conv_dim = inkling_conv_total_dim(text_config, attn_config.attn_tp_size)
     element_size = torch.bfloat16.itemsize
     pending_bytes = rows * torch.bool.itemsize

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -484,10 +484,7 @@ def _wrap_inkling_backend(
     The wrapper only adds conv metadata; all attention delegates to ``inner``.
     Returns ``(backend, conv_pool)``.
     """
-    from tokenspeed.runtime.configs.inkling_config import (
-        inkling_conv_total_dim,
-        inkling_mtp_decode_lookback_mode,
-    )
+    from tokenspeed.runtime.configs.inkling_config import inkling_conv_total_dim
     from tokenspeed.runtime.layers.attention.backends.inkling import (
         InklingAttnBackend,
         InklingConvStatePool,
@@ -497,13 +494,8 @@ def _wrap_inkling_backend(
     spec_tokens = max(1, int(getattr(attn_config, "speculative_num_draft_tokens", 1)))
     # Ring row of absolute position p is p % R. R must keep a round's
     # pre-chunk tap reads and chunk-row writes disjoint mod R: (W-1) history
-    # taps + K chunk rows, plus the draft's lookback depth (spec steps - 1
-    # = K - 2) in lookback mode; the frontier-anchored window keeps k rows.
-    # Uniform across target and draft.
-    lookback_rows = (
-        max(spec_tokens - 2, 0) if inkling_mtp_decode_lookback_mode() == 1 else 0
-    )
-    ring_size = (kernel_size - 1) + spec_tokens + lookback_rows
+    # taps + K chunk rows. Uniform across target and draft.
+    ring_size = (kernel_size - 1) + spec_tokens
     conv_pool = InklingConvStatePool(
         num_layers=num_layers,
         # Row 0 is reserved (1-based indices); +2 covers it plus a padding slot
@@ -781,19 +773,6 @@ def _prepare_verify_workspace(
         )
     elif is_inkling:
         model_name = "Inkling"
-        if draft_backend is not None:
-            from tokenspeed.runtime.configs.inkling_config import (
-                inkling_mtp_decode_lookback_mode,
-            )
-
-            steps = int(server_args.speculative_num_steps)
-            mode = inkling_mtp_decode_lookback_mode() if steps > 1 else 0
-            if mode == 1 and not draft_backend.configure_draft_lookback(steps - 1):
-                raise RuntimeError("Inkling MTP draft rejected its planned lookback")
-            if mode == 2 and not draft_backend.configure_draft_frontier():
-                raise RuntimeError(
-                    "Inkling MTP draft rejected the frontier-anchored window"
-                )
         actual_bytes = backend.fixed_workspace_bytes()
         if draft_backend is not None:
             actual_bytes += draft_backend.fixed_workspace_bytes()

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -484,7 +484,10 @@ def _wrap_inkling_backend(
     The wrapper only adds conv metadata; all attention delegates to ``inner``.
     Returns ``(backend, conv_pool)``.
     """
-    from tokenspeed.runtime.configs.inkling_config import inkling_conv_total_dim
+    from tokenspeed.runtime.configs.inkling_config import (
+        inkling_conv_total_dim,
+        inkling_mtp_decode_lookback_mode,
+    )
     from tokenspeed.runtime.layers.attention.backends.inkling import (
         InklingAttnBackend,
         InklingConvStatePool,
@@ -493,10 +496,14 @@ def _wrap_inkling_backend(
     kernel_size = text_config.sconv_kernel_size
     spec_tokens = max(1, int(getattr(attn_config, "speculative_num_draft_tokens", 1)))
     # Ring row of absolute position p is p % R. R must keep a round's
-    # pre-chunk tap reads and chunk-row writes disjoint mod R:
-    # (W-1) history taps + K chunk rows + the draft's lookback depth
-    # (spec steps - 1 = K - 2). Uniform across target and draft.
-    ring_size = (kernel_size - 1) + spec_tokens + max(spec_tokens - 2, 0)
+    # pre-chunk tap reads and chunk-row writes disjoint mod R: (W-1) history
+    # taps + K chunk rows, plus the draft's lookback depth (spec steps - 1
+    # = K - 2) in lookback mode; the frontier-anchored window keeps k rows.
+    # Uniform across target and draft.
+    lookback_rows = (
+        max(spec_tokens - 2, 0) if inkling_mtp_decode_lookback_mode() == 1 else 0
+    )
+    ring_size = (kernel_size - 1) + spec_tokens + lookback_rows
     conv_pool = InklingConvStatePool(
         num_layers=num_layers,
         # Row 0 is reserved (1-based indices); +2 covers it plus a padding slot
@@ -775,14 +782,18 @@ def _prepare_verify_workspace(
     elif is_inkling:
         model_name = "Inkling"
         if draft_backend is not None:
-            lookback = (
-                int(server_args.speculative_num_steps) - 1
-                if int(server_args.speculative_num_steps) > 1
-                and os.environ.get("INKLING_MTP_DECODE_LOOKBACK", "1") != "0"
-                else 0
+            from tokenspeed.runtime.configs.inkling_config import (
+                inkling_mtp_decode_lookback_mode,
             )
-            if lookback and not draft_backend.configure_draft_lookback(lookback):
+
+            steps = int(server_args.speculative_num_steps)
+            mode = inkling_mtp_decode_lookback_mode() if steps > 1 else 0
+            if mode == 1 and not draft_backend.configure_draft_lookback(steps - 1):
                 raise RuntimeError("Inkling MTP draft rejected its planned lookback")
+            if mode == 2 and not draft_backend.configure_draft_frontier():
+                raise RuntimeError(
+                    "Inkling MTP draft rejected the frontier-anchored window"
+                )
         actual_bytes = backend.fixed_workspace_bytes()
         if draft_backend is not None:
             actual_bytes += draft_backend.fixed_workspace_bytes()

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -491,7 +491,7 @@ def _wrap_inkling_backend(
     )
 
     kernel_size = text_config.sconv_kernel_size
-    spec_tokens = max(1, int(getattr(attn_config, "speculative_num_draft_tokens", 1)))
+    spec_tokens = attn_config.speculative_num_draft_tokens
     # Ring row of absolute position p is p % R. R must keep a round's
     # pre-chunk tap reads and chunk-row writes disjoint mod R: (W-1) history
     # taps + K chunk rows. Uniform across target and draft.
@@ -517,7 +517,7 @@ def _wrap_inkling_backend(
         inner,
         conv_pool,
         conv_columns=conv_columns,
-        spec_num_tokens=getattr(attn_config, "speculative_num_draft_tokens", 1),
+        spec_num_tokens=spec_tokens,
         is_draft=is_draft,
         enable_layerwise_cache_ready=enable_layerwise_cache_ready,
     )

--- a/python/tokenspeed/runtime/models/inkling_nextn.py
+++ b/python/tokenspeed/runtime/models/inkling_nextn.py
@@ -44,7 +44,6 @@ weight loading, and pool sizing (see ``inkling_mtp_text_config``).
 from __future__ import annotations
 
 import logging
-import os
 from collections.abc import Iterable
 
 import torch
@@ -53,6 +52,7 @@ from torch import nn
 from tokenspeed.runtime.configs.inkling_config import (
     InklingMMConfig,
     InklingModelConfig,
+    inkling_mtp_decode_lookback_mode,
     inkling_mtp_text_config,
 )
 from tokenspeed.runtime.distributed.mapping import Mapping
@@ -221,13 +221,14 @@ class InklingForConditionalGenerationNextN(nn.Module):
     # previous depth's full-row hidden), so every used depth gets dense
     # prompt KV and sconv prompt state.
     draft_extend_depth_catchup = True
-    # Provisional-tail recompute: decode windows carry D=steps-1
-    # lookback rows so the previous round's provisional tail entries (written
-    # from then-unverified drafts) are recomputed from committed tokens.
-    # Kept as an A/B knob for further experiments:
-    # INKLING_MTP_DECODE_LOOKBACK=0 reverts (depth-d KV/conv then keeps
-    # ~d/<a>*(1-p) stale slots).
-    draft_decode_lookback = os.environ.get("INKLING_MTP_DECODE_LOOKBACK", "1") != "0"
+    # Provisional-tail recompute mode (INKLING_MTP_DECODE_LOOKBACK A/B knob):
+    # the previous round's provisional tail entries (written from
+    # then-unverified drafts) are recomputed from committed tokens either by
+    # D=steps-1 lookback rows prepended to the verify-anchored window (1) or
+    # by re-anchoring the k-row window to end at the committed frontier
+    # (2, default, zero garbage rows); 0 reverts to the unrepaired window
+    # (depth-d KV/conv then keeps ~d/<a>*(1-p) stale slots).
+    draft_decode_lookback = inkling_mtp_decode_lookback_mode()
 
     def __init__(
         self,

--- a/python/tokenspeed/runtime/models/inkling_nextn.py
+++ b/python/tokenspeed/runtime/models/inkling_nextn.py
@@ -52,7 +52,6 @@ from torch import nn
 from tokenspeed.runtime.configs.inkling_config import (
     InklingMMConfig,
     InklingModelConfig,
-    inkling_mtp_decode_lookback_mode,
     inkling_mtp_text_config,
 )
 from tokenspeed.runtime.distributed.mapping import Mapping
@@ -211,25 +210,6 @@ class InklingMultiTokenPredictor(nn.Module):
 
 
 class InklingForConditionalGenerationNextN(nn.Module):
-    # Catch-up runs the full padded window; ctx.gather_ids narrows to one row per request.
-    draft_first_step_reduce_for_catchup = True
-    # Full-sequence depths: re-run each depth over the whole verify window
-    # (mtp.py window mode); the trained dataflow, not optional.
-    draft_multi_depth_windows = True
-    # Prompt catch-up: at EXTEND rounds run depths
-    # 1..steps-1 over the prompt rows too (inputs shifted d+1, chaining the
-    # previous depth's full-row hidden), so every used depth gets dense
-    # prompt KV and sconv prompt state.
-    draft_extend_depth_catchup = True
-    # Provisional-tail recompute mode (INKLING_MTP_DECODE_LOOKBACK A/B knob):
-    # the previous round's provisional tail entries (written from
-    # then-unverified drafts) are recomputed from committed tokens either by
-    # D=steps-1 lookback rows prepended to the verify-anchored window (1) or
-    # by re-anchoring the k-row window to end at the committed frontier
-    # (2, default, zero garbage rows); 0 reverts to the unrepaired window
-    # (depth-d KV/conv then keeps ~d/<a>*(1-p) stale slots).
-    draft_decode_lookback = inkling_mtp_decode_lookback_mode()
-
     def __init__(
         self,
         config: InklingMMConfig,

--- a/python/tokenspeed/runtime/multimodal/inputs.py
+++ b/python/tokenspeed/runtime/multimodal/inputs.py
@@ -72,27 +72,20 @@ def is_mm_pad_value_for(token_ids: torch.Tensor, modality: "Modality") -> torch.
     )
 
 
-def maybe_substitute_mm_pad(
-    input_ids: torch.Tensor,
-    substitute_ids: int | Mapping["Modality", int] | None,
+def substitute_mm_pad_(
+    token_ids: torch.Tensor,
+    substitute_ids: Mapping["Modality", int],
 ) -> torch.Tensor:
-    """Replace hash MM-pad positions with in-vocab draft token IDs.
+    """Replace hash MM-pad positions with in-vocab draft token IDs, in place.
 
-    A scalar keeps the legacy behavior and substitutes every modality with one
-    token. A mapping preserves modality-specific semantics, which is required
-    by mixed image+audio prompts such as TML/Inkling.
+    Rewrites every hash-derived multimodal pad id to its modality's in-vocab
+    substitute token, directly in ``token_ids``. Returns ``token_ids``.
+    Modality-specific substitutes are required by mixed image+audio prompts
+    such as TML/Inkling.
     """
-    if substitute_ids is None:
-        return input_ids
-    if isinstance(substitute_ids, int):
-        return input_ids.masked_fill(is_mm_pad_value(input_ids), substitute_ids)
-
-    output = input_ids
     for modality, substitute_id in substitute_ids.items():
-        if output is input_ids:
-            output = input_ids.clone()
-        output.masked_fill_(is_mm_pad_value_for(input_ids, modality), substitute_id)
-    return output
+        token_ids.masked_fill_(is_mm_pad_value_for(token_ids, modality), substitute_id)
+    return token_ids
 
 
 class Modality(Enum):

--- a/test/agentic_benchmark/inkling/tokenspeed/agentic_bench.sh
+++ b/test/agentic_benchmark/inkling/tokenspeed/agentic_bench.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+# Prepare dataset
+EVALSCOPE_COMMIT=acd09b44384d53174768bb1063f675420f76fae9
+pip install "evalscope[perf] @ git+https://github.com/modelscope/evalscope.git@${EVALSCOPE_COMMIT}"
+
+[ -f build_swe_smith_dataset.py ] || wget https://raw.githubusercontent.com/modelscope/evalscope/${EVALSCOPE_COMMIT}/examples/perf/build_swe_smith_dataset.py \
+    -O build_swe_smith_dataset.py
+
+# Note: Only 83 conversations can be built
+[ -f agentic_dataset.json ] || python3 build_swe_smith_dataset.py \
+    --model thinkingmachines/Inkling-NVFP4 \
+    --first-turn-length 50000 \
+    --subsequent-turn-length 800 \
+    --min-turns 10 \
+    --max-turns 15 \
+    --number 128 \
+    --output-path agentic_dataset.json \
+    --num-workers 32
+
+# Sweep configs
+CONFIGS=(
+    attn_tp4_moe_tp4
+    attn_tp4_moe_ep4
+)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_PID=
+SERVER_LOG=
+
+launch_server() {
+    local config=$1
+    SERVER_LOG=/tmp/tokenspeed_server_${config}.log
+    setsid ${SCRIPT_DIR}/configs/${config}.sh > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+}
+
+wait_for_ready() {
+    local TIMEOUT=600
+    local START=$SECONDS
+    until curl -sf -o /dev/null http://127.0.0.1:8000/readiness; do
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "Server died early. Last log lines:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if grep -qE "CUDA out of memory|OutOfMemory|RuntimeError|Killed" "$SERVER_LOG"; then
+            echo "Server hit a fatal error:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if (( SECONDS - START > TIMEOUT )); then
+            echo "Timeout after ${TIMEOUT}s waiting for server" >&2
+            return 1
+        fi
+        sleep 5
+    done
+    echo "Server ready after $((SECONDS - START))s"
+}
+
+stop_server() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Stopping ts serve (pgid $SERVER_PID)..."
+        kill -TERM -"$SERVER_PID" 2>/dev/null || true
+        for _ in {1..20}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL -"$SERVER_PID" 2>/dev/null || true
+    fi
+    SERVER_PID=
+}
+
+wait_for_port_free() {
+    local port=${1:-8000}
+    local timeout=${2:-90}
+    local start=$SECONDS
+    while ! python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', $port)); s.close()" 2>/dev/null; do
+        if (( SECONDS - start > timeout )); then
+            echo "Port ${port} still in use after ${timeout}s" >&2
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+trap stop_server EXIT  # safety net for Ctrl-C / errors
+
+# Preflight: bail out if port 8000 is already in use
+wait_for_port_free 8000
+
+SWEEP_TS=$(date +%Y%m%d_%H%M%S)
+SWEEP_DIR="${SCRIPT_DIR}/outputs/${SWEEP_TS}"
+echo "Sweep outputs: ${SWEEP_DIR}"
+
+for CONFIG in "${CONFIGS[@]}"; do
+    echo "=== Running $CONFIG ==="
+    launch_server "$CONFIG"
+
+    if ! wait_for_ready; then
+        stop_server
+        exit 1
+    fi
+
+    echo "Warmup..."
+    evalscope perf \
+        --model thinkingmachines/Inkling-NVFP4 \
+        --url http://127.0.0.1:8000/v1/chat/completions \
+        --api openai \
+        --dataset swe_smith \
+        --dataset-path agentic_dataset.json \
+        --max-tokens 500 \
+        --multi-turn \
+        --number 2 \
+        --parallel 2 \
+        --extra-args '{"ignore_eos": true}' \
+        --dataset-offset 68 \
+        --outputs-dir /tmp/outputs
+
+    echo "Benchmark..."
+    evalscope perf \
+        --model thinkingmachines/Inkling-NVFP4 \
+        --url http://127.0.0.1:8000/v1/chat/completions \
+        --api openai \
+        --dataset swe_smith \
+        --dataset-path agentic_dataset.json \
+        --max-tokens 500 \
+        --multi-turn \
+        --number 4 8 8 16 32 \
+        --parallel 1 2 4 8 16 \
+        --extra-args '{"ignore_eos": true}' \
+        --name $CONFIG \
+        --outputs-dir $SWEEP_DIR \
+        --no-timestamp
+
+    stop_server
+    wait_for_port_free 8000
+done

--- a/test/agentic_benchmark/inkling/tokenspeed/collect_outputs.py
+++ b/test/agentic_benchmark/inkling/tokenspeed/collect_outputs.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Collect a sweep's per-config benchmark_summary.json files into one CSV."""
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+COLUMNS = [
+    "config",
+    "Conc.",
+    "Latency (tps/user)",
+    "Throughput (tps/gpu)",
+    "Approx Cache Hit",
+    "Decoded Tok/Iter",
+]
+
+
+def num_gpus_from_config(config: str) -> int:
+    m = re.search(r"attn_(?:tp|dp)(\d+)", config)
+    if not m:
+        raise ValueError(f"Cannot infer GPU count from config name: {config}")
+    return int(m.group(1))
+
+
+def collect(sweep_dir: Path):
+    rows = []
+    for config_dir in sorted(p for p in sweep_dir.iterdir() if p.is_dir()):
+        config = config_dir.name
+        n_gpus = num_gpus_from_config(config)
+        for run_dir in sorted(config_dir.iterdir()):
+            summary_path = run_dir / "benchmark_summary.json"
+            if not summary_path.is_file():
+                continue
+            s = json.loads(summary_path.read_text())
+            tpot_ms = s["TPOT (ms)"]
+            decode_tps_user = 1000.0 / tpot_ms if tpot_ms else 0.0
+            tps_gpu = s["Total Throughput (tok/s)"] / n_gpus
+            rows.append(
+                {
+                    "config": config,
+                    "Conc.": s["Concurrency"],
+                    "Latency (tps/user)": round(decode_tps_user, 2),
+                    "Throughput (tps/gpu)": round(tps_gpu, 2),
+                    "Approx Cache Hit": round(s["KV Cache Hit Rate (%)"], 2),
+                    "Decoded Tok/Iter": round(s["Decoded Tok/Iter"], 4),
+                }
+            )
+    rows.sort(key=lambda r: (r["config"], r["Conc."]))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("sweep_dir", type=Path, help="e.g. outputs/20260505_152734")
+    ap.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="CSV output path (default: stdout)",
+    )
+    args = ap.parse_args()
+
+    if not args.sweep_dir.is_dir():
+        sys.exit(f"Not a directory: {args.sweep_dir}")
+
+    rows = collect(args.sweep_dir)
+    out = args.output.open("w", newline="") if args.output else sys.stdout
+    try:
+        w = csv.DictWriter(out, fieldnames=COLUMNS)
+        w.writeheader()
+        w.writerows(rows)
+    finally:
+        if args.output:
+            out.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/agentic_benchmark/inkling/tokenspeed/configs/attn_tp4_moe_ep4.sh
+++ b/test/agentic_benchmark/inkling/tokenspeed/configs/attn_tp4_moe_ep4.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+exec ts serve \
+    --model thinkingmachines/Inkling-NVFP4 \
+    --attn-tp-size 4 \
+    --ep-size 4 \
+    --max-model-len 81920 \
+    --max-num-seqs 16 \
+    --max-prefill-tokens 8192 \
+    --chunked-prefill-size 8192 \
+    --gpu-memory-utilization 0.95 \
+    --disable-cuda-graph-padding \
+    --trust-remote-code \
+    --attention-backend fa4 \
+    --moe-backend flashinfer_trtllm \
+    --speculative-algorithm MTP \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --enable-prefix-caching \
+    --disable-kvstore \
+    --block-size 128 \
+    --enable-cache-report \
+    --host 127.0.0.1 \
+    --port 8000

--- a/test/agentic_benchmark/inkling/tokenspeed/configs/attn_tp4_moe_tp4.sh
+++ b/test/agentic_benchmark/inkling/tokenspeed/configs/attn_tp4_moe_tp4.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+exec ts serve \
+    --model thinkingmachines/Inkling-NVFP4 \
+    --attn-tp-size 4 \
+    --moe-tp-size 4 \
+    --max-model-len 81920 \
+    --max-num-seqs 16 \
+    --max-prefill-tokens 8192 \
+    --chunked-prefill-size 8192 \
+    --gpu-memory-utilization 0.95 \
+    --disable-cuda-graph-padding \
+    --trust-remote-code \
+    --attention-backend fa4 \
+    --moe-backend flashinfer_trtllm \
+    --speculative-algorithm MTP \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --enable-prefix-caching \
+    --disable-kvstore \
+    --block-size 128 \
+    --enable-cache-report \
+    --host 127.0.0.1 \
+    --port 8000

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -8,7 +8,6 @@ from tokenspeed.runtime.execution.drafter.dflash import DFlash
 from tokenspeed.runtime.execution.drafter.eagle import Eagle, EagleDraftInput
 from tokenspeed.runtime.execution.drafter.mtp import (
     Mtp,
-    _committed_tail_update,
     _extend_depth_precompute,
     _extend_depth_shifted_ids_from,
     _frontier_hidden_splice,
@@ -16,7 +15,12 @@ from tokenspeed.runtime.execution.drafter.mtp import (
     _ragged_tail_rows,
 )
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-from tokenspeed.runtime.multimodal.inputs import Modality, MultimodalDataItem
+from tokenspeed.runtime.execution.input_buffer import InputBuffers
+from tokenspeed.runtime.multimodal.inputs import (
+    Modality,
+    MultimodalDataItem,
+    substitute_mm_pad_,
+)
 
 
 def _make_eagle(spec_num_tokens: int = 4, max_bs: int = 8) -> Eagle:
@@ -69,37 +73,32 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             [request_pool_rows, spec_num_tokens - 1, 8],
         )
 
-    def test_prepare_draft_input_ids_maps_media_then_clamps_to_vocab(self):
-        drafter = _make_eagle()
-        drafter.vocab_size = 100
-        drafter.set_mm_pad_substitute_ids({Modality.IMAGE: 10, Modality.AUDIO: 20})
+    def test_substitute_mm_pad_rewrites_media_ids_in_place(self):
         image = MultimodalDataItem(modality=Modality.IMAGE, hash=123)
         audio = MultimodalDataItem(modality=Modality.AUDIO, hash=456)
         image.set_pad_value()
         audio.set_pad_value()
         input_ids = torch.tensor(
-            [-4, image.pad_value, audio.pad_value, 42, 999], dtype=torch.int64
+            [7, image.pad_value, audio.pad_value, 42], dtype=torch.int64
         )
 
-        prepared = drafter._prepare_draft_input_ids(input_ids)
+        out = substitute_mm_pad_(input_ids, {Modality.IMAGE: 10, Modality.AUDIO: 20})
 
-        self.assertEqual(prepared.tolist(), [0, 10, 20, 42, 99])
-        self.assertEqual(
-            input_ids.tolist(),
-            [-4, image.pad_value, audio.pad_value, 42, 999],
+        self.assertIs(out, input_ids)
+        self.assertEqual(input_ids.tolist(), [7, 10, 20, 42])
+
+    def test_input_buffers_validate_modality_specific_mm_substitutes(self):
+        buffers = InputBuffers.__new__(InputBuffers)
+        buffers.set_mm_pad_substitute_ids(
+            {Modality.IMAGE: 10, Modality.AUDIO: 20}, vocab_size=256
         )
-
-    def test_eagle_validates_modality_specific_mm_substitutes(self):
-        drafter = _make_eagle()
-        drafter.vocab_size = 256
-        drafter.set_mm_pad_substitute_ids({Modality.IMAGE: 10, Modality.AUDIO: 20})
         self.assertEqual(
-            drafter.mm_pad_substitute_ids,
+            buffers.mm_pad_substitute_ids,
             {Modality.IMAGE: 10, Modality.AUDIO: 20},
         )
 
-        with self.assertRaisesRegex(ValueError, "inside the target vocabulary"):
-            drafter.set_mm_pad_substitute_ids({Modality.IMAGE: 256})
+        with self.assertRaisesRegex(ValueError, "inside the target"):
+            buffers.set_mm_pad_substitute_ids({Modality.IMAGE: 256}, vocab_size=256)
 
     def test_eagle_decode_first_step_gathers_last_accepted_output(self):
         drafter = _make_eagle(spec_num_tokens=4)
@@ -176,32 +175,36 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         # row i consumes t_{i+4}, i.e. drafts d_1..d_3.
         self.assertEqual(depth3.tolist(), [701, 702, 703])
 
-    def test_frontier_shifted_ids_reads_stash_verify_and_drafts(self):
+    def test_frontier_shifted_ids_reads_stash_and_verify(self):
         # k=4. Request A accepts 2 of [v0..v3]; request B accepts all 4.
         # Stash entry i holds the committed token at position vc-k+2+i.
         v = torch.tensor([[500, 501, 502, 503], [600, 601, 602, 603]])
         accept = torch.tensor([[2], [4]])
-        next_tokens = torch.tensor(
-            [[0, 51, 52, 53], [0, 61, 62, 63]], dtype=torch.int32
-        )
         stash = torch.tensor([[41, 42, 43], [71, 72, 73]])
 
-        depth0 = _frontier_shifted_ids(v, accept, next_tokens, stash, 0)
-        depth1 = _frontier_shifted_ids(v, accept, next_tokens, stash, 1)
-        depth2 = _frontier_shifted_ids(v, accept, next_tokens, stash, 2)
+        depth0 = _frontier_shifted_ids(v, accept, stash)
 
-        # depth 0: src = accept - 4 + j, all rows committed (stash/verify).
+        # src = accept - 4 + j, all rows committed (stash/verify).
         self.assertEqual(
             depth0.view(2, 4).tolist(),
             [[42, 43, 500, 501], [600, 601, 602, 603]],
         )
-        # depth d >= 1: the trailing d rows take this round's drafts d_1..d_d.
+
+    def test_frontier_window_rolls_left_into_drafts(self):
+        # Depth d+1 ids roll depth d's window one left, appending its draft:
+        # the trailing d rows of depth d take this round's drafts d_1..d_d.
+        window0 = torch.tensor([[42, 43, 500, 501], [600, 601, 602, 603]])
+        drafts = torch.tensor([[51, 52], [61, 62]])
+
+        depth1 = torch.cat([window0[:, 1:], drafts[:, 0:1]], 1)
+        depth2 = torch.cat([depth1[:, 1:], drafts[:, 1:2]], 1)
+
         self.assertEqual(
-            depth1.view(2, 4).tolist(),
+            depth1.tolist(),
             [[43, 500, 501, 51], [601, 602, 603, 61]],
         )
         self.assertEqual(
-            depth2.view(2, 4).tolist(),
+            depth2.tolist(),
             [[500, 501, 51, 52], [602, 603, 61, 62]],
         )
 
@@ -226,8 +229,8 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         # Positional oracle: the committed token at position p has id
         # 1000+p, the draft candidate for position frontier+m has id
         # 7000+m, and rejected verify entries (junk, id 9000+) must never
-        # be read. The stash rolls with the same _committed_tail_update as
-        # the drafter will use; row j of depth d must always compose the
+        # be read. The stash rolls the way the drafter does: the depth-0
+        # window's tail [:, 1:]; row j of depth d must always compose the
         # token at (frontier - k + j) + d + 1.
         torch.manual_seed(0)
         k, steps = 4, 3
@@ -238,17 +241,20 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             v = torch.tensor(
                 [[1000 + vc + 1 + i if i < accept else 9000 + i for i in range(k)]]
             )
-            next_tokens = torch.tensor([[0] + [7000 + m for m in range(1, steps + 1)]])
+            drafts = torch.tensor([[7000 + m for m in range(1, steps)]])
             frontier = vc + accept
+            depth0 = _frontier_shifted_ids(v, a, stash).view(1, k)
+            ids = depth0
             for d in range(steps):
-                ids = _frontier_shifted_ids(v, a, next_tokens, stash, d).view(1, k)
+                if d > 0:
+                    ids = torch.cat([ids[:, 1:], drafts[:, d - 1 : d]], 1)
                 for j in range(k):
                     consumed = (frontier - k + j) + d + 1
                     if consumed <= frontier:
                         self.assertEqual(ids[0, j].item(), 1000 + consumed)
                     else:
                         self.assertEqual(ids[0, j].item(), 7000 + consumed - frontier)
-            stash = _committed_tail_update(stash, v, torch.tensor([accept]), k - 1)
+            stash = depth0[:, 1:]
             vc = frontier
             self.assertEqual(stash.tolist(), [[1000 + vc - 2 + i for i in range(3)]])
 
@@ -273,30 +279,11 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
                 spliced.view(k).tolist(),
                 [float(frontier - k + j) for j in range(k)],
             )
-            stash = _committed_tail_update(stash, fresh, torch.tensor([accept]), k - 1)
+            stash = spliced.view(1, k, 1)[:, 1:]
             vc = frontier
             self.assertEqual(
                 stash.view(3).tolist(), [float(vc - 3 + i) for i in range(3)]
             )
-
-    def test_committed_tail_update_blends_across_rounds(self):
-        stash = torch.tensor([[10, 11], [20, 21]])
-        fresh = torch.tensor([[30, 31, 32, 33], [40, 41, 42, 43]])
-        valid = torch.tensor([1, 3])
-
-        updated = _committed_tail_update(stash, fresh, valid, 2)
-
-        # valid=1: rows [-1, 0] -> [old tail, fresh[0]]; valid=3: rows [1, 2].
-        self.assertEqual(updated.tolist(), [[11, 30], [41, 42]])
-
-    def test_committed_tail_update_keeps_feature_dims(self):
-        stash = torch.arange(4, dtype=torch.float32).view(1, 2, 2)
-        fresh = (torch.arange(8, dtype=torch.float32) + 10).view(1, 4, 2)
-        valid = torch.tensor([2])
-
-        updated = _committed_tail_update(stash, fresh, valid, 2)
-
-        self.assertEqual(updated.tolist(), [[[10.0, 11.0], [12.0, 13.0]]])
 
     def test_ragged_tail_rows_borrows_old_tail_on_short_chunks(self):
         flat = torch.arange(6) + 100  # request A rows 0..4, request B row 5

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -179,7 +179,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         # k=4. Request A accepts 2 of [v0..v3]; request B accepts all 4.
         # Stash entry i holds the committed token at position vc-k+2+i.
         v = torch.tensor([[500, 501, 502, 503], [600, 601, 602, 603]])
-        accept = torch.tensor([[2], [4]])
+        accept = torch.tensor([2, 4])
         stash = torch.tensor([[41, 42, 43], [71, 72, 73]])
 
         depth0 = _frontier_shifted_ids(v, accept, stash)
@@ -215,7 +215,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         fresh = torch.tensor(
             [[[0.0], [1.0], [2.0], [3.0]], [[10.0], [11.0], [12.0], [13.0]]]
         )
-        accept = torch.tensor([[2], [4]])
+        accept = torch.tensor([2, 4])
 
         spliced = _frontier_hidden_splice(stash, fresh, accept)
 
@@ -237,7 +237,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         vc = 10
         stash = torch.tensor([[1000 + vc - 2, 1000 + vc - 1, 1000 + vc]])
         for accept in [1, 4, 2, 1, 3, 4, 1, 2]:
-            a = torch.tensor([[accept]])
+            a = torch.tensor([accept])
             v = torch.tensor(
                 [[1000 + vc + 1 + i if i < accept else 9000 + i for i in range(k)]]
             )
@@ -267,7 +267,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         vc = 10
         stash = torch.tensor([float(vc - 3 + i) for i in range(3)]).view(1, 3, 1)
         for accept in [1, 4, 2, 1, 3]:
-            a = torch.tensor([[accept]])
+            a = torch.tensor([accept])
             fresh = torch.tensor(
                 [float(vc + i) if i < accept else 9000.0 for i in range(k)]
             ).view(1, k, 1)

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -11,6 +11,8 @@ from tokenspeed.runtime.execution.drafter.mtp import (
     _committed_tail_update,
     _extend_depth_precompute,
     _extend_depth_shifted_ids_from,
+    _frontier_hidden_splice,
+    _frontier_shifted_ids,
     _lookback_shifted_ids,
     _ragged_tail_rows,
 )
@@ -204,6 +206,144 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             depth2.view(2, 6).tolist(),
             [[500, 501, 51, 52, 52, 52], [600, 601, 602, 603, 61, 62]],
         )
+
+    def test_frontier_shifted_ids_reads_stash_verify_and_drafts(self):
+        # k=4. Request A accepts 2 of [v0..v3]; request B accepts all 4.
+        # Stash entry i holds the committed token at position vc-k+2+i.
+        v = torch.tensor([[500, 501, 502, 503], [600, 601, 602, 603]])
+        accept = torch.tensor([[2], [4]])
+        next_tokens = torch.tensor(
+            [[0, 51, 52, 53], [0, 61, 62, 63]], dtype=torch.int32
+        )
+        stash = torch.tensor([[41, 42, 43], [71, 72, 73]])
+
+        depth0 = _frontier_shifted_ids(v, accept, next_tokens, stash, 0)
+        depth1 = _frontier_shifted_ids(v, accept, next_tokens, stash, 1)
+        depth2 = _frontier_shifted_ids(v, accept, next_tokens, stash, 2)
+
+        # depth 0: src = accept - 4 + j, all rows committed (stash/verify).
+        self.assertEqual(
+            depth0.view(2, 4).tolist(),
+            [[42, 43, 500, 501], [600, 601, 602, 603]],
+        )
+        # depth d >= 1: the trailing d rows take this round's drafts d_1..d_d.
+        self.assertEqual(
+            depth1.view(2, 4).tolist(),
+            [[43, 500, 501, 51], [601, 602, 603, 61]],
+        )
+        self.assertEqual(
+            depth2.view(2, 4).tolist(),
+            [[500, 501, 51, 52], [602, 603, 61, 62]],
+        )
+
+    def test_frontier_hidden_splice_gathers_at_accept_boundary(self):
+        # H=1; stash rows are the hiddens at positions vc-3..vc-1, fresh
+        # rows this round's verify hiddens at vc..vc+3.
+        stash = torch.tensor([[[-3.0], [-2.0], [-1.0]], [[-13.0], [-12.0], [-11.0]]])
+        fresh = torch.tensor(
+            [[[0.0], [1.0], [2.0], [3.0]], [[10.0], [11.0], [12.0], [13.0]]]
+        )
+        accept = torch.tensor([[2], [4]])
+
+        spliced = _frontier_hidden_splice(stash, fresh, accept)
+
+        # accept=2: window rows at vc-2..vc+1; accept=4: rows at vc..vc+3.
+        self.assertEqual(
+            spliced.view(2, 4).tolist(),
+            [[-2.0, -1.0, 0.0, 1.0], [10.0, 11.0, 12.0, 13.0]],
+        )
+
+    def test_frontier_ids_and_stash_track_positions_over_rounds(self):
+        # Positional oracle: the committed token at position p has id
+        # 1000+p, the draft candidate for position frontier+m has id
+        # 7000+m, and rejected verify entries (junk, id 9000+) must never
+        # be read. The stash rolls with the same _committed_tail_update as
+        # the drafter will use; row j of depth d must always compose the
+        # token at (frontier - k + j) + d + 1.
+        torch.manual_seed(0)
+        k, steps = 4, 3
+        vc = 10
+        stash = torch.tensor([[1000 + vc - 2, 1000 + vc - 1, 1000 + vc]])
+        for accept in [1, 4, 2, 1, 3, 4, 1, 2]:
+            a = torch.tensor([[accept]])
+            v = torch.tensor(
+                [[1000 + vc + 1 + i if i < accept else 9000 + i for i in range(k)]]
+            )
+            next_tokens = torch.tensor([[0] + [7000 + m for m in range(1, steps + 1)]])
+            frontier = vc + accept
+            for d in range(steps):
+                ids = _frontier_shifted_ids(v, a, next_tokens, stash, d).view(1, k)
+                for j in range(k):
+                    consumed = (frontier - k + j) + d + 1
+                    if consumed <= frontier:
+                        self.assertEqual(ids[0, j].item(), 1000 + consumed)
+                    else:
+                        self.assertEqual(ids[0, j].item(), 7000 + consumed - frontier)
+            stash = _committed_tail_update(stash, v, torch.tensor([accept]), k - 1)
+            vc = frontier
+            self.assertEqual(stash.tolist(), [[1000 + vc - 2 + i for i in range(3)]])
+
+    def test_frontier_hidden_splice_tracks_positions_over_rounds(self):
+        # Same oracle for the hidden side: the target hidden of position p
+        # is encoded as float(p); the stash must always hold positions
+        # vc-3..vc-1 and the splice must yield the window rows
+        # frontier-4..frontier-1.
+        k = 4
+        vc = 10
+        stash = torch.tensor([float(vc - 3 + i) for i in range(3)]).view(1, 3, 1)
+        for accept in [1, 4, 2, 1, 3]:
+            a = torch.tensor([[accept]])
+            fresh = torch.tensor(
+                [float(vc + i) if i < accept else 9000.0 for i in range(k)]
+            ).view(1, k, 1)
+            frontier = vc + accept
+
+            spliced = _frontier_hidden_splice(stash, fresh, a)
+
+            self.assertEqual(
+                spliced.view(k).tolist(),
+                [float(frontier - k + j) for j in range(k)],
+            )
+            stash = _committed_tail_update(stash, fresh, torch.tensor([accept]), k - 1)
+            vc = frontier
+            self.assertEqual(
+                stash.view(3).tolist(), [float(vc - 3 + i) for i in range(3)]
+            )
+
+    def test_frontier_ids_match_lookback_ids_on_shared_positions(self):
+        # Designs (2) and (3) must compose identical tokens wherever their
+        # windows overlap. Design (2)'s D+k rows cover positions
+        # vc-D .. vc+k-1 (row r at vc-D+r); design (3)'s k rows cover
+        # frontier-k .. frontier-1 (row j at vc+accept-k+j). Both read the
+        # token at row position + depth + 1, so aligned rows satisfy
+        # r = j + accept + D - k. Stashes are consistent by construction:
+        # (2)'s D tokens are the tail of (3)'s k-1.
+        k, steps = 4, 3
+        lookback = steps - 1
+        v = torch.tensor([[500, 501, 502, 503], [600, 601, 602, 603]])
+        next_tokens = torch.tensor(
+            [[0, 51, 52, 53], [0, 61, 62, 63]], dtype=torch.int32
+        )
+        stash3 = torch.tensor([[41, 42, 43], [71, 72, 73]])
+        stash2 = stash3[:, -lookback:]
+        for accept_a, accept_b in [(1, 4), (2, 3), (4, 1)]:
+            accept = torch.tensor([[accept_a], [accept_b]])
+            for d in range(1, steps):
+                ids2 = _lookback_shifted_ids(
+                    v, accept, next_tokens, stash2, d, lookback
+                ).view(2, lookback + k)
+                ids3 = _frontier_shifted_ids(v, accept, next_tokens, stash3, d).view(
+                    2, k
+                )
+                for req, a in ((0, accept_a), (1, accept_b)):
+                    for j in range(k):
+                        r = j + a + lookback - k
+                        if 0 <= r < lookback + k:
+                            self.assertEqual(
+                                ids3[req, j].item(),
+                                ids2[req, r].item(),
+                                f"accept={a} depth={d} row={j}",
+                            )
 
     def test_committed_tail_update_blends_across_rounds(self):
         stash = torch.tensor([[10, 11], [20, 21]])

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -13,7 +13,6 @@ from tokenspeed.runtime.execution.drafter.mtp import (
     _extend_depth_shifted_ids_from,
     _frontier_hidden_splice,
     _frontier_shifted_ids,
-    _lookback_shifted_ids,
     _ragged_tail_rows,
 )
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -30,9 +29,10 @@ def _make_eagle(spec_num_tokens: int = 4, max_bs: int = 8) -> Eagle:
 
 
 class TestDrafterAcceptIndexing(unittest.TestCase):
-    def test_mtp_lookback_stash_uses_request_pool_capacity(self):
+    def test_mtp_stash_uses_request_pool_capacity(self):
         max_bs = 16
         request_pool_rows = 18
+        spec_num_tokens = 4
         input_buffers = SimpleNamespace(
             max_bs=max_bs,
             seq_lens_buf=torch.zeros(max_bs, dtype=torch.int32),
@@ -40,28 +40,34 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         model_runner = SimpleNamespace(
             device="cpu",
             mapping=SimpleNamespace(attn=SimpleNamespace(dp_size=1)),
-            model=SimpleNamespace(draft_decode_lookback=True),
+            model=SimpleNamespace(),
             model_config=SimpleNamespace(hidden_size=8, dtype=torch.float32),
         )
         runtime_states = SimpleNamespace(
             valid_cache_lengths=torch.zeros(request_pool_rows, dtype=torch.int32)
         )
-        backend = SimpleNamespace(configure_draft_lookback=lambda _: True)
+        backend = SimpleNamespace()
 
         drafter = Mtp(
-            spec_num_tokens=4,
+            spec_num_tokens=spec_num_tokens,
             spec_num_steps=3,
             draft_model_runner=model_runner,
             cache_view=CacheView(
-                torch.zeros((max_bs, 4), dtype=torch.int32), page_size=128
+                torch.zeros((max_bs, 4), dtype=torch.int32), kernel_page_size=128
             ),
             attn_backend=backend,
             runtime_states=runtime_states,
             input_buffers=input_buffers,
         )
 
-        self.assertEqual(drafter._lookback_tokens_buf.shape[0], request_pool_rows)
-        self.assertEqual(drafter._lookback_hidden_buf.shape[0], request_pool_rows)
+        self.assertEqual(
+            list(drafter._stash_tokens_buf.shape),
+            [request_pool_rows, spec_num_tokens - 1],
+        )
+        self.assertEqual(
+            list(drafter._stash_hidden_buf.shape),
+            [request_pool_rows, spec_num_tokens - 1, 8],
+        )
 
     def test_prepare_draft_input_ids_maps_media_then_clamps_to_vocab(self):
         drafter = _make_eagle()
@@ -180,33 +186,6 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         # row i consumes t_{i+4}, i.e. drafts d_1..d_3.
         self.assertEqual(depth3.tolist(), [701, 702, 703])
 
-    def test_lookback_shifted_ids_reads_stash_verify_and_drafts(self):
-        # k=4, D=2. Request A accepts 2 of [v0..v3]; request B accepts all 4.
-        # Stash entry i holds the committed token at position vc-D+1+i, so
-        # entry 1 (= token at vc) is the only one any depth >= 1 consumes.
-        v = torch.tensor([[500, 501, 502, 503], [600, 601, 602, 603]])
-        accept = torch.tensor([[2], [4]])
-        next_tokens = torch.tensor(
-            [[0, 51, 52, 53], [0, 61, 62, 63]], dtype=torch.int32
-        )
-        stash = torch.tensor([[41, 42], [71, 72]])
-
-        depth1 = _lookback_shifted_ids(v, accept, next_tokens, stash, 1, 2)
-        depth2 = _lookback_shifted_ids(v, accept, next_tokens, stash, 2, 2)
-
-        # depth 1: src = [-1, 0, 1, 2, 3, 4] per request.
-        self.assertEqual(
-            depth1.view(2, 6).tolist(),
-            [[42, 500, 501, 51, 51, 51], [72, 600, 601, 602, 603, 61]],
-        )
-        # depth 2: src = [0, 1, 2, 3, 4, 5]; past the accept the drafts
-        # continue from the accept point (m = src - accept -> d_{m+1}),
-        # clamped to this depth's filled columns.
-        self.assertEqual(
-            depth2.view(2, 6).tolist(),
-            [[500, 501, 51, 52, 52, 52], [600, 601, 602, 603, 61, 62]],
-        )
-
     def test_frontier_shifted_ids_reads_stash_verify_and_drafts(self):
         # k=4. Request A accepts 2 of [v0..v3]; request B accepts all 4.
         # Stash entry i holds the committed token at position vc-k+2+i.
@@ -309,41 +288,6 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             self.assertEqual(
                 stash.view(3).tolist(), [float(vc - 3 + i) for i in range(3)]
             )
-
-    def test_frontier_ids_match_lookback_ids_on_shared_positions(self):
-        # Designs (2) and (3) must compose identical tokens wherever their
-        # windows overlap. Design (2)'s D+k rows cover positions
-        # vc-D .. vc+k-1 (row r at vc-D+r); design (3)'s k rows cover
-        # frontier-k .. frontier-1 (row j at vc+accept-k+j). Both read the
-        # token at row position + depth + 1, so aligned rows satisfy
-        # r = j + accept + D - k. Stashes are consistent by construction:
-        # (2)'s D tokens are the tail of (3)'s k-1.
-        k, steps = 4, 3
-        lookback = steps - 1
-        v = torch.tensor([[500, 501, 502, 503], [600, 601, 602, 603]])
-        next_tokens = torch.tensor(
-            [[0, 51, 52, 53], [0, 61, 62, 63]], dtype=torch.int32
-        )
-        stash3 = torch.tensor([[41, 42, 43], [71, 72, 73]])
-        stash2 = stash3[:, -lookback:]
-        for accept_a, accept_b in [(1, 4), (2, 3), (4, 1)]:
-            accept = torch.tensor([[accept_a], [accept_b]])
-            for d in range(1, steps):
-                ids2 = _lookback_shifted_ids(
-                    v, accept, next_tokens, stash2, d, lookback
-                ).view(2, lookback + k)
-                ids3 = _frontier_shifted_ids(v, accept, next_tokens, stash3, d).view(
-                    2, k
-                )
-                for req, a in ((0, accept_a), (1, accept_b)):
-                    for j in range(k):
-                        r = j + a + lookback - k
-                        if 0 <= r < lookback + k:
-                            self.assertEqual(
-                                ids3[req, j].item(),
-                                ids2[req, r].item(),
-                                f"accept={a} depth={d} row={j}",
-                            )
 
     def test_committed_tail_update_blends_across_rounds(self):
         stash = torch.tensor([[10, 11], [20, 21]])

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -101,17 +101,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "inside the target vocabulary"):
             drafter.set_mm_pad_substitute_ids({Modality.IMAGE: 256})
 
-    def test_eagle_accept_output_indices_stay_inside_each_decode_row(self):
-        drafter = _make_eagle(spec_num_tokens=4)
-
-        indices = drafter._accepted_output_indices(
-            torch.tensor([0, 1, 4, 99], dtype=torch.int32),
-            row_count=4,
-        )
-
-        self.assertEqual(indices.tolist(), [0, 4, 11, 15])
-
-    def test_eagle_decode_first_step_uses_safe_gather_ids_for_zero_accept(self):
+    def test_eagle_decode_first_step_gathers_last_accepted_output(self):
         drafter = _make_eagle(spec_num_tokens=4)
         output_tokens = torch.arange(12, dtype=torch.int32)
         draft_input = EagleDraftInput(
@@ -119,7 +109,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             num_extends=0,
             forward_mode=ForwardMode.DECODE,
             base_model_output=output_tokens,
-            accept_lengths=torch.tensor([0, 1, 4], dtype=torch.int32),
+            accept_lengths=torch.tensor([1, 2, 4], dtype=torch.int32),
             base_out_hidden_states=torch.empty(0),
         )
 
@@ -130,7 +120,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
         )
 
         self.assertIs(input_ids, output_tokens)
-        self.assertEqual(gather_ids.tolist(), [0, 4, 11])
+        self.assertEqual(gather_ids.tolist(), [0, 5, 11])
 
     def test_eagle_mixed_first_step_keeps_decode_gather_ids_in_range(self):
         drafter = _make_eagle(spec_num_tokens=4)
@@ -144,7 +134,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             num_extends=1,
             forward_mode=ForwardMode.MIXED,
             base_model_output=output_tokens,
-            accept_lengths=torch.tensor([1, 0, 4], dtype=torch.int32),
+            accept_lengths=torch.tensor([1, 2, 4], dtype=torch.int32),
             base_out_hidden_states=torch.empty(0),
         )
 
@@ -154,7 +144,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             input_num_tokens=10,
         )
 
-        self.assertEqual(gather_ids.tolist(), [1, 2, 9])
+        self.assertEqual(gather_ids.tolist(), [1, 3, 9])
         self.assertEqual(input_ids[2:].tolist(), output_tokens[1:].tolist())
 
     def test_extend_depth_shifted_ids_shifts_within_each_request(self):
@@ -317,17 +307,17 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
 
         self.assertEqual(updated.tolist(), [[103, 104], [4, 105]])
 
-    def test_dflash_current_tokens_use_safe_in_row_dummy_for_zero_accept(self):
+    def test_dflash_current_tokens_gather_last_accepted_per_row(self):
         output_tokens = torch.arange(12, dtype=torch.int32)
 
         current = DFlash._current_tokens_from_output(
             output_tokens=output_tokens,
-            accept_lengths=torch.tensor([0, 1, 4], dtype=torch.int32),
+            accept_lengths=torch.tensor([1, 2, 4], dtype=torch.int32),
             num_extends=0,
             spec_num_tokens=4,
         )
 
-        self.assertEqual(current.tolist(), [0, 4, 11])
+        self.assertEqual(current.tolist(), [0, 5, 11])
 
     def test_dflash_mixed_current_tokens_do_not_cross_decode_rows(self):
         output_tokens = torch.tensor(
@@ -337,12 +327,12 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
 
         current = DFlash._current_tokens_from_output(
             output_tokens=output_tokens,
-            accept_lengths=torch.tensor([1, 0, 4], dtype=torch.int32),
+            accept_lengths=torch.tensor([1, 2, 4], dtype=torch.int32),
             num_extends=1,
             spec_num_tokens=4,
         )
 
-        self.assertEqual(current.tolist(), [100, 10, 23])
+        self.assertEqual(current.tolist(), [100, 11, 23])
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_inkling_activation_parity.py
+++ b/test/runtime/test_inkling_activation_parity.py
@@ -227,7 +227,7 @@ class _Harness:
             num_slots=6,
             conv_dim=inkling_conv_total_dim(text, 1),
             kernel_size=text.sconv_kernel_size,
-            # Non-spec ring: (W-1) + K(1) + lookback(0) = W.
+            # Non-spec ring: (W-1) + K(1) = W.
             ring_size=text.sconv_kernel_size,
             dtype=torch.bfloat16,
             device=device,

--- a/test/runtime/test_inkling_mtp_conv_state.py
+++ b/test/runtime/test_inkling_mtp_conv_state.py
@@ -744,6 +744,117 @@ class TestCheckpointMetadata(unittest.TestCase):
         # positional publish re-covers it with committed rows.
         self.assertEqual(md.seq_lens.tolist(), [132])
 
+    def test_draft_frontier_window_reanchors_conv_metadata(self):
+        """enter_draft_frontier_window keeps the k-row chunk shape and moves
+        only its anchor: seq_lens becomes the committed frontier, the paged
+        bridges ride through (positional publish re-covers rewritten
+        boundaries with committed content), and the inner backend gets the
+        same frontier for its seq_lens/write-loc re-anchor."""
+        from types import SimpleNamespace
+
+        from tokenspeed.runtime.layers.attention.backends.inkling import (
+            InklingAttnBackend,
+            InklingConvMetadata,
+        )
+
+        k, bs = 4, 1
+        backend = InklingAttnBackend.__new__(InklingAttnBackend)
+        backend.conv_is_draft = True
+        backend._draft_frontier = True
+        inner_calls = []
+        backend.inner = SimpleNamespace(
+            enter_draft_frontier=lambda bs, f: inner_calls.append((bs, f))
+        )
+        table = torch.tensor([[11, 12, 13]], dtype=torch.int32, device="cuda")
+        qsl = torch.arange(0, bs * k + 1, k, dtype=torch.int32, device="cuda")
+        backend.conv_metadata = InklingConvMetadata(
+            query_start_loc=qsl,
+            cache_indices=torch.tensor([2], dtype=torch.int32, device="cuda"),
+            has_initial_state=torch.ones(bs, dtype=torch.bool, device="cuda"),
+            is_decode=False,
+            seq_idx=torch.zeros(bs * k, dtype=torch.int32, device="cuda"),
+            seq_lens=torch.tensor([132], dtype=torch.int32, device="cuda"),
+            col_page_table={"state": table[:bs]},
+        )
+        frontier = torch.tensor([130], dtype=torch.int32, device="cuda")
+
+        backend.enter_draft_frontier_window(bs, frontier)
+
+        md = backend.conv_metadata
+        self.assertEqual(md.query_start_loc.tolist(), [0, k], "same k-row chunk")
+        self.assertEqual(md.seq_lens.tolist(), [130], "chunk end at the frontier")
+        self.assertFalse(md.is_decode)
+        self.assertIsNotNone(md.col_page_table)
+        self.assertTrue(torch.equal(md.col_page_table["state"], table[:bs]))
+        self.assertEqual(len(inner_calls), 1)
+        self.assertEqual(inner_calls[0][0], bs)
+        self.assertEqual(inner_calls[0][1].tolist(), [130])
+
+    def test_draft_frontier_window_raises_instead_of_falling_back(self):
+        """Every refusal condition must raise: an unarmed backend, and
+        wrong-shape (single-token decode) conv metadata."""
+        from types import SimpleNamespace
+
+        from tokenspeed.runtime.layers.attention.backends.inkling import (
+            InklingAttnBackend,
+            InklingConvMetadata,
+        )
+
+        backend = InklingAttnBackend.__new__(InklingAttnBackend)
+        backend.conv_is_draft = True
+        backend._draft_frontier = False
+        frontier = torch.tensor([10], dtype=torch.int32, device="cuda")
+        with self.assertRaisesRegex(RuntimeError, "configure_draft_frontier"):
+            backend.enter_draft_frontier_window(1, frontier)
+
+        backend._draft_frontier = True
+        backend.inner = SimpleNamespace(enter_draft_frontier=lambda bs, f: None)
+        qsl = torch.arange(2, dtype=torch.int32, device="cuda")
+        backend.conv_metadata = InklingConvMetadata(
+            query_start_loc=qsl,
+            cache_indices=torch.tensor([2], dtype=torch.int32, device="cuda"),
+            has_initial_state=torch.ones(1, dtype=torch.bool, device="cuda"),
+            is_decode=True,
+            seq_idx=qsl[:1],
+            seq_lens=torch.tensor([12], dtype=torch.int32, device="cuda"),
+            col_page_table=None,
+        )
+        with self.assertRaisesRegex(RuntimeError, "catch-up conv metadata"):
+            backend.enter_draft_frontier_window(1, frontier)
+
+    def test_enter_draft_frontier_recomputes_group_locs(self):
+        """The mixin hook must replace seq_lens with the frontier and point
+        the grouped write locs at the k positions ending there."""
+        from tokenspeed.runtime.layers.attention.backends.cache_groups import (
+            CacheGroupsMixin,
+        )
+        from tokenspeed.runtime.layers.attention.backends.mha import (
+            MHADecodeMetadata,
+        )
+
+        class _Host(CacheGroupsMixin):
+            pass
+
+        host = _Host()
+        host.page_size = 2
+        host.spec_num_tokens = 4
+        host.group_page_sizes = {"g": 2}
+        table = torch.tensor([[7, 8, 9]], dtype=torch.int32, device="cuda")
+        host.forward_decode_metadata = MHADecodeMetadata(
+            page_table=None,
+            seq_lens=torch.tensor([8], dtype=torch.int32, device="cuda"),
+            page_tables={"g": table},
+            out_cache_locs={"g": torch.zeros(4, dtype=torch.int32, device="cuda")},
+        )
+        frontier = torch.tensor([6], dtype=torch.int32, device="cuda")
+
+        host.enter_draft_frontier(1, frontier)
+
+        md = host.forward_decode_metadata
+        self.assertEqual(md.seq_lens.tolist(), [6])
+        # Positions 2..5 with page size 2 over table row [7, 8, 9].
+        self.assertEqual(md.out_cache_locs["g"].tolist(), [16, 17, 18, 19])
+
     def test_advance_draft_metadata_keeps_paged_checkpoints(self):
         """The classic per-step rebuild (catch-up -> T=1 decode metadata)
         must also carry the paged bridges, or single-token draft steps

--- a/test/runtime/test_inkling_mtp_conv_state.py
+++ b/test/runtime/test_inkling_mtp_conv_state.py
@@ -130,7 +130,7 @@ class TestInklingCacheContract(unittest.TestCase):
 @unittest.skipUnless(torch.cuda.is_available(), "needs a CUDA device")
 class TestInklingConvRingState(unittest.TestCase):
     W = 4  # sconv kernel size (W-1 = 3 history taps)
-    R = 9  # ring rows: (W-1) + K + lookback(K-2)
+    R = 9  # ring rows: >= (W-1) + K
     DIM = 8
     BS = 5
     K = 4  # spec_num_tokens (draft tokens per verify round)
@@ -695,55 +695,6 @@ class TestCheckpointMetadata(unittest.TestCase):
     W = 4
     DIM = 8
 
-    def test_draft_lookback_window_keeps_paged_checkpoints(self):
-        """enter_draft_lookback_window must carry the paged bridges into the
-        widened metadata: the in-kernel publish resolves pages from
-        col_block_table by position, so dropping it (the old refusal path)
-        would silently disable draft publication on every decode round."""
-        from types import SimpleNamespace
-
-        from tokenspeed.runtime.layers.attention.backends.inkling import (
-            InklingAttnBackend,
-            InklingConvMetadata,
-        )
-
-        k, lookback, bs = 4, 2, 1
-        backend = InklingAttnBackend.__new__(InklingAttnBackend)
-        backend.conv_pool = SimpleNamespace(kernel_size=self.W)
-        backend.conv_columns = {
-            "block_tokens": 128,
-            "group_block_tokens": {"state": 128},
-        }
-        backend.conv_is_draft = True
-        backend.conv_spec_num_tokens = k
-        backend._draft_lookback = lookback
-        backend.inner = SimpleNamespace()
-        table = torch.tensor([[11, 12, 13]], dtype=torch.int32, device="cuda")
-        seq_lens = torch.tensor([132], dtype=torch.int32, device="cuda")
-        qsl = torch.arange(0, bs * k + 1, k, dtype=torch.int32, device="cuda")
-        backend.conv_metadata = InklingConvMetadata(
-            query_start_loc=qsl,
-            cache_indices=torch.tensor([2], dtype=torch.int32, device="cuda"),
-            has_initial_state=torch.ones(bs, dtype=torch.bool, device="cuda"),
-            is_decode=False,
-            seq_idx=torch.zeros(bs * k, dtype=torch.int32, device="cuda"),
-            seq_lens=seq_lens,
-            col_block_table={"state": table[:bs]},
-        )
-
-        self.assertTrue(backend.enter_draft_lookback_window(bs))
-
-        md = backend.conv_metadata
-        self.assertEqual(
-            md.query_start_loc.tolist(), [0, k + lookback], "widened chunk"
-        )
-        self.assertIsNotNone(md.col_block_table)
-        self.assertTrue(torch.equal(md.col_block_table["state"], table[:bs]))
-        # Same through-chunk end: the boundary the accept landed on (128)
-        # is inside the widened chunk (132 - 6, 132], so the kernel's
-        # positional publish re-covers it with committed rows.
-        self.assertEqual(md.seq_lens.tolist(), [132])
-
     def test_draft_frontier_window_reanchors_conv_metadata(self):
         """enter_draft_frontier_window keeps the k-row chunk shape and moves
         only its anchor: seq_lens becomes the committed frontier, the paged
@@ -759,8 +710,6 @@ class TestCheckpointMetadata(unittest.TestCase):
 
         k, bs = 4, 1
         backend = InklingAttnBackend.__new__(InklingAttnBackend)
-        backend.conv_is_draft = True
-        backend._draft_frontier = True
         inner_calls = []
         backend.inner = SimpleNamespace(
             enter_draft_frontier=lambda bs, f: inner_calls.append((bs, f))
@@ -774,7 +723,7 @@ class TestCheckpointMetadata(unittest.TestCase):
             is_decode=False,
             seq_idx=torch.zeros(bs * k, dtype=torch.int32, device="cuda"),
             seq_lens=torch.tensor([132], dtype=torch.int32, device="cuda"),
-            col_page_table={"state": table[:bs]},
+            col_block_table={"state": table[:bs]},
         )
         frontier = torch.tensor([130], dtype=torch.int32, device="cuda")
 
@@ -784,43 +733,11 @@ class TestCheckpointMetadata(unittest.TestCase):
         self.assertEqual(md.query_start_loc.tolist(), [0, k], "same k-row chunk")
         self.assertEqual(md.seq_lens.tolist(), [130], "chunk end at the frontier")
         self.assertFalse(md.is_decode)
-        self.assertIsNotNone(md.col_page_table)
-        self.assertTrue(torch.equal(md.col_page_table["state"], table[:bs]))
+        self.assertIsNotNone(md.col_block_table)
+        self.assertTrue(torch.equal(md.col_block_table["state"], table[:bs]))
         self.assertEqual(len(inner_calls), 1)
         self.assertEqual(inner_calls[0][0], bs)
         self.assertEqual(inner_calls[0][1].tolist(), [130])
-
-    def test_draft_frontier_window_raises_instead_of_falling_back(self):
-        """Every refusal condition must raise: an unarmed backend, and
-        wrong-shape (single-token decode) conv metadata."""
-        from types import SimpleNamespace
-
-        from tokenspeed.runtime.layers.attention.backends.inkling import (
-            InklingAttnBackend,
-            InklingConvMetadata,
-        )
-
-        backend = InklingAttnBackend.__new__(InklingAttnBackend)
-        backend.conv_is_draft = True
-        backend._draft_frontier = False
-        frontier = torch.tensor([10], dtype=torch.int32, device="cuda")
-        with self.assertRaisesRegex(RuntimeError, "configure_draft_frontier"):
-            backend.enter_draft_frontier_window(1, frontier)
-
-        backend._draft_frontier = True
-        backend.inner = SimpleNamespace(enter_draft_frontier=lambda bs, f: None)
-        qsl = torch.arange(2, dtype=torch.int32, device="cuda")
-        backend.conv_metadata = InklingConvMetadata(
-            query_start_loc=qsl,
-            cache_indices=torch.tensor([2], dtype=torch.int32, device="cuda"),
-            has_initial_state=torch.ones(1, dtype=torch.bool, device="cuda"),
-            is_decode=True,
-            seq_idx=qsl[:1],
-            seq_lens=torch.tensor([12], dtype=torch.int32, device="cuda"),
-            col_page_table=None,
-        )
-        with self.assertRaisesRegex(RuntimeError, "catch-up conv metadata"):
-            backend.enter_draft_frontier_window(1, frontier)
 
     def test_enter_draft_frontier_recomputes_group_locs(self):
         """The mixin hook must replace seq_lens with the frontier and point
@@ -836,9 +753,9 @@ class TestCheckpointMetadata(unittest.TestCase):
             pass
 
         host = _Host()
-        host.page_size = 2
+        host.kernel_page_size = 2
         host.spec_num_tokens = 4
-        host.group_page_sizes = {"g": 2}
+        host.group_block_granularities = {"g": 2}
         table = torch.tensor([[7, 8, 9]], dtype=torch.int32, device="cuda")
         host.forward_decode_metadata = MHADecodeMetadata(
             page_table=None,
@@ -854,40 +771,6 @@ class TestCheckpointMetadata(unittest.TestCase):
         self.assertEqual(md.seq_lens.tolist(), [6])
         # Positions 2..5 with page size 2 over table row [7, 8, 9].
         self.assertEqual(md.out_cache_locs["g"].tolist(), [16, 17, 18, 19])
-
-    def test_advance_draft_metadata_keeps_paged_checkpoints(self):
-        """The classic per-step rebuild (catch-up -> T=1 decode metadata)
-        must also carry the paged bridges, or single-token draft steps
-        landing on a boundary silently skip their publish."""
-        from types import SimpleNamespace
-
-        from tokenspeed.runtime.layers.attention.backends.inkling import (
-            InklingAttnBackend,
-            InklingConvMetadata,
-        )
-
-        k, bs = 4, 2
-        backend = InklingAttnBackend.__new__(InklingAttnBackend)
-        backend.inner = SimpleNamespace()
-        backend._graph_has_initial_state = None
-        backend._decode_qsl = None
-        table = torch.tensor([[11, 12], [21, 22]], dtype=torch.int32, device="cuda")
-        qsl = torch.arange(0, bs * k + 1, k, dtype=torch.int32, device="cuda")
-        backend.conv_metadata = InklingConvMetadata(
-            query_start_loc=qsl,
-            cache_indices=torch.tensor([2, 3], dtype=torch.int32, device="cuda"),
-            has_initial_state=torch.ones(bs, dtype=torch.bool, device="cuda"),
-            is_decode=False,
-            seq_idx=torch.zeros(bs * k, dtype=torch.int32, device="cuda"),
-            seq_lens=torch.tensor([200, 260], dtype=torch.int32, device="cuda"),
-            col_block_table={"state": table},
-        )
-
-        backend.advance_draft_forward_metadata()
-
-        md = backend.conv_metadata
-        self.assertTrue(md.is_decode)
-        self.assertTrue(torch.equal(md.col_block_table["state"], table))
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_inkling_mtp_conv_state.py
+++ b/test/runtime/test_inkling_mtp_conv_state.py
@@ -89,7 +89,6 @@ class TestInklingCacheContract(unittest.TestCase):
                 ),
                 cache_indices=torch.tensor([1], dtype=torch.int32),
                 has_initial_state=torch.ones(1, dtype=torch.bool),
-                is_decode=restore,
                 seq_lens=torch.tensor([seq_len], dtype=torch.int32),
                 col_block_table={"state": torch.full((1, 2), page, dtype=torch.int32)},
                 remote_restore_mask=torch.tensor([True]) if restore else None,
@@ -696,7 +695,7 @@ class TestCheckpointMetadata(unittest.TestCase):
     DIM = 8
 
     def test_draft_frontier_window_reanchors_conv_metadata(self):
-        """enter_draft_frontier_window keeps the k-row chunk shape and moves
+        """update_draft_forward_metadata keeps the k-row chunk shape and moves
         only its anchor: seq_lens becomes the committed frontier, the paged
         bridges ride through (positional publish re-covers rewritten
         boundaries with committed content), and the inner backend gets the
@@ -712,7 +711,7 @@ class TestCheckpointMetadata(unittest.TestCase):
         backend = InklingAttnBackend.__new__(InklingAttnBackend)
         inner_calls = []
         backend.inner = SimpleNamespace(
-            enter_draft_frontier=lambda bs, f: inner_calls.append((bs, f))
+            update_draft_forward_metadata=lambda f: inner_calls.append(f)
         )
         table = torch.tensor([[11, 12, 13]], dtype=torch.int32, device="cuda")
         qsl = torch.arange(0, bs * k + 1, k, dtype=torch.int32, device="cuda")
@@ -720,26 +719,23 @@ class TestCheckpointMetadata(unittest.TestCase):
             query_start_loc=qsl,
             cache_indices=torch.tensor([2], dtype=torch.int32, device="cuda"),
             has_initial_state=torch.ones(bs, dtype=torch.bool, device="cuda"),
-            is_decode=False,
             seq_idx=torch.zeros(bs * k, dtype=torch.int32, device="cuda"),
             seq_lens=torch.tensor([132], dtype=torch.int32, device="cuda"),
             col_block_table={"state": table[:bs]},
         )
         frontier = torch.tensor([130], dtype=torch.int32, device="cuda")
 
-        backend.enter_draft_frontier_window(bs, frontier)
+        backend.update_draft_forward_metadata(frontier)
 
         md = backend.conv_metadata
         self.assertEqual(md.query_start_loc.tolist(), [0, k], "same k-row chunk")
         self.assertEqual(md.seq_lens.tolist(), [130], "chunk end at the frontier")
-        self.assertFalse(md.is_decode)
         self.assertIsNotNone(md.col_block_table)
         self.assertTrue(torch.equal(md.col_block_table["state"], table[:bs]))
         self.assertEqual(len(inner_calls), 1)
-        self.assertEqual(inner_calls[0][0], bs)
-        self.assertEqual(inner_calls[0][1].tolist(), [130])
+        self.assertEqual(inner_calls[0].tolist(), [130])
 
-    def test_enter_draft_frontier_recomputes_group_locs(self):
+    def test_update_draft_forward_metadata_recomputes_group_locs(self):
         """The mixin hook must replace seq_lens with the frontier and point
         the grouped write locs at the k positions ending there."""
         from tokenspeed.runtime.layers.attention.backends.cache_groups import (
@@ -765,7 +761,7 @@ class TestCheckpointMetadata(unittest.TestCase):
         )
         frontier = torch.tensor([6], dtype=torch.int32, device="cuda")
 
-        host.enter_draft_frontier(1, frontier)
+        host.update_draft_forward_metadata(frontier)
 
         md = host.forward_decode_metadata
         self.assertEqual(md.seq_lens.tolist(), [6])

--- a/test/runtime/test_multimodal_pad_ids.py
+++ b/test/runtime/test_multimodal_pad_ids.py
@@ -7,8 +7,8 @@ from tokenspeed.runtime.multimodal.inputs import (
     MultimodalDataItem,
     is_mm_pad_value,
     is_mm_pad_value_for,
-    maybe_substitute_mm_pad,
     resolve_mm_pad_substitute_ids,
+    substitute_mm_pad_,
 )
 
 
@@ -33,28 +33,20 @@ def test_content_pad_ids_preserve_modality_inside_int32_range():
         assert is_mm_pad_value_for(values, modality).tolist() == expected
 
 
-def test_mtp_substitution_restores_each_modality_token():
+def test_substitution_restores_each_modality_token_in_place():
     image = _item(Modality.IMAGE, 1)
     audio = _item(Modality.AUDIO, 2)
     input_ids = torch.tensor(
         [7, image.pad_value, audio.pad_value, 8], dtype=torch.int32
     )
 
-    output = maybe_substitute_mm_pad(
+    output = substitute_mm_pad_(
         input_ids,
         {Modality.IMAGE: 200005, Modality.AUDIO: 200023},
     )
 
-    assert output.tolist() == [7, 200005, 200023, 8]
-    assert input_ids.tolist() == [7, image.pad_value, audio.pad_value, 8]
-
-
-def test_scalar_mtp_substitution_remains_backward_compatible():
-    image = _item(Modality.IMAGE, 3)
-    audio = _item(Modality.AUDIO, 4)
-    input_ids = torch.tensor([image.pad_value, audio.pad_value], dtype=torch.int32)
-
-    assert maybe_substitute_mm_pad(input_ids, 42).tolist() == [42, 42]
+    assert output is input_ids
+    assert input_ids.tolist() == [7, 200005, 200023, 8]
 
 
 def test_resolve_mtp_tokens_supports_specific_and_shared_model_configs():

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/conv/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/conv/__init__.py
@@ -25,7 +25,7 @@ an optional residual connection, ``y = x + conv(window)``, as used by TML
 hybrid layers. One entry point, :func:`inkling_ring_sconv`, dispatching on
 ``num_extends`` to two kernels with hard-coded state sources: extend
 batches (``num_extends > 0``) tap the paged checkpoint and never read the
-ring; decode/verify/lookback batches tap the ring and never read the paged
+ring; decode/verify batches tap the ring and never read the paged
 cache. Both publish covered boundary checkpoints unconditionally. The per-request convolution state lives in a slot-indexed ring
 of the last ``R`` input rows, shape ``[num_slots, R, D]`` with D-contiguous
 rows: the ring row of absolute position ``p`` is ``p % R``, positions derive
@@ -112,7 +112,7 @@ def inkling_ring_sconv(
     ``min(chunk_len + W - 1, R)`` positions persist to the ring in place —
     chunk rows plus the checkpoint window itself.
 
-    ``num_extends == 0`` (decode/verify/lookback batches): chunks are
+    ``num_extends == 0`` (decode/verify batches): chunks are
     uniform per request and must fit ``R - (W - 1)`` (asserted) so every
     chunk row persists without aliasing any request's tap reads; pre-chunk
     taps read the request's ring rows; the paged cache is never read.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/conv/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/conv/triton.py
@@ -32,7 +32,7 @@ carries the other's paths:
   the checkpoint window itself, one writer per row via the
   ``pos >= through - R`` gate — and publishes the conv window at every
   covered boundary.
-- ``_inkling_ring_sconv_decode_kernel``: fixed-shape decode/verify/lookback
+- ``_inkling_ring_sconv_decode_kernel``: fixed-shape decode/verify
   chunks (uniform tokens per request). Pre-chunk taps read the RING; the
   paged cache is never read. Persists every chunk row (the wrapper asserts
   the uniform chunk fits ``R - (W - 1)``, so writes never alias another
@@ -143,9 +143,9 @@ def _inkling_ring_sconv_decode_kernel(
     W: tl.constexpr,
     W_POW2: tl.constexpr,
 ):
-    """Decode/verify/lookback sconv: ring taps, write-all, one boundary.
+    """Decode/verify sconv: ring taps, write-all, one boundary.
 
-    Chunks are uniform per request (1 / K / K + D tokens) and fit
+    Chunks are uniform per request (1 / K tokens) and fit
     ``R - (W - 1)``, so every chunk row persists at its position's ring row
     with no aliasing (the wrapper asserts the bound). Pre-chunk taps read
     the request's ring; the paged cache is never read. A token whose


### PR DESCRIPTION
## Summary

Makes the frontier-anchored decode window the only multi-depth MTP drafting
mechanism and cleans the path end to end.

### Core change

Every draft depth `0..steps-1` runs the **same k rows per request, ending at
the committed frontier** (`frontier = vc + accept`). Rows re-run committed
positions, so KV/sconv slots written last round from since-rejected drafts are
rewritten in place with exact values — no repair passes, no per-depth metadata
advance. All round geometry (positions, cache write locations, seq_lens,
sample gather) is `frontier ± const`, recomputed per CUDA-graph replay from
`accept` alone with pure tensor math; no host syncs.

Supporting pieces:
- **Cross-round drafter stash** (last k−1 committed tokens + target hiddens,
  keyed by req pool slot) reconstructs the window's pre-verify history; it is
  the tail `[:, 1:]` of the depth-0 window, so the roll is two slice copies.
- **Rolling per-depth ids**: depth d+1 = depth d's window shifted one left
  with its draft appended (one `cat`); only depth 0 is accept-dependent.
- **Backend hook** `update_draft_forward_metadata(frontier)` re-anchors conv
  metadata and grouped write locs (the per-round absolute counterpart of
  `advance_draft_forward_metadata`).
- The superseded designs (verify-anchored window, lookback variant) and their
  configure/arm handshakes are removed; EXTEND rounds always prime the stash.

### Cleanups riding along

- MM pad substitution hoisted from the drafters to `fill_input_buffers`
  (once per chunk on the drafter-only shift-1 buffer): drafters only ever see
  in-vocab ids; per-depth substitute+clamp deleted from MTP and EAGLE;
  unconfigured multimodal targets now fail loudly at startup.
- Never-binding defenses removed (accept-length clamps from #574 — their
  producer died in #974 — redundant casts/slices, dead `is_decode` conv
  metadata field, dead `bs` params, single-use locals).
- Token-value tensors unified to int32; docstrings/comments trimmed to
  constraints the code can't state.