### PR TITLE
fix(deepseek-v4): honor routed expert checkpoint dtype

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2504,6 +2504,37 @@ class DeepseekV4MegaMoEExperts(nn.Module):
         return y
 
 
+def _deepseek_v4_routed_expert_quant_config(
+    config: PretrainedConfig,
+    quant_config: QuantizationConfig,
+) -> tuple[QuantizationConfig, bool]:
+    # ``quant_method=fp8`` describes the model-wide quantization, but DeepSeek
+    # V4 can still serialize routed experts as packed MXFP4. Prefer the explicit
+    # expert contract so packed FP4 tensors are never allocated as block FP8.
+    is_block_fp8 = isinstance(quant_config, Fp8Config) and (
+        getattr(config, "expert_dtype", None) != "fp4"
+    )
+    if is_block_fp8:
+        return quant_config, True
+    return (
+        Mxfp4Config(
+            ignored_layers=quant_config.ignored_layers,
+            is_checkpoint_mxfp4_serialized=True,
+        ),
+        False,
+    )
+
+
+def _deepseek_v4_expert_scale_parameter_name(
+    config: PretrainedConfig,
+    *,
+    use_mega_moe: bool,
+) -> str:
+    if use_mega_moe or getattr(config, "expert_dtype", None) == "fp4":
+        return "weight_scale"
+    return "weight_scale_inv"
+
+
 class DeepseekV4MoE(nn.Module):
     def __init__(
         self,
@@ -2581,20 +2612,9 @@ class DeepseekV4MoE(nn.Module):
             )
             self.topk = None
         else:
-            # A block-FP8 checkpoint (quant_method=fp8, ue8m0 block scales, e.g.
-            # DeepSeek-V4-Flash) keeps its own Fp8Config and runs weight-only
-            # through the DeepGEMM block-FP8 grouped MoE (SM90 / Hopper via
-            # DeepEP). Its routed experts carry no GEMM bias -- the noaux_tc
-            # correction bias is a routing-only term applied in TopK. Only the
-            # MXFP4-serialized variant needs the Mxfp4 repack + expert bias.
-            is_block_fp8 = isinstance(quant_config, Fp8Config)
-            if is_block_fp8:
-                routed_quant_config = quant_config
-            else:
-                routed_quant_config = Mxfp4Config(
-                    ignored_layers=quant_config.ignored_layers,
-                    is_checkpoint_mxfp4_serialized=True,
-                )
+            routed_quant_config, is_block_fp8 = _deepseek_v4_routed_expert_quant_config(
+                config, quant_config
+            )
             self.experts = MoELayer(
                 top_k=config.num_experts_per_tok,
                 num_experts=config.n_routed_experts
@@ -4265,8 +4285,7 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
             ("compressor.fused_wkv_wgate", "compressor.wgate", 1),
         ]
 
-    @staticmethod
-    def _map_weight_name(name: str) -> str:
+    def _map_weight_name(self, name: str) -> str:
         if name.startswith("layers."):
             name = "model." + name
         elif name.startswith("embed."):
@@ -4282,13 +4301,11 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
         if ".ffn.gate.bias" in name:
             name = name.replace(".ffn.gate.bias", ".ffn.gate.e_score_correction_bias")
         if re.search(r"\.experts\.\d+\.w[123]\.scale$", name):
-            # MegaMoE experts register block scales as ``w{13,2}_weight_scale``;
-            # the generic block-FP8 MoELayer (non-mega, Hopper DeepEP path)
-            # registers ``..._weight_scale_inv`` via create_fp8_block_scale_inverses.
-            if get_moe_backend().is_mega_moe():
-                name = name.replace(".scale", ".weight_scale")
-            else:
-                name = name.replace(".scale", ".weight_scale_inv")
+            scale_name = _deepseek_v4_expert_scale_parameter_name(
+                self.config,
+                use_mega_moe=get_moe_backend().is_mega_moe(),
+            )
+            name = name.replace(".scale", f".{scale_name}")
         elif name.endswith(".scale"):
             name = name[:-6] + ".weight_scale_inv"
         return name

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
@@ -37,6 +37,7 @@ from tokenspeed.runtime.models.deepseek_v4 import (
     DeepseekV4DecoderLayer,
     DeepseekV4ForCausalLM,
     DeepseekV4MegaMoEExperts,
+    _deepseek_v4_expert_scale_parameter_name,
     hc_head,
     mhc_fused_hc,
     mhc_post,
@@ -668,15 +669,12 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
             return None
         name = self._map_stage_name(stage_id, match.group(2))
         if name.endswith(".scale"):
-            # MegaMoE experts register block scales as ``w{13,2}_weight_scale``;
-            # the generic block-FP8 MoELayer (non-mega, e.g. flashinfer_cutlass
-            # on Hopper) registers ``..._weight_scale_inv``. Mirror
-            # DeepseekV4ForCausalLM._map_weight_name.
-            scale_suffix = (
-                ".weight_scale"
-                if _EXPERT_SCALE_RE.search(name) and get_moe_backend().is_mega_moe()
-                else ".weight_scale_inv"
-            )
+            scale_suffix = ".weight_scale_inv"
+            if _EXPERT_SCALE_RE.search(name):
+                scale_suffix = "." + _deepseek_v4_expert_scale_parameter_name(
+                    self.config,
+                    use_mega_moe=get_moe_backend().is_mega_moe(),
+                )
             name = name.removesuffix(".scale") + scale_suffix
         if ".shared_experts.w2" in name:
             name = name.replace(".shared_experts.w2", ".shared_experts.down_proj")

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -95,14 +95,20 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     PagedCacheGroupSpec,
 )
 from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, RMSNorm
-from tokenspeed.runtime.layers.quantization import QUANTIZATION_METHODS
+from tokenspeed.runtime.layers.quantization import (
+    QUANTIZATION_METHODS,
+    Fp8Config,
+    Mxfp4Config,
+)
 from tokenspeed.runtime.models import deepseek_v4 as deepseek_v4_model
 from tokenspeed.runtime.models.deepseek_v4 import (
+    DeepseekV4ForCausalLM,
     DeepseekV4Indexer,
     DeepseekV4MLP,
     DeepseekV4Model,
     DeepseekV4MoE,
     DeepseekV4MoEGate,
+    _deepseek_v4_expert_scale_parameter_name,
     _deepseek_v4_forward_metadata,
     _deepseek_v4_fused_select_experts,
     _deepseek_v4_indexer_decode_max_len,
@@ -115,6 +121,7 @@ from tokenspeed.runtime.models.deepseek_v4 import (
     _deepseek_v4_indexer_topk_from_logits,
     _deepseek_v4_mega_moe_max_num_tokens,
     _deepseek_v4_reorder_c4_ape_2604,
+    _deepseek_v4_routed_expert_quant_config,
     _DeepseekV4TopKBuffer,
     deepseek_v4_rope_config,
     deepseek_v4_select_experts,
@@ -337,6 +344,62 @@ class TestDeepseekV4Config(unittest.TestCase):
     def test_config_registry(self):
         self.assertEqual(DeepseekV4Config.model_type, "deepseek_v4")
         self.assertIs(_CONFIG_REGISTRY["deepseek_v4"], DeepseekV4Config)
+
+    def test_fp4_expert_contract_overrides_model_wide_fp8_config(self):
+        quant_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+            scale_fmt="ue8m0",
+        )
+
+        routed_quant_config, is_block_fp8 = _deepseek_v4_routed_expert_quant_config(
+            SimpleNamespace(expert_dtype="fp4"), quant_config
+        )
+
+        self.assertFalse(is_block_fp8)
+        self.assertIsInstance(routed_quant_config, Mxfp4Config)
+        self.assertTrue(routed_quant_config.is_checkpoint_mxfp4_serialized)
+
+    def test_fp8_expert_contract_keeps_model_wide_fp8_config(self):
+        quant_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+            scale_fmt="ue8m0",
+        )
+
+        for expert_dtype in (None, "fp8"):
+            with self.subTest(expert_dtype=expert_dtype):
+                routed_quant_config, is_block_fp8 = (
+                    _deepseek_v4_routed_expert_quant_config(
+                        SimpleNamespace(expert_dtype=expert_dtype), quant_config
+                    )
+                )
+
+                self.assertTrue(is_block_fp8)
+                self.assertIs(routed_quant_config, quant_config)
+
+    def test_expert_scale_name_follows_expert_format_and_backend(self):
+        cases = (
+            ("fp4", False, "weight_scale"),
+            ("fp4", True, "weight_scale"),
+            ("fp8", False, "weight_scale_inv"),
+            ("fp8", True, "weight_scale"),
+            (None, False, "weight_scale_inv"),
+        )
+        for expert_dtype, use_mega_moe, expected in cases:
+            with self.subTest(
+                expert_dtype=expert_dtype,
+                use_mega_moe=use_mega_moe,
+            ):
+                self.assertEqual(
+                    _deepseek_v4_expert_scale_parameter_name(
+                        SimpleNamespace(expert_dtype=expert_dtype),
+                        use_mega_moe=use_mega_moe,
+                    ),
+                    expected,
+                )
 
     def test_forward_mode_mixed_predicate(self):
         self.assertTrue(ForwardMode.MIXED.is_mixed())
@@ -1590,15 +1653,41 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         self.assertIsNone(model._map_checkpoint_name("mtp.3.norm.weight"))
 
-    def test_dspark_expert_scale_mapping_follows_moe_backend(self):
-        # Expert block scales land on `w{13,2}_weight_scale` params only under
-        # the mega-MoE backend; every other backend registers
-        # `..._weight_scale_inv` via create_fp8_block_scale_inverses.
+    def test_target_expert_scale_mapping_follows_expert_format(self):
+        model = object.__new__(DeepseekV4ForCausalLM)
+        non_mega = SimpleNamespace(is_mega_moe=lambda: False)
+        with patch(
+            "tokenspeed.runtime.models.deepseek_v4.get_moe_backend",
+            return_value=non_mega,
+        ):
+            model.config = SimpleNamespace(expert_dtype="fp4")
+            self.assertEqual(
+                model._map_weight_name("layers.1.ffn.experts.7.w1.scale"),
+                "model.layers.1.ffn.experts.7.w1.weight_scale",
+            )
+            model.config = SimpleNamespace(expert_dtype="fp8")
+            self.assertEqual(
+                model._map_weight_name("layers.1.ffn.experts.7.w1.scale"),
+                "model.layers.1.ffn.experts.7.w1.weight_scale_inv",
+            )
+
+    def test_dspark_expert_scale_mapping_follows_expert_format(self):
         model = object.__new__(DeepseekV4ForCausalLMDSpark)
         model.model = SimpleNamespace(num_stages=3)
 
         mega = SimpleNamespace(is_mega_moe=lambda: True)
         non_mega = SimpleNamespace(is_mega_moe=lambda: False)
+        model.config = SimpleNamespace(expert_dtype="fp4")
+        with patch(
+            "tokenspeed.runtime.models.deepseek_v4_dspark.get_moe_backend",
+            return_value=non_mega,
+        ):
+            self.assertEqual(
+                model._map_checkpoint_name("mtp.1.ffn.experts.7.w1.scale"),
+                "model.stages.1.block.ffn.experts.7.w1.weight_scale",
+            )
+
+        model.config = SimpleNamespace(expert_dtype="fp8")
         with patch(
             "tokenspeed.runtime.models.deepseek_v4_dspark.get_moe_backend",
             return_value=mega,


### PR DESCRIPTION
## Summary

- honor the explicit routed-expert checkpoint dtype when the model-wide quantization config is FP8
- map packed FP4 expert scales consistently for the target and DSpark models
- preserve the existing block-FP8 and MegaMoE paths

## Root cause

The DeepSeek V4 Flash checkpoint declares model-wide FP8 quantization while storing its routed experts as packed FP4 through `expert_dtype: fp4`. The Hopper FP8 support added in #1048 inferred the routed-expert format from the model-wide quantization config alone. That allocated the routed experts as block FP8 and mapped their scales to the block-FP8 parameter names, so the packed FP4 checkpoint could not complete model startup.

## Validation

- `pre-commit run --all-files`
- runtime Ruff checks used by CI
- focused FP4/FP8 regression tests covering target and DSpark mappings, with MegaMoE and non-MegaMoE cases
- SM100 validation that the public checkpoint config resolves to the MXFP4 routed-expert path and selects `flashinfer_trtllm_mxfp4_moe_apply`
