### PR TITLE
perf(k3): fold the latent-tail projection into the reduction epilogue and pool its symmetric buffers

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -72,11 +72,6 @@ class K3MoETailTier(IntEnum):
     SEPARATE_REDUCE = 3  # portable: reduce each partial on its own
 
 
-# Below 256 tokens, two staged reduces lose ~4% TPOT to the joined single AR.
-# From 256..8192 (prefill graphs capture through 8192), the in-switch path wins
-# ~13% TTFT at 1k and ~19% at 8k over the split-AR fold. Above 8192, staging
-# copies grow linearly while grouped NCCL reduces in place; symmetric buffers
-# are pre-sized to the 8192 ceiling, so serving never grows them collectively.
 # Speculative decode may enter this prefill-tuned multimem window.
 MULTIMEM_AR_MIN_TOKENS = 256
 MULTIMEM_AR_MAX_TOKENS = 8192

--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -72,6 +72,11 @@ class K3MoETailTier(IntEnum):
     SEPARATE_REDUCE = 3  # portable: reduce each partial on its own
 
 
+# Below 256 tokens, two staged reduces lose ~4% TPOT to the joined single AR.
+# From 256..8192 (prefill graphs capture through 8192), the in-switch path wins
+# ~13% TTFT at 1k and ~19% at 8k over the split-AR fold. Above 8192, staging
+# copies grow linearly while grouped NCCL reduces in place; symmetric buffers
+# are pre-sized to the 8192 ceiling, so serving never grows them collectively.
 # Speculative decode may enter this prefill-tuned multimem window.
 MULTIMEM_AR_MIN_TOKENS = 256
 MULTIMEM_AR_MAX_TOKENS = 8192

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1734,12 +1734,11 @@ class KimiLinearMoE(nn.Module):
             else routed_reduced
         )
         start, width = self.routed_expert_up_proj.shard_slice
-        routed_projected_shard = self.routed_expert_up_proj.project_shard(
-            routed_reduced
-        )
-        shared_stage[:, start : start + width] += routed_projected_shard + (
-            prefix_sum.view(num_tokens, hidden_size).narrow(-1, start, width)
-        )
+        target = shared_stage[:, start : start + width]
+        target += prefix_sum.view(num_tokens, hidden_size).narrow(-1, start, width)
+        # Beta-add epilogue: the projection accumulates straight into the
+        # staged columns, no materialized block and no separate add.
+        target.addmm_(routed_reduced, self.routed_expert_up_proj.weight.t())
         shared_reduced = multimem_all_reduce_staged(shared_stage, group_name)
         # Clone: the staging buffer is recycled by the next layer's stage copy.
         return shared_reduced.view(num_tokens, hidden_size).clone()
@@ -1796,16 +1795,15 @@ class KimiLinearMoE(nn.Module):
         num_tokens: int,
         hidden_size: int,
     ) -> torch.Tensor:
-        routed_projected_shard = self.routed_expert_up_proj.project_shard(
-            routed_reduced
-        )
-        return self._inject_local_block(
-            routed_projected_shard,
-            shared_partial,
-            prefix_sum,
-            num_tokens,
-            hidden_size,
-        )
+        # addmm_ accumulates the projection in the GEMM's beta-add epilogue,
+        # so the block never materializes and the separate adds disappear
+        # (one fewer rounding than projecting then adding).
+        start, width = self.routed_expert_up_proj.shard_slice
+        shared_partial = shared_partial.view(num_tokens, hidden_size)
+        target = shared_partial[:, start : start + width]
+        target += prefix_sum.view(num_tokens, hidden_size)[:, start : start + width]
+        target.addmm_(routed_reduced, self.routed_expert_up_proj.weight.t())
+        return shared_partial
 
     def _inject_local_block(
         self,

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1055,8 +1055,9 @@ class KimiLinearMoE(nn.Module):
         self,
         config: KimiLinearConfig,
         mapping: Mapping,
+        layer_index: int,
+        model_scope: str,
         quant_config: QuantizationConfig | None = None,
-        layer_index: int = -1,
         prefix: str = "",
         alt_stream: torch.cuda.Stream | None = None,
     ) -> None:
@@ -1279,13 +1280,17 @@ class KimiLinearMoE(nn.Module):
             )
         )
 
-        self._initialize_tail_capabilities(config, mapping, prefix)
+        self._initialize_tail_capabilities(
+            config, mapping, prefix, layer_index, model_scope
+        )
 
     def _initialize_tail_capabilities(
         self,
         config: KimiLinearConfig,
         mapping: Mapping,
         prefix: str,
+        layer_index: int,
+        model_scope: str,
     ) -> None:
         """Probe locally, cast one collective vote, then allocate collectively."""
         # All ranks must agree on eligibility before either collective allocator runs.
@@ -1355,7 +1360,8 @@ class KimiLinearMoE(nn.Module):
                     latent_size=self.routed_hidden,
                     rms_eps=self.routed_expert_norm.variance_epsilon,
                     device=_device,
-                    owner=prefix,
+                    layer_index=layer_index,
+                    model_scope=model_scope,
                     # Staging may alias the workspace pool; each barrier-free mailbox must remain private.
                     scratch_allocator=workspace_pool(_device).allocate,
                 )
@@ -1736,8 +1742,6 @@ class KimiLinearMoE(nn.Module):
         start, width = self.routed_expert_up_proj.shard_slice
         target = shared_stage[:, start : start + width]
         target += prefix_sum.view(num_tokens, hidden_size).narrow(-1, start, width)
-        # Beta-add epilogue: the projection accumulates straight into the
-        # staged columns, no materialized block and no separate add.
         target.addmm_(routed_reduced, self.routed_expert_up_proj.weight.t())
         shared_reduced = multimem_all_reduce_staged(shared_stage, group_name)
         # Clone: the staging buffer is recycled by the next layer's stage copy.
@@ -1795,9 +1799,6 @@ class KimiLinearMoE(nn.Module):
         num_tokens: int,
         hidden_size: int,
     ) -> torch.Tensor:
-        # addmm_ accumulates the projection in the GEMM's beta-add epilogue,
-        # so the block never materializes and the separate adds disappear
-        # (one fewer rounding than projecting then adding).
         start, width = self.routed_expert_up_proj.shard_slice
         shared_partial = shared_partial.view(num_tokens, hidden_size)
         target = shared_partial[:, start : start + width]
@@ -1980,6 +1981,7 @@ class KimiLinearDecoderLayer(nn.Module):
         config: KimiLinearConfig,
         mapping: Mapping,
         layer_id: int,
+        model_scope: str,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         alt_stream: torch.cuda.Stream | None = None,
@@ -2025,11 +2027,12 @@ class KimiLinearDecoderLayer(nn.Module):
             # Named for the checkpoint index; not aliased as self.mlp (double
             # registration would duplicate every MoE param in state_dict).
             self.block_sparse_moe = KimiLinearMoE(
-                config,
-                mapping,
-                quant_config,
-                layer_id,
-                add_prefix("block_sparse_moe", prefix),
+                config=config,
+                mapping=mapping,
+                layer_index=layer_id,
+                model_scope=model_scope,
+                quant_config=quant_config,
+                prefix=add_prefix("block_sparse_moe", prefix),
                 alt_stream=alt_stream,
             )
         else:
@@ -2590,11 +2593,14 @@ class KimiLinearModel(nn.Module):
             tp_group=mapping.attn.tp_group,
         )
 
+        layers_scope = add_prefix("layers", prefix)
+
         def get_layer(idx: int, prefix: str):
             return KimiLinearDecoderLayer(
                 config=config,
                 mapping=mapping,
                 layer_id=idx,
+                model_scope=layers_scope,
                 quant_config=quant_config,
                 prefix=prefix,
                 alt_stream=alt_stream,
@@ -2603,7 +2609,7 @@ class KimiLinearModel(nn.Module):
         self.layers = make_layers(
             config.num_hidden_layers,
             get_layer,
-            prefix=add_prefix("layers", prefix),
+            prefix=layers_scope,
         )
         # Cross-layer attn-side mix precompute: a layer's aux stream computes
         # the NEXT layer's block partial alongside its own mlp-side partial

--- a/python/tokenspeed/runtime/models/kimi_k3_nextn.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_nextn.py
@@ -120,6 +120,7 @@ class KimiK3DraftDecoderLayer(nn.Module):
         self,
         config: KimiLinearConfig,
         mapping: Mapping,
+        model_scope: str,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         alt_stream: torch.cuda.Stream | None = None,
@@ -146,17 +147,15 @@ class KimiK3DraftDecoderLayer(nn.Module):
             alt_stream=alt_stream,
         )
         self.block_sparse_moe = KimiLinearMoE(
-            config,
-            mapping,
-            quant_config,
-            0,
-            add_prefix("block_sparse_moe", prefix),
+            config=config,
+            mapping=mapping,
+            layer_index=0,
+            model_scope=model_scope,
+            quant_config=quant_config,
+            prefix=add_prefix("block_sparse_moe", prefix),
             alt_stream=alt_stream,
         )
-        # The fused-AR lane workspace is a singleton shaped around the base
-        # model's usage; the draft takes the plain reduce path.
-        self.block_sparse_moe._fused_moe_ar = False
-        self.block_sparse_moe._lane_latent_norm_ar = False
+        # The old underscored flag writes were dead; making that intent effective needs a spec-decode run.
         self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
@@ -247,11 +246,13 @@ class KimiK3ModelNextN(nn.Module):
         self.eh_proj = nn.Linear(2 * config.hidden_size, config.hidden_size, bias=False)
 
         self.alt_stream = torch.cuda.Stream()
+        decoder_scope = add_prefix("decoder", prefix)
         self.decoder = KimiK3DraftDecoderLayer(
-            config,
-            mapping,
-            quant_config,
-            prefix=add_prefix("decoder", prefix),
+            config=config,
+            mapping=mapping,
+            model_scope=decoder_scope,
+            quant_config=quant_config,
+            prefix=decoder_scope,
             alt_stream=self.alt_stream,
         )
 

--- a/test/runtime/layers/test_kimi_k3_addmm_fold.py
+++ b/test/runtime/layers/test_kimi_k3_addmm_fold.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("m", [0, 1, 5])
+def test_narrowed_staging_addmm_matches_unfolded_expression(
+    dtype: torch.dtype, m: int
+) -> None:
+    torch.manual_seed(7)
+    hidden, start, width, latent = 11, 3, 5, 4
+    staging = torch.randn(m, hidden, dtype=dtype)
+    prefix = torch.randn(m, hidden * 2, dtype=dtype)[:, ::2]
+    routed = torch.randn(m, latent, dtype=dtype)
+    weight = torch.randn(width, latent, dtype=dtype)
+    expected = staging.clone()
+    expected[:, start : start + width] = (
+        expected[:, start : start + width]
+        + prefix[:, start : start + width]
+        + routed @ weight.t()
+    )
+
+    actual = staging.clone()
+    target = actual[:, start : start + width]
+    target += prefix[:, start : start + width]
+    target.addmm_(routed, weight.t())
+
+    torch.testing.assert_close(actual, expected)

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -250,7 +250,8 @@ def test_fused_tail_matches_reference(m):
         latent_size=L,
         rms_eps=EPS,
         device=dev,
-        owner="test.tail_fusion",
+        layer_index=0,
+        model_scope="test",
     )
     moe = _build_moe(dev, latent_tail=tail)
     routed, shared, prefix = _inputs(rank, dev, m, seed=11)
@@ -341,8 +342,8 @@ def test_tiers_agree_with_each_other():
             latent_size=L,
             rms_eps=EPS,
             device=dev,
-            # A mailbox of its own; the name above owns the other one.
-            owner="test.tiers_agree",
+            layer_index=0,
+            model_scope="test",
         )
     moe = _build_moe(dev, latent_tail=tail)
     routed, shared, prefix = _inputs(rank, dev, m, seed=44)

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -412,8 +412,9 @@ class KimiK3RegistrationTests(unittest.TestCase):
             layer = kimi_k3.KimiLinearMoE(
                 config,
                 mapping,
-                quant_config=None,
                 layer_index=1,
+                model_scope="model.layers",
+                quant_config=None,
                 prefix="model.layers.1.block_sparse_moe",
             )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
@@ -29,18 +29,28 @@ a *sharded* up-projection (each rank computes ``hidden/tp`` rows — 1/tp of the
 weight traffic, and 1/tp of the weight storage when the caller passes a
 column-parallel weight) whose epilogue multicast-stores the shard into every
 rank's mailbox (NVLS), and a barrier-free Lamport gather. Symmetric buffers
-come from stock ``torch.distributed._symmetric_memory``; the small per-call
-staging can come from the runtime's shared workspace pool via
-``scratch_allocator``.
+come from stock ``torch.distributed._symmetric_memory``. A depth-d rotation
+pool (d=2 by default) reduces their footprint from about 0.95 GB per rank for
+roughly 92 MoE layers to d x about 6 MB per rank. The small per-call staging
+can come from the runtime's shared workspace pool via ``scratch_allocator``.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
 
 import torch
 import torch.distributed as dist
+
+if TYPE_CHECKING:
+    from tokenspeed_kernel.thirdparty.cute_dsl.latent_moe_tail import (
+        AdaptiveUpProjectionKernel,
+        CollectiveKernel,
+    )
+
+_ScratchAllocator = Callable[..., list[torch.Tensor]]
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +63,25 @@ _COLLECTIVE_TOKEN_CTAS = 8
 _LAMPORT_COPY_CTAS = 32
 _LAMPORT_COPY_THREADS = 224
 _SUPPORTED_TP_SIZES = (8, 16)
+# The gather releases its PDL dependents before re-arming this slot's sentinels.
+# Rotating by decoder-layer index keeps adjacent layers off the same mailbox and,
+# in the supported sequential decoder, leaves the intervening layer's stream work
+# between same-slot writes. This is a scheduling assumption, not synchronization:
+# different modules scheduled with repeated/non-sequential indices need separate
+# model scopes (and concurrently executing models must not share a scope).
+_TAIL_POOL_DEPTH = 2
+
+
+def _tail_pool_slot(layer_index: int, depth: int = _TAIL_POOL_DEPTH) -> int:
+    """Map a decoder layer index to its rank-identical pool slot."""
+    if depth <= 0:
+        raise ValueError("tail pool depth must be greater than zero")
+    return layer_index % depth
+
+
+def _allocator_identity(allocator: _ScratchAllocator | None) -> object:
+    """Return the stable owner identity of a possibly bound allocator."""
+    return getattr(allocator, "__self__", allocator)
 
 
 def _multicast_reachable(group: dist.ProcessGroup | None = None) -> bool:
@@ -104,8 +133,10 @@ def latent_tail_supported(
     return _multicast_reachable(group)
 
 
-@dataclass(frozen=True)
+@dataclass
 class _Contract:
+    """Dimensions and identities shared by op construction and pooled slots."""
+
     # The registered group name, not id(group): stable for the process
     # lifetime and the same identity symmetric-memory rendezvous keys on.
     group_name: str
@@ -114,20 +145,29 @@ class _Contract:
     hidden_size: int
     latent_size: int
     rms_eps: float
-    # Mailboxes are owner-private because cleanup may overlap same-stream successors.
-    # Use module prefixes: draft models can repeat base-model layer indices.
-    owner: str
+
+
+@dataclass
+class _SymmetricPoolSlot:
+    """One indivisible collective-workspace and multicast-mailbox bundle."""
+
+    collective: CollectiveKernel
+    up_projection: AdaptiveUpProjectionKernel
+    scratch_allocator_key: object
 
 
 class KimiK3LatentTailOp:
-    """Multicast tail for one calling module; one instance (and mailbox) each.
+    """Multicast tail for one module, statically bound to a rotation-pool slot.
 
     Construction performs a collective symmetric-memory rendezvous — every
     rank in ``group`` must construct with identical arguments in lockstep
     (model-layer initialization satisfies this).
     """
 
-    _instances: dict[_Contract, "KimiK3LatentTailOp"] = {}
+    _symmetric_pools: dict[
+        tuple[str, int, torch.device, int, int, float, str, int],
+        _SymmetricPoolSlot,
+    ] = {}
 
     @classmethod
     def initialize(
@@ -138,10 +178,11 @@ class KimiK3LatentTailOp:
         latent_size: int,
         rms_eps: float,
         device: torch.device,
-        owner: str,
-        scratch_allocator=None,
+        layer_index: int,
+        model_scope: str,
+        scratch_allocator: _ScratchAllocator | None = None,
     ) -> "KimiK3LatentTailOp":
-        """Return this caller's tail op, constructing it on first use.
+        """Construct this caller's tail op with a statically bound pool slot.
 
         Args:
             group: Process group every rank constructs with, in lockstep.
@@ -149,9 +190,9 @@ class KimiK3LatentTailOp:
             latent_size: Routed-expert latent width.
             rms_eps: Epsilon of the routed-expert RMS norm.
             device: CUDA device owning the mailbox.
-            owner: Globally unique name for the calling module (its weight
-                prefix); part of the key so each caller gets its own mailbox.
-                Must be rank-identical -- it takes part in the rendezvous.
+            layer_index: Decoder layer index used to select the rotation slot.
+            model_scope: Rank-identical model scope separating pool bundles,
+                including base and draft models.
             scratch_allocator: Optional ``(*specs) -> list[Tensor]`` carving
                 per-call staging views from a shared block (the runtime's
                 workspace pool). The views are re-fetched on every collective
@@ -164,34 +205,22 @@ class KimiK3LatentTailOp:
             hidden_size=hidden_size,
             latent_size=latent_size,
             rms_eps=float(rms_eps),
-            owner=owner,
         )
-
-        def _alloc_identity(alloc):
-            # Bound method identity is unstable; compare the owning pool object.
-            return getattr(alloc, "__self__", alloc)
-
-        op = cls._instances.get(contract)
-        if op is None:
-            op = cls(contract, group, scratch_allocator=scratch_allocator)
-            op._scratch_allocator_key = _alloc_identity(scratch_allocator)
-            cls._instances[contract] = op
-        elif getattr(op, "_scratch_allocator_key", None) is not _alloc_identity(
-            scratch_allocator
-        ):
-            # Cached ops must not retain an allocator from a replaced workspace pool.
-            raise RuntimeError(
-                "KimiK3LatentTailOp for this contract already exists with a "
-                "different scratch_allocator; reset the instance cache when "
-                "rebuilding engines in one process"
-            )
-        return op
+        return cls(
+            contract,
+            group,
+            layer_index=layer_index,
+            model_scope=model_scope,
+            scratch_allocator=scratch_allocator,
+        )
 
     def __init__(
         self,
         contract: _Contract,
         group: dist.ProcessGroup,
-        scratch_allocator=None,
+        layer_index: int,
+        model_scope: str,
+        scratch_allocator: _ScratchAllocator | None = None,
     ) -> None:
         from tokenspeed_kernel.thirdparty.cute_dsl.latent_moe_tail import (
             AdaptiveUpProjectionKernel,
@@ -201,31 +230,58 @@ class KimiK3LatentTailOp:
 
         self.contract = contract
         self.rank = dist.get_rank(group)
+        slot_index = _tail_pool_slot(layer_index)
+        pool_key = (
+            contract.group_name,
+            contract.tp_size,
+            contract.device,
+            contract.hidden_size,
+            contract.latent_size,
+            contract.rms_eps,
+            model_scope,
+            slot_index,
+        )
+
+        allocator_key = _allocator_identity(scratch_allocator)
         with torch.accelerator.device_index(contract.device.index):
-            self._collective = CollectiveKernel(
-                group=group,
-                rank=self.rank,
-                tp_size=contract.tp_size,
-                latent_dim=contract.latent_size,
-                hidden_dim=contract.hidden_size,
-                max_m=_MAX_NUM_TOKENS,
-                max_token_ctas=_COLLECTIVE_TOKEN_CTAS,
-                rms_eps=contract.rms_eps,
-                fp32_internal=True,
-                scratch_allocator=scratch_allocator,
-            )
-            self._up_projection = AdaptiveUpProjectionKernel(
-                group=group,
-                rank=self.rank,
-                tp_size=contract.tp_size,
-                latent_dim=contract.latent_size,
-                hidden_dim=contract.hidden_size,
-                max_m=_MAX_NUM_TOKENS,
-                skinny_max_m=_SKINNY_MAX_NUM_TOKENS,
-                mma_tiler_mn=_MMA_TILER_MN,
-                cluster_shape_mn=_GEMM_CLUSTER_MN,
-                b_prime_stages=_B_PRIME_STAGES,
-            )
+            slot = type(self)._symmetric_pools.get(pool_key)
+            if slot is None:
+                # Allocate the rendezvous bundle atomically for this static slot.
+                slot = _SymmetricPoolSlot(
+                    collective=CollectiveKernel(
+                        group=group,
+                        rank=self.rank,
+                        tp_size=contract.tp_size,
+                        latent_dim=contract.latent_size,
+                        hidden_dim=contract.hidden_size,
+                        max_m=_MAX_NUM_TOKENS,
+                        max_token_ctas=_COLLECTIVE_TOKEN_CTAS,
+                        rms_eps=contract.rms_eps,
+                        fp32_internal=True,
+                        scratch_allocator=scratch_allocator,
+                    ),
+                    up_projection=AdaptiveUpProjectionKernel(
+                        group=group,
+                        rank=self.rank,
+                        tp_size=contract.tp_size,
+                        latent_dim=contract.latent_size,
+                        hidden_dim=contract.hidden_size,
+                        max_m=_MAX_NUM_TOKENS,
+                        skinny_max_m=_SKINNY_MAX_NUM_TOKENS,
+                        mma_tiler_mn=_MMA_TILER_MN,
+                        cluster_shape_mn=_GEMM_CLUSTER_MN,
+                        b_prime_stages=_B_PRIME_STAGES,
+                    ),
+                    scratch_allocator_key=allocator_key,
+                )
+                type(self)._symmetric_pools[pool_key] = slot
+            elif slot.scratch_allocator_key is not allocator_key:
+                raise RuntimeError(
+                    "KimiK3 latent-tail pool slot already exists with a "
+                    "different scratch_allocator"
+                )
+            self._collective = slot.collective
+            self._up_projection = slot.up_projection
             self._lamport_copy = LamportCopyKernel(
                 hidden_dim=contract.hidden_size,
                 max_m=_MAX_NUM_TOKENS,
@@ -265,7 +321,7 @@ class KimiK3LatentTailOp:
             ``[M, 7168]`` post-communication hidden (up-projection + shared,
             plus ``prefix`` when provided).
         """
-        # Owner-private mailboxes are reused only after every layer's peer-blocking gather.
+        # Same-slot calls are stream-ordered, preserving Lamport buffer rotation.
         m = routed_partial.shape[0]
         # JIT compilation launches kernels; under capture they would be
         # recorded into the graph. Warmup must have compiled this m already.

--- a/tokenspeed-kernel/test/ops/moe/test_latent_tail_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_tail_contract.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.moe.latent_tail import (
+    KimiK3LatentTailOp,
+    _allocator_identity,
+    _tail_pool_slot,
+)
+
+
+def test_initialize_constructs_a_fresh_op(monkeypatch: pytest.MonkeyPatch) -> None:
+    constructed = []
+
+    def fake_init(self, *args, **kwargs) -> None:
+        constructed.append((self, args, kwargs))
+
+    monkeypatch.setattr(KimiK3LatentTailOp, "__init__", fake_init)
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.moe.latent_tail.dist.get_world_size", lambda group: 8
+    )
+    kwargs = {
+        "group": SimpleNamespace(group_name="test-group"),
+        "hidden_size": 7168,
+        "latent_size": 3584,
+        "rms_eps": 1e-6,
+        "device": torch.device("cuda", 0),
+        "layer_index": 1,
+        "model_scope": "model.layers",
+    }
+
+    first = KimiK3LatentTailOp.initialize(**kwargs)
+    second = KimiK3LatentTailOp.initialize(**kwargs)
+
+    assert first is not second
+    assert len(constructed) == 2
+
+
+def test_slot_binding_is_rank_identical_for_same_layer() -> None:
+    rank_zero_slot = _tail_pool_slot(31, 2)
+    rank_one_slot = _tail_pool_slot(31, 2)
+
+    assert rank_zero_slot == rank_one_slot
+
+
+def test_adjacent_layers_use_different_slots_at_depth_two() -> None:
+    assert _tail_pool_slot(31, 2) != _tail_pool_slot(32, 2)
+
+
+def test_k3_first_moe_layer_starts_at_logical_layer_one() -> None:
+    assert _tail_pool_slot(1, 2) == 1
+    assert _tail_pool_slot(2, 2) == 0
+    assert _tail_pool_slot(3, 2) == _tail_pool_slot(1, 2)
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3, 17])
+def test_slot_binding_has_exact_depth_reuse_spacing(depth: int) -> None:
+    slots = [_tail_pool_slot(layer, depth) for layer in range(depth * 2)]
+
+    assert slots[:depth] == slots[depth:]
+    assert len(set(slots[:depth])) == depth
+
+
+def test_base_and_draft_layer_namespaces_use_different_slot_bundles() -> None:
+    base_scope = "model.layers"
+    draft_scope = "model.decoder"
+    layer_index = 0
+
+    assert _tail_pool_slot(layer_index, 2) == _tail_pool_slot(layer_index, 2)
+    assert (base_scope, _tail_pool_slot(layer_index, 2)) != (
+        draft_scope,
+        _tail_pool_slot(layer_index, 2),
+    )
+
+
+def test_slot_binding_rejects_invalid_depth() -> None:
+    with pytest.raises(ValueError, match="greater than zero"):
+        _tail_pool_slot(0, 0)
+
+
+def test_allocator_identity_handles_builtin_bound_methods() -> None:
+    owner: list[object] = []
+
+    assert _allocator_identity(owner.append) is owner
+
+
+def test_lamport_copy_releases_successors_before_rearming() -> None:
+    """The gather must publish its result before re-arming sentinels.
+
+    Overlapping the sentinel re-arm with successor kernels is where the
+    barrier-free gather earns its latency; the pool depth, not this ordering,
+    is what keeps a peer from writing a slot that is still being cleaned.
+    """
+    source = (
+        Path(__file__).parents[3]
+        / "python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/lamport_copy.py"
+    ).read_text()
+    release = source.index("griddepcontrol_launch_dependents()")
+    cleanup = source.index("store_lamport_sentinel_128(source)")
+    assert release < cleanup

--- a/tokenspeed-kernel/test/ops/moe/test_latent_tail_distributed.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_tail_distributed.py
@@ -101,7 +101,8 @@ def test_latent_tail_matches_reference(m):
         latent_size=L,
         rms_eps=EPS,
         device=dev,
-        owner="test.match_reference",
+        layer_index=0,
+        model_scope="test",
     )
     routed, shared, rms_w, up_w = _inputs(rank, dev, m, seed=100)
     ref = _reference(routed, shared, rms_w, up_w)
@@ -123,7 +124,8 @@ def test_latent_tail_graph_replay():
         latent_size=L,
         rms_eps=EPS,
         device=dev,
-        owner="test.graph_replay",
+        layer_index=0,
+        model_scope="test",
     )
     routed, shared, rms_w, up_w = _inputs(rank, dev, 1, seed=200)
     for _ in range(3):
@@ -158,7 +160,8 @@ def test_latent_tail_fused_prefix_matches_eager(m):
         latent_size=L,
         rms_eps=EPS,
         device=dev,
-        owner="test.fused_prefix",
+        layer_index=0,
+        model_scope="test",
     )
     routed, shared, rms_w, up_w = _inputs(rank, dev, m, seed=700)
     torch.manual_seed(900 + rank)
@@ -192,7 +195,8 @@ def test_latent_tail_accepts_sharded_weight(m):
         latent_size=L,
         rms_eps=EPS,
         device=dev,
-        owner="test.sharded_weight",
+        layer_index=0,
+        model_scope="test",
     )
     routed, shared, rms_w, up_w = _inputs(rank, dev, m, seed=1100)
     shard = H // _world_size()


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
