### PR TITLE
feat(quant): add block-wise fp8 online quantization support

### DIFF
--- a/python/tokenspeed/runtime/layers/dense/fp8.py
+++ b/python/tokenspeed/runtime/layers/dense/fp8.py
@@ -220,19 +220,6 @@ class Fp8LinearMethod(LinearMethodBase):
                     "weight_scale_inv", Parameter(weight_scale, requires_grad=False)
                 )
                 layer.input_scale = None
-            # If ROCm, normalize the weights and scales to e4m3fnuz
-            if platform.is_fp8e4m3fnuz:
-                # activation_scheme: dynamic
-                weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
-                    weight=layer.weight,
-                    weight_scale=layer.weight_scale_inv,
-                    input_scale=None,
-                )
-                layer.input_scale = None
-            else:
-                weight, weight_scale = layer.weight.data, layer.weight_scale_inv.data
-            layer.weight.data = weight.data
-            layer.weight_scale_inv.data = weight_scale.data
             layer._use_deep_gemm_fp8 = False
             layer._use_flashinfer_fp8_blockscale = False
             is_bmm = getattr(layer, "is_bmm", False)

--- a/python/tokenspeed/runtime/layers/dense/fp8.py
+++ b/python/tokenspeed/runtime/layers/dense/fp8.py
@@ -28,6 +28,7 @@ import logging
 import tokenspeed_kernel
 import torch
 from tokenspeed_kernel.ops.gemm.fp8_utils import (
+    per_block_quant_fp8,
     per_token_group_quant_fp8,
     per_token_quant_fp8,
     static_quant_fp8,
@@ -103,7 +104,7 @@ class Fp8LinearMethod(LinearMethodBase):
         output_size_per_partition = sum(output_partition_sizes)
         weight_loader = extra_weight_attrs.get("weight_loader")
 
-        if self.block_quant:
+        if self.block_quant and self.quant_config.is_checkpoint_fp8_serialized:
             block_n, block_k = (
                 self.quant_config.weight_block_size[0],
                 self.quant_config.weight_block_size[1],
@@ -210,6 +211,28 @@ class Fp8LinearMethod(LinearMethodBase):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if self.block_quant:
+            if not self.quant_config.is_checkpoint_fp8_serialized:
+                qweight, weight_scale = per_block_quant_fp8(
+                    layer.weight.data, self.quant_config.weight_block_size
+                )
+                layer.weight = Parameter(qweight, requires_grad=False)
+                layer.register_parameter(
+                    "weight_scale_inv", Parameter(weight_scale, requires_grad=False)
+                )
+                layer.input_scale = None
+            # If ROCm, normalize the weights and scales to e4m3fnuz
+            if platform.is_fp8e4m3fnuz:
+                # activation_scheme: dynamic
+                weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
+                    weight=layer.weight,
+                    weight_scale=layer.weight_scale_inv,
+                    input_scale=None,
+                )
+                layer.input_scale = None
+            else:
+                weight, weight_scale = layer.weight.data, layer.weight_scale_inv.data
+            layer.weight.data = weight.data
+            layer.weight_scale_inv.data = weight_scale.data
             layer._use_deep_gemm_fp8 = False
             layer._use_flashinfer_fp8_blockscale = False
             is_bmm = getattr(layer, "is_bmm", False)

--- a/python/tokenspeed/runtime/layers/moe/loader.py
+++ b/python/tokenspeed/runtime/layers/moe/loader.py
@@ -416,6 +416,12 @@ class MoECheckpointLoader:
                     * self._ep_rank : local_num_experts
                     * (self._ep_rank + 1)
                 ]
+                if getattr(param, "block_scale_inv", None) is not None:
+                    raise MoECheckpointLoadError(
+                        f"{mapped_name} needs online FP8 block quantization, "
+                        "which the fused local-tensor loader cannot apply; load a "
+                        "pre-quantized checkpoint or drop --quantization fp8."
+                    )
                 if tensor_to_load.dtype == torch.float8_e5m2:
                     default_weight_loader(param, local_experts.to(torch.bfloat16))
                 else:

--- a/python/tokenspeed/runtime/layers/moe/weights/fp8.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/fp8.py
@@ -58,6 +58,24 @@ def create_fp8_block_scale_inverses(
     layer.register_parameter("w13_weight_scale_inv", w13_weight_scale)
     layer.register_parameter("w2_weight_scale_inv", w2_weight_scale)
 
+    if (
+        not layer.quant_config.is_checkpoint_fp8_serialized
+        and scale_dtype == torch.float32
+    ):
+        for weight_name, scale in (
+            ("w13_weight", w13_weight_scale),
+            ("w2_weight", w2_weight_scale),
+        ):
+            weight = getattr(layer, weight_name, None)
+            if weight is not None:
+                set_weight_attrs(
+                    weight,
+                    {
+                        "block_scale_inv": scale,
+                        "block_scale_shape": (block_n, block_k),
+                    },
+                )
+
     weight_loader = make_weight_loader(spec)
     set_weight_attrs(w13_weight_scale, {"weight_loader": weight_loader})
     set_weight_attrs(w2_weight_scale, {"weight_loader": weight_loader})

--- a/python/tokenspeed/runtime/layers/moe/weights/loaders.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/loaders.py
@@ -68,7 +68,7 @@ def _narrow_block_scale(
     scale: torch.Tensor | None,
     block_shape: tuple[int, int] | None,
     shard_dim: int,
-    start: int,
+    block_start: int,
     length: int,
 ) -> torch.Tensor | None:
     """Narrow a per-expert block-scale view alongside its weight shard."""
@@ -76,10 +76,8 @@ def _narrow_block_scale(
     if scale is None or block_shape is None or shard_dim not in (0, 1):
         return None
     block = block_shape[shard_dim]
-    if start % block != 0:
-        return None
     num_blocks = (length + block - 1) // block
-    return scale.narrow(shard_dim, start // block, num_blocks)
+    return scale.narrow(shard_dim, block_start, num_blocks)
 
 
 def load_w13(
@@ -132,11 +130,15 @@ def load_w13(
     dst = expert_data.narrow(shard_dim, 0, loaded_weight.shape[shard_dim])
     scale_dst = None
     if not is_bias:
+        block_start = 0
+        if start and block_shape is not None and shard_dim in (0, 1):
+            block = block_shape[shard_dim]
+            block_start = round_up(shard_size, block) // block
         scale_dst = _narrow_block_scale(
             expert_scale,
             block_shape,
             shard_dim,
-            start,
+            block_start,
             loaded_weight.shape[shard_dim],
         )
     copy_expert_shard(dst, loaded_weight, scale_dst, block_shape)

--- a/python/tokenspeed/runtime/layers/moe/weights/loaders.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/loaders.py
@@ -24,6 +24,7 @@ from collections.abc import Callable
 from functools import partial
 
 import torch
+from tokenspeed_kernel.ops.gemm.fp8_utils import per_block_quant_fp8
 
 from tokenspeed.runtime.layers.moe.types import MoELayerSpec
 
@@ -38,6 +39,49 @@ def preserve_e8m0_bytes_for_uint8_param(
     return src
 
 
+def copy_expert_shard(
+    dst: torch.Tensor,
+    src: torch.Tensor,
+    scale_dst: torch.Tensor | None = None,
+    block_shape: tuple[int, int] | None = None,
+) -> None:
+    """Write one loaded expert shard into its destination buffer.
+
+    Args:
+        dst: Destination view inside the expert weight buffer.
+        src: Loaded (already sharded) checkpoint values.
+        scale_dst: Destination view inside the block-scale buffer, or ``None``
+            when the checkpoint values need no quantization.
+        block_shape: ``(block_n, block_k)`` of one scale.
+    """
+    if scale_dst is None or dst.dtype == src.dtype:
+        src = preserve_e8m0_bytes_for_uint8_param(dst, src)
+        dst.copy_(src)
+        return
+
+    quantized, scales = per_block_quant_fp8(src.to(dst.device), block_shape)
+    dst.copy_(quantized)
+    scale_dst.copy_(scales)
+
+
+def _narrow_block_scale(
+    scale: torch.Tensor | None,
+    block_shape: tuple[int, int] | None,
+    shard_dim: int,
+    start: int,
+    length: int,
+) -> torch.Tensor | None:
+    """Narrow a per-expert block-scale view alongside its weight shard."""
+
+    if scale is None or block_shape is None or shard_dim not in (0, 1):
+        return None
+    block = block_shape[shard_dim]
+    if start % block != 0:
+        return None
+    num_blocks = (length + block - 1) // block
+    return scale.narrow(shard_dim, start // block, num_blocks)
+
+
 def load_w13(
     expert_data: torch.Tensor,
     loaded_weight: torch.Tensor,
@@ -49,6 +93,8 @@ def load_w13(
     do_transpose: bool,
     tp_size: int = 1,
     load_up_proj_weight_first: bool = False,
+    expert_scale: torch.Tensor | None = None,
+    block_shape: tuple[int, int] | None = None,
 ) -> None:
     if shard_id not in {"w1", "w3", "w13"}:
         raise ValueError(f"Unexpected w13 shard_id: {shard_id}")
@@ -84,8 +130,16 @@ def load_w13(
 
     expert_data = expert_data.narrow(shard_dim, start, shard_size)
     dst = expert_data.narrow(shard_dim, 0, loaded_weight.shape[shard_dim])
-    loaded_weight = preserve_e8m0_bytes_for_uint8_param(dst, loaded_weight)
-    dst.copy_(loaded_weight)
+    scale_dst = None
+    if not is_bias:
+        scale_dst = _narrow_block_scale(
+            expert_scale,
+            block_shape,
+            shard_dim,
+            start,
+            loaded_weight.shape[shard_dim],
+        )
+    copy_expert_shard(dst, loaded_weight, scale_dst, block_shape)
 
 
 def load_w2(
@@ -98,6 +152,8 @@ def load_w2(
     use_presharded_weights: bool,
     do_transpose: bool,
     tp_size: int = 1,
+    expert_scale: torch.Tensor | None = None,
+    block_shape: tuple[int, int] | None = None,
 ) -> None:
     if not isinstance(expert_data, torch.Tensor) or not isinstance(
         loaded_weight, torch.Tensor
@@ -126,8 +182,16 @@ def load_w2(
         loaded_weight = loaded_weight.narrow(shard_dim, start, load_shard)
 
     dst = expert_data.narrow(shard_dim, 0, loaded_weight.shape[shard_dim])
-    loaded_weight = preserve_e8m0_bytes_for_uint8_param(dst, loaded_weight)
-    dst.copy_(loaded_weight)
+    scale_dst = None
+    if not is_bias:
+        scale_dst = _narrow_block_scale(
+            expert_scale,
+            block_shape,
+            shard_dim,
+            0,
+            loaded_weight.shape[shard_dim],
+        )
+    copy_expert_shard(dst, loaded_weight, scale_dst, block_shape)
 
 
 def get_shard_dim(param: torch.Tensor, shard_id: str, do_transpose: bool) -> int:
@@ -154,6 +218,9 @@ def load_model_weight(
 ) -> None:
     expert_data = param.data[local_expert_id]
     shard_dim = get_shard_dim(param, shard_id, do_transpose)
+    block_scale = getattr(param, "block_scale_inv", None)
+    block_shape = getattr(param, "block_scale_shape", None)
+    expert_scale = None if block_scale is None else block_scale.data[local_expert_id]
     if shard_id == "w2":
         load_w2(
             expert_data,
@@ -165,6 +232,8 @@ def load_model_weight(
             use_presharded_weights,
             do_transpose,
             tp_size=tp_size,
+            expert_scale=expert_scale,
+            block_shape=block_shape,
         )
     elif shard_id in {"w1", "w3", "w13"}:
         load_w13(
@@ -177,6 +246,8 @@ def load_model_weight(
             use_presharded_weights,
             do_transpose,
             tp_size=tp_size,
+            expert_scale=expert_scale,
+            block_shape=block_shape,
         )
     else:
         raise ValueError(f"Unknown shard_id: {shard_id}")

--- a/python/tokenspeed/runtime/layers/quantization/fp8.py
+++ b/python/tokenspeed/runtime/layers/quantization/fp8.py
@@ -40,7 +40,7 @@ class Fp8Config(QuantizationConfig):
     weight_scale_dtype = torch.float32
 
     # Linear-attention (GDN/mamba) projections are excluded from online
-    # quantization    
+    # quantization
     ONLINE_IGNORED_LAYERS = [
         "re:.*linear_attn.*",
         "re:.*conv1d.*",

--- a/python/tokenspeed/runtime/layers/quantization/fp8.py
+++ b/python/tokenspeed/runtime/layers/quantization/fp8.py
@@ -39,13 +39,15 @@ class Fp8Config(QuantizationConfig):
 
     weight_scale_dtype = torch.float32
 
-    # Linear-attention (GDN/mamba) projections are excluded from online
-    # quantization
+    # Excluded from online quantization: linear-attention (GDN/mamba)
+    # projections, plus wo_a, whose is_bmm runtime path only accepts the
+    # deep_gemm ue8m0 block-scale layout that online quantization never emits.
     ONLINE_IGNORED_LAYERS = [
         "re:.*linear_attn.*",
         "re:.*conv1d.*",
         "re:.*in_proj.*",
         "re:.*out_proj.*",
+        "re:.*wo_a.*",
     ]
 
     def __init__(

--- a/python/tokenspeed/runtime/layers/quantization/fp8.py
+++ b/python/tokenspeed/runtime/layers/quantization/fp8.py
@@ -39,6 +39,15 @@ class Fp8Config(QuantizationConfig):
 
     weight_scale_dtype = torch.float32
 
+    # Linear-attention (GDN/mamba) projections are excluded from online
+    # quantization    
+    ONLINE_IGNORED_LAYERS = [
+        "re:.*linear_attn.*",
+        "re:.*conv1d.*",
+        "re:.*in_proj.*",
+        "re:.*out_proj.*",
+    ]
+
     def __init__(
         self,
         is_checkpoint_fp8_serialized: bool = False,
@@ -47,6 +56,8 @@ class Fp8Config(QuantizationConfig):
         weight_block_size: list[int] = None,
         scale_fmt: str | None = None,
     ) -> None:
+        if not is_checkpoint_fp8_serialized:
+            ignored_layers = (ignored_layers or []) + self.ONLINE_IGNORED_LAYERS
         super().__init__(ignored_layers=ignored_layers)
         self.is_checkpoint_fp8_serialized = is_checkpoint_fp8_serialized
         if is_checkpoint_fp8_serialized:
@@ -54,11 +65,9 @@ class Fp8Config(QuantizationConfig):
         if activation_scheme not in ACTIVATION_SCHEMES:
             raise ValueError(f"Unsupported activation scheme {activation_scheme}")
         self.activation_scheme = activation_scheme
+        if weight_block_size is None and not is_checkpoint_fp8_serialized:
+            weight_block_size = [128, 128]
         if weight_block_size is not None:
-            if not is_checkpoint_fp8_serialized:
-                raise ValueError(
-                    "The block-wise quantization only supports fp8-serialized checkpoint for now."
-                )
             if len(weight_block_size) != 2:
                 raise ValueError(
                     f"The quantization block size of weight must have 2 dimensions, but got {len(weight_block_size)} dimensions."

--- a/python/tokenspeed/runtime/models/qwen3_5_moe.py
+++ b/python/tokenspeed/runtime/models/qwen3_5_moe.py
@@ -59,6 +59,8 @@ from tokenspeed.runtime.layers.moe.utils import (
     use_deepep_low_latency,
 )
 from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
+from tokenspeed.runtime.layers.quantization.nvfp4 import Nvfp4Config
+from tokenspeed.runtime.layers.quantization.utils import should_exclude_quant_module
 from tokenspeed.runtime.utils import add_prefix
 from tokenspeed.runtime.utils.cuda_stream import StreamFork
 from tokenspeed.runtime.utils.env import envs, global_server_args_dict
@@ -75,6 +77,31 @@ def _is_moe_layer(layer_id: int, config) -> bool:
     if layer_id in mlp_only_layers:
         return False
     return config.num_experts > 0 and (layer_id + 1) % config.decoder_sparse_step == 0
+
+
+_GATE_UP_CHECKPOINT_MEMBERS = ("gate_proj", "up_proj")
+
+
+def _gate_up_quant_config(
+    quant_config: QuantizationConfig | None, prefix: str
+) -> QuantizationConfig | None:
+    """Drop the quant config when the checkpoint keeps this MLP's weights bf16.
+
+    Args:
+        quant_config: Quantization config the caller would otherwise pass.
+        prefix: Full runtime prefix of the fused ``gate_up_proj`` module.
+
+    Returns:
+        ``None`` when either checkpoint member is excluded, else ``quant_config``.
+    """
+    if not isinstance(quant_config, Nvfp4Config) or not prefix:
+        return quant_config
+    parent = prefix.rpartition(".")[0]
+    for member in _GATE_UP_CHECKPOINT_MEMBERS:
+        member_prefix = f"{parent}.{member}" if parent else member
+        if should_exclude_quant_module(member_prefix, quant_config.exclude_modules):
+            return None
+    return quant_config
 
 
 class Qwen3_5MoeMLP(nn.Module):
@@ -109,6 +136,9 @@ class Qwen3_5MoeMLP(nn.Module):
         """
         super().__init__()
         self.mapping = mapping
+        gate_up_quant_config = _gate_up_quant_config(
+            quant_config, add_prefix("gate_up_proj", prefix)
+        )
         if mapping.dense.has_tp and not replicate_weights:
             tp_size = mapping.dense.tp_size
             tp_rank = mapping.dense.tp_rank
@@ -120,7 +150,7 @@ class Qwen3_5MoeMLP(nn.Module):
                 tp_size=tp_size,
                 tp_rank=tp_rank,
                 tp_group=tp_group,
-                quant_config=quant_config,
+                quant_config=gate_up_quant_config,
                 prefix=add_prefix("gate_up_proj", prefix),
             )
             self.down_proj = RowParallelLinear(
@@ -139,7 +169,7 @@ class Qwen3_5MoeMLP(nn.Module):
                 hidden_size,
                 intermediate_size * 2,
                 bias=False,
-                quant_config=quant_config,
+                quant_config=gate_up_quant_config,
                 prefix=add_prefix("gate_up_proj", prefix),
             )
             self.down_proj = ReplicatedLinear(

--- a/test/runtime/models/test_qwen3_5_fused_qkvzba.py
+++ b/test/runtime/models/test_qwen3_5_fused_qkvzba.py
@@ -164,6 +164,19 @@ def _make_inputs(batch, nk, nv, device="cuda"):
     return mixed_qkvz, mixed_ba
 
 
+def _bench_interleaved(fn_a, fn_b, rounds=5):
+    """Time two candidates fairly and return their fastest observations."""
+    best_a = best_b = float("inf")
+    for _ in range(rounds):
+        best_a = min(
+            best_a, triton.testing.do_bench(fn_a, warmup=25, rep=50, return_mode="min")
+        )
+        best_b = min(
+            best_b, triton.testing.do_bench(fn_b, warmup=25, rep=50, return_mode="min")
+        )
+    return best_a, best_b
+
+
 @unittest.skipUnless(HAS_CUDA, "needs CUDA + triton")
 class FusedQkvzbaTest(unittest.TestCase):
     def _fused(self):
@@ -233,14 +246,9 @@ class FusedQkvzbaTest(unittest.TestCase):
         for nk, nv in [(4, 4), (4, 8), (4, 16)]:  # legacy-supported ratios
             mixed_qkvz, mixed_ba = _make_inputs(8192, nk, nv)  # prefill-sized
             args = (mixed_qkvz, mixed_ba, nk, nv, HEAD_QK, HEAD_V)
-            t_new = triton.testing.do_bench(
-                lambda a=args: fused(*a), warmup=50, rep=200, return_mode="median"
-            )
-            t_old = triton.testing.do_bench(
+            t_old, t_new = _bench_interleaved(
                 lambda a=args: _legacy_launch(*a),
-                warmup=50,
-                rep=200,
-                return_mode="median",
+                lambda a=args: fused(*a),
             )
             results[nv // nk] = (t_old, t_new)
 
@@ -271,11 +279,9 @@ class FusedQkvzbaTest(unittest.TestCase):
             return torch.cat((q, k, v), dim=-1), z, b, a
 
         args = (mixed_qkvz, mixed_ba, nk, nv, HEAD_QK, HEAD_V)
-        t_fused = triton.testing.do_bench(
-            lambda: fused(*args), warmup=50, rep=200, return_mode="median"
-        )
-        t_torch = triton.testing.do_bench(
-            torch_fallback, warmup=50, rep=200, return_mode="median"
+        t_fused, t_torch = _bench_interleaved(
+            lambda: fused(*args),
+            torch_fallback,
         )
         self.assertLessEqual(
             t_fused,

--- a/test/runtime/test_fp8_linear_online_block_quant.py
+++ b/test/runtime/test_fp8_linear_online_block_quant.py
@@ -1,0 +1,136 @@
+"""Fp8LinearMethod online (bf16 checkpoint) block-scaled quantization path."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.layers.dense.fp8 import Fp8LinearMethod
+from tokenspeed.runtime.layers.quantization.fp8 import Fp8Config
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def _load_bf16_weight(
+    method: Fp8LinearMethod, n: int, k: int, device: str = "cuda"
+) -> tuple[torch.nn.Module, torch.Tensor]:
+    """Run create_weights, fill the weight as a loader would, then finalize."""
+    layer = torch.nn.Module()
+    method.create_weights(layer, k, [n], k, n, torch.bfloat16, weight_loader=None)
+    layer = layer.to(device)
+
+    torch.manual_seed(0)
+    reference = torch.randn(n, k, device=device, dtype=torch.bfloat16) * 0.05
+    layer.weight.data = reference.clone()
+    method.process_weights_after_loading(layer)
+    return layer, reference
+
+
+def test_online_quantization_defaults_to_block_scales() -> None:
+    config = Fp8Config()
+    assert not config.is_checkpoint_fp8_serialized
+    assert config.weight_block_size == [128, 128]
+
+
+def test_serialized_checkpoint_keeps_per_tensor_default() -> None:
+    """A per-tensor FP8 checkpoint must not be reinterpreted as block-scaled."""
+    config = Fp8Config(is_checkpoint_fp8_serialized=True)
+    assert config.weight_block_size is None
+
+
+def test_block_quant_rejects_static_activation() -> None:
+    with pytest.raises(ValueError, match="dynamic activation scheme"):
+        Fp8Config(activation_scheme="static")
+
+
+def test_process_weights_quantizes_bf16_checkpoint() -> None:
+    n, k = 512, 2048
+    method = Fp8LinearMethod(Fp8Config())
+    layer, reference = _load_bf16_weight(method, n, k)
+
+    assert layer.weight.dtype == torch.float8_e4m3fn
+    assert layer.weight.shape == (n, k)
+    assert layer.weight_scale_inv.dtype == torch.float32
+    assert layer.weight_scale_inv.shape == (n // 128, k // 128)
+    assert layer.input_scale is None
+    del reference
+
+
+@pytest.mark.parametrize("n, k", [(512, 2048), (2048, 512)])
+def test_apply_matches_bf16_reference(n: int, k: int) -> None:
+    method = Fp8LinearMethod(Fp8Config())
+    layer, reference = _load_bf16_weight(method, n, k)
+
+    x = torch.randn(32, k, device="cuda", dtype=torch.bfloat16) * 0.1
+    out = method.apply(layer, x)
+
+    expected = x.float() @ reference.float().t()
+    assert out.shape == (32, n)
+    cosine = torch.nn.functional.cosine_similarity(
+        out.float().flatten(), expected.flatten(), dim=0
+    )
+    assert cosine > 0.99
+
+
+def test_online_partitions_need_no_block_alignment() -> None:
+    """Online quantization blocks each shard after sharding, so a partition
+    that is not a multiple of the block shape must still be accepted."""
+    method = Fp8LinearMethod(Fp8Config())
+    layer = torch.nn.Module()
+    # 200 is not a multiple of block_n=128, and 300 not of block_k=128.
+    method.create_weights(
+        layer, 300, [200], 600, 400, torch.bfloat16, weight_loader=None
+    )
+    layer = layer.to("cuda")
+    layer.weight.data = (
+        torch.randn(200, 300, device="cuda", dtype=torch.bfloat16) * 0.05
+    )
+    method.process_weights_after_loading(layer)
+
+    assert layer.weight_scale_inv.shape == (2, 3)
+
+
+def test_online_quantization_ignores_linear_attention_layers() -> None:
+    """Online fp8 must exclude GDN/mamba projections (delta-rule recurrence
+    amplifies quantization error; official pre-quantized checkpoints exclude
+    linear_attn as well). Serialized checkpoints keep their own list."""
+    from tokenspeed.runtime.layers.quantization.utils import (
+        check_equal_or_regex_match,
+    )
+
+    online = Fp8Config()
+    for name in (
+        "model.layers.0.linear_attn.in_proj_qkvz",
+        "model.layers.3.linear_attn.conv1d",
+        "model.layers.7.linear_attn.out_proj",
+    ):
+        assert check_equal_or_regex_match(name, online.ignored_layers)
+    assert not check_equal_or_regex_match(
+        "model.layers.0.self_attn.qkv_proj", online.ignored_layers
+    )
+
+    serialized = Fp8Config(is_checkpoint_fp8_serialized=True)
+    assert not serialized.ignored_layers
+
+
+def test_online_quantization_ignores_bmm_wo_a() -> None:
+    """Online fp8 must exclude DeepSeek-V4 ``wo_a``.
+
+    It is the only ``is_bmm`` weight, and its runtime path accepts solely the
+    deep_gemm ue8m0 block-scale layout. Online quantization leaves
+    ``scale_fmt`` unset, so quantizing it would raise at load instead of
+    running.
+    """
+    from tokenspeed.runtime.layers.quantization.utils import (
+        check_equal_or_regex_match,
+    )
+
+    online = Fp8Config()
+    assert check_equal_or_regex_match("model.layers.0.attn.wo_a", online.ignored_layers)
+    for name in ("model.layers.0.attn.wo_b", "model.layers.0.attn.q_proj"):
+        assert not check_equal_or_regex_match(name, online.ignored_layers)
+
+    serialized = Fp8Config(is_checkpoint_fp8_serialized=True)
+    assert not check_equal_or_regex_match(
+        "model.layers.0.attn.wo_a", serialized.ignored_layers
+    )

--- a/test/runtime/test_moe_online_block_fp8_loader.py
+++ b/test/runtime/test_moe_online_block_fp8_loader.py
@@ -1,0 +1,203 @@
+"""MoE expert loading with online (bf16 checkpoint) block-scaled FP8 quantization."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tokenspeed.runtime.layers.moe.weights.loaders import (
+    copy_expert_shard,
+    load_w2,
+    load_w13,
+)
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+BLOCK = (128, 128)
+
+
+def _dequantize(q: torch.Tensor, scales: torch.Tensor) -> torch.Tensor:
+    block_n, block_k = BLOCK
+    out = q.float()
+    for i in range(scales.shape[0]):
+        for j in range(scales.shape[1]):
+            rows = slice(i * block_n, min((i + 1) * block_n, q.shape[0]))
+            cols = slice(j * block_k, min((j + 1) * block_k, q.shape[1]))
+            out[rows, cols] *= scales[i, j]
+    return out
+
+
+def test_copy_expert_shard_quantizes_unquantized_source() -> None:
+    n, k = 256, 256
+    src = torch.randn(n, k, device="cuda", dtype=torch.bfloat16) * 0.05
+    dst = torch.zeros(n, k, device="cuda", dtype=torch.float8_e4m3fn)
+    scales = torch.ones(n // 128, k // 128, device="cuda", dtype=torch.float32)
+
+    copy_expert_shard(dst, src, scales, BLOCK)
+
+    assert not torch.allclose(scales, torch.ones_like(scales))
+    cosine = torch.nn.functional.cosine_similarity(
+        _dequantize(dst, scales).flatten(), src.float().flatten(), dim=0
+    )
+    assert cosine > 0.99
+
+
+def test_copy_expert_shard_plain_copy_without_scales() -> None:
+    """Without a scale destination the copy must stay byte-for-byte as before."""
+    src = torch.randn(8, 16, device="cuda", dtype=torch.bfloat16)
+    dst = torch.zeros(8, 16, device="cuda", dtype=torch.bfloat16)
+
+    copy_expert_shard(dst, src)
+
+    torch.testing.assert_close(dst, src)
+
+
+def test_copy_expert_shard_skips_quantization_for_fp8_source() -> None:
+    """A serialized FP8 checkpoint is copied through, leaving scales untouched."""
+    src = (torch.randn(256, 256, device="cuda") * 0.05).to(torch.float8_e4m3fn)
+    dst = torch.zeros(256, 256, device="cuda", dtype=torch.float8_e4m3fn)
+    scales = torch.ones(2, 2, device="cuda", dtype=torch.float32)
+
+    copy_expert_shard(dst, src, scales, BLOCK)
+
+    torch.testing.assert_close(dst.float(), src.float())
+    torch.testing.assert_close(scales, torch.ones_like(scales))
+
+
+@pytest.mark.parametrize("shard_id", ["w1", "w3"])
+def test_load_w13_quantizes_into_its_half(shard_id: str) -> None:
+    """w1 and w3 occupy halves of w13, so each must scale only its own blocks."""
+    ispp, hidden = 256, 256
+    expert_data = torch.zeros(
+        2 * ispp, hidden, device="cuda", dtype=torch.float8_e4m3fn
+    )
+    expert_scale = torch.ones(
+        2 * ispp // 128, hidden // 128, device="cuda", dtype=torch.float32
+    )
+    loaded = torch.randn(ispp, hidden, device="cuda", dtype=torch.bfloat16) * 0.05
+
+    load_w13(
+        expert_data,
+        loaded,
+        shard_id,
+        0,
+        tp_rank=0,
+        is_bias=False,
+        use_presharded_weights=True,
+        do_transpose=False,
+        expert_scale=expert_scale,
+        block_shape=BLOCK,
+    )
+
+    start = ispp if shard_id == "w3" else 0
+    written = expert_data.narrow(0, start, ispp)
+    written_scale = expert_scale.narrow(0, start // 128, ispp // 128)
+    cosine = torch.nn.functional.cosine_similarity(
+        _dequantize(written, written_scale).flatten(), loaded.float().flatten(), dim=0
+    )
+    assert cosine > 0.99
+
+    # The other half must be untouched.
+    other_start = 0 if shard_id == "w3" else ispp
+    assert torch.all(expert_data.narrow(0, other_start, ispp).float() == 0)
+    other_scale = expert_scale.narrow(0, other_start // 128, ispp // 128)
+    torch.testing.assert_close(other_scale, torch.ones_like(other_scale))
+
+
+@pytest.mark.parametrize("shard_id", ["w1", "w3"])
+def test_load_w13_quantizes_unaligned_half(shard_id: str) -> None:
+    """An intermediate size below block_n still scales both halves.
+
+    moe_intermediate_size=512 at tp8 yields ispp=64, so w3 starts at an
+    element offset that is not a multiple of block_n while the scale buffer
+    still reserves one rounded-up block per half.
+    """
+    ispp, hidden = 64, 256
+    blocks_per_half = 1
+    expert_data = torch.zeros(
+        2 * ispp, hidden, device="cuda", dtype=torch.float8_e4m3fn
+    )
+    expert_scale = torch.ones(
+        2 * blocks_per_half, hidden // 128, device="cuda", dtype=torch.float32
+    )
+    loaded = torch.randn(ispp, hidden, device="cuda", dtype=torch.bfloat16) * 0.05
+
+    load_w13(
+        expert_data,
+        loaded,
+        shard_id,
+        0,
+        tp_rank=0,
+        is_bias=False,
+        use_presharded_weights=True,
+        do_transpose=False,
+        expert_scale=expert_scale,
+        block_shape=BLOCK,
+    )
+
+    half = 1 if shard_id == "w3" else 0
+    written = expert_data.narrow(0, half * ispp, ispp)
+    written_scale = expert_scale.narrow(0, half * blocks_per_half, blocks_per_half)
+    # A plain fp8 cast would leave the scale at one and lose the small values.
+    assert not torch.allclose(written_scale, torch.ones_like(written_scale))
+    cosine = torch.nn.functional.cosine_similarity(
+        _dequantize(written, written_scale).flatten(), loaded.float().flatten(), dim=0
+    )
+    assert cosine > 0.99
+
+    other = 1 - half
+    assert torch.all(expert_data.narrow(0, other * ispp, ispp).float() == 0)
+    other_scale = expert_scale.narrow(0, other * blocks_per_half, blocks_per_half)
+    torch.testing.assert_close(other_scale, torch.ones_like(other_scale))
+
+
+def test_load_w2_quantizes_shard() -> None:
+    hidden, ispp = 256, 256
+    expert_data = torch.zeros(hidden, ispp, device="cuda", dtype=torch.float8_e4m3fn)
+    expert_scale = torch.ones(
+        hidden // 128, ispp // 128, device="cuda", dtype=torch.float32
+    )
+    loaded = torch.randn(hidden, ispp, device="cuda", dtype=torch.bfloat16) * 0.05
+
+    load_w2(
+        expert_data,
+        loaded,
+        "w2",
+        1,
+        tp_rank=0,
+        is_bias=False,
+        use_presharded_weights=True,
+        do_transpose=False,
+        expert_scale=expert_scale,
+        block_shape=BLOCK,
+    )
+
+    cosine = torch.nn.functional.cosine_similarity(
+        _dequantize(expert_data, expert_scale).flatten(),
+        loaded.float().flatten(),
+        dim=0,
+    )
+    assert cosine > 0.99
+
+
+def test_load_w13_bias_is_not_quantized() -> None:
+    """Bias is stored unquantized, so it must take the plain-copy path."""
+    expert_data = torch.zeros(4, 512, device="cuda", dtype=torch.bfloat16)
+    loaded = torch.randn(256, device="cuda", dtype=torch.bfloat16)
+    expert_scale = torch.ones(4, 4, device="cuda", dtype=torch.float32)
+
+    load_w13(
+        expert_data,
+        loaded,
+        "w1",
+        0,
+        tp_rank=0,
+        is_bias=True,
+        use_presharded_weights=True,
+        do_transpose=False,
+        expert_scale=expert_scale,
+        block_shape=BLOCK,
+    )
+
+    torch.testing.assert_close(expert_data[:, :256], loaded.expand(4, 256))
+    torch.testing.assert_close(expert_scale, torch.ones_like(expert_scale))

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/fp8_utils.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/fp8_utils.py
@@ -563,6 +563,7 @@ def per_token_group_quant_fp8(
 
     if (
         _is_nvidia
+        and group_size == 128
         and not column_major_scales
         and not scale_tma_aligned
         and not scale_ue8m0
@@ -659,6 +660,94 @@ def flashinfer_fp8_blockscale_quantize_prepacked(
         num_stages=1,
     )
     return x_q, x_s
+
+
+@triton.jit
+def _per_block_quant_fp8_kernel(
+    x_ptr,
+    q_ptr,
+    s_ptr,
+    N,
+    K,
+    x_stride_n,
+    s_stride_n,
+    block_n,
+    block_k,
+    eps,
+    bit8_min,
+    bit8_max,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Quantize one ``[block_n, block_k]`` tile with a single shared scale."""
+    pid_n = tl.program_id(0)
+    pid_k = tl.program_id(1)
+
+    rows = tl.arange(0, BLOCK_N)
+    cols = tl.arange(0, BLOCK_K)
+    offs_n = pid_n * block_n + rows
+    offs_k = pid_k * block_k + cols
+    mask = (rows[:, None] < block_n) & (cols[None, :] < block_k)
+    mask &= (offs_n[:, None] < N) & (offs_k[None, :] < K)
+    offsets = offs_n[:, None].to(tl.int64) * x_stride_n + offs_k[None, :]
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    absmax = tl.maximum(tl.max(tl.abs(x)), eps)
+    scale = absmax / bit8_max
+    q = tl.clamp(x / scale, bit8_min, bit8_max).to(q_ptr.dtype.element_ty)
+
+    tl.store(q_ptr + offsets, q, mask=mask)
+    tl.store(s_ptr + pid_n * s_stride_n + pid_k, scale)
+
+
+def per_block_quant_fp8(
+    x: torch.Tensor,
+    block_size: Tuple[int, int] = (128, 128),
+    eps: float = 1e-10,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize a 2D tensor to FP8 with one scale per 2D block.
+
+    Args:
+        x: Weight matrix ``[N, K]`` in a floating-point dtype, row-major.
+        block_size: ``(block_n, block_k)`` tile shape of one scale.
+        eps: Lower bound on a tile's absmax, to avoid dividing by zero.
+
+    Returns:
+        Tuple of the FP8 tensor shaped like ``x`` and its ``float32`` scales
+        shaped ``[ceil(N / block_n), ceil(K / block_k)]``. The scales are
+        dequantization multipliers: ``x ~= q * scale``.
+    """
+    if x.dim() != 2:
+        raise ValueError(f"per_block_quant_fp8 expects a 2D tensor, got {x.dim()}D.")
+    block_n, block_k = int(block_size[0]), int(block_size[1])
+
+    x = x.contiguous()
+    N, K = x.shape
+    q = torch.empty_like(x, dtype=fp8_dtype)
+    scales = torch.empty(
+        (ceil_div(N, block_n), ceil_div(K, block_k)),
+        dtype=torch.float32,
+        device=x.device,
+    )
+
+    _per_block_quant_fp8_kernel[(scales.shape[0], scales.shape[1])](
+        x,
+        q,
+        scales,
+        N,
+        K,
+        x.stride(0),
+        scales.stride(0),
+        block_n,
+        block_k,
+        eps,
+        fp8_min,
+        fp8_max,
+        BLOCK_N=triton.next_power_of_2(block_n),
+        BLOCK_K=triton.next_power_of_2(block_k),
+        num_warps=8,
+    )
+    return q, scales
 
 
 def per_token_quant_fp8(

--- a/tokenspeed-kernel/test/ops/gemm/test_per_block_quant_fp8.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_per_block_quant_fp8.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel import mm
+from tokenspeed_kernel.ops.gemm.fp8_utils import per_block_quant_fp8
+
+
+def _dequantize(
+    q: torch.Tensor, scales: torch.Tensor, block_size: tuple[int, int]
+) -> torch.Tensor:
+    block_n, block_k = block_size
+    n, k = q.shape
+    out = q.float()
+    for i in range(scales.shape[0]):
+        for j in range(scales.shape[1]):
+            rows = slice(i * block_n, min((i + 1) * block_n, n))
+            cols = slice(j * block_k, min((j + 1) * block_k, k))
+            out[rows, cols] *= scales[i, j]
+    return out
+
+
+@pytest.mark.parametrize(
+    "n, k, block_size",
+    [
+        (256, 256, (128, 128)),
+        (6144, 2048, (128, 128)),
+        # Dimensions that are not a multiple of the block shape.
+        (130, 300, (128, 128)),
+        # Block shape that is not a power of two.
+        (192, 256, (96, 128)),
+    ],
+)
+def test_per_block_quant_fp8_roundtrip(
+    device: str, n: int, k: int, block_size: tuple[int, int]
+) -> None:
+    torch.manual_seed(0)
+    x = torch.randn(n, k, device=device, dtype=torch.bfloat16) * 0.05
+
+    q, scales = per_block_quant_fp8(x, block_size)
+
+    block_n, block_k = block_size
+    assert q.shape == x.shape
+    assert q.dtype == torch.float8_e4m3fn
+    assert scales.dtype == torch.float32
+    assert scales.shape == (
+        (n + block_n - 1) // block_n,
+        (k + block_k - 1) // block_k,
+    )
+
+    dequantized = _dequantize(q, scales, block_size)
+    cosine = torch.nn.functional.cosine_similarity(
+        dequantized.flatten(), x.float().flatten(), dim=0
+    )
+    assert cosine > 0.99
+
+
+def test_per_block_quant_fp8_scale_is_per_block(device: str) -> None:
+    """Each block must be scaled independently, so a huge outlier in one block
+    must not degrade the resolution of its neighbours."""
+    torch.manual_seed(0)
+    block_size = (128, 128)
+    x = torch.full((128, 256), 0.01, device=device, dtype=torch.bfloat16)
+    x[0, 0] = 1000.0
+
+    q, scales = per_block_quant_fp8(x, block_size)
+
+    assert scales[0, 0] > scales[0, 1] * 100
+    dequantized = _dequantize(q, scales, block_size)
+    torch.testing.assert_close(
+        dequantized[:, 128:], x[:, 128:].float(), atol=1e-4, rtol=1e-2
+    )
+
+
+def test_per_block_quant_fp8_rejects_non_2d(device: str) -> None:
+    x = torch.randn(4, 8, 16, device=device, dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="2D tensor"):
+        per_block_quant_fp8(x)
+
+
+def test_per_block_quant_fp8_feeds_block_scaled_gemm(device: str) -> None:
+    """The produced weights must be consumable by the block-scaled FP8 GEMM."""
+    torch.manual_seed(0)
+    m, n, k = 16, 256, 256
+    block_size = (128, 128)
+    a = torch.randn(m, k, device=device, dtype=torch.bfloat16) * 0.1
+    weight = torch.randn(n, k, device=device, dtype=torch.bfloat16) * 0.1
+
+    q_weight, weight_scales = per_block_quant_fp8(weight, block_size)
+    out = mm(
+        a,
+        q_weight,
+        B_scales=weight_scales,
+        out_dtype=torch.bfloat16,
+        quant="mxfp8",
+        block_size=list(block_size),
+        override="triton_mm_fp8_blockscale",
+    )
+
+    reference = a.float() @ _dequantize(q_weight, weight_scales, block_size).t()
+    torch.testing.assert_close(out.float(), reference, atol=0.05, rtol=0.05)


### PR DESCRIPTION
## Summary
Support for FP8 blockwise online quantization. Previously, tokenspeed only supported loading offline FP8 block-wise weights. 
To use online quantization, add `--quantization fp8` to the engine arguments, which will default to using FP8 blockwise quantization with priority. For weights with a draft component (MTP/DFLASH/DSPARK), quantization is disabled by default. To enable quantization for the draft component, add the parameter `--speculative-draft-model-quantization fp8`.

This PR also adds support for loading the draft component from NVFP4 serialized checkpoints, currently validated only on MTP; DFLASH/DSPARK remain unverified.

Quantize only the target part.
```
ts serve \
      --model Qwen/Qwen3.5-35B-A3B \
      --quantization fp8 \
      --host 0.0.0.0 \
      --port 8001 \
      --world-size 4 \
      --gpu-memory-utilization 0.8 \
      --moe-backend flashinfer_trtllm \
      --attention-backend trtllm \
      --chunked-prefill-size 8192 \
      --speculative-algorithm MTP \
      --speculative-draft-model-path Qwen/Qwen3.5-35B-A3B \                               
      --speculative-num-steps 3 \
      --speculative-eagle-topk 1 \
      --speculative-num-draft-tokens 4
```
Quantize target + draft part.
```
ts serve \
      --model Qwen/Qwen3.5-35B-A3B \
      --quantization fp8 \
      --speculative-draft-model-quantization fp8 \
      --host 0.0.0.0 \
      --port 8001 \
      --world-size 4 \
      --gpu-memory-utilization 0.8 \
      --moe-backend flashinfer_trtllm \
      --attention-backend trtllm \
      --chunked-prefill-size 8192 \
      --speculative-algorithm MTP \
      --speculative-draft-model-path Qwen/Qwen3.5-35B-A3B \                               
      --speculative-num-steps 3 \
      --speculative-eagle-topk 1 \
      --speculative-num-draft-tokens 4
```

## Test Plan
Test Qwen3.5-35B-A3B on AIME25 with different quantization configurations, running on GB200 with bs = 32.
| target + draft | acc | dec_tps | tpot | ttft | avg len| max len |
| --- | --- | --- | --- | --- | --- | --- |
| bf16 + bf16 | 0.900 | 278.3 | 3.59ms | 0.83s | 32364 | 110795 |
| bf16 + fp8 | 0.867 | 279.2 | 3.58ms | 0.37s | 35478 | 123844 |
| fp8 + fp8 | 0.900 | 279.7 | 3.58ms | 0.39s | 31367 | 91535 |
| fp8 + bf16 | 0.867 | 263.6 | 3.79ms | 0.39s | 32221 | 92054 |

<!-- How was this validated? -->
