### PR TITLE
fix(spec): preserve draft KV prewrite locations

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -148,12 +148,18 @@ class CacheGroupsMixin:
     def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
         """Per-group write locations for out-of-backend KV writers (fused
         RoPE prewrite): the write must land in the pages this layer's group
-        reads, never the scheduler's single-table locations.
+        reads, never the scheduler's single-table locations. Draft chains own
+        their per-step locations, so they must keep the caller-provided tensor.
         """
         metadata = self._prewrite_metadata(forward_mode)
         if metadata is None or metadata.out_cache_locs is None:
             return out_cache_loc
-        return self._select_out_cache_loc(layer, metadata, out_cache_loc)
+        return self._select_out_cache_loc(
+            layer,
+            metadata,
+            out_cache_loc,
+            prefer_caller=self.is_draft,
+        )
 
     def _shed_state_groups(self, tables):
         """Drop family="state" groups (GDN/mamba state blocks, consumed by the

--- a/test/runtime/test_group_write_locations.py
+++ b/test/runtime/test_group_write_locations.py
@@ -320,6 +320,7 @@ class SelectOutCacheLocTest(_MHACase):
     def setUp(self):
         super().setUp()
         backend = self.MHAAttnBackend.__new__(self.MHAAttnBackend)
+        backend.is_draft = False
         backend.forward_decode_metadata = None
         backend.forward_extend_metadata = None
         self.backend = backend
@@ -389,6 +390,21 @@ class SelectOutCacheLocTest(_MHACase):
             )
             is fb
         )
+
+    def test_public_select_preserves_draft_chain_locations(self):
+        torch = self.torch
+        metadata_loc = torch.tensor([6], dtype=torch.int32)
+        caller_loc = torch.tensor([99, 100, 101], dtype=torch.int32)
+        self.backend.is_draft = True
+        self.backend.forward_decode_metadata = SimpleNamespace(
+            out_cache_locs={"full_attention": metadata_loc}
+        )
+
+        got = self.backend.select_out_cache_loc(
+            SimpleNamespace(group_id="full_attention"), caller_loc
+        )
+
+        assert got is caller_loc
 
 
 _GROUP_IDS = ("sliding_attention", "full_attention")

--- a/test/runtime/test_trtllm_cache_groups.py
+++ b/test/runtime/test_trtllm_cache_groups.py
@@ -234,6 +234,21 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
             full_loc,
         )
 
+    def test_public_prewrite_preserves_draft_chain_locations(self):
+        b = self._bare_backend(spec_num_tokens=4)
+        metadata_loc = self.torch.tensor([64], dtype=self.torch.int32)
+        caller_loc = self.torch.tensor([7, 8, 9, 10], dtype=self.torch.int32)
+        b.is_draft = True
+        b.forward_decode_metadata = self.Metadata(
+            out_cache_locs={"full_attention": metadata_loc}
+        )
+
+        got = b.select_out_cache_loc(
+            self._layer("full_attention"), caller_loc, _DecodeMode()
+        )
+
+        self.assertIs(got, caller_loc)
+
     def test_decode_metadata_grouped_drops_single_table(self):
         b = self._bare_backend()
         bs = 2


### PR DESCRIPTION
## Summary

MiniMax-M3 EAGLE3 acceptance collapsed because fused draft KV prewrites were routed through grouped metadata containing one write location per request, rather than the drafter’s per-step locations. Preserve caller-owned locations for draft backends and cover the public MHA and TRT-LLM prewrite paths.

This restores the contract between draft KV prewrite and subsequent draft reads without changing target-model routing.

## Validation

- `pre-commit run --all-files`
- `git diff --check`
- `python -m compileall -q python/tokenspeed/runtime/layers/attention/backends/cache_groups.py test/runtime/test_group_write_locations.py test/runtime/test_trtllm_cache_groups.py`
- B200 runtime/unit-test matrix passed
- [Targeted MiniMax-M3 NVFP4 AIME25 Slurm run](https://github.com/lightseekorg/tokenspeed/actions/runs/31867699808): acceptance restored from `0.0824334` to `0.650481` (`1415` samples); AIME25 score `0.9` with threshold `>= 0.86`

Local targeted unit discovery was skipped because this host lacks `torch` / `tokenspeed_kernel`; the same runtime test suite executed successfully on B200 CI.

## CI note

The unrelated AMD GPT-OSS GPQA check failed because the worker registered `gpt-oss-120b-w-mxfp4-a-fp8` while the evaluator requested `amd/gpt-oss-120b-w-mxfp4-a-fp8`, producing a gateway `model_not_found` 404.