### PR TITLE
perf(inkling): eliminate per-step elementwise/copy kernels on the decode path

### DIFF
--- a/python/tokenspeed/runtime/configs/inkling_config.py
+++ b/python/tokenspeed/runtime/configs/inkling_config.py
@@ -155,6 +155,7 @@ class InklingModelConfig(PretrainedConfig):
     def __init__(
         self,
         *,
+        model_max_length: int = 1048576,
         vocab_size: int = 201024,
         hidden_size: int = 1536,
         intermediate_size: int = 768,
@@ -240,6 +241,7 @@ class InklingModelConfig(PretrainedConfig):
         if eos_token_id is None and vocab_size > INKLING_MODEL_END_SAMPLING_TOKEN_ID:
             eos_token_id = INKLING_MODEL_END_SAMPLING_TOKEN_ID
 
+        self.model_max_length = model_max_length
         self.vocab_size = vocab_size
         self.padded_vocab_size = padded_vocab_size
         self.hidden_size = hidden_size

--- a/python/tokenspeed/runtime/configs/inkling_config.py
+++ b/python/tokenspeed/runtime/configs/inkling_config.py
@@ -101,35 +101,6 @@ def inkling_conv_stream_layout(
     return layout
 
 
-def inkling_kv_heads_for_layer(
-    config: "InklingModelConfig", layer_id: int, hetero: bool
-) -> int:
-    """Served KV head count for one layer.
-
-    Uniform mode replicates every layer to ``num_key_value_heads`` (the max
-    over layer kinds). Heterogeneous mode (byte-uniform slots, #647) serves
-    each kind's native count: full layers keep the checkpoint's
-    ``ckpt_num_key_value_heads``, so one slot's fixed bytes hold
-    proportionally more tokens for the narrower kind. How much more follows
-    from the two configured head counts, so consumers must derive page sizes
-    from the returned counts.
-
-    Args:
-        config: The Inkling text config.
-        layer_id: Absolute decoder layer index.
-        hetero: Heterogeneous KV block sizes enabled.
-
-    Returns:
-        The KV head count this layer serves (pre-TP).
-    """
-    if not hetero:
-        return config.num_key_value_heads
-    is_local = layer_id in config.local_layer_ids
-    return (
-        config.swa_num_key_value_heads if is_local else config.ckpt_num_key_value_heads
-    )
-
-
 def inkling_mtp_text_config(
     config: "InklingModelConfig", num_steps: int | None = None
 ) -> "InklingModelConfig":

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -642,6 +642,7 @@ class InklingAttnBackend(AttentionBackend):
         **kwargs,
     ):
         rel_logits = kwargs.pop("rel_logits", None)
+        tau = kwargs.pop("log_scaling_tau", None)
         if rel_logits is None:
             return self.inner.forward_decode(
                 q,
@@ -695,6 +696,7 @@ class InklingAttnBackend(AttentionBackend):
             max_seqlen_q=max_seqlen_q,
             window_left=layer.sliding_window_size,
             softmax_scale=layer.scaling,
+            tau=tau,
             enable_pdl=pdl_enabled(),
             solution=inner.kernel_solution,
             **scale_kwargs,
@@ -714,6 +716,7 @@ class InklingAttnBackend(AttentionBackend):
         **kwargs,
     ):
         rel_logits = kwargs.pop("rel_logits", None)
+        tau = kwargs.pop("log_scaling_tau", None)
         if rel_logits is None:
             return self.inner.forward_extend(
                 q,
@@ -759,6 +762,7 @@ class InklingAttnBackend(AttentionBackend):
                 max_seqlen=metadata.max_extend_seq_len,
                 window_left=layer.sliding_window_size,
                 softmax_scale=layer.scaling,
+                tau=tau,
                 enable_pdl=pdl_enabled(),
                 solution=inner.kernel_solution,
             )
@@ -791,6 +795,7 @@ class InklingAttnBackend(AttentionBackend):
             rel_logits=rel_logits,
             window_left=layer.sliding_window_size,
             softmax_scale=layer.scaling,
+            tau=tau,
             enable_pdl=pdl_enabled(),
             solution=inner.kernel_solution,
             **scale_kwargs,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
@@ -148,11 +148,16 @@ def inkling_cache_fields(
 
 
 def inkling_layer_kv_head_counts(model_config) -> tuple[int, ...]:
-    from tokenspeed.runtime.configs.inkling_config import inkling_kv_heads_for_layer
-
+    """Served KV heads per layer: each kind's native checkpoint count
+    (hetero byte-uniform slots, #647), so page sizes derive from these."""
     text_config = model_config.hf_config.get_text_config()
+    local = set(text_config.local_layer_ids)
     return tuple(
-        inkling_kv_heads_for_layer(text_config, layer_id, True)
+        (
+            text_config.swa_num_key_value_heads
+            if layer_id in local
+            else text_config.ckpt_num_key_value_heads
+        )
         for layer_id in range(text_config.num_hidden_layers)
     )
 

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -21,7 +21,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
 import torch
@@ -562,53 +561,6 @@ def _inkling_conv_columns(pool, text_config):
     return conv_columns
 
 
-def _start_inkling_pool_probe(kv_pool, conv_pool, rank, probe_dir) -> None:
-    """Diagnostic (INKLING_POOL_PROBE_DIR=<dir>): background thread
-    checksumming pool regions that must stay INVARIANT under traffic — the
-    dummy page's tail rows and the top quarter of each layer buffer — to catch
-    wrong-location KV writes in the act. One JSONL line per interval per rank;
-    ~seconds of bandwidth per sweep, diagnosis only."""
-    import json
-    import threading
-    import time
-
-    path = f"{probe_dir}/pool_probe_rank{rank}.jsonl"
-
-    def _pool_probe():
-        while True:
-            try:
-                rec = {"t": time.time()}
-                d0 = top = tot = 0.0
-                d0_layers = []
-                for lid, bufs in enumerate(zip(kv_pool.k_buffer, kv_pool.v_buffer)):
-                    for tb in bufs:
-                        if tb is None:
-                            continue
-                        n = tb.shape[0]
-                        v = float(tb[4:128].float().abs().sum())
-                        d0 += v
-                        if v > 0.0:
-                            d0_layers.append((lid, round(v, 3)))
-                        top += float(tb[(3 * n) // 4 :].float().abs().sum())
-                        tot += float(tb.float().abs().sum())
-                rec["dummy_tail_abs"] = round(d0, 4)
-                rec["dummy_tail_layers"] = d0_layers[:8]
-                rec["top_quarter_abs"] = round(top, 4)
-                rec["total_abs"] = round(tot, 2)
-                rec["conv_abs"] = round(
-                    float(conv_pool.conv_state.float().abs().sum()), 2
-                )
-                with open(path, "a") as f:
-                    f.write(json.dumps(rec) + "\n")
-            except Exception as exc:  # noqa: BLE001 - diagnostics must not kill serving
-                with open(path, "a") as f:
-                    f.write(json.dumps({"error": repr(exc)}) + "\n")
-            time.sleep(10)
-
-    threading.Thread(target=_pool_probe, daemon=True).start()
-    logger.info("Inkling pool probe enabled -> %s", probe_dir)
-
-
 def _create_target_components(
     *,
     server_args,
@@ -654,7 +606,7 @@ def _create_target_components(
         return backend, pool
 
     text_config = model_config.hf_config.get_text_config()
-    backend, conv_pool = _wrap_inkling_backend(
+    backend, _ = _wrap_inkling_backend(
         backend,
         text_config,
         config,
@@ -666,9 +618,6 @@ def _create_target_components(
             and getattr(server_args, "disaggregation_layerwise_interval", 0) > 0
         ),
     )
-    probe_dir = os.environ.get("INKLING_POOL_PROBE_DIR")
-    if probe_dir:
-        _start_inkling_pool_probe(pool, conv_pool, rank, probe_dir)
     return backend, pool
 
 

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -278,14 +278,6 @@ def _load_block_param(
     return False
 
 
-def compute_log_scaling_tau(
-    positions: torch.Tensor, n_floor: int, alpha: float
-) -> torch.Tensor:
-    """Long-context query scaling factor (config-gated; see InklingAttention)."""
-    effective_n = (positions + 1).to(torch.float32)
-    return 1.0 + alpha * torch.log(torch.clamp(effective_n / float(n_floor), min=1.0))
-
-
 class InklingShortConvolution(nn.Module):
     """Residual per-channel causal FIR (sconv) over one stream.
 
@@ -1437,6 +1429,18 @@ class InklingTextModel(nn.Module):
             if config.use_embed_norm
             else None
         )
+        if config.log_scaling_n_floor is not None:
+            effective_n = torch.arange(
+                1, config.model_max_length + 1, dtype=torch.float32
+            )
+            log_scaling_tau_table = 1.0 + config.log_scaling_alpha * torch.log(
+                torch.clamp(effective_n / float(config.log_scaling_n_floor), min=1.0)
+            )
+            self.register_buffer(
+                "log_scaling_tau_table",
+                log_scaling_tau_table,
+                persistent=False,
+            )
 
         alt_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
 
@@ -1497,11 +1501,7 @@ class InklingTextModel(nn.Module):
 
         log_scaling_tau = None
         if self.config.log_scaling_n_floor is not None:
-            log_scaling_tau = compute_log_scaling_tau(
-                positions,
-                self.config.log_scaling_n_floor,
-                self.config.log_scaling_alpha,
-            )
+            log_scaling_tau = self.log_scaling_tau_table[positions]
 
         residual = None
         for layer in self.layers:

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -81,6 +81,9 @@ from collections.abc import Callable, Iterable
 
 import torch
 import torch.nn.functional as F
+from tokenspeed_kernel.ops.attention.triton.log_scaling import (
+    log_scaling_tau as compute_log_scaling_tau,
+)
 from tokenspeed_kernel.ops.conv import inkling_ring_sconv
 from tokenspeed_kernel.ops.gemm.cuda import dsv3_router_gemm
 from tokenspeed_kernel.ops.layernorm.triton import qk_rmsnorm
@@ -1429,19 +1432,6 @@ class InklingTextModel(nn.Module):
             if config.use_embed_norm
             else None
         )
-        if config.log_scaling_n_floor is not None:
-            effective_n = torch.arange(
-                1, config.model_max_length + 1, dtype=torch.float32
-            )
-            log_scaling_tau_table = 1.0 + config.log_scaling_alpha * torch.log(
-                torch.clamp(effective_n / float(config.log_scaling_n_floor), min=1.0)
-            )
-            self.register_buffer(
-                "log_scaling_tau_table",
-                log_scaling_tau_table,
-                persistent=False,
-            )
-
         alt_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
 
         def get_layer(idx: int, prefix: str) -> InklingDecoderLayer:
@@ -1501,7 +1491,11 @@ class InklingTextModel(nn.Module):
 
         log_scaling_tau = None
         if self.config.log_scaling_n_floor is not None:
-            log_scaling_tau = self.log_scaling_tau_table[positions]
+            log_scaling_tau = compute_log_scaling_tau(
+                positions,
+                self.config.log_scaling_n_floor,
+                self.config.log_scaling_alpha,
+            )
 
         residual = None
         for layer in self.layers:

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -286,10 +286,6 @@ def compute_log_scaling_tau(
     return 1.0 + alpha * torch.log(torch.clamp(effective_n / float(n_floor), min=1.0))
 
 
-def _apply_log_scaling_tau(x: torch.Tensor, tau: torch.Tensor) -> torch.Tensor:
-    return x * tau.to(dtype=x.dtype)
-
-
 class InklingShortConvolution(nn.Module):
     """Residual per-channel causal FIR (sconv) over one stream.
 
@@ -606,10 +602,6 @@ class InklingAttention(nn.Module):
                 rel_logits = self.rel_logits_proj(
                     r.view(num_tokens, self.num_tp_heads, self.d_rel)
                 )
-                if log_scaling_tau is not None and not self.is_local:
-                    rel_logits = _apply_log_scaling_tau(
-                        rel_logits, log_scaling_tau.view(-1, 1, 1)
-                    )
 
             # K/V are adjacent in the qkvr output AND the conv pool, so both
             # sconv streams fuse into one call reading the strided slice.
@@ -636,9 +628,6 @@ class InklingAttention(nn.Module):
                 enable_pdl=pdl_enabled(),
             )
 
-            if log_scaling_tau is not None and not self.is_local:
-                q = _apply_log_scaling_tau(q, log_scaling_tau.view(-1, 1))
-
         attn_output = self.attn(
             q,
             k,
@@ -646,6 +635,7 @@ class InklingAttention(nn.Module):
             ctx,
             out_cache_loc,
             rel_logits=rel_logits,
+            log_scaling_tau=None if self.is_local else log_scaling_tau,
             # Inkling's readiness boundary is after both hidden-state sconv
             # writes below, not immediately after attention KV publication.
             record_kv_cache=False,

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -44,8 +44,8 @@ Layer layout: ``local_layer_ids`` use SWA (``sliding_window_size``) with
 ``rel_extent == sliding_window_size``; the rest are full attention with the
 config ``rel_extent``. KV heads default to the hetero layout (#647
 byte-uniform slots): full-attention layers keep their checkpoint-native
-head count (unconditional; the INKLING_HETERO_KV gate is retired) — uniform serving with
-full-layer KV replicated at load (see the config docstring).
+head count — uniform serving with full-layer KV replicated at load (see the
+config docstring).
 
 Multimodal towers (gated on ``*_config.decoder_dmodel`` being set; text-only
 checkpoints leave both off):
@@ -95,7 +95,6 @@ from tokenspeed.runtime.configs.inkling_config import (
     InklingModelConfig,
     InklingVisionConfig,
     inkling_conv_stream_layout,
-    inkling_kv_heads_for_layer,
 )
 from tokenspeed.runtime.distributed.comm_manager import CommManager
 from tokenspeed.runtime.distributed.mapping import Mapping
@@ -139,12 +138,6 @@ from tokenspeed.runtime.utils.pdl import pdl_enabled
 logger = logging.getLogger(__name__)
 
 _is_hopper_plus = current_platform().is_hopper_plus
-
-# Escape hatch: disable the rel-logits aux-stream fork (serial pre-attention).
-_ATTN_RELFORK = os.environ.get("INKLING_ATTN_RELFORK", "1") == "1"
-# Hetero KV (#647 byte-uniform slots): full layers keep their native half KV
-# head count. Unconditional since 2026-07-15 (INKLING_HETERO_KV gate retired).
-_HETERO_KV = True
 
 
 # Checkpoint attention projections -> qkvr fused shard ids.
@@ -484,7 +477,11 @@ class InklingAttention(nn.Module):
         self.scaling = 1.0 / self.head_dim
 
         total_heads = config.num_attention_heads
-        total_kv_heads = inkling_kv_heads_for_layer(config, layer_id, _HETERO_KV)
+        total_kv_heads = (
+            config.swa_num_key_value_heads
+            if is_local
+            else config.ckpt_num_key_value_heads
+        )
         assert total_heads % attn_tp_size == 0
         self.num_tp_heads = total_heads // attn_tp_size
         if total_kv_heads >= attn_tp_size:
@@ -601,10 +598,8 @@ class InklingAttention(nn.Module):
         qkvr, _ = self.qkvr(hidden_states)
         q, kv, r = qkvr.split([self.q_size, 2 * self.kv_size, self.r_size], dim=-1)
 
-        # Warm the R-slice projection serially on the capture topology, then
-        # overlap it during capture. INKLING_ATTN_RELFORK=0 stays serial.
         with self.stream_fork.scope(
-            enable=_ATTN_RELFORK and get_is_cuda_graph_phase(),
+            enable=get_is_cuda_graph_phase(),
             overlap=get_is_capture_mode(),
         ) as fork:
             with fork.branch():
@@ -1769,8 +1764,7 @@ class InklingForConditionalGeneration(nn.Module):
         ckpt_heads = (
             cfg.swa_num_key_value_heads if is_local else cfg.ckpt_num_key_value_heads
         )
-        served = inkling_kv_heads_for_layer(cfg, layer_id, _HETERO_KV)
-        target_heads = max(served, self.mapping.attn.tp_size)
+        target_heads = max(ckpt_heads, self.mapping.attn.tp_size)
         if target_heads == ckpt_heads:
             return loaded_weight
         assert (

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -616,10 +616,11 @@ class InklingAttention(nn.Module):
                         rel_logits, log_scaling_tau.view(-1, 1, 1)
                     )
 
-            # K/V are adjacent in the qkvr output AND the conv pool, so both sconv streams fuse into one call.
+            # K/V are adjacent in the qkvr output AND the conv pool, so both
+            # sconv streams fuse into one call reading the strided slice.
             if self.use_sconv:
                 kv = _sconv_apply(
-                    kv.contiguous(),
+                    kv,
                     self._merged_kv_sconv_weight(),
                     ctx,
                     self.layer_id,

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -453,7 +453,7 @@ class InklingRelLogitsProj(nn.Module):
 
     def forward(self, r_out: torch.Tensor) -> torch.Tensor:
         # r_out: [T, num_heads, d_rel] -> rel_logits [T, num_heads, rel_extent]
-        return torch.einsum("thd,de->the", r_out, self.proj)
+        return torch.matmul(r_out, self.proj)
 
 
 class InklingAttention(nn.Module):
@@ -650,7 +650,7 @@ class InklingAttention(nn.Module):
             v,
             ctx,
             out_cache_loc,
-            rel_logits=rel_logits.contiguous(),
+            rel_logits=rel_logits,
             # Inkling's readiness boundary is after both hidden-state sconv
             # writes below, not immediately after attention KV publication.
             record_kv_cache=False,

--- a/test/runtime/test_inkling_activation_parity.py
+++ b/test/runtime/test_inkling_activation_parity.py
@@ -244,14 +244,15 @@ class _Harness:
             },
         }
         self.backend = InklingAttnBackend(inner, conv_pool, conv_columns=conv_columns)
-        from tokenspeed.runtime.configs.inkling_config import (
-            inkling_kv_heads_for_layer,
-        )
-
         self.pool_view = _ConvCheckpointPool(
             self.kv_pool,
             layer_kv_widths=[
-                inkling_kv_heads_for_layer(text, i, True) * text.head_dim
+                (
+                    text.swa_num_key_value_heads
+                    if i in text.local_layer_ids
+                    else text.ckpt_num_key_value_heads
+                )
+                * text.head_dim
                 for i in range(text.num_hidden_layers)
             ],
             num_pages=num_conv_pages + 1,

--- a/test/runtime/test_inkling_load_weights.py
+++ b/test/runtime/test_inkling_load_weights.py
@@ -211,50 +211,24 @@ class TestInklingLoadWeights(unittest.TestCase):
         missing = sorted(set(params) - self.loaded)
         self.assertEqual(missing, [], f"params never loaded: {missing}")
 
-    def test_qkvr_fusion_and_kv_replication(self):
-        from tokenspeed.runtime.configs.inkling_config import (
-            inkling_kv_heads_for_layer,
-        )
-
-        text = self.text
-        hd = text.head_dim
-        hetero = True  # gate retired 2026-07-15; hetero KV is unconditional
-        local = set(text.local_layer_ids)
-        for i in range(text.num_hidden_layers):
+    def test_qkvr_fusion(self):
+        # Hetero KV serves every layer's native checkpoint head count, so the
+        # fused qkvr and sconv taps carry the checkpoint tensors verbatim.
+        for i in range(self.text.num_hidden_layers):
             p = f"model.llm.layers.{i}"
-            kv = (
-                text.swa_num_key_value_heads
-                if i in local
-                else text.ckpt_num_key_value_heads
-            )
-            # Hetero (default): full layers serve their native ckpt heads
-            # (factor 1, no replication); uniform mode replicates to the max.
-            served = inkling_kv_heads_for_layer(text, i, hetero)
-            factor = served // kv
-            wk = self.ckpt[f"{p}.attn.wk_dv.weight"]
-            wv = self.ckpt[f"{p}.attn.wv_dv.weight"]
-            # Served head j must carry checkpoint head j // factor.
-            rep_k = torch.cat(
-                [wk[(j // factor) * hd : (j // factor + 1) * hd] for j in range(served)]
-            )
-            rep_v = torch.cat(
-                [wv[(j // factor) * hd : (j // factor + 1) * hd] for j in range(served)]
-            )
             expected = torch.cat(
                 [
                     self.ckpt[f"{p}.attn.wq_du.weight"],
-                    rep_k,
-                    rep_v,
+                    self.ckpt[f"{p}.attn.wk_dv.weight"],
+                    self.ckpt[f"{p}.attn.wv_dv.weight"],
                     self.ckpt[f"{p}.attn.wr_du.weight"],
                 ]
             )
             self._assert_eq(f"model.layers.{i}.attn.qkvr.weight", expected)
-            # K/V sconv taps replicate the same way.
-            ks = self.ckpt[f"{p}.attn.k_sconv.weight"]
-            rep_ks = torch.cat(
-                [ks[(j // factor) * hd : (j // factor + 1) * hd] for j in range(served)]
+            self._assert_eq(
+                f"model.layers.{i}.attn.k_sconv.weight",
+                self.ckpt[f"{p}.attn.k_sconv.weight"],
             )
-            self._assert_eq(f"model.layers.{i}.attn.k_sconv.weight", rep_ks)
 
     def test_dense_mlp_deinterleave_and_scale(self):
         for i in range(self.text.dense_mlp_idx):
@@ -458,24 +432,18 @@ class TestInklingLoadWeightsParallel(unittest.TestCase):
         return dict(model.named_parameters())[name].data.cpu()
 
     def test_attention_tp2_and_moe_tp2(self):
-        from tokenspeed.runtime.configs.inkling_config import (
-            inkling_kv_heads_for_layer,
-        )
-
-        hetero = True  # gate retired 2026-07-15; hetero KV is unconditional
         for rank in range(2):
             model, text = self._load_rank(rank, 2)
             hd = text.head_dim
             tp = 2
             q_heads = text.num_attention_heads // tp
-            # Layer 4 is local (ckpt KV == served). Layer 5 is full: hetero
-            # (default) serves its native 8 heads (4 per rank, factor 1);
-            # uniform mode replicates 8 -> 16.
+            # Each layer serves its native head count, replicated up to one
+            # head per rank when tp exceeds it.
             for layer, ckpt_kv in (
                 (4, text.swa_num_key_value_heads),
                 (5, text.ckpt_num_key_value_heads),
             ):
-                served = max(inkling_kv_heads_for_layer(text, layer, hetero), tp)
+                served = max(ckpt_kv, tp)
                 p = f"model.llm.layers.{layer}.attn"
                 qkvr = self._param(model, f"model.layers.{layer}.attn.qkvr.weight")
                 wq = self.ckpt[f"{p}.wq_du.weight"]

--- a/test/runtime/test_inkling_mtp_text_config.py
+++ b/test/runtime/test_inkling_mtp_text_config.py
@@ -12,10 +12,7 @@ import os
 import sys
 import unittest
 
-from tokenspeed.runtime.configs.inkling_config import (
-    inkling_kv_heads_for_layer,
-    inkling_mtp_text_config,
-)
+from tokenspeed.runtime.configs.inkling_config import inkling_mtp_text_config
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
@@ -58,17 +55,6 @@ class TestInklingMTPTextConfig(unittest.TestCase):
         self.assertEqual(cfg.num_nextn_predict_layers, 3)
         self.assertEqual(cfg.local_layer_ids, [0, 2])
         self.assertEqual(cfg.dense_mlp_idx, 3)
-        # Depth 1 is full attention at the ckpt head count; depths 0/2 are
-        # SWA at the swa count — the target model's byte-uniform pairing.
-        heads = [inkling_kv_heads_for_layer(cfg, i, True) for i in range(3)]
-        self.assertEqual(
-            heads,
-            [
-                cfg.swa_num_key_value_heads,
-                cfg.ckpt_num_key_value_heads,
-                cfg.swa_num_key_value_heads,
-            ],
-        )
         # Every depth gets its own paged-cache group so the shared slab has
         # no dead rows (1 full + 2 sliding sub-groups of one layer each).
         self.assertEqual(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -1867,6 +1867,7 @@ def rel_mha_prefill(
     window_left: int = -1,
     return_lse: bool = False,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,
     enable_pdl: bool = False,
     # dispatch options
     override: str | None = None,
@@ -1893,6 +1894,9 @@ def rel_mha_prefill(
             shape [total_q, num_q_heads].
         softmax_scale: Scale applied to QK logits before softmax. None uses the
             backend default 1/sqrt(head_dim).
+        tau: Optional fp32 per-query-row multiplier on the total pre-softmax
+            logits, ``tau * (softmax_scale * q@k^T + rel)``; shape matches
+            q's row count and values must be positive.
         enable_pdl: Launch eligible kernels with Programmatic Dependent
             Launch (Hopper+).
         override: Optional kernel override name.
@@ -1953,6 +1957,7 @@ def rel_mha_prefill(
             window_left=window_left,
             return_lse=return_lse,
             softmax_scale=softmax_scale,
+            tau=tau,
             enable_pdl=enable_pdl,
         )
 
@@ -1973,6 +1978,7 @@ def rel_mha_extend_with_kvcache(
     window_left: int = -1,
     return_lse: bool = False,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,
     enable_pdl: bool = False,
     q_scale: torch.Tensor | None = None,
     k_scale: torch.Tensor | None = None,
@@ -2004,6 +2010,9 @@ def rel_mha_extend_with_kvcache(
             shape [total_q, num_q_heads].
         softmax_scale: Scale applied to QK logits before softmax. None uses the
             backend default 1/sqrt(head_dim).
+        tau: Optional fp32 per-query-row multiplier on the total pre-softmax
+            logits, ``tau * (softmax_scale * q@k^T + rel)``; shape matches
+            q's row count and values must be positive.
         enable_pdl: Launch eligible kernels with Programmatic Dependent
             Launch (Hopper+).
         override: Optional kernel override name.
@@ -2077,6 +2086,7 @@ def rel_mha_extend_with_kvcache(
             window_left=window_left,
             return_lse=return_lse,
             softmax_scale=softmax_scale,
+            tau=tau,
             enable_pdl=enable_pdl,
             **scale_kwargs,
         )
@@ -2096,6 +2106,7 @@ def rel_mha_decode_with_kvcache(
     # attention options
     window_left: int = -1,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,
     enable_pdl: bool = False,
     q_scale: torch.Tensor | None = None,
     k_scale: torch.Tensor | None = None,
@@ -2127,6 +2138,9 @@ def rel_mha_decode_with_kvcache(
         window_left: Exclusive left sliding-window size. -1 means full attention.
         softmax_scale: Scale applied to QK logits before softmax. None uses the
             backend default 1/sqrt(head_dim).
+        tau: Optional fp32 per-query-row multiplier on the total pre-softmax
+            logits, ``tau * (softmax_scale * q@k^T + rel)``; shape matches
+            q's row count and values must be positive.
         enable_pdl: Launch eligible kernels with Programmatic Dependent
             Launch (Hopper+).
         override: Optional kernel override name.
@@ -2201,6 +2215,7 @@ def rel_mha_decode_with_kvcache(
             max_seqlen_q=max_seqlen_q,
             window_left=window_left,
             softmax_scale=softmax_scale,
+            tau=tau,
             enable_pdl=enable_pdl,
             **scale_kwargs,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/flash_fwd_sm100_bias.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/flash_fwd_sm100_bias.py
@@ -739,6 +739,9 @@ class FlashAttentionForwardSm100:
         mLSE: Optional[cute.Tensor],
         mRowMax: Optional[cute.Tensor],
         softmax_scale: Float32,
+        # (total_q,) varlen / (b, s_q) batch fp32 per-query-row multiplier on
+        # the total pre-softmax logits, tau * (scale * q@k^T + bias); > 0.
+        mTau: Optional[cute.Tensor] = None,
         mSFQ: Optional[cute.Tensor] = None,
         mSFK: Optional[cute.Tensor] = None,
         mSFV: Optional[cute.Tensor] = None,
@@ -1697,6 +1700,9 @@ class FlashAttentionForwardSm100:
             smem_size_bytes <= 227 * 1024
         ), f"insufficient smem, requested {smem_size_bytes}"
         # Launch the kernel synchronously
+        if const_expr(mTau is not None):
+            assert mTau.dtype == Float32
+            assert cute.rank(mTau) == (1 if mCuSeqlensQ is not None else 2)
         self.kernel(
             mQ,
             mK,
@@ -1725,6 +1731,7 @@ class FlashAttentionForwardSm100:
             softmax_scale,
             softmax_scale_true,
             inv_softmax_scale,
+            mTau,
             window_size_left,
             window_size_right,
             learnable_sink,
@@ -1799,6 +1806,7 @@ class FlashAttentionForwardSm100:
         softmax_scale: Float32 | None,
         softmax_scale_true: Float32,
         inv_softmax_scale: Float32,
+        mTau: Optional[cute.Tensor],
         window_size_left: Optional[Int32],
         window_size_right: Optional[Int32],
         learnable_sink: Optional[cute.Tensor],
@@ -2464,6 +2472,7 @@ class FlashAttentionForwardSm100:
                 softmax_scale=softmax_scale,
                 softmax_scale_true=softmax_scale_true,
                 inv_softmax_scale=inv_softmax_scale,
+                mTau=mTau,
                 thr_mma_qk=thr_mma_qk,
                 sScale=sScale,
                 mLSE=mLSE,
@@ -3693,6 +3702,7 @@ class FlashAttentionForwardSm100:
         softmax_scale: Float32,
         softmax_scale_true: Float32,
         inv_softmax_scale: Float32,
+        mTau: Optional[cute.Tensor],
         thr_mma_qk: cute.core.ThrMma,
         tStS: cute.Tensor,  # ((TILE_M, TILE_N), 1, 1, q_stage)
         sScale: cute.Tensor,
@@ -3920,6 +3930,7 @@ class FlashAttentionForwardSm100:
                 head_idx=head_idx,
                 m_block=(self.q_stage * m_block + stage) * self.cta_group_size,
                 inv_softmax_scale=inv_softmax_scale,
+                mTau=mTau,
                 seqlen=seqlen,
                 aux_tensors=aux_tensors,
                 fastdiv_mods=fastdiv_mods,
@@ -4260,6 +4271,7 @@ class FlashAttentionForwardSm100:
         head_idx: Int32,
         m_block: Int32,
         inv_softmax_scale: Float32,
+        mTau: Optional[cute.Tensor],
         seqlen,
         aux_tensors: Optional[list] = None,
         fastdiv_mods=(None, None),
@@ -4365,6 +4377,24 @@ class FlashAttentionForwardSm100:
                 head_divmod,
             )
 
+        if const_expr(mTau is not None):
+            # Per-query-row scale on the raw (qk + bias/scale) tile; the later
+            # scale_log2 multiply distributes it over the total logits. Must
+            # precede masking (-inf rows) and the online row-max.
+            cTau = cute.make_identity_tensor((self.m_block_size, self.n_block_size))
+            cTau = cute.domain_offset((m_block * self.m_block_size, 0), cTau)
+            tScTau = thr_mma_qk.partition_C(cTau)
+            tau_row = thr_tmem_load.partition_D(tScTau[(None, None), 0, 0])[0][0]
+            if const_expr(self.pack_gqa):
+                tau_row, _ = divmod(tau_row, head_divmod)
+            tau = Float32(1.0)
+            if tau_row < seqlen.seqlen_q:
+                if const_expr(seqlen.has_cu_seqlens_q):
+                    tau = mTau[seqlen.offset_q + tau_row]
+                else:
+                    tau = mTau[batch_idx, tau_row]
+            tSrS_t2r.store(tSrS_t2r.load() * tau)
+
         # may need to mask out dummy bias add
         if const_expr(mask_fn is not None):
             mask_fn(tSrS_t2r, n_block=n_block)
@@ -4401,7 +4431,7 @@ class FlashAttentionForwardSm100:
             tSrP_r2t,
             ex2_emu_freq=(
                 self.ex2_emu_freq
-                if const_expr(mask_fn is None and not apply_bias)
+                if const_expr(mask_fn is None and not apply_bias and mTau is None)
                 else 0
             ),
             ex2_emu_start_frg=self.ex2_emu_start_frg,
@@ -6466,6 +6496,7 @@ def _flash_attn_fwd_standalone(
         m_lse,
         m_logits_max,
         softmax_scale,
+        None,  # mTau
         m_sfq,
         m_sfk,
         m_sfv,
@@ -6523,7 +6554,7 @@ def _flash_attn_fwd_standalone(
     if compiled is None:
         compiled = cute.compile(kernel, *compile_args)
         _STANDALONE_FORWARD_CACHE[cache_key] = compiled
-    runtime_args = compile_args[:10] + compile_args[12:]
+    runtime_args = compile_args[:11] + compile_args[13:]
     compiled(*runtime_args)
     return out, lse, logits_max
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/flash_fwd_sm100_bias_decode.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/flash_fwd_sm100_bias_decode.py
@@ -1044,6 +1044,7 @@ class FlashAttentionDecodeSm100Bias:
         m_partial_bsh: Optional[cute.Tensor],  # partial colmax_s per kv split
         l_partial_bsh: Optional[cute.Tensor],  # partial colsum_p per kv split
         scale_s: Float32,
+        mTau: Optional[cute.Tensor] = None,
         mCuSeqlensQ: Optional[cute.Tensor] = None,
         mCuSeqlensK: Optional[cute.Tensor] = None,
         mSeqUsedQ: Optional[cute.Tensor] = None,
@@ -1057,6 +1058,10 @@ class FlashAttentionDecodeSm100Bias:
         """Launch fixed-length, native packed-varlen, or paged-KV Decode.
 
         ``bias_bshr=None`` selects static no-relative-bias codegen.
+        ``mTau`` is an optional fp32 per-query-row multiplier on the total
+        pre-softmax logits, ``tau * (scale_s * q@k^T + bias)`` — (B, Sq) for
+        fixed/paged launches, flat (total_q,) for packed varlen. Values must
+        be positive (masked -inf lanes must stay -inf).
         ``rel_bias_layout="compact"`` consumes (B, Sq, Hq, R).
         ``rel_bias_layout="sheared"`` consumes the corresponding Prefill
         ShearingBias allocation (B, round_up(Sq, 128), Hq, R + 256). The layout
@@ -1110,6 +1115,9 @@ class FlashAttentionDecodeSm100Bias:
         assert k_bshd.dtype == qk_dtype
         if cutlass.const_expr(bias_bshr is not None):
             assert bias_bshr.dtype == v_mma_dtype
+        if cutlass.const_expr(mTau is not None):
+            assert mTau.dtype == Float32
+            assert cute.rank(mTau) == (1 if is_varlen_q else 2)
         if cutlass.const_expr(is_paged_kv):
             assert mPageTable is not None and mPageTableOffsets is not None
             assert mSeqUsedK is not None
@@ -1798,6 +1806,7 @@ class FlashAttentionDecodeSm100Bias:
             mM_partial_nl,
             mL_partial_nl,
             scale_s_log2_e,
+            mTau,
         ).launch(
             grid=grid,
             block=[self.threads_per_cta, 1, 1],
@@ -2171,6 +2180,8 @@ class FlashAttentionDecodeSm100Bias:
         mM_partial: Optional[cute.Tensor],
         mL_partial: Optional[cute.Tensor],
         scale_s_log2_e: Float32,
+        # Optional fp32 per-query-row scale on the total pre-softmax logits
+        mTau: Optional[cute.Tensor] = None,
     ):
         ##############################
         # Static variables
@@ -3572,6 +3583,21 @@ class FlashAttentionDecodeSm100Bias:
                                                     )
                                                     score_log2 += bias_log2
                                     scores_log2_rmem[h, p, sm] = score_log2
+                if cutlass.const_expr(mTau is not None):
+                    # Per-query-row scale on the total logits. log2 space is
+                    # linear, so this composes with scale_s and the bias; it
+                    # must sit outside the bias window skip above.
+                    for p in cutlass.range_constexpr(blk_tile_p):
+                        query_idx = coord_p * blk_tile_p + p
+                        tau = Float32(1.0)
+                        if query_idx < prediction:
+                            if cutlass.const_expr(is_varlen_q):
+                                tau = mTau[offset_q + query_idx]
+                            else:
+                                tau = mTau[coord_b, query_idx]
+                        for sm in cutlass.range_constexpr(tiles_sm):
+                            row_scores = scores_log2_rmem[None, p, sm]
+                            row_scores.store(row_scores.load() * tau)
                 scores_log2 = scores_log2_rmem.load().reshape((blk_tile_n, tiles_sm))
 
                 # Reduce colmax in thread RF
@@ -4823,6 +4849,7 @@ def run(
         m_partial_cute,
         l_partial_cute,
         scale_s,
+        None,  # mTau
         None,  # mCuSeqlensQ
         None,  # mCuSeqlensK
         None,  # mSeqUsedQ
@@ -4885,6 +4912,7 @@ def run(
             m_partial_cute,
             l_partial_cute,
             scale_s,
+            None,  # mTau
             None,
             None,
             None,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/rel_decode.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/rel_decode.py
@@ -173,6 +173,7 @@ class _FwdCache:
         use_pdl,
         blocks_per_page=1,
         blockscaled=False,
+        has_tau=False,
     ):
         key = (
             num_q_heads,
@@ -185,6 +186,7 @@ class _FwdCache:
             use_pdl,
             blocks_per_page,
             blockscaled,
+            has_tau,
         )
         if key not in self._cache:
             self._cache[key] = _compile_fwd(*key)
@@ -202,6 +204,7 @@ def _compile_fwd(
     use_pdl=False,
     blocks_per_page=1,
     blockscaled=False,
+    has_tau=False,
 ):
     """``dtype`` is the bias/output dtype. With ``blockscaled`` the data
     tensors are fp8-e4m3 (MXFP8: UE8M0 vec-32 scales, fp8 V dequantized
@@ -284,6 +287,13 @@ def _compile_fwd(
         for t in (pt, seqused)
     ]
     m_lse = to_cute_tensor(lse, assumed_align=4) if lse is not None else None
+    m_tau = (
+        to_cute_tensor(
+            torch.empty(B, 128, device=dev, dtype=torch.float32), assumed_align=4
+        )
+        if has_tau
+        else None
+    )
     compile_args = (
         m_q,
         m_k,
@@ -292,6 +302,7 @@ def _compile_fwd(
         m_lse,  # mLSE (split partials when num_splits > 1)
         None,  # mRowMax
         1.0 / math.sqrt(head_dim),
+        m_tau,
         m_sfq,
         m_sfk,
         m_sfv,
@@ -399,6 +410,7 @@ def rel_mha_decode_tsmha(
     cu_seqlens_q: torch.Tensor,  # unused (batch mode); kept for call parity
     window_left: int,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,  # (B * prediction,) fp32 per-row logit scale
     enable_pdl: bool = False,
     q_scale: torch.Tensor | None = None,  # (B * P, H, D // 32) e8m0
     k_scale: torch.Tensor | None = None,  # (pages, h_kv, k, 32, 4, 4) e8m0
@@ -473,6 +485,7 @@ def rel_mha_decode_tsmha(
         enable_pdl,
         blocks_per_page,
         blockscaled,
+        tau is not None,
     )
     o = torch.empty(q.shape, device=q.device, dtype=out_dtype)
     if num_splits > 1:
@@ -505,6 +518,7 @@ def rel_mha_decode_tsmha(
         lse_arg,
         None,
         scale,
+        tau.view(B, P) if tau is not None else None,
         *sf_args,
         None,  # mCuSeqlensQ: batch mode
         None,
@@ -537,7 +551,13 @@ def rel_mha_decode_tsmha(
 
 
 def is_compiled_for(
-    q, k_cache, rel_logits, window_left, enable_pdl=False, blockscaled=False
+    q,
+    k_cache,
+    rel_logits,
+    window_left,
+    enable_pdl=False,
+    blockscaled=False,
+    has_tau=False,
 ) -> bool:
     """True when both prepass and fwd kernels for this config are cached."""
     H = q.shape[1]
@@ -556,6 +576,7 @@ def is_compiled_for(
         enable_pdl,
         k_cache.shape[1] // 128,
         blockscaled,
+        has_tau,
     )
     if fwd_key not in _FWD._cache:
         return False
@@ -573,6 +594,7 @@ def warmup(
     enable_pdl=False,
     blocks_per_page=1,
     blockscaled=False,
+    has_tau=False,
 ):
     """Pre-compile shear + fwd kernels outside CUDA-graph capture.
 
@@ -595,6 +617,7 @@ def warmup(
             enable_pdl,
             blocks_per_page,
             blockscaled,
+            has_tau,
         )
         if not is_local and _FULL_ATTN_SPLITS > 1:
             _COMBINE.get(head_dim, dtype, _FULL_ATTN_SPLITS, enable_pdl)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/rel_decode_v2.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/rel_decode_v2.py
@@ -106,6 +106,7 @@ def _compile_decode(
     page_size: int,
     use_pdl: bool,
     prediction: int = 1,
+    has_tau: bool = False,
 ):
     from cutlass import cute
     from flash_attn.cute.cute_dsl_utils import to_cute_tensor
@@ -143,6 +144,7 @@ def _compile_decode(
     pt = torch.empty(FB * 4, device=dev, dtype=torch.int32)
     po = torch.empty(FB, device=dev, dtype=torch.int32)
     su = torch.empty(FB, device=dev, dtype=torch.int32)
+    tau = torch.empty(FB, P, device=dev, dtype=torch.float32) if has_tau else None
     return cute.compile(
         kernel,
         kv_splits,
@@ -158,6 +160,7 @@ def _compile_decode(
         to_cute_tensor(mp, assumed_align=4),
         to_cute_tensor(lp, assumed_align=4),
         1.0 / math.sqrt(head_dim),
+        to_cute_tensor(tau, assumed_align=4) if has_tau else None,
         None,  # mCuSeqlensQ
         None,  # mCuSeqlensK
         None,  # mSeqUsedQ
@@ -227,7 +230,13 @@ def v2_buffers_ready(q, window_left, page_table, prediction: int = 1) -> bool:
 
 
 def is_compiled_for_v2(
-    q, k_cache, rel_logits, window_left, enable_pdl: bool = True, prediction: int = 1
+    q,
+    k_cache,
+    rel_logits,
+    window_left,
+    enable_pdl: bool = True,
+    prediction: int = 1,
+    has_tau: bool = False,
 ) -> bool:
     """Whether the config's kernel is already compiled (graph-capture guard)."""
     kv_splits = 1 if window_left >= 0 else _V2_FULL_SPLITS
@@ -243,6 +252,7 @@ def is_compiled_for_v2(
         k_cache.shape[1],
         enable_pdl,
         prediction,
+        has_tau,
     )
     return key in _DECODE._cache
 
@@ -270,6 +280,7 @@ def rel_mha_decode_tsmha_v2(
     rel_logits: torch.Tensor,  # (B * prediction, num_q_heads, extent)
     window_left: int,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,  # (B * prediction,) fp32
     enable_pdl: bool = True,
     prediction: int = 1,
 ) -> torch.Tensor:
@@ -287,7 +298,9 @@ def rel_mha_decode_tsmha_v2(
     256 tokens — the kernel's sub-page TMA boxes cover all three). It must
     be (a view of) the engine's address-stable per-step table with a dense
     innermost dim (column-sliced row strides are fine) and ``-1`` holes
-    only outside the sliding window. Returns
+    only outside the sliding window. ``tau`` is an optional fp32 per-query-row
+    multiplier fused onto the total pre-softmax logits,
+    ``tau * (softmax_scale * q@k^T + rel)``; values must be positive. Returns
     ``(B * prediction, num_q_heads * head_dim)`` in the query dtype.
     """
     P = max(prediction, 1)
@@ -317,6 +330,7 @@ def rel_mha_decode_tsmha_v2(
         page_tokens,
         enable_pdl,
         P,
+        tau is not None,
     )
 
     row_stride = page_table.stride(0)
@@ -348,6 +362,7 @@ def rel_mha_decode_tsmha_v2(
         mp_w,
         lp_w,
         softmax_scale,
+        tau.view(B, P) if tau is not None else None,
         None,
         None,
         None,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/rel_extend.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/cute_dsl/rel_mha/rel_extend.py
@@ -60,6 +60,7 @@ def _compile_fwd_varlen(
     use_pdl=False,
     blocks_per_page=1,
     blockscaled=False,
+    has_tau=False,
 ):
     """``dtype`` is the bias/output dtype. ``blockscaled`` (paged only)
     compiles the MXFP8 variant: fp8-e4m3 q/k/v, UE8M0 vec-32 scales (flat
@@ -104,6 +105,13 @@ def _compile_fwd_varlen(
         TOTAL_Q + 128, num_q_heads, extent + 256, device=dev, dtype=dtype
     )
     cu_q = torch.empty(B + 1, device=dev, dtype=torch.int32)
+    m_tau = (
+        to_cute_tensor(
+            torch.empty(TOTAL_Q, device=dev, dtype=torch.float32), assumed_align=4
+        )
+        if has_tau
+        else None
+    )
     m_q, m_o, m_bias = [to_cute_tensor(t) for t in (q, o, bias)]
     m_cu_q = to_cute_tensor(cu_q, assumed_align=4, leading_dim=0)
     if paged:
@@ -154,6 +162,7 @@ def _compile_fwd_varlen(
         None,  # mLSE
         None,  # mRowMax
         1.0 / math.sqrt(head_dim),
+        m_tau,
         m_sfq,
         m_sfk,
         m_sfv,
@@ -278,6 +287,7 @@ def is_compiled_for(
     blocks_per_page=1,
     blockscaled=False,
     out_dtype=None,
+    has_tau=False,
 ) -> bool:
     """True when the prep, shear, and fwd kernels for this config are cached."""
     dtype = out_dtype or (torch.bfloat16 if blockscaled else q.dtype)
@@ -292,6 +302,7 @@ def is_compiled_for(
         enable_pdl,
         blocks_per_page,
         blockscaled,
+        has_tau,
     )
     shear_key = (extent, is_local, dtype, paged)
     return fwd_key in _FWD_VARLEN and shear_key in _SHEAR and "prep" in _PREP
@@ -310,6 +321,7 @@ def rel_mha_varlen_tsmha(
     page_table: torch.Tensor | None = None,  # (B, max_pages) int32, paged extend
     cache_seqlens: torch.Tensor | None = None,  # (B,) int32, paged extend
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,  # (total_q,) fp32 per-row logit scale
     enable_pdl: bool = False,
     q_scale: torch.Tensor | None = None,  # (total_q, H, D // 32) e8m0
     k_scale: torch.Tensor | None = None,  # (pages, h_kv, k, 32, 4, 4) e8m0
@@ -366,6 +378,7 @@ def rel_mha_varlen_tsmha(
         enable_pdl,
         blocks_per_page,
         blockscaled,
+        tau is not None,
     )
     fwd = _FWD_VARLEN.get(fwd_key)
     if fwd is None:
@@ -380,6 +393,7 @@ def rel_mha_varlen_tsmha(
             enable_pdl,
             blocks_per_page,
             blockscaled,
+            tau is not None,
         )
 
     cu_blocks = torch.empty(B + 1, device=dev, dtype=torch.int32)
@@ -423,6 +437,7 @@ def rel_mha_varlen_tsmha(
         None,
         None,
         scale,
+        tau,
         *sf_args,
         cu_seqlens_q,
         cu_seqlens_k,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/flash_attn/__init__.py
@@ -623,6 +623,7 @@ if platform.is_nvidia and platform.is_blackwell:
         window_left: int = -1,
         return_lse: bool = False,
         softmax_scale: float | None = None,
+        tau: torch.Tensor | None = None,
         enable_pdl: bool = False,
         q_scale: torch.Tensor | None = None,
         k_scale: torch.Tensor | None = None,
@@ -648,6 +649,7 @@ if platform.is_nvidia and platform.is_blackwell:
                     window_left >= 0,
                     False,
                     enable_pdl,
+                    has_tau=tau is not None,
                 )
                 or not torch.cuda.is_current_stream_capturing()
             ):
@@ -662,8 +664,13 @@ if platform.is_nvidia and platform.is_blackwell:
                     max_seqlen_k=max_seqlen,
                     cu_seqlens_k=cu_seqlens,
                     softmax_scale=softmax_scale,
+                    tau=tau,
                     enable_pdl=enable_pdl,
                 )
+        if tau is not None:
+            # The fork fallback lacks fused tau; fold it into q and the bias.
+            q = q * tau[:, None, None].to(q.dtype)
+            rel_logits = rel_logits * tau[:, None, None].to(rel_logits.dtype)
         extra, window_size = _rel_attention_kwargs(rel_logits, window_left)
         out, lse = flash_attn_varlen_func(
             q=q,
@@ -717,6 +724,7 @@ if platform.is_nvidia and platform.is_blackwell:
         return_lse: bool = False,
         softmax_scale: float | None = None,
         enable_pdl: bool = False,
+        tau: torch.Tensor | None = None,
         # Call parity with the dispatcher's unconditional scale pass; the
         # dense path takes no scales (mxfp8 rides its own registration).
         q_scale: torch.Tensor | None = None,
@@ -745,6 +753,7 @@ if platform.is_nvidia and platform.is_blackwell:
                     window_left >= 0,
                     True,
                     enable_pdl,
+                    has_tau=tau is not None,
                 )
                 or not torch.cuda.is_current_stream_capturing()
             ):
@@ -760,8 +769,13 @@ if platform.is_nvidia and platform.is_blackwell:
                     page_table=page_table,
                     cache_seqlens=cache_seqlens,
                     softmax_scale=softmax_scale,
+                    tau=tau,
                     enable_pdl=enable_pdl,
                 )
+        if tau is not None:
+            # The fork fallback lacks fused tau; fold it into q and the bias.
+            q = q * tau[:, None, None].to(q.dtype)
+            rel_logits = rel_logits * tau[:, None, None].to(rel_logits.dtype)
         extra, window_size = _rel_attention_kwargs(rel_logits, window_left)
         out, lse = flash_attn_varlen_func(
             q=q,
@@ -813,6 +827,7 @@ if platform.is_nvidia and platform.is_blackwell:
         max_seqlen_q: int = 1,
         window_left: int = -1,
         softmax_scale: float | None = None,
+        tau: torch.Tensor | None = None,
         enable_pdl: bool = False,
         q_scale: torch.Tensor | None = None,
         k_scale: torch.Tensor | None = None,
@@ -844,7 +859,13 @@ if platform.is_nvidia and platform.is_blackwell:
             _pred = max_seqlen_q if _native_multiq else 1
             if not torch.cuda.is_current_stream_capturing() or (
                 is_compiled_for_v2(
-                    q, k_cache, _rl, window_left, enable_pdl, prediction=_pred
+                    q,
+                    k_cache,
+                    _rl,
+                    window_left,
+                    enable_pdl,
+                    prediction=_pred,
+                    has_tau=tau is not None,
                 )
                 and v2_buffers_ready(q, window_left, page_table, prediction=_pred)
             ):
@@ -859,6 +880,7 @@ if platform.is_nvidia and platform.is_blackwell:
                     rel_logits=_rl,
                     window_left=window_left,
                     softmax_scale=softmax_scale,
+                    tau=tau,
                     enable_pdl=enable_pdl,
                     prediction=_pred,
                 ).view(q.shape)
@@ -877,7 +899,14 @@ if platform.is_nvidia and platform.is_blackwell:
 
             # Never compile during graph capture; the engine's uncaptured warmup decode compiles first.
             if (
-                is_compiled_for(q, k_cache, rel_logits, window_left, enable_pdl)
+                is_compiled_for(
+                    q,
+                    k_cache,
+                    rel_logits,
+                    window_left,
+                    enable_pdl,
+                    has_tau=tau is not None,
+                )
                 or not torch.cuda.is_current_stream_capturing()
             ):
                 return rel_mha_decode_tsmha(
@@ -890,11 +919,18 @@ if platform.is_nvidia and platform.is_blackwell:
                     cu_seqlens_q=cu_seqlens_q,
                     window_left=window_left,
                     softmax_scale=softmax_scale,
+                    tau=tau,
                     enable_pdl=enable_pdl,
                 )
         # Varlen required: batch mode reports offset_q 0 for every request (wrong rel_logits rows).
         if softmax_scale is None:
             softmax_scale = 1.0 / math.sqrt(q.shape[-1])
+        if tau is not None:
+            # The fork fallback lacks fused tau; fold it into q and the bias.
+            q = q * tau[:, None, None].to(q.dtype)
+            rel_logits = rel_logits.reshape(q.shape[0], q.shape[1], -1) * tau[
+                :, None, None
+            ].to(rel_logits.dtype)
         extra, window_size = _rel_attention_kwargs(rel_logits, window_left)
         # Use split-kv heuristic (num_splits=0) for full attention.
         num_splits = 0 if window_left < 0 else 1
@@ -944,6 +980,7 @@ if platform.is_nvidia and platform.is_blackwell:
         max_seqlen_q: int = 1,
         window_left: int = -1,
         softmax_scale: float | None = None,
+        tau: torch.Tensor | None = None,
         enable_pdl: bool = False,
         q_scale: torch.Tensor | None = None,
         k_scale: torch.Tensor | None = None,
@@ -967,7 +1004,13 @@ if platform.is_nvidia and platform.is_blackwell:
 
         if (
             not is_compiled_for(
-                q, k_cache, rel_logits, window_left, enable_pdl, blockscaled=True
+                q,
+                k_cache,
+                rel_logits,
+                window_left,
+                enable_pdl,
+                blockscaled=True,
+                has_tau=tau is not None,
             )
             and torch.cuda.is_current_stream_capturing()
         ):
@@ -986,6 +1029,7 @@ if platform.is_nvidia and platform.is_blackwell:
             cu_seqlens_q=cu_seqlens_q,
             window_left=window_left,
             softmax_scale=softmax_scale,
+            tau=tau,
             enable_pdl=enable_pdl,
             q_scale=q_scale,
             k_scale=k_scale,
@@ -1023,6 +1067,7 @@ if platform.is_nvidia and platform.is_blackwell:
         window_left: int = -1,
         return_lse: bool = False,
         softmax_scale: float | None = None,
+        tau: torch.Tensor | None = None,
         enable_pdl: bool = False,
         q_scale: torch.Tensor | None = None,
         k_scale: torch.Tensor | None = None,
@@ -1058,6 +1103,7 @@ if platform.is_nvidia and platform.is_blackwell:
                 k_cache.shape[1] // 128,
                 blockscaled=True,
                 out_dtype=rel_logits.dtype,
+                has_tau=tau is not None,
             )
             and torch.cuda.is_current_stream_capturing()
         ):
@@ -1078,6 +1124,7 @@ if platform.is_nvidia and platform.is_blackwell:
             page_table=page_table,
             cache_seqlens=cache_seqlens,
             softmax_scale=softmax_scale,
+            tau=tau,
             enable_pdl=enable_pdl,
             q_scale=q_scale,
             k_scale=k_scale,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -1393,6 +1393,14 @@ if current_platform().is_amd:
     )
     def gluon_rel_mha_prefill_gfx950(*args, **kwargs):
         kwargs.pop("enable_pdl", None)
+        tau = kwargs.pop("tau", None)
+        if tau is not None:
+            # No fused per-row logit scale in the gluon backend; fold tau
+            # into q and the rel bias: tau*(scale*qk + rel).
+            kwargs["q"] = kwargs["q"] * tau[:, None, None].to(kwargs["q"].dtype)
+            kwargs["rel_logits"] = kwargs["rel_logits"] * tau[:, None, None].to(
+                kwargs["rel_logits"].dtype
+            )
         return _rel_prefill_impl(*args, **kwargs)
 
     @register_kernel(
@@ -1418,6 +1426,14 @@ if current_platform().is_amd:
     )
     def gluon_rel_mha_extend_gfx950(*args, **kwargs):
         kwargs.pop("enable_pdl", None)
+        tau = kwargs.pop("tau", None)
+        if tau is not None:
+            # No fused per-row logit scale in the gluon backend; fold tau
+            # into q and the rel bias: tau*(scale*qk + rel).
+            kwargs["q"] = kwargs["q"] * tau[:, None, None].to(kwargs["q"].dtype)
+            kwargs["rel_logits"] = kwargs["rel_logits"] * tau[:, None, None].to(
+                kwargs["rel_logits"].dtype
+            )
         return _rel_extend_impl(*args, **kwargs)
 
     @register_kernel(
@@ -1443,4 +1459,12 @@ if current_platform().is_amd:
     )
     def gluon_rel_mha_decode_gfx950(*args, **kwargs):
         kwargs.pop("enable_pdl", None)
+        tau = kwargs.pop("tau", None)
+        if tau is not None:
+            # No fused per-row logit scale in the gluon backend; fold tau
+            # into q and the rel bias: tau*(scale*qk + rel).
+            kwargs["q"] = kwargs["q"] * tau[:, None, None].to(kwargs["q"].dtype)
+            kwargs["rel_logits"] = kwargs["rel_logits"] * tau[:, None, None].to(
+                kwargs["rel_logits"].dtype
+            )
         return _rel_decode_impl(*args, **kwargs)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/log_scaling.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/log_scaling.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Fused long-context log-scaling tau from per-token positions."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+
+__all__ = ["log_scaling_tau"]
+
+
+@triton.jit
+def _log_scaling_tau_kernel(
+    positions_ptr,
+    out_ptr,
+    n,
+    n_floor,
+    alpha,
+    BLOCK: tl.constexpr,
+):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < n
+    pos = tl.load(positions_ptr + offs, mask=mask, other=0)
+    effective_n = (pos + 1).to(tl.float32) / n_floor
+    tau = 1.0 + alpha * tl.log(tl.maximum(effective_n, 1.0))
+    tl.store(out_ptr + offs, tau, mask=mask)
+
+
+def log_scaling_tau(
+    positions: torch.Tensor, n_floor: int, alpha: float
+) -> torch.Tensor:
+    """Per-token attention-logit scale ``1 + alpha * log(max((pos+1)/n_floor, 1))``.
+
+    One fused launch replacing the eager elementwise chain; valid for any
+    position value (no precomputed-table bound).
+
+    Args:
+        positions: ``[T]`` integer absolute positions (CUDA).
+        n_floor: Context length below which tau is exactly 1.
+        alpha: Log-scaling slope from the model config.
+
+    Returns:
+        ``[T]`` fp32 tau values.
+    """
+    n = positions.shape[0]
+    out = torch.empty(n, dtype=torch.float32, device=positions.device)
+    if n == 0:
+        return out
+    BLOCK = 1024
+    _log_scaling_tau_kernel[(triton.cdiv(n, BLOCK),)](
+        positions,
+        out,
+        n,
+        float(n_floor),
+        float(alpha),
+        BLOCK=BLOCK,
+    )
+    return out

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/rel_mha.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/rel_mha.py
@@ -862,10 +862,16 @@ def triton_rel_mha_prefill(
     window_left: int = -1,
     return_lse: bool = False,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,
     enable_pdl: bool = False,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(q.shape[-1])
+    if tau is not None:
+        # No fused per-row logit scale in this backend; fold tau into q and
+        # the rel bias: tau*(scale*qk + rel).
+        q = q * tau[:, None, None].to(q.dtype)
+        rel_logits = rel_logits * tau[:, None, None].to(rel_logits.dtype)
     out = torch.empty_like(q)
     lse = (
         torch.empty((q.shape[0], q.shape[1]), dtype=torch.float32, device=q.device)
@@ -926,6 +932,7 @@ def triton_rel_mha_extend_with_kvcache(
     window_left: int = -1,
     return_lse: bool = False,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,
     enable_pdl: bool = False,
     q_scale: torch.Tensor | None = None,
     k_scale: torch.Tensor | None = None,
@@ -933,6 +940,11 @@ def triton_rel_mha_extend_with_kvcache(
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(q.shape[-1])
+    if tau is not None:
+        # No fused per-row logit scale in this backend; fold tau into q and
+        # the rel bias: tau*(scale*qk + rel).
+        q = q * tau[:, None, None].to(q.dtype)
+        rel_logits = rel_logits * tau[:, None, None].to(rel_logits.dtype)
     k = torch.empty(
         (0, k_cache.shape[2], k_cache.shape[3]),
         dtype=k_cache.dtype,
@@ -1001,6 +1013,7 @@ def triton_rel_mha_decode_with_kvcache(
     max_seqlen_q: int = 1,
     window_left: int = -1,
     softmax_scale: float | None = None,
+    tau: torch.Tensor | None = None,
     enable_pdl: bool = False,
     q_scale: torch.Tensor | None = None,
     k_scale: torch.Tensor | None = None,
@@ -1008,6 +1021,11 @@ def triton_rel_mha_decode_with_kvcache(
 ) -> torch.Tensor:
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(q.shape[-1])
+    if tau is not None:
+        # No fused per-row logit scale in this backend; fold tau into q and
+        # the rel bias: tau*(scale*qk + rel).
+        q = q * tau[:, None, None].to(q.dtype)
+        rel_logits = rel_logits * tau[:, None, None].to(rel_logits.dtype)
     out = torch.empty_like(q)
     max_kv_splits = _decode_split_count(max_seqlen_k, window_left)
     attn_logits = torch.empty(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/conv/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/conv/__init__.py
@@ -122,7 +122,8 @@ def inkling_ring_sconv(
     later round covering the same boundary.
 
     Args:
-        x: Varlen-packed input ``[T, D]`` (e.g. bf16), D-contiguous.
+        x: Varlen-packed input ``[T, D]`` (e.g. bf16). May be a strided
+            slice of a wider buffer.
         weight: Per-channel FIR taps ``[D, W]``; tap ``W - 1`` multiplies
             the current token.
         conv_cache: Conv state ring ``[num_slots, R, D]`` with

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_nvfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_nvfp4.py
@@ -313,13 +313,11 @@ if platform.is_nvidia:
         )
 
         if routed:
-            # FlashInfer's UnpackedPrecomputed mode requires bf16 route weights
-            # regardless of whether it finalizes the expert outputs. Deferred
-            # callers retain their original fp32 weights for the later fused
-            # finalize step.
+            # UnpackedPrecomputed route weights pass at their native dtype
+            # (fp32 or bf16), no cast needed since flashinfer 0.6.16.
             topk = (
                 topk_ids.to(torch.int32),
-                topk_weights.to(torch.bfloat16),
+                topk_weights,
             )
             result = trtllm_fp4_block_scale_routed_moe(
                 topk_ids=topk,


### PR DESCRIPTION
## Summary

Inkling decode showed a tail of small elementwise/copy kernels between the MoE and attention all-reduces of every layer. This PR removes them at the source, plus a debug-path cleanup found along the way.

### Changes

**Copy/cast elimination**
- **sconv**: feed the fused kvconv call the strided `qkvr` K/V slice directly —
  the kernel already takes explicit strides, the `.contiguous()` only paid a
  per-layer copy.
- **rel-logits projection**: `einsum` → `torch.matmul`, which hands cuBLAS the
  strided R slice with no input copy; the downstream `.contiguous()` became a
  no-op and is dropped.
- **MoE route weights**: pass fp32 top-k weights to FlashInfer's routed NVFP4
  MoE unchanged. Restores the #689 pass-through removed by #716 for FlashInfer
  0.6.15; the pinned 0.6.16 consumes them at native dtype, and deferred callers
  never have the values read at all.

**Fused log-scaling tau** (`tau = 1 + α·log((pos+1)/n_floor)`, full-attention layers)
- Previously two multiplies + two casts per full layer per step (post-norm q
  and rel_logits). Now an optional fp32 per-query-row logit scale in the
  rel-MHA kernels: `softmax(tau · (scale·qkᵀ + rel))`, fused into the
  log2-space softmax of both the decode and prefill cute_dsl kernels (MXFP8
  included — single softmax body, fp32 accumulator).
- Wired through the wrappers (with `has_tau` in compile caches and CUDA-graph
  capture gates), the public ops, backend, and model. triton/gluon and the
  fork-varlen fallback fold tau into q/rel exactly as before, so portable/AMD
  behavior is unchanged.
- tau itself is computed by one fused triton kernel from positions per
  forward (replacing a ~6-kernel eager recompute), valid for any position —
  including speculative-verify overshoot rows past the context limit, which a
  precomputed table would index out of bounds (review finding on this PR).
  `tl.log` differs from `torch.log` by ≤1 ulp. `model_max_length` is now a
  declared config field (checkpoint value 1048576) consumed by the
  context-length validation.

**Cleanup**
- Remove `INKLING_POOL_PROBE_DIR` diagnostics and the `INKLING_ATTN_RELFORK`
  escape hatch (fork now unconditional), and dissolve the retired
  `INKLING_HETERO_KV` gate end to end (dead uniform branch,
  `inkling_kv_heads_for_layer` inlined into its 4 call sites, factor-1
  replication scaffolding dropped from tests).

