### PR TITLE
perf(kimi-k3): keep small AMD decode batches on one stream

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -92,6 +92,7 @@ from tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxfp4 import (
     situ_moe_unavailable_reason,
 )
 from tokenspeed_kernel.ops.tuning import load_packaged_flashinfer_tuning_cache
+from tokenspeed_kernel.platform import current_platform
 from torch import nn
 
 from tokenspeed.runtime.configs.kimi_k3_config import KimiK3Config, KimiLinearConfig
@@ -958,6 +959,9 @@ class KimiLinearMoEGate(nn.Module):
 # this is a prefill chunk and takes the unsplit path; the scratch buffers are
 # allocated to exactly this many rows. Raise together with --max-num-seqs.
 ATTNRES_FAST_PATH_MAX_TOKENS = 32
+# Paired MI350 measurements show that stream scheduling costs more than the
+# available attention/AttnRes overlap through M=16. Preserve NVIDIA's policy.
+ATTNRES_STREAM_FORK_MIN_TOKENS = 17 if current_platform().is_amd else 0
 
 
 def _attnres_mlp_slot(layer_id: int) -> int:
@@ -1827,7 +1831,11 @@ class KimiLinearDecoderLayer(nn.Module):
             )
         )
         with self.attn_fork.scope(
-            enable=get_is_capture_mode() and (attnres_partial_args is None or own_mlp)
+            enable=(
+                get_is_capture_mode()
+                and num_tokens >= ATTNRES_STREAM_FORK_MIN_TOKENS
+                and (attnres_partial_args is None or own_mlp)
+            )
         ) as fork:
             with fork.branch():
                 if next_mix is not None:

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -961,7 +961,7 @@ class KimiLinearMoEGate(nn.Module):
 ATTNRES_FAST_PATH_MAX_TOKENS = 32
 # Paired MI350 measurements show that stream scheduling costs more than the
 # available attention/AttnRes overlap through M=16. Preserve NVIDIA's policy.
-ATTNRES_STREAM_FORK_MIN_TOKENS = 17 if current_platform().is_amd else 0
+ATTNRES_STREAM_FORK_THRESHOLD = 16 if current_platform().is_amd else 0
 
 
 def _attnres_mlp_slot(layer_id: int) -> int:
@@ -1833,7 +1833,7 @@ class KimiLinearDecoderLayer(nn.Module):
         with self.attn_fork.scope(
             enable=(
                 get_is_capture_mode()
-                and num_tokens >= ATTNRES_STREAM_FORK_MIN_TOKENS
+                and num_tokens > ATTNRES_STREAM_FORK_THRESHOLD
                 and (attnres_partial_args is None or own_mlp)
             )
         ) as fork:


### PR DESCRIPTION
## Summary

Keep Kimi K3 attention and AttnRes work on one stream for AMD decode batches through M=16. At these sizes, stream scheduling and synchronization cost more than the available overlap. Batches above 16 retain the existing forked-stream path, and non-AMD behavior is unchanged.

## Performance

MI350, 4K/1K, TP=8/EP=8, CUDA graphs, median of three runs:

| M | Forked tok/s | Single-stream tok/s | Change |
|---:|---:|---:|---:|
| 1 | 58.43 | 64.92 | +11.10% |
| 2 | 67.46 | 68.47 | +1.49% |
| 4 | 124.04 | 127.33 | +2.65% |
| 8 | 196.69 | 199.75 | +1.55% |
| 16 | 305.18 | 307.67 | +0.81% |

## Tests

- Kimi K3 coherency canary completed 31 requests across M=1,2,4,8,16 without numerical-corruption symptoms.
- `ruff check python/tokenspeed/runtime/models/kimi_k3.py`
- `git diff --check`