### PR TITLE
perf(dsa): fuse scoring-query head reduction

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/indexing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/indexing.py
@@ -27,6 +27,7 @@ from tokenspeed_kernel_amd._triton import gl, gluon
 
 __all__ = [
     "_check_packed_fp8_inputs",
+    "_combine_scoring_query_heads_kernel",
     "_dsa_decode_logits_fp8_kernel",
     "_dsa_prefill_logits_fp8_kernel",
 ]
@@ -39,6 +40,42 @@ def _score_layout(
     NUM_WARPS: gl.constexpr,
 ):
     return gl.BlockedLayout([1, 8], [4, 8], [NUM_WARPS, 1], [1, 0])
+
+
+@gluon.jit
+def _combine_scoring_query_heads_kernel(
+    q,
+    weights,
+    out,
+    q_stride_token,
+    q_stride_head,
+    q_stride_dim,
+    weight_stride_token,
+    weight_stride_head,
+    num_heads: gl.constexpr,
+    head_dim: gl.constexpr,
+    BLOCK_D: gl.constexpr,
+):
+    token = gl.program_id(0)
+    layout: gl.constexpr = _score_layout(1, BLOCK_D, gl.num_warps())
+    dim_layout: gl.constexpr = gl.SliceLayout(0, layout)
+    dims = gl.arange(0, BLOCK_D, layout=dim_layout)
+    combined = gl.zeros([BLOCK_D], dtype=gl.float32, layout=dim_layout)
+    for head in gl.static_range(0, num_heads):
+        q_offsets = token * q_stride_token + head * q_stride_head + dims * q_stride_dim
+        weight_offset = token * weight_stride_token + head * weight_stride_head
+        head_weight = gl.load(weights + weight_offset).to(gl.float32)
+        q_vals = gl.load(
+            q + q_offsets,
+            mask=dims < head_dim,
+            other=0.0,
+        ).to(gl.float32)
+        combined += q_vals * head_weight
+    gl.store(
+        out + token * head_dim + dims,
+        combined,
+        mask=dims < head_dim,
+    )
 
 
 @gluon.jit

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
@@ -26,6 +26,7 @@ import torch
 from tokenspeed_kernel_amd._triton import gl, gluon, triton
 from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.indexing import (
     _check_packed_fp8_inputs,
+    _combine_scoring_query_heads_kernel,
     _dsa_decode_logits_fp8_kernel,
     _dsa_prefill_logits_fp8_kernel,
 )
@@ -403,7 +404,30 @@ def _combine_scoring_query_heads(
     q: torch.Tensor,
     weights: torch.Tensor,
 ) -> torch.Tensor:
-    return (q.float() * weights.float().unsqueeze(-1)).sum(dim=1)
+    """Combine weighted query heads with FP32 accumulation on GFX1250."""
+
+    combined = torch.empty(
+        (q.shape[0], q.shape[2]),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    if q.shape[0] == 0:
+        return combined
+    _combine_scoring_query_heads_kernel[(q.shape[0],)](
+        q,
+        weights,
+        combined,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        weights.stride(0),
+        weights.stride(1),
+        num_heads=q.shape[1],
+        head_dim=q.shape[2],
+        BLOCK_D=128,
+        num_warps=1,
+    )
+    return combined
 
 
 def gluon_dsa_decode_topk_fp8_gfx1250(

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/indexing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/indexing.py
@@ -27,6 +27,7 @@ from tokenspeed_kernel_amd._triton import gl, gluon
 
 __all__ = [
     "_check_packed_fp8_inputs",
+    "_combine_scoring_query_heads_kernel",
     "_dsa_decode_logits_fp8_kernel",
     "_dsa_prefill_logits_fp8_kernel",
 ]
@@ -39,6 +40,41 @@ def _score_layout(
     NUM_WARPS: gl.constexpr,
 ):
     return gl.BlockedLayout([1, 8], [8, 8], [NUM_WARPS, 1], [1, 0])
+
+
+@gluon.jit
+def _combine_scoring_query_heads_kernel(
+    q,
+    weights,
+    out,
+    num_heads: gl.constexpr,
+    head_dim: gl.constexpr,
+    BLOCK_D: gl.constexpr,
+):
+    token = gl.program_id(0)
+    layout: gl.constexpr = _score_layout(1, BLOCK_D, gl.num_warps())
+    dim_layout: gl.constexpr = gl.SliceLayout(0, layout)
+    dims = gl.arange(0, BLOCK_D, layout=dim_layout)
+    combined = gl.full(
+        [BLOCK_D],
+        value=0.0,
+        dtype=gl.float32,
+        layout=dim_layout,
+    )
+    for head in gl.static_range(0, num_heads):
+        head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
+        q_vals = gl.amd.cdna4.buffer_load(
+            ptr=q,
+            offsets=((token * num_heads + head) * head_dim + dims).to(gl.int32),
+            mask=dims < head_dim,
+            other=0.0,
+        ).to(gl.float32)
+        combined += q_vals * head_weight
+    gl.store(
+        out + token * head_dim + dims,
+        combined,
+        mask=dims < head_dim,
+    )
 
 
 @gluon.jit

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/sparse_mla.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/sparse_mla.py
@@ -31,6 +31,7 @@ import torch
 from tokenspeed_kernel_amd._triton import gl, gluon, triton
 from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.indexing import (
     _check_packed_fp8_inputs,
+    _combine_scoring_query_heads_kernel,
     _dsa_decode_logits_fp8_kernel,
     _dsa_prefill_logits_fp8_kernel,
 )
@@ -1900,7 +1901,25 @@ def _combine_scoring_query_heads(
     q: torch.Tensor,
     weights: torch.Tensor,
 ) -> torch.Tensor:
-    return (q.float() * weights.float().unsqueeze(-1)).sum(dim=1)
+    if not weights.is_contiguous():
+        weights = weights.contiguous()
+    combined = torch.empty(
+        (q.shape[0], q.shape[2]),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    if q.shape[0] == 0:
+        return combined
+    _combine_scoring_query_heads_kernel[(q.shape[0],)](
+        q,
+        weights,
+        combined,
+        num_heads=q.shape[1],
+        head_dim=q.shape[2],
+        BLOCK_D=128,
+        num_warps=4,
+    )
+    return combined
 
 
 def gluon_dsa_decode_topk_fp8_gfx950(


### PR DESCRIPTION
## Summary
Follow-up of #1052 and #1063. Replace the three-dispatch (BF16 query-to-FP32 conversion, weighted elementwise multiplication, and head reduction) PyTorch scoring-query head reduction with one architecture-specific Gluon kernel.

## Performance
| Device | Scope | Baseline | Fused | Difference |
|---|---|---:|---:|---:|
| MI355X | 4K DSA prefill | 2263.72 µs | 2231.55 µs | -32.18 µs / -1.44% |
| MI455X| 4K DSA prefill | 2493.75 µs | 2406.68 µs | -87.07 µs / -3.49% |