### PR TITLE
perf(amd): tune GFX1250 DSA and KDA prefill kernels

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
@@ -68,6 +68,7 @@ def _dsa_selected_dense_wmma_kernel(
     BLOCK_H: gl.constexpr,
     BLOCK_K: gl.constexpr,
     IS_FP8: gl.constexpr,
+    OUTPUT_WITHIN_2GB: gl.constexpr,
 ):
     """Wave32 WMMA attention with a two-stage selected-row TDM pipeline."""
 
@@ -329,16 +330,21 @@ def _dsa_selected_dense_wmma_kernel(
     )
     d_out = gl.arange(0, KV_LORA_RANK, layout=gl.SliceLayout(0, q_lora_load_layout))
     result = gl.convert_layout(result.to(out.dtype.element_ty), q_lora_load_layout)
-    gl.amd.gfx1250.buffer_store(
-        result,
-        out,
-        (
-            token.to(tl.int64) * stride_o_t
-            + h_out[:, None].to(tl.int64) * stride_o_h
-            + d_out[None, :].to(tl.int64)
-        ).to(tl.int32),
-        mask=h_out[:, None] < num_heads,
+    output_offsets = (
+        token.to(tl.int64) * stride_o_t
+        + h_out[:, None].to(tl.int64) * stride_o_h
+        + d_out[None, :].to(tl.int64)
     )
+    output_mask = h_out[:, None] < num_heads
+    if OUTPUT_WITHIN_2GB:
+        gl.amd.gfx1250.buffer_store(
+            result,
+            out,
+            output_offsets.to(tl.int32),
+            mask=output_mask,
+        )
+    else:
+        gl.store(out + output_offsets, result, mask=output_mask)
 
 
 @gluon.constexpr_function
@@ -905,6 +911,15 @@ def _allocate_output(q: torch.Tensor, kv_lora_rank: int) -> torch.Tensor:
     )
 
 
+def _output_within_2gb(out: torch.Tensor) -> bool:
+    """Return whether the output storage span stays below the 2 GiB limit."""
+
+    max_element_offset = sum(
+        (dim - 1) * stride for dim, stride in zip(out.shape, out.stride())
+    )
+    return (max_element_offset + 1) * out.element_size() < 1 << 31
+
+
 def _run_dense(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -953,6 +968,7 @@ def _run_dense(
         BLOCK_H=block_h,
         BLOCK_K=64 if is_fp8 else 32,
         IS_FP8=is_fp8,
+        OUTPUT_WITHIN_2GB=_output_within_2gb(out),
         num_warps=4,
     )
     return out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
@@ -38,8 +38,12 @@ __all__ = [
 
 _RADIX_BITS = (12, 12, 8)
 _MAX_BUCKETS = gl.constexpr(1 << max(_RADIX_BITS))
-_TOPK_BLOCK_N = 4096
+_TOPK_BLOCK_N = 2048
 _TOPK_NUM_WARPS = 8
+_TOPK_WAVES_PER_EU = 1
+_PREFILL_LOGITS_BLOCK_N = 128
+_PREFILL_LOGITS_NUM_WARPS = 8
+_PREFILL_LOGITS_WAVES_PER_EU = 1
 _GLM52_SCORING_HEADS = 32
 _GLM52_FUSED_DECODE_MAX_CANDIDATES = 98_304
 
@@ -137,7 +141,7 @@ def _emit_topk_tile(
     gl.store(
         out + row * out_stride + reservation,
         logical_offsets,
-        mask=greater,
+        mask=greater & (reservation < count_greater),
     )
     gl.store(
         out + row * out_stride + count_greater + reservation,
@@ -271,7 +275,7 @@ def _dsa_wave32_radix_topk_kernel(
                 BLOCK_N,
                 pass_index == 0,
             )
-        gl.barrier()
+            gl.barrier()
 
         counts = shared_histogram.load(histogram_layout)
         count_pairs = counts.reshape([_MAX_BUCKETS // 2, 2])
@@ -395,7 +399,7 @@ def _dsa_topk_indices(
         BLOCK_N=_TOPK_BLOCK_N,
         LOAD_ELEMS=_TOPK_BLOCK_N // (32 * _TOPK_NUM_WARPS),
         num_warps=_TOPK_NUM_WARPS,
-        waves_per_eu=1,
+        waves_per_eu=_TOPK_WAVES_PER_EU,
     )
     return out, lens_out
 
@@ -630,7 +634,7 @@ def gluon_dsa_prefill_topk_fp8_gfx1250(
     else:
         max_query_rows = max(1, int(max_logits_bytes) // (max(seq_len_sum, 1) * 4))
 
-    block_n = 32
+    block_n = _PREFILL_LOGITS_BLOCK_N
     for start in range(0, q.shape[0], max_query_rows):
         end = min(start + max_query_rows, q.shape[0])
         combined_q = _combine_scoring_query_heads(q[start:end], weights[start:end])
@@ -659,8 +663,8 @@ def gluon_dsa_prefill_topk_fp8_gfx1250(
             softmax_scale=float(softmax_scale),
             BLOCK_N=block_n,
             BLOCK_D=128,
-            num_warps=4,
-            waves_per_eu=1,
+            num_warps=_PREFILL_LOGITS_NUM_WARPS,
+            waves_per_eu=_PREFILL_LOGITS_WAVES_PER_EU,
         )
         _dsa_topk_indices(
             logits,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/prefill.py
@@ -63,7 +63,9 @@ from tokenspeed_kernel_amd._triton import gl, gluon, triton
 _CHUNK_SIZE = 64
 _SUBCHUNK_SIZE = 16
 _FUSED_PREPROCESS_WARPS = 8
-_SCAN_OUTPUT_BLOCK = 16
+_SCAN_OUTPUT_BLOCK = 8
+_SCAN_WAVES_PER_EU = 2
+_OUTPUT_WAVES_PER_EU = 4
 gfx1250 = gl.amd.gfx1250
 
 
@@ -335,13 +337,30 @@ def _preprocess_intra_fwd_kernel(
     mask = (tokens[:, None] < length) & (keys[None, :] < K)
     offsets = ((begin + tokens[:, None]) * H + head) * K + keys[None, :]
 
-    q_value = gl.load(q + offsets, mask=mask, other=0.0).to(gl.float32)
-    k_value = gl.load(k + offsets, mask=mask, other=0.0).to(gl.float32)
-    q_norm = gl.rsqrt(gl.sum(q_value * q_value, axis=1) + 1e-6)
-    k_norm = gl.rsqrt(gl.sum(k_value * k_value, axis=1) + 1e-6)
-    normalized_q = (q_value * q_norm[:, None]).to(gl.bfloat16)
-    normalized_k = (k_value * k_norm[:, None]).to(gl.bfloat16)
-    gl.store(kn + offsets, normalized_k, mask=mask)
+    shared_qk: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[K, 8]], [BT, K], [1, 0]
+    )
+    shared_bg: gl.constexpr = gl.SwizzledSharedLayout(4, 1, 8, order=[1, 0])
+    q_smem = gl.allocate_shared_memory(gl.bfloat16, [BT, K], shared_qk)
+    k_smem = gl.allocate_shared_memory(gl.bfloat16, [BT, K], shared_qk)
+    bg_smem = gl.allocate_shared_memory(gl.float32, [BT, K], shared_bg)
+
+    q_desc = gfx1250.tdm.make_tensor_descriptor(
+        base=q + (begin * H + head) * K,
+        shape=(length, K),
+        strides=(H * K, 1),
+        block_shape=(BT, K),
+        layout=shared_qk,
+    )
+    k_desc = gfx1250.tdm.make_tensor_descriptor(
+        base=k + (begin * H + head) * K,
+        shape=(length, K),
+        strides=(H * K, 1),
+        block_shape=(BT, K),
+        layout=shared_qk,
+    )
+    gfx1250.tdm.async_load(q_desc, [token0, 0], q_smem)
+    gfx1250.tdm.async_load(k_desc, [token0, 0], k_smem)
 
     gate_input = gl.load(raw_g + offsets, mask=mask, other=0.0).to(gl.float32)
     gate_input += gl.load(
@@ -358,19 +377,32 @@ def _preprocess_intra_fwd_kernel(
         )
         gate_value = -a * softplus
     gate_value = gl.where(mask, gate_value, 0.0)
-    cumulative_gate = gl.associative_scan(gate_value, 0, _add)
-    gl.store(bg + offsets, cumulative_gate, mask=mask)
-    gated_query = normalized_q.to(gl.float32)
-    gated_query *= gl.exp(cumulative_gate) * SCALE
-    gl.store(qg + offsets, gated_query.to(gl.bfloat16), mask=mask)
 
-    shared_qk: gl.constexpr = gl.SwizzledSharedLayout(8, 2, 8, order=[1, 0])
-    shared_bg: gl.constexpr = gl.SwizzledSharedLayout(4, 1, 8, order=[1, 0])
-    q_smem = gl.allocate_shared_memory(gl.bfloat16, [BT, K], shared_qk)
-    k_smem = gl.allocate_shared_memory(gl.bfloat16, [BT, K], shared_qk)
-    bg_smem = gl.allocate_shared_memory(gl.float32, [BT, K], shared_bg)
+    gfx1250.tdm.async_wait(0)
+    q_value = q_smem.load(producer_layout).to(gl.float32)
+    k_value = k_smem.load(producer_layout).to(gl.float32)
+    q_norm = gl.rsqrt(gl.sum(q_value * q_value, axis=1) + 1e-6)
+    k_norm = gl.rsqrt(gl.sum(k_value * k_value, axis=1) + 1e-6)
+    normalized_q = (q_value * q_norm[:, None]).to(gl.bfloat16)
+    normalized_k = (k_value * k_norm[:, None]).to(gl.bfloat16)
+    gl.store(kn + offsets, normalized_k, mask=mask)
     q_smem.store(normalized_q)
     k_smem.store(normalized_k)
+    bg_smem.store(gate_value)
+    gl.barrier()
+
+    scan_layout: gl.constexpr = gl.BlockedLayout([1, 2], [4, 8], [1, NUM_WARPS], [1, 0])
+    scan_rows = gl.arange(0, BT, layout=gl.SliceLayout(1, scan_layout))
+    scan_keys = gl.arange(0, K, layout=gl.SliceLayout(0, scan_layout))
+    scan_tokens = token0 + scan_rows
+    scan_mask = (scan_tokens[:, None] < length) & (scan_keys[None, :] < K)
+    scan_offsets = ((begin + scan_tokens[:, None]) * H + head) * K + scan_keys[None, :]
+    gate_scan = bg_smem.load(scan_layout)
+    cumulative_gate = gl.associative_scan(gate_scan, 0, _add)
+    gl.store(bg + scan_offsets, cumulative_gate, mask=scan_mask)
+    gated_query = q_smem.load(scan_layout).to(gl.float32)
+    gated_query *= gl.exp(cumulative_gate) * SCALE
+    gl.store(qg + scan_offsets, gated_query.to(gl.bfloat16), mask=scan_mask)
     bg_smem.store(cumulative_gate)
     gl.barrier()
 
@@ -1066,7 +1098,7 @@ def gluon_kda_paged_prefill_gfx1250(
         BO=scan_output_block,
         num_warps=4,
         num_stages=2,
-        waves_per_eu=1,
+        waves_per_eu=_SCAN_WAVES_PER_EU,
     )
     _output_fwd_kernel[(num_chunks, heads)](
         aqk,
@@ -1079,7 +1111,7 @@ def gluon_kda_paged_prefill_gfx1250(
         BT=chunk_size,
         num_warps=4,
         num_stages=2,
-        waves_per_eu=1,
+        waves_per_eu=_OUTPUT_WAVES_PER_EU,
     )
     return output.unsqueeze(0), final_state
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/prefill.py
@@ -341,8 +341,8 @@ def _preprocess_intra_fwd_kernel(
         [[K, 8]], [BT, K], [1, 0]
     )
     shared_bg: gl.constexpr = gl.SwizzledSharedLayout(4, 1, 8, order=[1, 0])
-    q_smem = gl.allocate_shared_memory(gl.bfloat16, [BT, K], shared_qk)
-    k_smem = gl.allocate_shared_memory(gl.bfloat16, [BT, K], shared_qk)
+    q_smem = gl.allocate_shared_memory(q.dtype.element_ty, [BT, K], shared_qk)
+    k_smem = gl.allocate_shared_memory(k.dtype.element_ty, [BT, K], shared_qk)
     bg_smem = gl.allocate_shared_memory(gl.float32, [BT, K], shared_bg)
 
     q_desc = gfx1250.tdm.make_tensor_descriptor(
@@ -383,8 +383,8 @@ def _preprocess_intra_fwd_kernel(
     k_value = k_smem.load(producer_layout).to(gl.float32)
     q_norm = gl.rsqrt(gl.sum(q_value * q_value, axis=1) + 1e-6)
     k_norm = gl.rsqrt(gl.sum(k_value * k_value, axis=1) + 1e-6)
-    normalized_q = (q_value * q_norm[:, None]).to(gl.bfloat16)
-    normalized_k = (k_value * k_norm[:, None]).to(gl.bfloat16)
+    normalized_q = (q_value * q_norm[:, None]).to(q.dtype.element_ty)
+    normalized_k = (k_value * k_norm[:, None]).to(k.dtype.element_ty)
     gl.store(kn + offsets, normalized_k, mask=mask)
     q_smem.store(normalized_q)
     k_smem.store(normalized_k)


### PR DESCRIPTION
## DSA prefill changes

- Radix top-k block size: `4096` → `2048`.
- Prefill logits block size: `32` → `128`.
- Prefill logits warps: `4` → `8`.
- Synchronize the radix histogram after every subpass.
- Bound radix output writes by the number of qualifying entries.
- Use 64-bit-addressed stores for dense-attention outputs exceeding the 2 GiB buffer-offset limit.

| Batch | Sequence length | Before | After | Difference |
|---:|---:|---:|---:|---:|
| 1 | 1K | 193.29 µs | 124.31 µs | -35.7% |
| 1 | 4K | 2.357 ms | 989.49 µs | -58.0% |
| 1 | 8K | 8.172 ms | 2.595 ms | -68.2% |
| 8 | 1K | 6.366 ms | 1.330 ms | -79.1% |
| 8 | 4K | 96.452 ms | 17.578 ms | -81.8% |
| 8 | 8K | 367.206 ms | 60.489 ms | -83.5% |
| 32 | 1K | 91.050 ms | 13.605 ms | -85.1% |
| 32 | 4K | 1,429.879 ms | 205.198 ms | -85.6% |
| 32 | 8K | 6,037.544 ms | 789.627 ms | -86.9% |

## KDA prefill changes

- Make the cumulative gate scan wave-local, reducing LDS and VGPR usage while doubling residency.
- Asynchronously TDM-load Q/K into LDS and overlap the loads with gate computation.
- State-scan output block: `16` → `8`.
- State-scan `waves_per_eu`: `1` → `2`.
- Output-kernel `waves_per_eu`: `1` → `4`.

| Batch | Sequence length | Before | After | Difference |
|---:|---:|---:|---:|---:|
| 1 | 1K | 144.95 µs | 124.61 µs | -14.0% |
| 1 | 4K | 312.80 µs | 272.84 µs | -12.8% |
| 1 | 8K | 565.76 µs | 486.75 µs | -14.0% |
| 8 | 1K | 383.91 µs | 336.80 µs | -12.3% |
| 8 | 4K | 1.323 ms | 1.090 ms | -17.6% |
| 8 | 8K | 2.555 ms | 2.117 ms | -17.1% |
| 32 | 1K | 1.333 ms | 1.095 ms | -17.8% |
| 32 | 4K | 5.063 ms | 4.150 ms | -18.0% |
| 32 | 8K | 10.089 ms | 8.251 ms | -18.2% |