### PR TITLE
fix(cli): allocate the gateway metrics port right before spawn

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -241,9 +241,13 @@ def _gateway_args_with_default_prometheus_port(gateway_args: list[str]) -> list[
     A dead metrics server makes the gateway exit during startup, the
     tokenizer registration job never runs, and the first request surfaces
     ``tokenizer_not_found`` / ``no worker available``. Allocating a fresh
-    free port per launch (like the engine and control ports) avoids every
-    collision; callers that need a stable scrape target can still pass an
-    explicit ``--prometheus-port``.
+    free port per launch (like the engine and control ports) avoids stale
+    collisions, but only if it happens right before ``spawn_gateway``: a
+    port picked at argv-build time sits unreserved through the whole engine
+    startup — minutes for large models — and the kernel can hand it to any
+    outbound connection (engine bootstrap, readiness probes) as an ephemeral
+    source port, failing the gateway bind. Callers that need a stable scrape
+    target can still pass an explicit ``--prometheus-port``.
     """
     if "--prometheus-port" in gateway_args:
         return gateway_args
@@ -436,8 +440,7 @@ def _gateway_args_with_defaults(gateway_args: list[str]) -> list[str]:
     gateway_args = _gateway_args_with_smg_disable_defaults(gateway_args)
     gateway_args = _gateway_args_with_default_policy(gateway_args)
     gateway_args = _gateway_args_with_default_tokenizer_cache(gateway_args)
-    gateway_args = _gateway_args_with_default_log_level(gateway_args)
-    return _gateway_args_with_default_prometheus_port(gateway_args)
+    return _gateway_args_with_default_log_level(gateway_args)
 
 
 def _add_rl_control_port(engine_args: list[str]) -> tuple[list[str], str]:
@@ -596,6 +599,9 @@ async def run_smg(
             label=ENGINE_TAG,
         )
 
+        # Allocate the metrics port only now — see
+        # _gateway_args_with_default_prometheus_port for why earlier is racy.
+        gateway_args = _gateway_args_with_default_prometheus_port(gateway_args)
         gateway = await spawn_gateway(
             gateway_args, engine_host="127.0.0.1", engine_port=engine_port
         )

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -137,10 +137,10 @@ def test_gateway_args_preserve_user_policy():
 def test_gateway_args_defaults_include_port_and_reasoning_parser():
     gateway_args = _gateway_args_with_defaults(["--model", "/tmp/x"])
 
-    # The Prometheus port is a freshly allocated free port (see
-    # test_gateway_args_default_prometheus_port_is_free_port), so assert the
-    # fixed prefix exactly and the trailing port slot structurally.
-    assert gateway_args[:-1] == [
+    # No --prometheus-port here: run_smg allocates it right before
+    # spawn_gateway so the port cannot be lost during engine startup (see
+    # test_run_smg_allocates_prometheus_port_at_gateway_spawn).
+    assert gateway_args == [
         "--model",
         "/tmp/x",
         "--port",
@@ -155,9 +155,7 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "--tokenizer-cache-enable-l1",
         "--log-level",
         "warn",
-        "--prometheus-port",
     ]
-    assert gateway_args[-1].isdigit()
 
 
 def test_gateway_args_defaults_inject_passthrough_policy():
@@ -702,6 +700,54 @@ async def test_gateway_first_then_engine_on_clean_shutdown():
         )
     assert call_order == ["gateway", "engine"]
     assert rc == 0
+
+
+@pytest.mark.asyncio
+async def test_run_smg_allocates_prometheus_port_at_gateway_spawn():
+    """The metrics port is injected by run_smg right before spawn_gateway:
+    a port allocated at argv-build time can be reclaimed as an ephemeral
+    source port while the engine starts up."""
+    engine = _make_proc(returncode=0)
+    gateway = _make_proc(returncode=0)
+
+    startup_done = asyncio.Event()
+
+    async def wait_then_zero():
+        await startup_done.wait()
+        return 0
+
+    engine.wait = AsyncMock(side_effect=wait_then_zero)
+    gateway.wait = AsyncMock(side_effect=wait_then_zero)
+
+    async def probe_then_schedule_release(*args, **kwargs):
+        loop = asyncio.get_running_loop()
+        loop.call_later(0.05, startup_done.set)
+
+    opts = OrchestratorOpts(engine_startup_timeout=10, gateway_startup_timeout=10)
+    spawn_gateway_mock = AsyncMock(return_value=gateway)
+    with patch(
+        "tokenspeed.cli.serve_smg.spawn_engine", AsyncMock(return_value=engine)
+    ), patch("tokenspeed.cli.serve_smg.spawn_gateway", spawn_gateway_mock), patch(
+        "tokenspeed.cli.serve_smg.wait_grpc_serving", AsyncMock()
+    ), patch(
+        "tokenspeed.cli.serve_smg.wait_http_ready",
+        side_effect=probe_then_schedule_release,
+    ), patch(
+        "tokenspeed.cli.serve_smg.terminate_then_kill", AsyncMock()
+    ):
+        rc = await run_smg(
+            engine_args=[],
+            gateway_args=["--model", "/tmp/x"],
+            opts=opts,
+            user_host="127.0.0.1",
+            user_port=8000,
+        )
+
+    assert rc == 0
+    spawned_args = spawn_gateway_mock.await_args.args[0]
+    idx = spawned_args.index("--prometheus-port")
+    assert spawned_args[idx + 1].isdigit()
+    assert 1 <= int(spawned_args[idx + 1]) <= 65535
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`ts serve` allocates the smg `--prometheus-port` free port at argv-build time, but the gateway only binds it after the engine reaches SERVING — minutes for large models. In that window the freed port sits in the kernel's ephemeral range, so any outbound connection on the host (engine bootstrap, readiness probes) can take it as a source port; the gateway then dies during startup with `AddrInUse` on the metrics bind.

Seen repeatedly in CI, e.g. `perf-kimi-k3-mxfp4-tp8ep8-random-4k-1k-mi35x` in https://github.com/lightseekorg/tokenspeed/actions/runs/31729729947/job/94549749972: the port was allocated when `ts serve` started (18:51:57), the engine loaded until 18:54:55, and the gateway hit `Address already in use (os error 98)` on that same port at 18:55:01. Note the collision window is wider than "port taken at bind time": a connect()-side socket never sets `SO_REUSEADDR`, so even after it closes, its TIME_WAIT blocks a wildcard listener bind on that port for ~60s.

This moves the allocation into `run_smg`, immediately before `spawn_gateway`, shrinking the allocation-to-bind window from the whole engine startup to the gateway exec itself. An explicit `--prometheus-port` is preserved unchanged, and follower-rank / headless paths (which never spawn a gateway) no longer allocate a port they don't use.

## Test Plan

`pytest test/cli/test_serve_smg_unit.py test/cli/test_serve_headless.py` → 62 passed, 4 skipped.

- New `test_run_smg_allocates_prometheus_port_at_gateway_spawn` drives `run_smg` with mocked spawn/probes and asserts `--prometheus-port <digits>` is present in the argv handed to `spawn_gateway`.
- `test_gateway_args_defaults_include_port_and_reasoning_parser` updated: the defaults chain no longer appends `--prometheus-port`, so it now asserts the full argv exactly.
- Existing `test_gateway_args_default_prometheus_port_is_free_port` / `test_gateway_args_preserve_user_prometheus_port` still cover the helper itself unchanged.
- 2 pre-existing failures in this file are unrelated and fail identically on unmodified `main` in my environment (CPU-only aarch64 box without the GPU kernel wheels; they import `tokenspeed_kernel.ops.communication`): `test_run_smg_from_args_sets_process_title`, `test_run_smg_from_args_applies_deepseek_v4_parser_defaults`.
