### PR TITLE
refactor(pd): clarify cache transfer contract ownership

### DIFF
--- a/python/tokenspeed/runtime/cache/transfer/layout.py
+++ b/python/tokenspeed/runtime/cache/transfer/layout.py
@@ -25,6 +25,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+    cache_field_layer_id,
+)
+
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
         CacheMemoryPlan,
@@ -59,17 +63,7 @@ def select_layer_fields(
     selected = set()
     consumers = [[] for _ in range(num_layers)]
     for field in fields:
-        parts = field.field_id.split(".", 2)
-        if len(parts) != 3 or parts[0] != "layer":
-            raise ValueError(
-                f"cache field {field.field_id!r} is not owned by a model layer"
-            )
-        try:
-            layer_id = int(parts[1])
-        except ValueError as exc:
-            raise ValueError(
-                f"cache field {field.field_id!r} has an invalid layer id"
-            ) from exc
+        layer_id = cache_field_layer_id(field.field_id)
         if first_layer <= layer_id < last_layer:
             selected.add(field.field_id)
             consumers[layer_id - first_layer].append(field.field_id)

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -85,6 +85,7 @@ from tokenspeed.runtime.pd.kv_events import (
 )
 from tokenspeed.runtime.pd.mooncake.entities import KVManagerArgs
 from tokenspeed.runtime.pd.prefill_executor import DisaggPrefillExecutor
+from tokenspeed.runtime.pd.topology import PDParallelTopology
 from tokenspeed.runtime.sampling.sampling_params import SamplingParams
 from tokenspeed.runtime.utils import (
     configure_logger,
@@ -193,6 +194,10 @@ class EventLoop:
         # Do not pass server_args further down the stack after this point.
 
         self.server_args = server_args
+        pd_topology = None
+        if server_args.disaggregation_mode != "null":
+            pd_topology = PDParallelTopology.from_mapping(server_args.mapping)
+            pd_topology.require_cache_pd_supported()
         self.port_args = port_args
         self.gpu_id = gpu_id
         self.global_rank = global_rank
@@ -563,6 +568,7 @@ class EventLoop:
             metrics=self.metrics,
         )
         if server_args.disaggregation_mode != "null":
+            assert pd_topology is not None
             kv_args = get_kv_args(
                 global_rank,
                 global_rank,
@@ -574,9 +580,7 @@ class EventLoop:
             pd_manager_args = KVManagerArgs(
                 bootstrap_port=server_args.disaggregation_bootstrap_port,
                 dist_init_addr=server_args.dist_init_addr,
-                world_size=server_args.world_size or mapping.world_size,
-                dp_size=server_args.data_parallel_size or mapping.attn.dp_size,
-                attn_tp_rank=attn_tp_rank,
+                topology=pd_topology,
                 enable_metrics=False,
                 served_model_name=server_args.served_model_name,
                 app_key=server_args.app_key,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
@@ -34,6 +34,20 @@ _MAX_LCM_BLOCK_BYTES = (1 << 63) - 1
 _MAX_KERNEL_PAGE_ID = (1 << 31) - 1
 
 
+def cache_field_layer_id(field_id: str) -> int:
+    """Return the owning model layer encoded in a cache field ID."""
+    parts = field_id.split(".", 2)
+    if len(parts) != 3 or parts[0] != "layer":
+        raise ValueError(f"cache field {field_id!r} is not owned by a model layer")
+    try:
+        layer_id = int(parts[1])
+    except ValueError as exc:
+        raise ValueError(f"cache field {field_id!r} has an invalid layer id") from exc
+    if layer_id < 0:
+        raise ValueError(f"cache field {field_id!r} has an invalid layer id")
+    return layer_id
+
+
 @dataclass(frozen=True)
 class CacheGroupLayout:
     group_id: str

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/transfer.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/transfer.py
@@ -128,6 +128,7 @@ def _text_config(model_config: ModelConfig):
         return text_config
     return getattr(model_config.hf_config, "text_config", model_config.hf_config)
 
+
 def _source_model(
     layer_id: int,
     *,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/transfer.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/transfer.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Cache-recipe transfer distribution schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+    CacheFieldLayout,
+    CacheMemoryPlan,
+    cache_field_layer_id,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    MXFP8_KV_SCALE_TILE_TOKENS,
+)
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.configs.model_config import ModelConfig
+
+
+@dataclass(frozen=True, slots=True)
+class CacheFieldPartition:
+    """Dense global-to-rank-local partitioning for one PD cache field."""
+
+    axis: int
+    global_extent: int
+    global_parts: tuple[int, ...] = ()
+
+    def validate(self, *, field_id: str, local_shape: tuple[int, ...]) -> None:
+        if (
+            isinstance(self.axis, bool)
+            or not isinstance(self.axis, int)
+            or not 0 <= self.axis < len(local_shape)
+            or isinstance(self.global_extent, bool)
+            or not isinstance(self.global_extent, int)
+            or self.global_extent < local_shape[self.axis]
+        ):
+            raise ValueError(f"cache field {field_id!r} has invalid partition geometry")
+        local_extent = local_shape[self.axis]
+        if self.global_extent % local_extent:
+            raise ValueError(
+                f"cache field {field_id!r} global partition extent is not "
+                "divisible by its local extent"
+            )
+        distinct_shards = self.global_extent // local_extent
+        if self.global_parts and (
+            len(self.global_parts) < 2
+            or len(self.global_parts) > 16
+            or any(
+                isinstance(part, bool)
+                or not isinstance(part, int)
+                or part <= 0
+                or part % distinct_shards
+                for part in self.global_parts
+            )
+            or sum(self.global_parts) != self.global_extent
+        ):
+            raise ValueError(
+                f"cache field {field_id!r} has invalid global partition parts"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class CacheFieldTransferSpec:
+    field_id: str
+    partition: CacheFieldPartition
+
+    def __post_init__(self) -> None:
+        if not self.field_id:
+            raise ValueError("cache transfer field_id must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class CacheTransferSchema:
+    """PD wire semantics omitted from the rank-local cache memory plan."""
+
+    fields: tuple[CacheFieldTransferSpec, ...] = ()
+
+    def __post_init__(self) -> None:
+        field_ids = tuple(field.field_id for field in self.fields)
+        if len(field_ids) != len(set(field_ids)):
+            raise ValueError("cache transfer schema contains a duplicate field")
+
+    def partition_for(self, field_id: str) -> CacheFieldPartition | None:
+        for field in self.fields:
+            if field.field_id == field_id:
+                return field.partition
+        return None
+
+    def validate(self, plan: CacheMemoryPlan) -> None:
+        planned_fields = {field.field_id: field for field in plan.fields}
+        unknown = {field.field_id for field in self.fields} - set(planned_fields)
+        if unknown:
+            raise ValueError(
+                f"cache transfer schema references unknown fields {sorted(unknown)}"
+            )
+        for transfer_field in self.fields:
+            field = planned_fields[transfer_field.field_id]
+            transfer_field.partition.validate(
+                field_id=field.field_id,
+                local_shape=field.shape,
+            )
+
+
+def _text_config(model_config: ModelConfig):
+    text_config = getattr(model_config, "hf_text_config", None)
+    if text_config is not None:
+        return text_config
+    return getattr(model_config.hf_config, "text_config", model_config.hf_config)
+
+def _source_model(
+    layer_id: int,
+    *,
+    model_config: ModelConfig,
+    draft_model_config: ModelConfig | None,
+) -> tuple[ModelConfig, int]:
+    target_layers = model_config.num_attention_layers
+    if layer_id < target_layers:
+        return model_config, layer_id
+    if draft_model_config is None:
+        raise ValueError(
+            f"PD cache field layer {layer_id} exceeds the target model without a draft"
+        )
+    draft_layer_id = layer_id - target_layers
+    if draft_layer_id >= draft_model_config.num_attention_layers:
+        raise ValueError(f"PD cache field layer {layer_id} exceeds the merged model")
+    return draft_model_config, draft_layer_id
+
+
+def _partition_for_field(
+    field: CacheFieldLayout,
+    *,
+    model_config: ModelConfig,
+    draft_model_config: ModelConfig | None,
+    prefix_granularity: int,
+    inkling_layers: frozenset[int],
+) -> CacheFieldPartition | None:
+    layer_id = cache_field_layer_id(field.field_id)
+    source_model, source_layer_id = _source_model(
+        layer_id,
+        model_config=model_config,
+        draft_model_config=draft_model_config,
+    )
+    suffix = field.field_id.split(".", 2)[2]
+
+    if layer_id in inkling_layers:
+        from tokenspeed.runtime.layers.attention.kv_cache.recipes.inkling import (
+            inkling_layer_kv_head_counts,
+        )
+
+        global_heads = inkling_layer_kv_head_counts(source_model)[source_layer_id]
+        if suffix in ("k", "v"):
+            return CacheFieldPartition(1, global_heads)
+        if suffix in ("k_scale", "v_scale"):
+            return CacheFieldPartition(0, global_heads)
+        if suffix.startswith("kvconv_"):
+            return CacheFieldPartition(1, global_heads * source_model.head_dim)
+        return None
+
+    if suffix in ("k", "v"):
+        return CacheFieldPartition(1, source_model.num_key_value_heads)
+    if suffix in ("k_scale", "v_scale"):
+        # Tiled mxfp8 scales are head-major; per-token scales are token-major.
+        axis = 0 if prefix_granularity == MXFP8_KV_SCALE_TILE_TOKENS else 1
+        return CacheFieldPartition(axis, source_model.num_key_value_heads)
+
+    text_config = _text_config(source_model)
+    if suffix in ("conv", "ssm") and hasattr(text_config, "linear_num_key_heads"):
+        key_width = text_config.linear_key_head_dim * text_config.linear_num_key_heads
+        value_width = (
+            text_config.linear_value_head_dim * text_config.linear_num_value_heads
+        )
+        if suffix == "conv":
+            return CacheFieldPartition(
+                0,
+                2 * key_width + value_width,
+                (key_width, key_width, value_width),
+            )
+        return CacheFieldPartition(0, text_config.linear_num_value_heads)
+
+    linear_config = getattr(text_config, "linear_attn_config", None)
+    if suffix in ("conv_state", "recurrent_state") and linear_config is not None:
+        num_heads = int(linear_config["num_heads"])
+        head_dim = int(linear_config["head_dim"])
+        if suffix == "conv_state":
+            width = num_heads * head_dim
+            return CacheFieldPartition(0, 3 * width, (width, width, width))
+        return CacheFieldPartition(0, num_heads)
+
+    return None
+
+
+def build_cache_transfer_schema(
+    plan: CacheMemoryPlan,
+    *,
+    model_config: ModelConfig,
+    draft_model_config: ModelConfig | None = None,
+) -> CacheTransferSchema:
+    """Compile model-specific PD distribution semantics beside a pure plan."""
+
+    inkling_layers = frozenset(
+        cache_field_layer_id(field.field_id)
+        for field in plan.fields
+        if field.field_id.split(".", 2)[-1].startswith("kvconv_")
+    )
+    fields = []
+    for field in plan.fields:
+        partition = _partition_for_field(
+            field,
+            model_config=model_config,
+            draft_model_config=draft_model_config,
+            prefix_granularity=plan.prefix_granularity,
+            inkling_layers=inkling_layers,
+        )
+        if partition is not None:
+            fields.append(CacheFieldTransferSpec(field.field_id, partition))
+    return CacheTransferSchema(tuple(fields))
+
+
+__all__ = [
+    "CacheFieldPartition",
+    "CacheFieldTransferSpec",
+    "CacheTransferSchema",
+    "build_cache_transfer_schema",
+]

--- a/python/tokenspeed/runtime/pd/cache_protocol.py
+++ b/python/tokenspeed/runtime/pd/cache_protocol.py
@@ -20,11 +20,11 @@
 
 """Paged cache transfer contract and per-request PD protocol.
 
-The cache recipe owns semantic group specs and the memory planner owns physical
-geometry. PD transports those objects directly instead of maintaining a second
-physical layout schema. The same module owns the transfer schema, request page
-manifests, producer-step projection, and peer validation so all derived PD cache
-control data stays beside the protocol that consumes it.
+The cache recipe owns semantic group specs and the transfer schema, while the
+memory planner owns physical geometry. PD transports those objects directly
+instead of maintaining a second physical layout schema. This module owns the
+wire contract, request block manifests, producer-step projection, and peer
+validation.
 """
 
 from __future__ import annotations
@@ -32,23 +32,26 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING
+from typing import Any
 
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldLayout,
     CacheGroupLayout,
     CacheMemoryPlan,
     CachePlaneLayout,
+    cache_field_layer_id,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    MXFP8_KV_SCALE_TILE_TOKENS,
     PagedCacheGroupSpec,
     Retention,
     TransferPolicy,
 )
-
-if TYPE_CHECKING:
-    from tokenspeed.runtime.configs.model_config import ModelConfig
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.transfer import (
+    CacheFieldPartition,
+    CacheFieldTransferSpec,
+    CacheTransferSchema,
+    build_cache_transfer_schema,
+)
 
 MAX_CACHE_CONTRACT_WIRE_BYTES = 256 << 10
 MAX_CACHE_MANIFEST_WIRE_BYTES = 2 << 20
@@ -81,221 +84,6 @@ def _load_wire_json(raw: bytes, *, name: str, maximum: int) -> dict:
     if not isinstance(value, dict):
         raise CacheContractError(f"{name} payload must be a JSON object")
     return value
-
-
-@dataclass(frozen=True, slots=True)
-class CacheFieldPartition:
-    """Dense global-to-rank-local partitioning for one PD cache field."""
-
-    axis: int
-    global_extent: int
-    global_parts: tuple[int, ...] = ()
-
-    def validate(self, *, field_id: str, local_shape: tuple[int, ...]) -> None:
-        if (
-            isinstance(self.axis, bool)
-            or not isinstance(self.axis, int)
-            or not 0 <= self.axis < len(local_shape)
-            or isinstance(self.global_extent, bool)
-            or not isinstance(self.global_extent, int)
-            or self.global_extent < local_shape[self.axis]
-        ):
-            raise ValueError(f"cache field {field_id!r} has invalid partition geometry")
-        local_extent = local_shape[self.axis]
-        if self.global_extent % local_extent:
-            raise ValueError(
-                f"cache field {field_id!r} global partition extent is not "
-                "divisible by its local extent"
-            )
-        distinct_shards = self.global_extent // local_extent
-        if self.global_parts and (
-            len(self.global_parts) < 2
-            or len(self.global_parts) > 16
-            or any(
-                isinstance(part, bool)
-                or not isinstance(part, int)
-                or part <= 0
-                or part % distinct_shards
-                for part in self.global_parts
-            )
-            or sum(self.global_parts) != self.global_extent
-        ):
-            raise ValueError(
-                f"cache field {field_id!r} has invalid global partition parts"
-            )
-
-
-@dataclass(frozen=True, slots=True)
-class CacheFieldTransferSpec:
-    field_id: str
-    partition: CacheFieldPartition
-
-    def __post_init__(self) -> None:
-        if not self.field_id:
-            raise ValueError("cache transfer field_id must be non-empty")
-
-
-@dataclass(frozen=True, slots=True)
-class CacheTransferSchema:
-    """PD wire semantics omitted from the rank-local cache memory plan."""
-
-    fields: tuple[CacheFieldTransferSpec, ...] = ()
-
-    def __post_init__(self) -> None:
-        field_ids = tuple(field.field_id for field in self.fields)
-        if len(field_ids) != len(set(field_ids)):
-            raise ValueError("cache transfer schema contains a duplicate field")
-
-    def partition_for(self, field_id: str) -> CacheFieldPartition | None:
-        for field in self.fields:
-            if field.field_id == field_id:
-                return field.partition
-        return None
-
-    def validate(self, plan: CacheMemoryPlan) -> None:
-        planned_fields = {field.field_id: field for field in plan.fields}
-        unknown = {field.field_id for field in self.fields} - set(planned_fields)
-        if unknown:
-            raise ValueError(
-                f"cache transfer schema references unknown fields {sorted(unknown)}"
-            )
-        for transfer_field in self.fields:
-            field = planned_fields[transfer_field.field_id]
-            transfer_field.partition.validate(
-                field_id=field.field_id,
-                local_shape=field.shape,
-            )
-
-
-def _text_config(model_config: ModelConfig):
-    text_config = getattr(model_config, "hf_text_config", None)
-    if text_config is not None:
-        return text_config
-    return getattr(model_config.hf_config, "text_config", model_config.hf_config)
-
-
-def _field_layer_id(field_id: str) -> int:
-    parts = field_id.split(".", 2)
-    if len(parts) != 3 or parts[0] != "layer":
-        raise ValueError(f"PD cache field {field_id!r} is not layer-owned")
-    try:
-        layer_id = int(parts[1])
-    except ValueError as exc:
-        raise ValueError(
-            f"PD cache field {field_id!r} has an invalid layer id"
-        ) from exc
-    if layer_id < 0:
-        raise ValueError(f"PD cache field {field_id!r} has an invalid layer id")
-    return layer_id
-
-
-def _source_model(
-    layer_id: int,
-    *,
-    model_config: ModelConfig,
-    draft_model_config: ModelConfig | None,
-) -> tuple[ModelConfig, int]:
-    target_layers = model_config.num_attention_layers
-    if layer_id < target_layers:
-        return model_config, layer_id
-    if draft_model_config is None:
-        raise ValueError(
-            f"PD cache field layer {layer_id} exceeds the target model without a draft"
-        )
-    draft_layer_id = layer_id - target_layers
-    if draft_layer_id >= draft_model_config.num_attention_layers:
-        raise ValueError(f"PD cache field layer {layer_id} exceeds the merged model")
-    return draft_model_config, draft_layer_id
-
-
-def _partition_for_field(
-    field: CacheFieldLayout,
-    *,
-    model_config: ModelConfig,
-    draft_model_config: ModelConfig | None,
-    prefix_granularity: int,
-    inkling_layers: frozenset[int],
-) -> CacheFieldPartition | None:
-    layer_id = _field_layer_id(field.field_id)
-    source_model, source_layer_id = _source_model(
-        layer_id,
-        model_config=model_config,
-        draft_model_config=draft_model_config,
-    )
-    suffix = field.field_id.split(".", 2)[2]
-
-    if layer_id in inkling_layers:
-        from tokenspeed.runtime.layers.attention.kv_cache.recipes.inkling import (
-            inkling_layer_kv_head_counts,
-        )
-
-        global_heads = inkling_layer_kv_head_counts(source_model)[source_layer_id]
-        if suffix in ("k", "v"):
-            return CacheFieldPartition(1, global_heads)
-        if suffix in ("k_scale", "v_scale"):
-            return CacheFieldPartition(0, global_heads)
-        if suffix.startswith("kvconv_"):
-            return CacheFieldPartition(1, global_heads * source_model.head_dim)
-        return None
-
-    if suffix in ("k", "v"):
-        return CacheFieldPartition(1, source_model.num_key_value_heads)
-    if suffix in ("k_scale", "v_scale"):
-        # Tiled mxfp8 scales are head-major; per-token scales are token-major.
-        axis = 0 if prefix_granularity == MXFP8_KV_SCALE_TILE_TOKENS else 1
-        return CacheFieldPartition(axis, source_model.num_key_value_heads)
-
-    text_config = _text_config(source_model)
-    if suffix in ("conv", "ssm") and hasattr(text_config, "linear_num_key_heads"):
-        key_width = text_config.linear_key_head_dim * text_config.linear_num_key_heads
-        value_width = (
-            text_config.linear_value_head_dim * text_config.linear_num_value_heads
-        )
-        if suffix == "conv":
-            return CacheFieldPartition(
-                0,
-                2 * key_width + value_width,
-                (key_width, key_width, value_width),
-            )
-        return CacheFieldPartition(0, text_config.linear_num_value_heads)
-
-    linear_config = getattr(text_config, "linear_attn_config", None)
-    if suffix in ("conv_state", "recurrent_state") and linear_config is not None:
-        num_heads = int(linear_config["num_heads"])
-        head_dim = int(linear_config["head_dim"])
-        if suffix == "conv_state":
-            width = num_heads * head_dim
-            return CacheFieldPartition(0, 3 * width, (width, width, width))
-        return CacheFieldPartition(0, num_heads)
-
-    return None
-
-
-def build_cache_transfer_schema(
-    plan: CacheMemoryPlan,
-    *,
-    model_config: ModelConfig,
-    draft_model_config: ModelConfig | None = None,
-) -> CacheTransferSchema:
-    """Compile model-specific PD distribution semantics beside a pure plan."""
-
-    inkling_layers = frozenset(
-        _field_layer_id(field.field_id)
-        for field in plan.fields
-        if field.field_id.split(".", 2)[-1].startswith("kvconv_")
-    )
-    fields = []
-    for field in plan.fields:
-        partition = _partition_for_field(
-            field,
-            model_config=model_config,
-            draft_model_config=draft_model_config,
-            prefix_granularity=plan.prefix_granularity,
-            inkling_layers=inkling_layers,
-        )
-        if partition is not None:
-            fields.append(CacheFieldTransferSpec(field.field_id, partition))
-    return CacheTransferSchema(tuple(fields))
 
 
 @dataclass(frozen=True, slots=True)
@@ -487,7 +275,7 @@ def build_cache_fields_by_producer_step(
 
     fields_by_layer: dict[int, list[str]] = {}
     for field in plan.fields:
-        layer_id = _field_layer_id(field.field_id)
+        layer_id = cache_field_layer_id(field.field_id)
         fields_by_layer.setdefault(layer_id, []).append(field.field_id)
 
     if not fields_by_layer:
@@ -519,32 +307,32 @@ def build_cache_fields_by_producer_step(
 
 
 @dataclass(frozen=True, slots=True)
-class CachePDGroupPages:
+class CachePDGroupBlocks:
     group_id: str
-    page_ids: tuple[int, ...]
+    block_ids: tuple[int, ...]
 
 
 @dataclass(frozen=True, slots=True)
-class CachePDPageManifest:
-    groups: tuple[CachePDGroupPages, ...]
+class CachePDBlockManifest:
+    groups: tuple[CachePDGroupBlocks, ...]
     prefix_len: int
     prompt_len: int
 
     def to_wire_bytes(self) -> bytes:
         return _dump_wire_json(
             self,
-            name="Paged cache manifest",
+            name="Cache block manifest",
             maximum=MAX_CACHE_MANIFEST_WIRE_BYTES,
         )
 
     @classmethod
-    def from_wire_bytes(cls, raw: bytes) -> "CachePDPageManifest":
+    def from_wire_bytes(cls, raw: bytes) -> "CachePDBlockManifest":
         payload = _load_wire_json(
-            raw, name="Paged cache manifest", maximum=MAX_CACHE_MANIFEST_WIRE_BYTES
+            raw, name="Cache block manifest", maximum=MAX_CACHE_MANIFEST_WIRE_BYTES
         )
         return cls(
             groups=tuple(
-                CachePDGroupPages(group["group_id"], tuple(group["page_ids"]))
+                CachePDGroupBlocks(group["group_id"], tuple(group["block_ids"]))
                 for group in payload["groups"]
             ),
             prefix_len=payload["prefix_len"],
@@ -554,15 +342,15 @@ class CachePDPageManifest:
 
 @dataclass(frozen=True, slots=True)
 class CachePDLayerwiseGroupSelection:
-    """Source pages for one group and their positions in Decode's manifest."""
+    """Source blocks for one group and their positions in Decode's manifest."""
 
-    source_page_ids: tuple[int, ...]
+    source_block_ids: tuple[int, ...]
     destination_positions: tuple[int, ...]
 
 
 @dataclass(frozen=True, slots=True)
-class CachePDLayerwisePageSelection:
-    """One prompt chunk's group-aware source-to-destination page selection.
+class CachePDLayerwiseBlockSelection:
+    """One prompt chunk's group-aware source-to-destination block selection.
 
     This object stays process-local on Prefill. Decode publishes the full
     request manifest once; each queued layerwise chunk references positions in
@@ -585,7 +373,7 @@ def _logical_slots(
         begin = prefix_len // block_granularity
         if retention == "sliding_window":
             # The next decode token can attend the preceding window - 1 raw
-            # tokens. Include every slot intersecting that retained tail.
+            # tokens. Include every group block intersecting that retained tail.
             retained_begin = max(0, prompt_len - sliding_window_tokens + 1)
             begin = max(begin, retained_begin // block_granularity)
         end = (prompt_len + block_granularity - 1) // block_granularity
@@ -654,7 +442,7 @@ def validate_cache_peer_layout(
 
 
 def validate_cache_manifest(
-    manifest: CachePDPageManifest,
+    manifest: CachePDBlockManifest,
     *,
     layout: CacheTransferContract,
     peer: str,
@@ -666,7 +454,9 @@ def validate_cache_manifest(
     if actual != expected:
         raise CacheContractError(f"{peer} manifest group order disagrees with layout")
     if manifest.prefix_len % layout.plan.prefix_granularity:
-        raise CacheContractError(f"{peer} manifest prefix_len is not page aligned")
+        raise CacheContractError(
+            f"{peer} manifest prefix_len is not aligned to prefix_granularity"
+        )
     for group, spec in zip(manifest.groups, layout.group_specs, strict=True):
         required = _logical_slots(
             spec.transfer_policy,
@@ -676,31 +466,33 @@ def validate_cache_manifest(
             spec.retention,
             spec.sliding_window_tokens,
         )
-        if len(group.page_ids) != len(required):
+        if len(group.block_ids) != len(required):
             raise CacheContractError(
-                f"{peer} manifest group {group.group_id!r} page count disagrees "
+                f"{peer} manifest group {group.group_id!r} block count disagrees "
                 "with its transfer policy"
             )
         group_capacity = layout.plan.group(spec.group_id).page_count
-        if any(page <= 0 or page >= group_capacity for page in group.page_ids):
+        if any(block <= 0 or block >= group_capacity for block in group.block_ids):
             raise CacheContractError(
-                f"{peer} manifest group {group.group_id!r} has an out-of-bounds page"
+                f"{peer} manifest group {group.group_id!r} has an out-of-bounds block"
             )
 
 
-def build_cache_page_manifest(
+def build_cache_block_manifest(
     forward_op: object,
     *,
     layout: CacheTransferContract,
     request_row: int,
     prefix_len: int,
     prompt_len: int,
-) -> CachePDPageManifest:
-    """Select each group's pages according to its explicit transfer policy."""
+) -> CachePDBlockManifest:
+    """Select each group's blocks according to its explicit transfer policy."""
     if prefix_len >= prompt_len:
         raise CacheContractError("Paged cache PD requires prefix_len < prompt_len")
     if prefix_len % layout.plan.prefix_granularity:
-        raise CacheContractError("Paged cache PD prefix_len must be page aligned")
+        raise CacheContractError(
+            "Paged cache PD prefix_len must be aligned to prefix_granularity"
+        )
     mapping = forward_op.block_tables_arrays()  # type: ignore[attr-defined]
     expected_ids = {group.group_id for group in layout.group_specs}
     if set(mapping) != expected_ids:
@@ -710,7 +502,7 @@ def build_cache_page_manifest(
             f"extra={sorted(set(mapping) - expected_ids)}"
         )
 
-    groups: list[CachePDGroupPages] = []
+    groups: list[CachePDGroupBlocks] = []
     for spec in layout.group_specs:
         table = mapping[spec.group_id]
         logical_slots = _logical_slots(
@@ -725,28 +517,28 @@ def build_cache_page_manifest(
             raise CacheContractError(
                 f"table {spec.group_id!r} misses logical slot " f"{logical_slots[-1]}"
             )
-        page_ids = tuple(
+        block_ids = tuple(
             int(table[request_row, logical_slot]) for logical_slot in logical_slots
         )
-        for logical_slot, page_id in zip(logical_slots, page_ids, strict=True):
+        for logical_slot, block_id in zip(logical_slots, block_ids, strict=True):
             group_capacity = layout.plan.group(spec.group_id).page_count
-            if page_id <= 0 or page_id >= group_capacity:
+            if block_id <= 0 or block_id >= group_capacity:
                 raise CacheContractError(
                     f"table {spec.group_id!r} logical slot {logical_slot} "
-                    f"has invalid page ID {page_id}"
+                    f"has invalid block ID {block_id}"
                 )
         groups.append(
-            CachePDGroupPages(
+            CachePDGroupBlocks(
                 spec.group_id,
-                page_ids,
+                block_ids,
             )
         )
-    return CachePDPageManifest(
+    return CachePDBlockManifest(
         groups=tuple(groups), prefix_len=prefix_len, prompt_len=prompt_len
     )
 
 
-def build_cache_layerwise_page_selection(
+def build_cache_layerwise_block_selection(
     forward_op: object,
     *,
     layout: CacheTransferContract,
@@ -755,16 +547,18 @@ def build_cache_layerwise_page_selection(
     prompt_len: int,
     chunk_start: int,
     chunk_end: int,
-) -> CachePDLayerwisePageSelection:
-    """Select pages that became transferable during one Prefill chunk.
+) -> CachePDLayerwiseBlockSelection:
+    """Select blocks that became transferable during one Prefill chunk.
 
-    Full-suffix groups publish newly completed retained pages (plus the final
-    partial page). Latest-snapshot groups publish only the prompt's final
+    Full-suffix groups publish newly completed retained blocks (plus the final
+    partial block). Latest-snapshot groups publish only the prompt's final
     snapshot. The returned destination positions refer to Decode's immutable
     full manifest.
     """
     if prefix_len % layout.plan.prefix_granularity:
-        raise CacheContractError("Paged cache PD prefix_len must be page aligned")
+        raise CacheContractError(
+            "Paged cache PD prefix_len must be aligned to prefix_granularity"
+        )
     if prefix_len >= prompt_len:
         raise CacheContractError("layerwise selection requires prefix_len < prompt_len")
     if chunk_start >= chunk_end:
@@ -827,40 +621,42 @@ def build_cache_layerwise_page_selection(
             raise CacheContractError(
                 f"table {spec.group_id!r} misses logical slot " f"{logical_slots[-1]}"
             )
-        source_page_ids = tuple(
+        source_block_ids = tuple(
             int(table[request_row, logical_slot]) for logical_slot in logical_slots
         )
         group_capacity = layout.plan.group(spec.group_id).page_count
-        for logical_slot, page_id in zip(logical_slots, source_page_ids, strict=True):
-            if page_id <= 0 or page_id >= group_capacity:
+        for logical_slot, block_id in zip[Any](
+            logical_slots, source_block_ids, strict=True
+        ):
+            if block_id <= 0 or block_id >= group_capacity:
                 raise CacheContractError(
                     f"table {spec.group_id!r} logical slot {logical_slot} "
-                    f"has invalid page ID {page_id}"
+                    f"has invalid block ID {block_id}"
                 )
         selections.append(
             CachePDLayerwiseGroupSelection(
-                source_page_ids=source_page_ids,
+                source_block_ids=source_block_ids,
                 destination_positions=destination_positions,
             )
         )
 
-    return CachePDLayerwisePageSelection(groups=tuple(selections))
+    return CachePDLayerwiseBlockSelection(groups=tuple(selections))
 
 
 __all__ = [
     "CacheContractError",
     "CacheFieldPartition",
     "CacheFieldTransferSpec",
-    "CachePDGroupPages",
+    "CachePDBlockManifest",
+    "CachePDGroupBlocks",
     "CachePDLayerwiseGroupSelection",
-    "CachePDLayerwisePageSelection",
-    "CachePDPageManifest",
+    "CachePDLayerwiseBlockSelection",
     "CacheProducerSchedule",
     "CacheTransferContract",
     "CacheTransferSchema",
     "build_cache_fields_by_producer_step",
-    "build_cache_layerwise_page_selection",
-    "build_cache_page_manifest",
+    "build_cache_block_manifest",
+    "build_cache_layerwise_block_selection",
     "build_cache_transfer_schema",
     "build_cache_transfer_contract",
     "build_pool_cache_transfer_contract",

--- a/python/tokenspeed/runtime/pd/cache_protocol.py
+++ b/python/tokenspeed/runtime/pd/cache_protocol.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
-from typing import Any
 
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldLayout,
@@ -515,7 +514,7 @@ def build_cache_block_manifest(
         )
         if logical_slots and logical_slots[-1] >= table.shape[1]:
             raise CacheContractError(
-                f"table {spec.group_id!r} misses logical slot " f"{logical_slots[-1]}"
+                f"table {spec.group_id!r} misses logical slot {logical_slots[-1]}"
             )
         block_ids = tuple(
             int(table[request_row, logical_slot]) for logical_slot in logical_slots
@@ -619,15 +618,13 @@ def build_cache_layerwise_block_selection(
             logical_slots = (final_slots[0],) if is_final else ()
         if logical_slots and logical_slots[-1] >= table.shape[1]:
             raise CacheContractError(
-                f"table {spec.group_id!r} misses logical slot " f"{logical_slots[-1]}"
+                f"table {spec.group_id!r} misses logical slot {logical_slots[-1]}"
             )
         source_block_ids = tuple(
             int(table[request_row, logical_slot]) for logical_slot in logical_slots
         )
         group_capacity = layout.plan.group(spec.group_id).page_count
-        for logical_slot, block_id in zip[Any](
-            logical_slots, source_block_ids, strict=True
-        ):
+        for logical_slot, block_id in zip(logical_slots, source_block_ids, strict=True):
             if block_id <= 0 or block_id >= group_capacity:
                 raise CacheContractError(
                     f"table {spec.group_id!r} logical slot {logical_slot} "

--- a/python/tokenspeed/runtime/pd/decode_executor.py
+++ b/python/tokenspeed/runtime/pd/decode_executor.py
@@ -24,7 +24,7 @@ from tokenspeed_scheduler import PD, Forward
 
 from tokenspeed.runtime.pd.base.bootstrap import BootstrapInfo
 from tokenspeed.runtime.pd.base.status import TransferPoll
-from tokenspeed.runtime.pd.cache_protocol import build_cache_page_manifest
+from tokenspeed.runtime.pd.cache_protocol import build_cache_block_manifest
 from tokenspeed.runtime.pd.mooncake.decode import MooncakeKVManagerDecode
 from tokenspeed.runtime.pd.mooncake.receiver import MooncakeKVReceiver
 from tokenspeed.runtime.pd.utils import poll_and_all_reduce
@@ -69,7 +69,7 @@ class DisaggDecodeExecutor:
             if receiver is None:
                 continue
             prefix_len = int(op.extend_prefix_lens[index])
-            manifest = build_cache_page_manifest(
+            block_manifest = build_cache_block_manifest(
                 op,
                 layout=self.cache_layout,
                 request_row=index,
@@ -81,15 +81,15 @@ class DisaggDecodeExecutor:
                     request_id,
                     receiver,
                     op.request_pool_indices[index],
-                    manifest,
+                    block_manifest,
                 )
             )
 
         # Validate every row before publishing any destination manifest. A later
         # invalid row must not leave an earlier Prefill sender waiting forever.
-        for request_id, receiver, request_pool_index, manifest in pending:
+        for request_id, receiver, request_pool_index, block_manifest in pending:
             self._request_pool_indices[request_id] = request_pool_index
-            receiver.prefill(page_manifest=manifest)
+            receiver.prefill(block_manifest=block_manifest)
 
     def register(
         self,

--- a/python/tokenspeed/runtime/pd/factory.py
+++ b/python/tokenspeed/runtime/pd/factory.py
@@ -20,9 +20,11 @@
 
 """Factories for PD KV transfer helpers."""
 
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.transfer import (
+    build_cache_transfer_schema,
+)
 from tokenspeed.runtime.pd.cache_protocol import (
     build_cache_fields_by_producer_step,
-    build_cache_transfer_schema,
     build_pool_cache_transfer_contract,
 )
 from tokenspeed.runtime.pd.decode_executor import DisaggDecodeExecutor

--- a/python/tokenspeed/runtime/pd/mooncake/conn.py
+++ b/python/tokenspeed/runtime/pd/mooncake/conn.py
@@ -44,13 +44,12 @@ class MooncakeKVManagerBase(DisaggManagerBase):
         disaggregation_mode: DisaggregationMode,
     ):
         self.kv_args = kv_args
-        self.attn_tp_rank = args.attn_tp_rank
+        self.topology = args.topology
+        self.topology.require_cache_pd_supported()
         self.disaggregation_mode = disaggregation_mode
         self.bootstrap_port = args.bootstrap_port
         self.dist_init_addr = args.dist_init_addr
-        self.world_size = args.world_size
-        self.dp_size = args.dp_size
-        if not args.enable_dp_attention and args.dp_size != 1:
+        if not args.enable_dp_attention and self.topology.dp_size != 1:
             raise ValueError(
                 "If dp_attention is not enabled, dp size must be 1 in disaggregation mode."
             )

--- a/python/tokenspeed/runtime/pd/mooncake/entities.py
+++ b/python/tokenspeed/runtime/pd/mooncake/entities.py
@@ -22,11 +22,12 @@ import dataclasses
 import struct
 
 from tokenspeed.runtime.pd.cache_protocol import (
-    CachePDLayerwisePageSelection,
-    CachePDPageManifest,
+    CachePDBlockManifest,
+    CachePDLayerwiseBlockSelection,
     CacheProducerSchedule,
     CacheTransferContract,
 )
+from tokenspeed.runtime.pd.topology import PDParallelTopology
 from tokenspeed.runtime.pd.transfer_plan import (
     MAX_PAGED_CACHE_TP_SIZE,
     CacheTransferFragment,
@@ -86,10 +87,10 @@ class TransferKVChunk:
     layerwise_interval: int = 1
     wait_for_bootstrap_token: bool = False
     spec_candidate_ids: list[int] | None = None
-    page_manifest: CachePDPageManifest | None = None
-    # Process-local group-aware page window for CachePD layerwise transfer.
+    block_manifest: CachePDBlockManifest | None = None
+    # Process-local group-aware block window for CachePD layerwise transfer.
     # Decode continues to publish one immutable full request manifest.
-    cache_page_selection: CachePDLayerwisePageSelection | None = None
+    cache_block_selection: CachePDLayerwiseBlockSelection | None = None
 
 
 # decode
@@ -99,11 +100,11 @@ class TransferInfo:
 
     room: int
     mooncake_session_id: str
-    page_manifest: CachePDPageManifest | None = None
+    block_manifest: CachePDBlockManifest | None = None
 
     @property
     def is_dummy(self) -> bool:
-        return self.page_manifest is None
+        return self.block_manifest is None
 
     @staticmethod
     def route_header_from_zmq(msg: list[bytes]) -> tuple[int, str]:
@@ -120,11 +121,13 @@ class TransferInfo:
     @classmethod
     def from_zmq(cls, msg: list[bytes]):
         room, session_id = cls.route_header_from_zmq(msg)
-        page_manifest = CachePDPageManifest.from_wire_bytes(msg[2]) if msg[2] else None
+        block_manifest = (
+            CachePDBlockManifest.from_wire_bytes(msg[2]) if msg[2] else None
+        )
         return cls(
             room=room,
             mooncake_session_id=session_id,
-            page_manifest=page_manifest,
+            block_manifest=block_manifest,
         )
 
 
@@ -196,9 +199,7 @@ class KVManagerArgs:
     bootstrap_port: int
     dist_init_addr: str
 
-    world_size: int
-    dp_size: int
-    attn_tp_rank: int
+    topology: PDParallelTopology
 
     enable_metrics: bool
     enable_dp_attention: bool

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -33,8 +33,8 @@ import requests
 
 from tokenspeed.runtime.pd.base.status import TransferPoll
 from tokenspeed.runtime.pd.cache_protocol import (
-    CachePDLayerwisePageSelection,
-    CachePDPageManifest,
+    CachePDBlockManifest,
+    CachePDLayerwiseBlockSelection,
     CacheProducerSchedule,
     CacheTransferContract,
     validate_cache_manifest,
@@ -288,8 +288,8 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         """Validate and cache the route owned by this Prefill rank once."""
         layout = self.kv_args.cache_layout
         peer_layout = registration.peer_cache_layout
-        prefill_tp_size = self.world_size // self.dp_size
-        local_tp_rank = self.attn_tp_rank % prefill_tp_size
+        prefill_tp_size = self.topology.tp_size
+        local_tp_rank = self.topology.tp_rank
         planner = PagedCacheTransferPlanner(
             prefill_tp_size=prefill_tp_size,
             decode_tp_size=registration.decode_tp_size,
@@ -350,11 +350,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         self,
         *,
         dst_ptr: int,
-        src_manifest: CachePDPageManifest | None,
-        dst_manifest: CachePDPageManifest,
+        src_block_manifest: CachePDBlockManifest | None,
+        dst_block_manifest: CachePDBlockManifest,
         transfer_fragments: tuple[CacheTransferFragment, ...] = (),
         dst_cache_layout: CacheTransferContract,
-        page_selection: CachePDLayerwisePageSelection | None = None,
+        block_selection: CachePDLayerwiseBlockSelection | None = None,
         field_ids: frozenset[str] | None = None,
     ) -> Iterator[tuple[int, int, int]]:
         layout = self.kv_args.cache_layout
@@ -372,33 +372,35 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         for fragment in cache_fragments:
             fragments_by_group[fragment.group_id].append(fragment)
 
-        # Resolve page ids directly from the validated manifest/selection. This
-        # leaves one authoritative representation of the request's page map.
+        # Resolve block ids directly from the validated manifest/selection. This
+        # leaves one authoritative representation of the request's block map.
         group_transfers = []
         source_groups = (
-            page_selection.groups if page_selection is not None else src_manifest.groups
+            block_selection.groups
+            if block_selection is not None
+            else src_block_manifest.groups
         )
         for group_spec, src_group, dst_group in zip(
-            layout.group_specs, source_groups, dst_manifest.groups, strict=True
+            layout.group_specs, source_groups, dst_block_manifest.groups, strict=True
         ):
-            source_page_ids = (
-                src_group.source_page_ids
-                if page_selection is not None
-                else src_group.page_ids
+            source_block_ids = (
+                src_group.source_block_ids
+                if block_selection is not None
+                else src_group.block_ids
             )
-            destination_page_ids = (
+            destination_block_ids = (
                 tuple(
-                    dst_group.page_ids[position]
+                    dst_group.block_ids[position]
                     for position in src_group.destination_positions
                 )
-                if page_selection is not None
-                else dst_group.page_ids
+                if block_selection is not None
+                else dst_group.block_ids
             )
             group_transfers.append(
                 (
                     group_spec,
-                    source_page_ids,
-                    destination_page_ids,
+                    source_block_ids,
+                    destination_block_ids,
                 )
             )
 
@@ -517,7 +519,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         reqs: tuple[TransferInfo, ...],
     ) -> bool:
         """Wait one producer interval, then fan it out to every Decode peer."""
-        selection = kv_chunk.cache_page_selection
+        block_selection = kv_chunk.cache_block_selection
 
         registered_reqs = []
         for req in reqs:
@@ -562,14 +564,14 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             # Start every peer's lazy generator before transferring this interval.
             prepared = []
             for req, registration in registered_reqs:
-                assert req.page_manifest is not None
+                assert req.block_manifest is not None
                 blocks = self._cache_transfer_blocks(
                     dst_ptr=registration.dst_kv_ptr,
-                    src_manifest=None,
-                    dst_manifest=req.page_manifest,
+                    src_block_manifest=None,
+                    dst_block_manifest=req.block_manifest,
                     transfer_fragments=registration.transfer_fragments,
                     dst_cache_layout=registration.peer_cache_layout,
-                    page_selection=selection,
+                    block_selection=block_selection,
                     field_ids=producer_schedule.fields_in_range(begin_step, end_step),
                 )
                 prepared.append(
@@ -618,7 +620,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 registration.dst_port,
                 req.room,
                 TransferPoll.Success,
-                self.attn_tp_rank,
+                self.topology.tp_rank,
                 bootstrap_token=bootstrap_token,
                 spec_candidate_ids=spec_candidate_ids,
             )
@@ -691,7 +693,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                         dst_port,
                         req.room,
                         TransferPoll.Failed,
-                        self.attn_tp_rank,
+                        self.topology.tp_rank,
                     )
                 except Exception:
                     logger.exception(
@@ -719,7 +721,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                         self.transfer_infos.pop(kv_chunk.room, None)
                     continue
 
-                if kv_chunk.cache_page_selection is not None:
+                if kv_chunk.cache_block_selection is not None:
                     self._send_cache_layerwise_fanout(kv_chunk, reqs)
                     if kv_chunk.room not in self.request_status or self.check_status(
                         kv_chunk.room
@@ -739,11 +741,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                                 f"Decode session {req.mooncake_session_id} is not alive"
                             )
                     registration = self.get_decode_registration(req)
-                    assert req.page_manifest is not None
+                    assert req.block_manifest is not None
                     blocks = self._cache_transfer_blocks(
                         dst_ptr=registration.dst_kv_ptr,
-                        src_manifest=kv_chunk.page_manifest,
-                        dst_manifest=req.page_manifest,
+                        src_block_manifest=kv_chunk.block_manifest,
+                        dst_block_manifest=req.block_manifest,
                         transfer_fragments=registration.transfer_fragments,
                         dst_cache_layout=registration.peer_cache_layout,
                     )
@@ -794,7 +796,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                         registration.dst_port,
                         req.room,
                         TransferPoll.Success,
-                        self.attn_tp_rank,
+                        self.topology.tp_rank,
                         bootstrap_token=bootstrap_token,
                         spec_candidate_ids=spec_candidate_ids,
                     )
@@ -870,12 +872,12 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     registration.dst_port,
                     parsed_room,
                     TransferPoll.Failed,
-                    self.attn_tp_rank,
+                    self.topology.tp_rank,
                 )
                 return
-            if transfer_info.page_manifest is not None:
+            if transfer_info.block_manifest is not None:
                 validate_cache_manifest(
-                    transfer_info.page_manifest,
+                    transfer_info.block_manifest,
                     layout=registration.peer_cache_layout,
                     peer="destination",
                 )
@@ -924,7 +926,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     dst_port,
                     parsed_room,
                     TransferPoll.Failed,
-                    self.attn_tp_rank,
+                    self.topology.tp_rank,
                 )
             except Exception:
                 logger.exception(
@@ -944,7 +946,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 registration.dst_port,
                 parsed_room,
                 TransferPoll.Failed,
-                self.attn_tp_rank,
+                self.topology.tp_rank,
             )
             return
         complete = len(candidate_infos) == expected_fanout
@@ -1003,8 +1005,8 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         layerwise_interval: int = 1,
         wait_for_bootstrap_token: bool = False,
         spec_candidate_ids: list[int] | None = None,
-        page_manifest: CachePDPageManifest | None = None,
-        cache_page_selection: CachePDLayerwisePageSelection | None = None,
+        block_manifest: CachePDBlockManifest | None = None,
+        cache_block_selection: CachePDLayerwiseBlockSelection | None = None,
     ):
         if self.disaggregation_mode != DisaggregationMode.PREFILL:
             raise RuntimeError("Transfer requests can only be added in prefill mode.")
@@ -1039,8 +1041,8 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 layerwise_interval=layerwise_interval,
                 wait_for_bootstrap_token=wait_for_bootstrap_token,
                 spec_candidate_ids=spec_candidate_ids,
-                page_manifest=page_manifest,
-                cache_page_selection=cache_page_selection,
+                block_manifest=block_manifest,
+                cache_block_selection=cache_block_selection,
             )
         )
 
@@ -1055,11 +1057,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         url = f"http://{bootstrap_server_url}/route"
         payload = {
             "role": "Prefill",
-            "world_size": self.world_size,
-            "dp_size": self.dp_size,
+            "world_size": self.topology.world_size,
+            "dp_size": self.topology.dp_size,
             "rank_ip": get_local_ip_by_remote(),
             "rank_port": self.rank_port,
-            "engine_rank": self.kv_args.engine_rank,
+            "engine_rank": self.topology.global_rank,
             "cache_layout": self.kv_args.cache_layout.to_wire_bytes().decode("ascii"),
         }
 

--- a/python/tokenspeed/runtime/pd/mooncake/receiver.py
+++ b/python/tokenspeed/runtime/pd/mooncake/receiver.py
@@ -30,7 +30,7 @@ import zmq
 
 from tokenspeed.runtime.pd.base.status import TransferPoll
 from tokenspeed.runtime.pd.cache_protocol import (
-    CachePDPageManifest,
+    CachePDBlockManifest,
     CacheTransferContract,
     validate_cache_manifest,
 )
@@ -121,13 +121,13 @@ class ReceiverRoutePlan:
 
 def _calc(kv_mgr, prefill_parallel_info: PrefillParallelInfo) -> ReceiverRoutePlan:
     prefill_tp_size_per_dp_rank = prefill_parallel_info.prefill_tp_size_per_dp_rank
-    local_tp_size_per_dp_rank = kv_mgr.world_size // kv_mgr.dp_size
+    local_tp_size_per_dp_rank = kv_mgr.topology.tp_size
     local_cache_layout = kv_mgr.kv_args.cache_layout
     prefill_cache_layout = prefill_parallel_info.cache_layout
 
     if prefill_cache_layout is None:
         raise RuntimeError("Paged cache decode connected to a non-Paged cache prefill")
-    decode_tp_rank = kv_mgr.kv_args.engine_rank % local_tp_size_per_dp_rank
+    decode_tp_rank = kv_mgr.topology.tp_rank
     planner = PagedCacheTransferPlanner(
         prefill_tp_size=prefill_tp_size_per_dp_rank,
         decode_tp_size=local_tp_size_per_dp_rank,
@@ -281,8 +281,8 @@ class MooncakeKVReceiver:
             )
             packed_kv_data_ptr = struct.pack("Q", self.kv_mgr.kv_args.kv_data_ptr)
             cache_layout = self.kv_mgr.kv_args.cache_layout
-            decode_tp_size = self.kv_mgr.world_size // self.kv_mgr.dp_size
-            decode_tp_rank = self.kv_mgr.kv_args.engine_rank % decode_tp_size
+            decode_tp_size = self.kv_mgr.topology.tp_size
+            decode_tp_rank = self.kv_mgr.topology.tp_rank
 
             sock, lock = self._connect("tcp://" + self.prefill_server_url)
             with lock:
@@ -311,17 +311,17 @@ class MooncakeKVReceiver:
 
     def prefill(
         self,
-        page_manifest: CachePDPageManifest | None = None,
+        block_manifest: CachePDBlockManifest | None = None,
     ):
         logger.info(
             "[MooncakeKVReceiver.init] bootstrap_room=%s",
             self.bootstrap_room,
         )
         cache_layout = self.kv_mgr.kv_args.cache_layout
-        if page_manifest is None:
-            raise ValueError("Mooncake PD requires a page manifest")
+        if block_manifest is None:
+            raise ValueError("Mooncake PD requires a block manifest")
         validate_cache_manifest(
-            page_manifest,
+            block_manifest,
             layout=cache_layout,
             peer="destination",
         )
@@ -345,7 +345,7 @@ class MooncakeKVReceiver:
                 message_parts = [
                     str(self.bootstrap_room).encode("ascii"),
                     self.session_id.encode("ascii"),
-                    page_manifest.to_wire_bytes() if not is_dummy else b"",
+                    block_manifest.to_wire_bytes() if not is_dummy else b"",
                 ]
                 sock.send_multipart(message_parts)
 

--- a/python/tokenspeed/runtime/pd/mooncake/sender.py
+++ b/python/tokenspeed/runtime/pd/mooncake/sender.py
@@ -22,8 +22,8 @@ import time
 
 from tokenspeed.runtime.pd.base.status import TransferPoll
 from tokenspeed.runtime.pd.cache_protocol import (
-    CachePDLayerwisePageSelection,
-    CachePDPageManifest,
+    CachePDBlockManifest,
+    CachePDLayerwiseBlockSelection,
 )
 from tokenspeed.runtime.pd.mooncake.entities import KVTransferError
 from tokenspeed.runtime.utils import get_colorful_logger
@@ -65,7 +65,7 @@ class MooncakeKVSender:
         is_last,
         bootstrap_token: int = -1,
         spec_candidate_ids: list[int] | None = None,
-        page_manifest: CachePDPageManifest | None = None,
+        block_manifest: CachePDBlockManifest | None = None,
     ):
         """Submit one final, manifest-backed CachePD transfer."""
         if not is_last:
@@ -83,7 +83,7 @@ class MooncakeKVSender:
             True,
             bootstrap_token=bootstrap_token,
             spec_candidate_ids=spec_candidate_ids,
-            page_manifest=page_manifest,
+            block_manifest=block_manifest,
         )
 
     def send_layerwise(
@@ -94,7 +94,7 @@ class MooncakeKVSender:
         bootstrap_token: int = -1,
         wait_for_bootstrap_token: bool = False,
         spec_candidate_ids: list[int] | None = None,
-        cache_page_selection: CachePDLayerwisePageSelection | None = None,
+        cache_block_selection: CachePDLayerwiseBlockSelection | None = None,
     ):
         self._layerwise_chunk_submitted = True
         self._layerwise_final_chunk_submitted = (
@@ -117,7 +117,7 @@ class MooncakeKVSender:
             layerwise_interval=layerwise_interval,
             wait_for_bootstrap_token=wait_for_bootstrap_token,
             spec_candidate_ids=spec_candidate_ids,
-            cache_page_selection=cache_page_selection,
+            cache_block_selection=cache_block_selection,
         )
 
     def poll(self) -> TransferPoll:

--- a/python/tokenspeed/runtime/pd/prefill_executor.py
+++ b/python/tokenspeed/runtime/pd/prefill_executor.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 from tokenspeed.runtime.pd.base.bootstrap import BootstrapInfo
 from tokenspeed.runtime.pd.base.status import TransferPoll
 from tokenspeed.runtime.pd.cache_protocol import (
-    build_cache_layerwise_page_selection,
-    build_cache_page_manifest,
+    build_cache_block_manifest,
+    build_cache_layerwise_block_selection,
 )
 from tokenspeed.runtime.pd.mooncake.prefill import (
     MooncakeKVManagerPrefill,
@@ -124,7 +124,7 @@ class DisaggPrefillExecutor:
         """Preflight and enqueue one group-aware CachePD chunk per request.
 
         Decode's manifest is immutable for the request. Each Prefill chunk
-        selects newly ready source pages and positions inside that manifest;
+        selects newly ready source blocks and positions inside that manifest;
         the producer step range is reserved once for the whole forward batch.
         """
         pending = []
@@ -150,10 +150,10 @@ class DisaggPrefillExecutor:
             if not destinations:
                 continue
             first = destinations[0]
-            if first.page_manifest is None:
+            if first.block_manifest is None:
                 raise RuntimeError("Paged cache destination metadata is unavailable")
-            prefix_len = first.page_manifest.prefix_len
-            prompt_len = first.page_manifest.prompt_len
+            prefix_len = first.block_manifest.prefix_len
+            prompt_len = first.block_manifest.prompt_len
             chunk_begin = int(op.extend_prefix_lens[index])
             chunk_end = chunk_begin + int(op.input_lengths[index])
             if chunk_end > prompt_len:
@@ -161,14 +161,14 @@ class DisaggPrefillExecutor:
                     "Paged cache Prefill chunk extends past Decode's prompt manifest"
                 )
             is_last = chunk_end == prompt_len
-            # On the first submitted chunk, include pages that Prefill found in
+            # On the first submitted chunk, include blocks that Prefill found in
             # its local cache but Decode still needs. Once a chunk has been
             # submitted, each later selection starts at its own chunk boundary
-            # so already transferred pages are not sent again.
+            # so already transferred blocks are not sent again.
             selection_start = chunk_begin
             if not sender.layerwise_chunk_submitted():
                 selection_start = min(selection_start, prefix_len)
-            selection = build_cache_layerwise_page_selection(
+            block_selection = build_cache_layerwise_block_selection(
                 op,
                 layout=self.cache_layout,
                 request_row=index,
@@ -178,19 +178,19 @@ class DisaggPrefillExecutor:
                 chunk_end=chunk_end,
             )
             for destination in destinations:
-                if destination.page_manifest is None:
+                if destination.block_manifest is None:
                     raise RuntimeError(
                         "Paged cache destination metadata is unavailable"
                     )
                 if (
-                    destination.page_manifest.prefix_len != prefix_len
-                    or destination.page_manifest.prompt_len != prompt_len
+                    destination.block_manifest.prefix_len != prefix_len
+                    or destination.block_manifest.prompt_len != prompt_len
                 ):
                     raise ValueError(
                         "Paged cache destinations disagree on the prompt window"
                     )
             if (
-                not any(group.source_page_ids for group in selection.groups)
+                not any(group.source_block_ids for group in block_selection.groups)
                 and not is_last
             ):
                 continue
@@ -198,20 +198,20 @@ class DisaggPrefillExecutor:
                 (
                     sender,
                     is_last,
-                    selection,
+                    block_selection,
                 )
             )
 
         # The attention backend records one producer range for every forward,
-        # including batches whose current chunk completes no history page.
+        # including batches whose current chunk completes no history block.
         begin_cache_step = self.kv_manager.reserve_layerwise_cache_steps()
-        for sender, is_last, selection in pending:
+        for sender, is_last, block_selection in pending:
             sender.send_layerwise(
                 is_last,
                 begin_cache_step=begin_cache_step,
                 layerwise_interval=self._layerwise_interval,
                 wait_for_bootstrap_token=is_last,
-                cache_page_selection=selection,
+                cache_block_selection=block_selection,
             )
 
     def _cache_decode(self, op) -> None:
@@ -249,7 +249,7 @@ class DisaggPrefillExecutor:
                             True,
                             bootstrap_token=token,
                             spec_candidate_ids=spec_candidate_ids,
-                            page_manifest=None,
+                            block_manifest=None,
                         )
                         self._request_token.pop(request_id, None)
                         self._request_spec_candidate_ids.pop(request_id, None)
@@ -319,23 +319,24 @@ class DisaggPrefillExecutor:
                 )
                 continue
             destination = destinations[0]
-            if destination.page_manifest is None:
+            if destination.block_manifest is None:
                 raise RuntimeError("Paged cache destination metadata is unavailable")
-            manifest = build_cache_page_manifest(
+            block_manifest = build_cache_block_manifest(
                 op,
                 layout=self.cache_layout,
                 request_row=index,
-                prefix_len=destination.page_manifest.prefix_len,
-                prompt_len=destination.page_manifest.prompt_len,
+                prefix_len=destination.block_manifest.prefix_len,
+                prompt_len=destination.block_manifest.prompt_len,
             )
             for destination in destinations:
-                if destination.page_manifest is None:
+                if destination.block_manifest is None:
                     raise RuntimeError(
                         "Paged cache destination metadata is unavailable"
                     )
                 if (
-                    destination.page_manifest.prefix_len != manifest.prefix_len
-                    or destination.page_manifest.prompt_len != manifest.prompt_len
+                    destination.block_manifest.prefix_len != block_manifest.prefix_len
+                    or destination.block_manifest.prompt_len
+                    != block_manifest.prompt_len
                 ):
                     raise ValueError(
                         "Paged cache destinations disagree on the prompt window"
@@ -350,7 +351,7 @@ class DisaggPrefillExecutor:
                     sender,
                     token,
                     spec_candidate_ids,
-                    manifest,
+                    block_manifest,
                 )
             )
 
@@ -359,13 +360,13 @@ class DisaggPrefillExecutor:
             sender,
             token,
             spec_candidate_ids,
-            manifest,
+            block_manifest,
         ) in pending:
             sender.send(
                 True,
                 bootstrap_token=token,
                 spec_candidate_ids=spec_candidate_ids,
-                page_manifest=manifest,
+                block_manifest=block_manifest,
             )
             self._request_token.pop(request_id, None)
             self._request_spec_candidate_ids.pop(request_id, None)

--- a/python/tokenspeed/runtime/pd/topology.py
+++ b/python/tokenspeed/runtime/pd/topology.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class _AttentionParallelMapping(Protocol):
+    tp_size: int
+    tp_rank: int
+    cp_size: int
+    cp_rank: int
+    dp_size: int
+    dp_rank: int
+
+
+class _PDMapping(Protocol):
+    rank: int
+    world_size: int
+    attn: _AttentionParallelMapping
+
+
+@dataclass(frozen=True)
+class PDParallelTopology:
+    """Attention parallel coordinates used by the PD cache-transfer path."""
+
+    tp_size: int
+    tp_rank: int
+    cp_size: int
+    cp_rank: int
+    dp_size: int
+    dp_rank: int
+    world_size: int
+    global_rank: int
+
+    def __post_init__(self) -> None:
+        """Validate parallel sizes and rank coordinates."""
+        for name in ("tp", "cp", "dp"):
+            size = getattr(self, f"{name}_size")
+            rank = getattr(self, f"{name}_rank")
+            if size <= 0:
+                raise ValueError(f"{name}_size must be greater than 0, got {size}")
+            if not 0 <= rank < size:
+                raise ValueError(
+                    f"{name}_rank must be in [0, {size}), got {rank}"
+                )
+
+        expected_world_size = self.tp_size * self.cp_size * self.dp_size
+        if self.world_size != expected_world_size:
+            raise ValueError(
+                "world_size must equal tp_size * cp_size * dp_size: "
+                f"expected {expected_world_size}, got {self.world_size}"
+            )
+        if not 0 <= self.global_rank < self.world_size:
+            raise ValueError(
+                f"global_rank must be in [0, {self.world_size}), "
+                f"got {self.global_rank}"
+            )
+
+    @classmethod
+    def from_mapping(cls, mapping: _PDMapping) -> PDParallelTopology:
+        """Build PD coordinates from a runtime mapping.
+
+        Args:
+            mapping: Runtime mapping whose ``attn`` member exposes TP/CP/DP
+                sizes and ranks.
+
+        Returns:
+            The immutable PD attention topology for the current process.
+        """
+        attention = mapping.attn
+        return cls(
+            tp_size=attention.tp_size,
+            tp_rank=attention.tp_rank,
+            cp_size=attention.cp_size,
+            cp_rank=attention.cp_rank,
+            dp_size=attention.dp_size,
+            dp_rank=attention.dp_rank,
+            world_size=mapping.world_size,
+            global_rank=mapping.rank,
+        )
+
+    def require_cache_pd_supported(self) -> None:
+        """Reject attention topologies unsupported by paged-cache PD."""
+        if self.cp_size != 1:
+            raise ValueError(
+                "CachePD does not support context parallelism: "
+                f"cp_size={self.cp_size}; cp_size must be 1"
+            )

--- a/python/tokenspeed/runtime/pd/topology.py
+++ b/python/tokenspeed/runtime/pd/topology.py
@@ -60,9 +60,7 @@ class PDParallelTopology:
             if size <= 0:
                 raise ValueError(f"{name}_size must be greater than 0, got {size}")
             if not 0 <= rank < size:
-                raise ValueError(
-                    f"{name}_rank must be in [0, {size}), got {rank}"
-                )
+                raise ValueError(f"{name}_rank must be in [0, {size}), got {rank}")
 
         expected_world_size = self.tp_size * self.cp_size * self.dp_size
         if self.world_size != expected_world_size:

--- a/test/runtime/cache_pd_test_utils.py
+++ b/test/runtime/cache_pd_test_utils.py
@@ -36,8 +36,8 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
 from tokenspeed.runtime.pd.cache_protocol import (
     CacheFieldPartition,
     CacheFieldTransferSpec,
-    CachePDGroupPages,
-    CachePDPageManifest,
+    CachePDBlockManifest,
+    CachePDGroupBlocks,
     CacheProducerSchedule,
     CacheTransferContract,
     CacheTransferSchema,
@@ -228,13 +228,13 @@ def producer_schedule(
     )
 
 
-def manifest(
+def block_manifest(
     *groups: tuple[str, tuple[int, ...]],
     prefix: int = 0,
     prompt: int = 2,
-) -> CachePDPageManifest:
-    return CachePDPageManifest(
-        groups=tuple(CachePDGroupPages(*entry) for entry in groups),
+) -> CachePDBlockManifest:
+    return CachePDBlockManifest(
+        groups=tuple(CachePDGroupBlocks(*entry) for entry in groups),
         prefix_len=prefix,
         prompt_len=prompt,
     )

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -316,7 +316,7 @@ def test_decode_receiver_sends_static_registration_then_three_frame_request() ->
             cache_layout=layout,
             engine_rank=0,
         ),
-        topology=_topology(tp_size=2, tp_rank=1, global_rank=3),
+        topology=_topology(tp_size=2, tp_rank=1, global_rank=1),
         rank_port=9000,
         update_status=lambda room, status: statuses.append((room, status)),
     )

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -17,14 +17,14 @@ from ci_system.ci_register import register_cuda_ci  # noqa: E402
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
+from runtime.cache_pd_test_utils import block_manifest as make_block_manifest
 from runtime.cache_pd_test_utils import group as make_group  # noqa: E402
 from runtime.cache_pd_test_utils import layout as make_layout
-from runtime.cache_pd_test_utils import manifest as make_manifest
 from runtime.cache_pd_test_utils import operation as make_operation
 from runtime.cache_pd_test_utils import segment as make_segment
 
 from tokenspeed.runtime.pd.cache_protocol import (  # noqa: E402
-    CachePDPageManifest,
+    CachePDBlockManifest,
     CacheTransferContract,
 )
 from tokenspeed.runtime.pd.mooncake.entities import (  # noqa: E402
@@ -32,7 +32,29 @@ from tokenspeed.runtime.pd.mooncake.entities import (  # noqa: E402
     TransferInfo,
     TransferKVChunk,
 )
+from tokenspeed.runtime.pd.topology import PDParallelTopology  # noqa: E402
 from tokenspeed.runtime.pd.transfer_plan import CacheTransferFragment  # noqa: E402
+
+
+def _topology(
+    *,
+    tp_size: int = 1,
+    tp_rank: int = 0,
+    dp_size: int = 1,
+    dp_rank: int = 0,
+    world_size: int | None = None,
+    global_rank: int = 0,
+) -> PDParallelTopology:
+    return PDParallelTopology(
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+        cp_size=1,
+        cp_rank=0,
+        dp_size=dp_size,
+        dp_rank=dp_rank,
+        world_size=world_size or tp_size * dp_size,
+        global_rank=global_rank,
+    )
 
 
 def _layout(
@@ -110,21 +132,23 @@ def _op(*, state_page: int = 6):
     )
 
 
-def _destination_manifest() -> CachePDPageManifest:
-    return make_manifest(("history", (10, 11)), ("state", (12,)), prefix=2, prompt=5)
+def _destination_block_manifest() -> CachePDBlockManifest:
+    return make_block_manifest(
+        ("history", (10, 11)), ("state", (12,)), prefix=2, prompt=5
+    )
 
 
-def _single_group_manifest(
-    group_id: str, page_ids: tuple[int, ...]
-) -> CachePDPageManifest:
-    return make_manifest((group_id, page_ids))
+def _single_group_block_manifest(
+    group_id: str, block_ids: tuple[int, ...]
+) -> CachePDBlockManifest:
+    return make_block_manifest((group_id, block_ids))
 
 
 def _destination_transfer_frames() -> list[bytes]:
     return [
         b"9",
         b"session",
-        _destination_manifest().to_wire_bytes(),
+        _destination_block_manifest().to_wire_bytes(),
     ]
 
 
@@ -179,16 +203,16 @@ def _transfer_cache(
     dst_ptr: int,
     transfer_fragments: tuple[CacheTransferFragment, ...],
     *,
-    src_page_manifest: CachePDPageManifest,
-    dst_page_manifest: CachePDPageManifest,
+    src_block_manifest: CachePDBlockManifest,
+    dst_block_manifest: CachePDBlockManifest,
     dst_cache_layout,
 ) -> int:
     return manager._transfer_data(
         session,
         manager._cache_transfer_blocks(
             dst_ptr=dst_ptr,
-            src_manifest=src_page_manifest,
-            dst_manifest=dst_page_manifest,
+            src_block_manifest=src_block_manifest,
+            dst_block_manifest=dst_block_manifest,
             transfer_fragments=transfer_fragments,
             dst_cache_layout=dst_cache_layout,
         ),
@@ -217,12 +241,11 @@ def _route_manager():
         cache_layout=_typed_layout(local_heads=4, global_heads=4),
         kv_data_ptr=0x1000,
     )
-    manager.world_size = manager.dp_size = 1
-    manager.attn_tp_rank = 0
+    manager.topology = _topology()
     return manager
 
 
-def _real_destinations(manager, page_manifest=None):
+def _real_destinations(manager, block_manifest=None):
     destination_layout = _typed_layout(local_heads=2, global_heads=4)
     registrations = tuple(
         manager._prepare_decode_registration(
@@ -233,9 +256,9 @@ def _real_destinations(manager, page_manifest=None):
     manager.decode_kv_args_table = {
         registration.mooncake_session_id: registration for registration in registrations
     }
-    page_manifest = page_manifest or _single_group_manifest("history", (2,))
+    block_manifest = block_manifest or _single_group_block_manifest("history", (2,))
     requests = tuple(
-        TransferInfo(9, registration.mooncake_session_id, page_manifest)
+        TransferInfo(9, registration.mooncake_session_id, block_manifest)
         for registration in registrations
     )
     return destination_layout, registrations, requests
@@ -291,10 +314,9 @@ def test_decode_receiver_sends_static_registration_then_three_frame_request() ->
         kv_args=SimpleNamespace(
             kv_data_ptr=0x1000,
             cache_layout=layout,
-            engine_rank=1,
+            engine_rank=0,
         ),
-        world_size=2,
-        dp_size=1,
+        topology=_topology(tp_size=2, tp_rank=1, global_rank=3),
         rank_port=9000,
         update_status=lambda room, status: statuses.append((room, status)),
     )
@@ -307,7 +329,7 @@ def test_decode_receiver_sends_static_registration_then_three_frame_request() ->
     receiver._connect = lambda _endpoint: (_Socket(), nullcontext())
 
     receiver._register_kv_args()
-    receiver.prefill(page_manifest=_destination_manifest())
+    receiver.prefill(block_manifest=_destination_block_manifest())
 
     assert len(messages[0]) == 8
     registration = KVArgsRegisterInfo.from_zmq(messages[0])
@@ -316,7 +338,7 @@ def test_decode_receiver_sends_static_registration_then_three_frame_request() ->
     assert len(messages[1]) == 3
     transfer = TransferInfo.from_zmq(messages[1])
     assert transfer.room == room
-    assert transfer.page_manifest == _destination_manifest()
+    assert transfer.block_manifest == _destination_block_manifest()
     assert receiver.init_time is not None
     assert statuses == [(room, TransferPoll.WaitingForInput)]
 
@@ -343,11 +365,11 @@ def test_rejected_registration_fails_later_request_without_stopping_handler() ->
             (endpoint, port, room, status, rank)
         )
     )
-    manager.attn_tp_rank = 0
+    manager.topology = _topology(tp_size=2, tp_rank=1, global_rank=1)
 
     manager._handle_bootstrap_message(registration_frames)
     manager._handle_bootstrap_message(
-        [b"9", b"session", _destination_manifest().to_wire_bytes()]
+        [b"9", b"session", _destination_block_manifest().to_wire_bytes()]
     )
     manager._handle_bootstrap_message([b"9"])
 
@@ -356,7 +378,7 @@ def test_rejected_registration_fails_later_request_without_stopping_handler() ->
         9000,
     )
     assert aborts and aborts[0][0] == 9
-    assert notifications == [("127.0.0.1", 9000, 9, TransferPoll.Failed, 0)]
+    assert notifications == [("127.0.0.1", 9000, 9, TransferPoll.Failed, 1)]
 
 
 @pytest.mark.parametrize(
@@ -385,7 +407,7 @@ def test_failed_room_fanout_never_restores_state(
     manager.request_status = {
         9: (TransferPoll.WaitingForInput if fail_during_commit else TransferPoll.Failed)
     }
-    manager.attn_tp_rank = 0
+    manager.topology = _topology()
     if fail_during_commit:
         manager._validate_cache_room_fanout = lambda _requests: (
             manager.request_status.__setitem__(9, TransferPoll.Failed)
@@ -398,7 +420,7 @@ def test_failed_room_fanout_never_restores_state(
     )
 
     manager._handle_bootstrap_message(
-        [b"9", b"session", _destination_manifest().to_wire_bytes()]
+        [b"9", b"session", _destination_block_manifest().to_wire_bytes()]
     )
 
     assert manager.transfer_infos == {}
@@ -615,7 +637,7 @@ def test_decode_publishes_manifest_through_contract_receiver() -> None:
     assert len(calls) == 1
     args, kwargs = calls[0]
     assert args == ()
-    assert kwargs["page_manifest"].groups[0].page_ids == (2, 3)
+    assert kwargs["block_manifest"].groups[0].block_ids == (2, 3)
     assert executor._request_pool_indices == {"request-0": 7}
 
 
@@ -645,7 +667,7 @@ def test_prefill_submits_manifest_through_contract_sender() -> None:
     args, kwargs = calls[0]
     assert args == (True,)
     assert kwargs["bootstrap_token"] == 42
-    assert kwargs["page_manifest"].prompt_len == 5
+    assert kwargs["block_manifest"].prompt_len == 5
     assert executor._request_token == {}
 
 
@@ -671,7 +693,7 @@ def test_idle_prefill_rank_submits_final_dummy_rendezvous() -> None:
     assert kwargs == {
         "bootstrap_token": 42,
         "spec_candidate_ids": None,
-        "page_manifest": None,
+        "block_manifest": None,
     }
     assert executor._request_token == {}
 
@@ -699,7 +721,7 @@ def test_idle_layerwise_prefill_rank_submits_final_dummy_rendezvous() -> None:
     assert kwargs == {
         "bootstrap_token": 42,
         "spec_candidate_ids": [7, 8],
-        "page_manifest": None,
+        "block_manifest": None,
     }
     assert executor._request_token == {}
     assert executor._request_spec_candidate_ids == {}
@@ -754,8 +776,8 @@ def test_shared_manager_executes_strided_paged_cache_tp_fragment() -> None:
 
     source_layout = one_field_layout(source_segment)
     destination_layout = one_field_layout(destination_segment)
-    source_manifest = _single_group_manifest("history", (1,))
-    destination_manifest = _single_group_manifest("history", (2,))
+    source_manifest = _single_group_block_manifest("history", (1,))
+    destination_manifest = _single_group_block_manifest("history", (2,))
     fragment = CacheTransferFragment(
         group_id="history",
         field_id="layer.0.k",
@@ -774,8 +796,8 @@ def test_shared_manager_executes_strided_paged_cache_tp_fragment() -> None:
             "session",
             0x2000,
             (fragment,),
-            src_page_manifest=source_manifest,
-            dst_page_manifest=destination_manifest,
+            src_block_manifest=source_manifest,
+            dst_block_manifest=destination_manifest,
             dst_cache_layout=destination_layout,
         )
         == 0
@@ -793,12 +815,12 @@ def test_shared_manager_executes_strided_paged_cache_tp_fragment() -> None:
 def test_transfer_worker_completes_real_heterogeneous_fanout_before_status() -> None:
     from tokenspeed.runtime.pd.base.status import TransferPoll
 
-    source_manifest = _single_group_manifest("history", (1,))
+    source_manifest = _single_group_block_manifest("history", (1,))
     chunk = TransferKVChunk(
         room=9,
         is_last=True,
         bootstrap_token=42,
-        page_manifest=source_manifest,
+        block_manifest=source_manifest,
     )
 
     manager = _route_manager()
@@ -822,7 +844,7 @@ def test_transfer_worker_completes_real_heterogeneous_fanout_before_status() -> 
         )
     )
     manager.kv_transfer_metrics = None
-    manager.attn_tp_rank = 0
+    manager.topology = _topology()
 
     with pytest.raises(_StopWorker):
         manager.transfer_worker(_OneChunkQueue(chunk), None)
@@ -875,8 +897,12 @@ def test_shared_manager_uses_destination_page_zero_offsets() -> None:
         history_offset=8,
         state_offset=40,
     )
-    source_manifest = make_manifest(("history", (1, 2)), ("state", (4,)), prompt=4)
-    destination_manifest = make_manifest(("history", (5, 6)), ("state", (3,)), prompt=4)
+    source_manifest = make_block_manifest(
+        ("history", (1, 2)), ("state", (4,)), prompt=4
+    )
+    destination_manifest = make_block_manifest(
+        ("history", (5, 6)), ("state", (3,)), prompt=4
+    )
     manager, calls = _recording_transfer_manager(source_layout, 0x10000)
 
     assert (
@@ -885,8 +911,8 @@ def test_shared_manager_uses_destination_page_zero_offsets() -> None:
             "session",
             0x20000,
             (),
-            src_page_manifest=source_manifest,
-            dst_page_manifest=destination_manifest,
+            src_block_manifest=source_manifest,
+            dst_block_manifest=destination_manifest,
             dst_cache_layout=destination_layout,
         )
         == 0
@@ -908,8 +934,7 @@ def test_cache_heterogeneous_gqa_route_rendezvous_idle_prefill_ranks() -> None:
     decode_layout = _typed_layout(local_heads=2, global_heads=2)
     prefill_layout = _typed_layout(local_heads=1, global_heads=2)
     manager = SimpleNamespace(
-        world_size=1,
-        dp_size=1,
+        topology=_topology(),
         kv_args=SimpleNamespace(
             engine_rank=0,
             cache_layout=decode_layout,

--- a/test/runtime/distributed/test_cache_pd_layerwise.py
+++ b/test/runtime/distributed/test_cache_pd_layerwise.py
@@ -38,18 +38,18 @@ from ci_system.ci_register import register_cuda_ci  # noqa: E402
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
+from runtime.cache_pd_test_utils import block_manifest as make_block_manifest
 from runtime.cache_pd_test_utils import group as make_group  # noqa: E402
 from runtime.cache_pd_test_utils import layout as make_layout
-from runtime.cache_pd_test_utils import manifest as make_manifest
 from runtime.cache_pd_test_utils import producer_schedule as make_producer_schedule
 from runtime.cache_pd_test_utils import segment as make_segment
 
 from tokenspeed.runtime.pd.base.status import TransferPoll  # noqa: E402
 from tokenspeed.runtime.pd.cache_protocol import (  # noqa: E402
+    CachePDLayerwiseBlockSelection,
     CachePDLayerwiseGroupSelection,
-    CachePDLayerwisePageSelection,
     CacheTransferContract,
-    build_cache_layerwise_page_selection,
+    build_cache_layerwise_block_selection,
 )
 from tokenspeed.runtime.pd.mooncake.entities import (  # noqa: E402
     TransferInfo,
@@ -145,7 +145,7 @@ def test_group_aware_two_chunk_history_and_state_selection() -> None:
         "state-b": np.asarray([[9, 10, 11, 12]], dtype=np.int32),
     }
     operation = SimpleNamespace(block_tables_arrays=lambda: tables)
-    first = build_cache_layerwise_page_selection(
+    first = build_cache_layerwise_block_selection(
         operation,
         layout=layout,
         request_row=0,
@@ -159,7 +159,7 @@ def test_group_aware_two_chunk_history_and_state_selection() -> None:
         CachePDLayerwiseGroupSelection((), ()),
         CachePDLayerwiseGroupSelection((), ()),
     )
-    final = build_cache_layerwise_page_selection(
+    final = build_cache_layerwise_block_selection(
         operation,
         layout=layout,
         request_row=0,
@@ -179,7 +179,7 @@ def test_prepare_cache_prefill_preflights_batch_and_reserves_once() -> None:
     from tokenspeed.runtime.pd.prefill_executor import DisaggPrefillExecutor
 
     layout = _grouped_layout()
-    destination_manifest = make_manifest(
+    destination_block_manifest = make_block_manifest(
         ("history", (20, 21)),
         ("state-a", (22,)),
         ("state-b", (23,)),
@@ -187,7 +187,7 @@ def test_prepare_cache_prefill_preflights_batch_and_reserves_once() -> None:
     )
     destination = SimpleNamespace(
         is_dummy=False,
-        page_manifest=destination_manifest,
+        block_manifest=destination_block_manifest,
     )
     calls = []
 
@@ -245,7 +245,7 @@ def test_prepare_cache_prefill_preflights_batch_and_reserves_once() -> None:
     calls.clear()
     reserves.clear()
     tables["history"][1, 0] = 0
-    with pytest.raises(ValueError, match="invalid page ID"):
+    with pytest.raises(ValueError, match="invalid block ID"):
         executor._prepare_cache_prefill(operation)
     assert reserves == []
     assert calls == []
@@ -258,7 +258,7 @@ def test_first_layerwise_chunk_includes_deeper_prefill_cache_hit() -> None:
     layout = _grouped_layout()
     destination = SimpleNamespace(
         is_dummy=False,
-        page_manifest=make_manifest(
+        block_manifest=make_block_manifest(
             ("history", (20, 21, 22, 23)),
             ("state-a", (24,)),
             ("state-b", (25,)),
@@ -302,11 +302,11 @@ def test_first_layerwise_chunk_includes_deeper_prefill_cache_hit() -> None:
     executor._prepare_cache_prefill(operation(7, 2))
     assert sender.layerwise_final_chunk_submitted()
 
-    first_history = calls[0][1]["cache_page_selection"].groups[0]
-    assert first_history.source_page_ids == (2, 3)
+    first_history = calls[0][1]["cache_block_selection"].groups[0]
+    assert first_history.source_block_ids == (2, 3)
     assert first_history.destination_positions == (0, 1)
-    second_history = calls[1][1]["cache_page_selection"].groups[0]
-    assert second_history.source_page_ids == (4, 5)
+    second_history = calls[1][1]["cache_block_selection"].groups[0]
+    assert second_history.source_block_ids == (4, 5)
     assert second_history.destination_positions == (2, 3)
 
 
@@ -410,8 +410,8 @@ def test_draft_final_reservation_stays_aligned_across_forwards() -> None:
     assert counter.reserved == counter.ready == 6
 
 
-def _single_history_selection() -> CachePDLayerwisePageSelection:
-    return CachePDLayerwisePageSelection(
+def _single_history_selection() -> CachePDLayerwiseBlockSelection:
+    return CachePDLayerwiseBlockSelection(
         groups=(CachePDLayerwiseGroupSelection((2,), (0,)),),
     )
 
@@ -463,19 +463,19 @@ def test_heterogeneous_zero_edge_interval_does_not_fall_back_to_identity() -> No
         (fragment.group_id, fragment.field_id) for fragment in rank_one_fragments
     ) == (("state", "layer.2.state"),)
 
-    selection = CachePDLayerwisePageSelection(
+    selection = CachePDLayerwiseBlockSelection(
         groups=(
             CachePDLayerwiseGroupSelection((1,), (0,)),
             CachePDLayerwiseGroupSelection((2,), (0,)),
         ),
     )
-    destination_manifest = make_manifest(("history", (3,)), ("state", (4,)))
+    destination_block_manifest = make_block_manifest(("history", (3,)), ("state", (4,)))
     manager = object.__new__(MooncakeKVManagerPrefill)
     manager.kv_args = SimpleNamespace(
         cache_layout=source_layout,
         kv_data_ptr=0x10000,
     )
-    manager.attn_tp_rank = 1
+    manager.topology = SimpleNamespace(tp_rank=1)
 
     # Rank 1 has no edge for the replicated latent field in layer 0. An empty
     # fragment set for this interval is a no-op, never a raw-page identity copy.
@@ -487,11 +487,11 @@ def test_heterogeneous_zero_edge_interval_does_not_fall_back_to_identity() -> No
         return list(
             manager._cache_transfer_blocks(
                 dst_ptr=0x20000,
-                src_manifest=None,
-                dst_manifest=destination_manifest,
+                src_block_manifest=None,
+                dst_block_manifest=destination_block_manifest,
                 transfer_fragments=rank_one_fragments,
                 dst_cache_layout=destination_layout,
-                page_selection=selection,
+                block_selection=selection,
                 field_ids=schedule.fields_in_range(begin, end),
             )
         )
@@ -504,12 +504,12 @@ def _layerwise_fanout_context():
     from tokenspeed.runtime.pd.mooncake.prefill import MooncakeKVManagerPrefill
 
     layout = _ordinary_layerwise_layout()
-    manifest = make_manifest(("history", (3,)))
+    block_manifest = make_block_manifest(("history", (3,)))
     requests = tuple(
         TransferInfo(
             room=9,
             mooncake_session_id=f"session-{rank}",
-            page_manifest=manifest,
+            block_manifest=block_manifest,
         )
         for rank in range(2)
     )
@@ -546,7 +546,7 @@ def test_layerwise_fanout_is_layer_major_and_completes_once() -> None:
         begin_cache_step=100,
         layerwise_interval=2,
         wait_for_bootstrap_token=True,
-        cache_page_selection=_single_history_selection(),
+        cache_block_selection=_single_history_selection(),
     )
     events = []
     status_updates = []
@@ -576,7 +576,7 @@ def test_layerwise_fanout_is_layer_major_and_completes_once() -> None:
             (endpoint, port, room, status, rank, kwargs)
         )
     )
-    manager.attn_tp_rank = 0
+    manager.topology = SimpleNamespace(tp_rank=0)
     manager.abort_room = lambda *_args: pytest.fail("successful fanout must not abort")
 
     assert manager._send_cache_layerwise_fanout(chunk, requests)
@@ -623,7 +623,7 @@ def test_layerwise_fanout_failure_aborts_before_later_intervals() -> None:
         is_last=True,
         begin_cache_step=100,
         layerwise_interval=2,
-        cache_page_selection=_single_history_selection(),
+        cache_block_selection=_single_history_selection(),
     )
     events = []
     aborts = []

--- a/test/runtime/distributed/test_cache_pd_manifest.py
+++ b/test/runtime/distributed/test_cache_pd_manifest.py
@@ -27,16 +27,26 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     PagedCacheGroupSpec,
 )
-from tokenspeed.runtime.pd.cache_protocol import (  # noqa: E402
-    CacheContractError,
-    CachePDGroupPages,
-    CachePDPageManifest,
-    CacheTransferContract,
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.transfer import (
+    CacheFieldPartition,
+    CacheFieldTransferSpec,
     CacheTransferSchema,
-    build_cache_fields_by_producer_step,
-    build_cache_page_manifest,
-    build_cache_transfer_contract,
     build_cache_transfer_schema,
+)
+from tokenspeed.runtime.pd.cache_protocol import (
+    CacheContractError,
+    CachePDBlockManifest,
+    CachePDGroupBlocks,
+    CacheTransferContract,
+    _logical_slots,
+    build_cache_block_manifest,
+    build_cache_fields_by_producer_step,
+    build_cache_transfer_contract,
+)
+from tokenspeed.runtime.pd.cache_protocol import (  # noqa: E402
+    build_cache_transfer_schema as compatibility_build_cache_transfer_schema,
+)
+from tokenspeed.runtime.pd.cache_protocol import (
     validate_cache_manifest,
     validate_cache_peer_layout,
 )
@@ -149,8 +159,33 @@ def _op(page_offset: int = 0) -> SimpleNamespace:
     return SimpleNamespace(block_tables_arrays=lambda: tables)
 
 
+def test_recipe_layer_owns_transfer_schema_api() -> None:
+    schema = build_cache_transfer_schema(
+        _two_plane_lcm_plan(3),
+        model_config=SimpleNamespace(
+            num_attention_layers=1,
+            num_key_value_heads=8,
+            hf_config=SimpleNamespace(),
+        ),
+    )
+
+    assert schema == CacheTransferSchema(
+        tuple(
+            CacheFieldTransferSpec(
+                f"layer.0.{suffix}",
+                CacheFieldPartition(axis=1, global_extent=8),
+            )
+            for suffix in ("k", "v")
+        )
+    )
+
+
+def test_cache_protocol_compatibility_reexports_recipe_compiler() -> None:
+    assert compatibility_build_cache_transfer_schema is build_cache_transfer_schema
+
+
 def test_manifest_selects_history_suffix_and_only_final_state_slot() -> None:
-    manifest = build_cache_page_manifest(
+    manifest = build_cache_block_manifest(
         _op(),
         layout=_layout(),
         request_row=0,
@@ -158,10 +193,10 @@ def test_manifest_selects_history_suffix_and_only_final_state_slot() -> None:
         prompt_len=14,
     )
 
-    assert manifest.groups[0] == CachePDGroupPages("attention", (2, 3, 4))
+    assert manifest.groups[0] == CachePDGroupBlocks("attention", (2, 3, 4))
     assert manifest.groups[1:] == (
-        CachePDGroupPages("linear-a", (14,)),
-        CachePDGroupPages("linear-b", (24,)),
+        CachePDGroupBlocks("linear-a", (14,)),
+        CachePDGroupBlocks("linear-b", (24,)),
     )
 
 
@@ -175,17 +210,17 @@ def test_contract_serializes_recipe_specs_without_a_pd_group_projection() -> Non
     ]
 
 
-def test_source_and_destination_page_ids_are_independent() -> None:
+def test_source_and_destination_block_ids_are_independent() -> None:
     source_layout = _layout(64)
     destination_layout = _layout(128)
-    source = build_cache_page_manifest(
+    source = build_cache_block_manifest(
         _op(),
         layout=source_layout,
         request_row=0,
         prefix_len=4,
         prompt_len=14,
     )
-    destination = build_cache_page_manifest(
+    destination = build_cache_block_manifest(
         _op(40),
         layout=destination_layout,
         request_row=0,
@@ -194,17 +229,17 @@ def test_source_and_destination_page_ids_are_independent() -> None:
     )
 
     validate_cache_peer_layout(source_layout, destination_layout)
-    assert source.groups[0].page_ids != destination.groups[0].page_ids
+    assert source.groups[0].block_ids != destination.groups[0].block_ids
 
 
-@pytest.mark.parametrize("bad_page", [0, -1, 64])
-def test_manifest_rejects_null_padding_and_out_of_capacity_page(
-    bad_page: int,
+@pytest.mark.parametrize("bad_block", [0, -1, 64])
+def test_manifest_rejects_null_padding_and_out_of_capacity_block(
+    bad_block: int,
 ) -> None:
     operation = _op()
-    operation.block_tables_arrays()["linear-a"][0, 3] = bad_page
-    with pytest.raises(CacheContractError, match="invalid page ID"):
-        build_cache_page_manifest(
+    operation.block_tables_arrays()["linear-a"][0, 3] = bad_block
+    with pytest.raises(CacheContractError, match="invalid block ID"):
+        build_cache_block_manifest(
             operation,
             layout=_layout(),
             request_row=0,
@@ -214,8 +249,8 @@ def test_manifest_rejects_null_padding_and_out_of_capacity_page(
 
 
 def test_manifest_accepts_reordered_mapping_but_rejects_wrong_keys() -> None:
-    with pytest.raises(CacheContractError, match="aligned"):
-        build_cache_page_manifest(
+    with pytest.raises(CacheContractError, match="prefix_granularity"):
+        build_cache_block_manifest(
             _op(),
             layout=_layout(),
             request_row=0,
@@ -230,7 +265,7 @@ def test_manifest_accepts_reordered_mapping_but_rejects_wrong_keys() -> None:
         "attention": tables["attention"],
         "linear-b": tables["linear-b"],
     }
-    manifest = build_cache_page_manifest(
+    manifest = build_cache_block_manifest(
         reordered,
         layout=_layout(),
         request_row=0,
@@ -249,7 +284,7 @@ def test_manifest_accepts_reordered_mapping_but_rejects_wrong_keys() -> None:
     ):
         wrong = SimpleNamespace(block_tables_arrays=lambda: wrong_tables)
         with pytest.raises(CacheContractError, match="group IDs disagree"):
-            build_cache_page_manifest(
+            build_cache_block_manifest(
                 wrong,
                 layout=_layout(),
                 request_row=0,
@@ -260,7 +295,7 @@ def test_manifest_accepts_reordered_mapping_but_rejects_wrong_keys() -> None:
 
 def test_contract_and_manifest_wire_round_trip_has_no_version_field() -> None:
     layout = _layout()
-    manifest = build_cache_page_manifest(
+    manifest = build_cache_block_manifest(
         _op(),
         layout=layout,
         request_row=0,
@@ -279,9 +314,12 @@ def test_contract_and_manifest_wire_round_trip_has_no_version_field() -> None:
         "linear-b",
     ]
     assert "version" not in contract_payload
-    assert "version" not in json.loads(manifest_wire)
+    manifest_payload = json.loads(manifest_wire)
+    assert "version" not in manifest_payload
+    assert manifest_payload["groups"][0]["block_ids"] == [2, 3, 4]
+    assert "page_ids" not in manifest_payload["groups"][0]
     assert CacheTransferContract.from_wire_bytes(layout_wire) == layout
-    assert CachePDPageManifest.from_wire_bytes(manifest_wire) == manifest
+    assert CachePDBlockManifest.from_wire_bytes(manifest_wire) == manifest
 
 
 def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
@@ -305,7 +343,7 @@ def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
     tables = {"history": np.array([[5, 6]], dtype=np.int32)}
     operation = SimpleNamespace(block_tables_arrays=lambda: tables)
 
-    build_cache_page_manifest(
+    build_cache_block_manifest(
         operation,
         layout=layout,
         request_row=0,
@@ -313,8 +351,8 @@ def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
         prompt_len=8,
     )
     tables["history"][0, 1] = 7
-    with pytest.raises(CacheContractError, match="invalid page ID"):
-        build_cache_page_manifest(
+    with pytest.raises(CacheContractError, match="invalid block ID"):
+        build_cache_block_manifest(
             operation,
             layout=layout,
             request_row=0,
@@ -351,13 +389,13 @@ def test_destination_manifest_uses_peer_local_group_packing() -> None:
 
     source_layout = layout(packing=1, physical_page_bytes=8)
     destination_layout = layout(packing=2, physical_page_bytes=16)
-    source = CachePDPageManifest(
-        groups=(CachePDGroupPages("history", (3,)),),
+    source = CachePDBlockManifest(
+        groups=(CachePDGroupBlocks("history", (3,)),),
         prefix_len=0,
         prompt_len=2,
     )
-    destination = CachePDPageManifest(
-        groups=(CachePDGroupPages("history", (6,)),),
+    destination = CachePDBlockManifest(
+        groups=(CachePDGroupBlocks("history", (6,)),),
         prefix_len=0,
         prompt_len=2,
     )
@@ -375,6 +413,17 @@ def test_destination_manifest_uses_peer_local_group_packing() -> None:
             layout=source_layout,
             peer="destination",
         )
+
+
+def test_logical_slots_accepts_block_granularity() -> None:
+    assert _logical_slots(
+        "full_suffix",
+        prefix_len=4,
+        prompt_len=14,
+        block_granularity=4,
+        retention="full_history",
+        sliding_window_tokens=None,
+    ) == (1, 2, 3)
 
 
 def _cache_buffer(nbytes: int, data_ptr: int = 0x10000):
@@ -545,6 +594,20 @@ def test_peer_layout_allows_capacity_and_offsets_to_differ() -> None:
         "layer.0.v", 0
     ) != large.plan.field_page_byte_offset("layer.0.v", 0)
     validate_cache_peer_layout(small, large)
+
+
+def test_peer_layout_reports_prefix_granularity_mismatch() -> None:
+    local = _layout()
+    peer = replace(
+        local,
+        plan=replace(local.plan, prefix_granularity=8),
+    )
+
+    with pytest.raises(
+        CacheContractError,
+        match="^Paged cache P/D contract mismatch: prefix_granularity$",
+    ):
+        validate_cache_peer_layout(local, peer)
 
 
 @pytest.mark.parametrize("family", ("mha", "mla", "dsa"))

--- a/test/runtime/distributed/test_pd_topology.py
+++ b/test/runtime/distributed/test_pd_topology.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+
+import pytest
+
+from tokenspeed.runtime.pd.topology import PDParallelTopology
+
+
+@pytest.mark.parametrize(
+    ("override", "match"),
+    [
+        ({"tp_size": 0}, "tp_size must be greater than 0"),
+        ({"cp_size": 0}, "cp_size must be greater than 0"),
+        ({"dp_size": 0}, "dp_size must be greater than 0"),
+        ({"tp_rank": -1}, "tp_rank must be in \\[0, 2\\)"),
+        ({"tp_rank": 2}, "tp_rank must be in \\[0, 2\\)"),
+        ({"cp_rank": -1}, "cp_rank must be in \\[0, 2\\)"),
+        ({"cp_rank": 2}, "cp_rank must be in \\[0, 2\\)"),
+        ({"dp_rank": -1}, "dp_rank must be in \\[0, 2\\)"),
+        ({"dp_rank": 2}, "dp_rank must be in \\[0, 2\\)"),
+        ({"world_size": 7}, "world_size must equal tp_size \\* cp_size \\* dp_size"),
+        ({"global_rank": -1}, "global_rank must be in \\[0, 8\\)"),
+        ({"global_rank": 8}, "global_rank must be in \\[0, 8\\)"),
+    ],
+)
+def test_direct_constructor_rejects_invalid_topology(
+    override: dict[str, int], match: str
+) -> None:
+    values = {
+        "tp_size": 2,
+        "tp_rank": 1,
+        "cp_size": 2,
+        "cp_rank": 1,
+        "dp_size": 2,
+        "dp_rank": 1,
+        "world_size": 8,
+        "global_rank": 7,
+    }
+    values.update(override)
+
+    with pytest.raises(ValueError, match=match):
+        PDParallelTopology(**values)
+
+
+def _mapping(
+    *,
+    tp_size: int,
+    cp_size: int,
+    dp_size: int,
+    world_size: int,
+    global_rank: int,
+) -> SimpleNamespace:
+    tp_rank = global_rank % tp_size
+    cp_rank = global_rank // tp_size % cp_size
+    dp_rank = global_rank // (tp_size * cp_size) % dp_size
+    return SimpleNamespace(
+        rank=global_rank,
+        world_size=world_size,
+        attn=SimpleNamespace(
+            tp_size=tp_size,
+            tp_rank=tp_rank,
+            cp_size=cp_size,
+            cp_rank=cp_rank,
+            dp_size=dp_size,
+            dp_rank=dp_rank,
+        ),
+    )
+
+
+def test_topology_preserves_typed_attention_coordinates() -> None:
+    mapping = _mapping(
+        tp_size=2,
+        cp_size=2,
+        dp_size=2,
+        world_size=8,
+        global_rank=3,
+    )
+
+    topology = PDParallelTopology.from_mapping(mapping)
+
+    assert topology == PDParallelTopology(
+        tp_size=2,
+        tp_rank=1,
+        cp_size=2,
+        cp_rank=1,
+        dp_size=2,
+        dp_rank=0,
+        world_size=8,
+        global_rank=3,
+    )
+    assert topology.tp_rank != topology.global_rank % (
+        topology.world_size // topology.dp_size
+    )
+
+
+def test_cache_pd_rejects_context_parallel_topology() -> None:
+    topology = PDParallelTopology.from_mapping(
+        _mapping(
+            tp_size=2,
+            cp_size=2,
+            dp_size=2,
+            world_size=8,
+            global_rank=6,
+        )
+    )
+
+    with pytest.raises(ValueError, match="context parallelism.*cp_size=2"):
+        topology.require_cache_pd_supported()
+
+
+def test_cache_pd_accepts_heterogeneous_tp_with_cp_one() -> None:
+    topology = PDParallelTopology.from_mapping(
+        _mapping(
+            tp_size=4,
+            cp_size=1,
+            dp_size=2,
+            world_size=8,
+            global_rank=7,
+        )
+    )
+
+    topology.require_cache_pd_supported()
+    assert (topology.tp_size, topology.tp_rank) == (4, 3)

--- a/test/test_cache_transfer_layout.py
+++ b/test/test_cache_transfer_layout.py
@@ -32,6 +32,9 @@ from tokenspeed.runtime.cache.transfer.layout import (
     layout_from_lcm_plan,
     select_layer_fields,
 )
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+    cache_field_layer_id,
+)
 
 
 def _field(field_id: str, *, stride: int = 64, payload: int = 48):
@@ -42,6 +45,19 @@ def _field(field_id: str, *, stride: int = 64, payload: int = 48):
         block_stride_bytes=stride,
         payload_bytes=payload,
     )
+
+
+def test_cache_field_layer_id_parses_layer_owned_field():
+    assert cache_field_layer_id("layer.12.k") == 12
+
+
+@pytest.mark.parametrize(
+    "field_id",
+    ("attention.k", "layer.bad.k", "layer.-1.k", "layer.0"),
+)
+def test_cache_field_layer_id_rejects_invalid_field(field_id):
+    with pytest.raises(ValueError, match="cache field"):
+        cache_field_layer_id(field_id)
 
 
 def test_layout_rejects_duplicate_group_ids():


### PR DESCRIPTION
Centralize PD topology and recipe-owned transfer semantics so cache-block manifests remain model-neutral across transfer modes.

## Summary

- Introduce typed `PDParallelTopology` as the single Prefill/Decode TP/CP/DP owner, and fail fast when CachePD is asked for unsupported CP.
- Move model-specific field partition / transfer schema into the cache recipe layer, so `cache_protocol` stays a model-neutral wire and validation envelope.
- Rename request manifests from page-centric naming to CacheBlock terminology (`block_ids`), so history KV and state/checkpoint groups share one generic PD contract across transfer modes.