### PR TITLE
feat(zmq): materialize precomputed multimodal inputs on msgpack ingest

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -1109,6 +1109,10 @@ class EventLoop:
             ready_response,
             self.model_config.vocab_size,
             enable_output_logprobs=self.server_args.enable_output_logprobs,
+            # Multimodal ingest: the msgpack path materializes precomputed mm
+            # inputs itself (pad values, M-RoPE, pad substitution) — the
+            # frontend that normally does it is bypassed on this wire.
+            model_config=self.model_config,
         )
 
     # ------------------------------------------------------------------

--- a/python/tokenspeed/runtime/engine/input_processor.py
+++ b/python/tokenspeed/runtime/engine/input_processor.py
@@ -37,8 +37,9 @@ from tokenspeed.runtime.engine.io_struct import (
 from tokenspeed.runtime.grammar.reasoning_structural_tag import (
     structural_tag_for_reasoning_json_schema,
 )
-from tokenspeed.runtime.multimodal.embedder import pad_input_tokens
-from tokenspeed.runtime.multimodal.mrope import compute_mrope_positions
+from tokenspeed.runtime.multimodal.materialize import (
+    materialize_precomputed_inputs,
+)
 from tokenspeed.runtime.sampling.sampling_params import SamplingParams
 
 if TYPE_CHECKING:
@@ -157,39 +158,21 @@ class InputProcessor:
                 raise ValueError(
                     "precomputed_multimodal_inputs is provided for a text-only model."
                 )
+            # Shared with the direct msgpack ZMQ ingest (which bypasses this
+            # frontend): pad values, M-RoPE on the un-padded ids, then
+            # pad_input_tokens — see materialize.py for the ordering contract.
             multimodal_inputs = obj.precomputed_multimodal_inputs
-            multimodal_inputs.ensure_pad_values()
-            # MRoPE-aware models (Qwen2/3-VL, …) require 3-axis position_ids
-            # derived from image_grid_thw + the image_token_id placeholders in
-            # input_ids. SMG ships precomputed mm inputs with mrope_* unset; if
-            # left None, model_executor falls back to a 1-D linear position
-            # override — silently degrading OCR accuracy. Compute them here, on
-            # the un-padded input_ids (so get_rope_index can still locate the
-            # image regions) BEFORE pad_input_tokens substitutes per-image
-            # pad_value over the placeholders, then pad for the embed splice.
-            input_ids_list = None
             if input_ids is not None:
                 input_ids_list = (
                     input_ids if isinstance(input_ids, list) else list(input_ids)
                 )
-            if (
-                input_ids_list is not None
-                and getattr(multimodal_inputs, "mrope_positions", None) is None
-            ):
-                mrope_positions, mrope_position_delta = compute_mrope_positions(
+                input_ids, input_ids_unpadded = materialize_precomputed_inputs(
                     self.engine.model_config.hf_config,
                     input_ids_list,
-                    multimodal_inputs.mm_items,
+                    multimodal_inputs,
                 )
-                multimodal_inputs.mrope_positions = mrope_positions
-                multimodal_inputs.mrope_position_delta = mrope_position_delta
-                if mrope_position_delta is not None:
-                    multimodal_inputs.mrope_position_delta_scalar = int(
-                        mrope_position_delta.flatten()[0].item()
-                    )
-            if input_ids_list is not None:
-                input_ids_unpadded = input_ids_list
-                input_ids = pad_input_tokens(input_ids_list, multimodal_inputs)
+            else:
+                multimodal_inputs.ensure_pad_values()
 
         if self.engine.is_generation:
             session_params = (

--- a/python/tokenspeed/runtime/engine/zmq_msgpack.py
+++ b/python/tokenspeed/runtime/engine/zmq_msgpack.py
@@ -28,6 +28,9 @@ from tokenspeed.runtime.engine.io_struct import (
     MsgpackEncoder,
     TokenizedGenerateReqInput,
 )
+from tokenspeed.runtime.multimodal.materialize import (
+    materialize_precomputed_inputs,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,10 +74,12 @@ class MsgpackRecvSocket:
         socket: zmq.Socket,
         vocab_size: int,
         enable_output_logprobs: bool = False,
+        model_config=None,
     ) -> None:
         self._socket = socket
         self._vocab_size = vocab_size
         self._enable_output_logprobs = enable_output_logprobs
+        self._model_config = model_config
         self._pending: collections.deque = collections.deque()
 
     def _validation_error(self, obj: TokenizedGenerateReqInput) -> str | None:
@@ -88,6 +93,38 @@ class MsgpackRecvSocket:
             obj.sampling_params.verify(self._vocab_size)
         except ValueError as exc:
             return str(exc)
+        return None
+
+    def _materialize_multimodal(self, obj: TokenizedGenerateReqInput) -> str | None:
+        """Derive the scheduler-required multimodal state on ingest.
+
+        The pickle path's InputProcessor performs this in the frontend; the
+        msgpack path bypasses it, so requests arrive with expanded placeholder
+        ``input_ids`` plus items carrying features/hashes/offsets, and the
+        derived pieces (pad values, M-RoPE, pad substitution) are produced
+        here — by the same shared function, so both admission paths agree.
+        Returns a rejection reason, or None on success. A payload that already
+        carries ``input_ids_unpadded`` is taken as fully materialized upstream
+        and passed through untouched.
+        """
+        if obj.multimodal_inputs is None or obj.input_ids_unpadded is not None:
+            return None
+        if self._model_config is None or not getattr(
+            self._model_config, "is_multimodal_active", False
+        ):
+            return "multimodal_inputs were provided for a text-only model"
+        if obj.input_ids is None:
+            return "multimodal_inputs require input_ids"
+        try:
+            obj.input_ids, obj.input_ids_unpadded = materialize_precomputed_inputs(
+                self._model_config.hf_config,
+                list(obj.input_ids),
+                obj.multimodal_inputs,
+            )
+        except Exception as exc:
+            # A malformed mm payload must terminate this request's stream, not
+            # the scheduler; surface the reason like any validation failure.
+            return f"failed to materialize multimodal inputs: {exc}"
         return None
 
     def recv_pyobj(self, flags: int = 0):
@@ -115,7 +152,11 @@ class MsgpackRecvSocket:
                 # are validated. A rejected request still flows, pre-marked.
                 # The wire layer may have marked it already (e.g. n != 1).
                 if isinstance(obj, TokenizedGenerateReqInput):
-                    reason = obj.validation_error or self._validation_error(obj)
+                    reason = (
+                        obj.validation_error
+                        or self._validation_error(obj)
+                        or self._materialize_multimodal(obj)
+                    )
                     if reason is not None:
                         logger.warning(
                             "msgpack input: aborting invalid request %s: %s",
@@ -197,6 +238,7 @@ def connect_msgpack_engine(
     ready_response: "zmq_wire.WireEngineCoreReadyResponse",
     vocab_size: int,
     enable_output_logprobs: bool = False,
+    model_config=None,
 ) -> tuple[MsgpackRecvSocket, MsgpackSendSocket]:
     """Run the startup handshake against SMG and return the wrapped
     data-plane sockets.
@@ -253,6 +295,11 @@ def connect_msgpack_engine(
     handshake.close()
     logger.info("msgpack handshake: complete (engine_index=%s)", engine_index)
     return (
-        MsgpackRecvSocket(input_socket, vocab_size, enable_output_logprobs),
+        MsgpackRecvSocket(
+            input_socket,
+            vocab_size,
+            enable_output_logprobs,
+            model_config=model_config,
+        ),
         MsgpackSendSocket(output_socket, engine_index=engine_index),
     )

--- a/python/tokenspeed/runtime/multimodal/materialize.py
+++ b/python/tokenspeed/runtime/multimodal/materialize.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Materialize gateway-precomputed multimodal inputs for the scheduler.
+
+An upstream preprocessor ships ``MultimodalInputs`` whose items carry
+preprocessed features, content hashes, and placeholder ``offsets``, with the
+prompt's ``input_ids`` containing expanded placeholder tokens at those
+offsets. Before the scheduler can admit such a request, three derived pieces
+must exist, in this order:
+
+1. per-item ``pad_value``s (hash-derived ids in the >1M interval space),
+2. M-RoPE positions, computed on the UN-padded ids (``get_rope_index`` must
+   still see the placeholder tokens to locate the image regions) — skipped
+   when the payload already carries them,
+3. ``pad_input_tokens``: placeholder runs rewritten to each item's
+   ``pad_value`` so distinct images prefix-compare unequal in the text-only
+   prefix cache, keeping the original ids as ``input_ids_unpadded`` for
+   detokenization.
+
+This is one function so every admission path derives them identically: the
+in-process frontend (``InputProcessor.tokenize_one_request``) and the direct
+msgpack ZMQ ingest, which bypasses the frontend entirely.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tokenspeed.runtime.multimodal.embedder import pad_input_tokens
+from tokenspeed.runtime.multimodal.mrope import compute_mrope_positions
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.multimodal.inputs import MultimodalInputs
+
+
+def materialize_precomputed_inputs(
+    hf_config,
+    input_ids: list[int],
+    multimodal_inputs: "MultimodalInputs",
+) -> tuple[list[int], list[int]]:
+    """Derive pad values, M-RoPE positions, and padded ids in place.
+
+    Mutates ``multimodal_inputs`` (pad values, mrope fields) and returns
+    ``(padded_input_ids, input_ids_unpadded)``.
+    """
+    multimodal_inputs.ensure_pad_values()
+
+    # MRoPE-aware models (Qwen-VL family, ...) require 3-axis position ids
+    # derived from grid metadata plus the placeholder positions. A payload may
+    # precompute them upstream (any mrope field set means "upstream owns it");
+    # left entirely None they would silently degrade to 1-D linear positions.
+    if (
+        multimodal_inputs.mrope_positions is None
+        and multimodal_inputs.mrope_position_delta is None
+        and multimodal_inputs.mrope_position_delta_scalar is None
+    ):
+        mrope_positions, mrope_position_delta = compute_mrope_positions(
+            hf_config,
+            input_ids,
+            multimodal_inputs.mm_items,
+        )
+        multimodal_inputs.mrope_positions = mrope_positions
+        multimodal_inputs.mrope_position_delta = mrope_position_delta
+        if mrope_position_delta is not None:
+            multimodal_inputs.mrope_position_delta_scalar = int(
+                mrope_position_delta.flatten()[0].item()
+            )
+
+    padded = pad_input_tokens(input_ids, multimodal_inputs)
+    return padded, input_ids

--- a/test/runtime/test_zmq_msgpack.py
+++ b/test/runtime/test_zmq_msgpack.py
@@ -743,3 +743,114 @@ def test_two_dp_ranks_connect_with_distinct_identities():
         frontend.close()
         ctx.term()
         tmp.cleanup()
+
+
+# --------------------------------------------------------------------------
+# Multimodal ingest materialization
+# --------------------------------------------------------------------------
+
+
+def _mm_payload(**overrides):
+    """A precomputed-mm request as the gateway ships it: expanded placeholder
+    input_ids plus one image item carrying feature/hash/offsets, with M-RoPE
+    precomputed upstream (the scalar-only contract) so materialization on the
+    ingest is deterministic without a real HF config."""
+    import torch
+
+    from tokenspeed.runtime.multimodal.inputs import (
+        Modality,
+        MultimodalDataItem,
+        MultimodalInputs,
+    )
+
+    item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        hash=1234567,
+        offsets=[(2, 4)],
+        feature=torch.zeros(3, 2, 2),
+    )
+    mm = MultimodalInputs(
+        mm_items=[item],
+        im_token_id=9,
+        mrope_position_delta_scalar=0,
+    )
+    fields = dict(
+        rid="mm-1",
+        # tokens 2..4 are the expanded <image> placeholder run.
+        input_ids=[1, 2, 9, 9, 9, 3],
+        sampling_params=SamplingParams(),
+        multimodal_inputs=mm,
+    )
+    fields.update(overrides)
+    return TokenizedGenerateReqInput(**fields)
+
+
+class _MultimodalModelConfig:
+    is_multimodal_active = True
+    hf_config = object()  # never consulted: M-RoPE arrives precomputed
+
+
+class _FakeRecvZmqSocket:
+    def __init__(self, frames_list):
+        import collections
+
+        self._frames = collections.deque(frames_list)
+
+    def recv_multipart(self, flags=0):
+        if not self._frames:
+            raise zmq.Again()
+        return self._frames.popleft()
+
+
+def _recv_one(payload_obj, model_config):
+    frames = [zmq_wire.REQ_TYPE_ADD, _ENCODER.encode(payload_obj)[0]]
+    sock = zmq_msgpack.MsgpackRecvSocket(
+        _FakeRecvZmqSocket([frames]),
+        vocab_size=32000,
+        model_config=model_config,
+    )
+    return sock.recv_pyobj()
+
+
+def test_mm_ingest_materializes_pad_values_and_padded_ids():
+    io = _recv_one(_mm_payload(), _MultimodalModelConfig())
+    assert io.validation_error is None
+    # Original ids preserved for detokenization; placeholder run rewritten to
+    # the item's hash-derived pad value for prefix-cache uniqueness.
+    assert io.input_ids_unpadded == [1, 2, 9, 9, 9, 3]
+    item = io.multimodal_inputs.mm_items[0]
+    assert item.pad_value is not None
+    assert io.input_ids == [1, 2, item.pad_value, item.pad_value, item.pad_value, 3]
+
+
+def test_mm_ingest_rejects_text_only_model():
+    class _TextOnly:
+        is_multimodal_active = False
+        hf_config = object()
+
+    io = _recv_one(_mm_payload(), _TextOnly())
+    # Rejected requests still flow, pre-marked, so the frontend's stream gets
+    # a terminal abort instead of a silent drop.
+    assert io.validation_error is not None
+    assert "text-only" in io.validation_error
+
+
+def test_mm_ingest_passes_through_upstream_materialized_payloads():
+    io = _recv_one(
+        _mm_payload(
+            input_ids=[1, 2, 777, 777, 777, 3],
+            input_ids_unpadded=[1, 2, 9, 9, 9, 3],
+        ),
+        _MultimodalModelConfig(),
+    )
+    assert io.validation_error is None
+    # input_ids_unpadded set means fully materialized upstream: untouched.
+    assert io.input_ids == [1, 2, 777, 777, 777, 3]
+    assert io.multimodal_inputs.mm_items[0].pad_value is None
+
+
+def test_text_requests_untouched_by_mm_ingest():
+    io = _recv_one(_make_request(), _MultimodalModelConfig())
+    assert io.validation_error is None
+    assert io.multimodal_inputs is None
+    assert io.input_ids_unpadded is None


### PR DESCRIPTION
The msgpack ZMQ path decodes multimodal payloads (the wire type is
mm-complete and the decoder is tensor-aware) but bypasses the frontend
InputProcessor, so three derived pieces the scheduler requires never
get produced: per-item pad_values, M-RoPE positions, and the
pad_input_tokens substitution that makes distinct images
prefix-compare unequal. A precomputed-mm request over this wire would
reach the scheduler unmaterialized.

Extract the InputProcessor's precomputed-mm block into
materialize_precomputed_inputs (runtime/multimodal/materialize.py) and
run it from both admission paths: the in-process frontend as before,
and now MsgpackRecvSocket on ingest, alongside the existing sampling
validation. The engine owns the mm math on every path; an external
frontend owes only expanded-placeholder input_ids plus items carrying
feature/hash/offsets (and grid metadata).

Ingest semantics:
- a payload with input_ids_unpadded set is taken as fully materialized
  upstream and passed through untouched;
- M-RoPE is computed only when ALL mrope fields are unset — a payload
  carrying any of them (including the documented scalar-only contract)
  owns its positions. The frontend path previously keyed only on
  mrope_positions, which would have recomputed over a scalar-only
  payload; both paths now honor the decode-side contract;
- a malformed mm payload (or mm on a text-only model) is marked via
  validation_error like any invalid request, so the frontend gets a
  terminal abort instead of a dropped stream or a dead scheduler.

model_config threads into the recv socket the same way vocab_size does.

Tests (CPU-only, riding the scalar-only M-RoPE contract): ingest
materializes pad values and padded ids while preserving the unpadded
originals; text-only model rejection flows pre-marked; upstream-
materialized payloads pass through untouched; text requests unaffected.