### PR TITLE
fix(scheduler): prioritize batched prefill handoffs

### DIFF
--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -536,6 +536,12 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
         const bool recovery_front = !recovery_queue_.empty() && request->Id() == recovery_queue_.front();
         const bool local_decode_prefill =
             request->Is<fsm::Prefilling>() && request->PrefillSource() == fsm::PrefillSource::kLocal;
+        if (config_.role == Role::kP && request->Is<fsm::PrefillDone>()) {
+            // Completed P-side prefills hold their KV pages until the remote
+            // transfer finishes, so start their handoffs before admitting
+            // more prompt tokens.
+            return 0;
+        }
         if (config_.role == Role::kD && (local_decode_prefill || request->Is<fsm::PrefillDone>() ||
                                          (recovery_front && request->Is<fsm::Decoding>()))) {
             // Keep the oldest retracted request at the head of line through
@@ -565,6 +571,14 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
         const int rhs_priority = priority(rhs);
         return lhs_priority != rhs_priority ? lhs_priority < rhs_priority : lhs->Id() < rhs->Id();
     });
+
+    // EventLoop selects the P-side KV-transfer path only for an all-zero-extend
+    // ForwardBatch.  Once the highest-priority candidate selects that batch
+    // kind, collect every consecutive PrefillDone candidate but do not mix in
+    // local prefill work.  PrefillDone candidates are contiguous because they
+    // all have priority zero above.
+    const bool build_prefill_handoff_batch =
+        config_.role == Role::kP && !candidates.empty() && candidates.front()->Is<fsm::PrefillDone>();
 
     const bool has_local_prefill = std::ranges::any_of(candidates, [this](const Request* request) {
         return (request->Is<fsm::Prefilling>() && request->PrefillSource() == fsm::PrefillSource::kLocal) ||
@@ -608,6 +622,9 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
 
     for (Request* request : candidates) {
         if (token_budget <= 0 || operations.size() == static_cast<std::size_t>(config_.max_batch_size)) {
+            break;
+        }
+        if (build_prefill_handoff_batch && !request->Is<fsm::PrefillDone>()) {
             break;
         }
 

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -585,10 +585,10 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
                (config_.role != Role::kD && request->Is<fsm::Submitted>()) ||
                (request->Is<fsm::Retracted>() && !recovery_queue_.empty() && request->Id() == recovery_queue_.front());
     });
-    const std::int32_t state_prefill_reserve =
-        config_.enable_mixed_prefill_decode && coordinator_.HasMambaStateGroup() && has_local_prefill
-            ? coordinator_.PrefixGranularity()
-            : 0;
+    const std::int32_t state_prefill_reserve = !build_prefill_handoff_batch && config_.enable_mixed_prefill_decode &&
+                                                       coordinator_.HasMambaStateGroup() && has_local_prefill
+                                                   ? coordinator_.PrefixGranularity()
+                                                   : 0;
 
     std::vector<ForwardOperation> operations;
     std::vector<LoadBackOperation> load_back_operations;

--- a/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
+++ b/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
@@ -32,12 +32,14 @@ Covers:
 
 import pytest
 from tokenspeed_scheduler import (
+    PD,
     ExecutionEvent,
     ExecutionPlan,
     ForwardEvent,
     PagedCacheGroupConfig,
     PagedCacheGroupFamily,
     PagedCacheRetention,
+    PagedCacheTransferPolicy,
     RequestSpec,
     Scheduler,
     SchedulerConfig,
@@ -283,6 +285,38 @@ class TestPrefillFirst:
         assert s.decoding_size() == 0
         assert plan2.forward[0].num_extends() > 0
         assert plan2.forward[0].request_ids == ["r0"]
+
+    def test_prefill_role_batches_handoffs_before_new_admission(self):
+        """Priority selects a pure, batched P-side handoff round."""
+        cfg = make_config(max_scheduled_tokens=8)
+        cfg.role = SchedulerConfig.Role.P
+        cfg.decode_input_tokens = 0
+        cfg.enable_pd_cache = True
+        cfg.paged_cache_groups[0].transfer_policy = PagedCacheTransferPolicy.FullSuffix
+        s = Scheduler(cfg)
+        s.submit_requests(
+            [
+                make_spec("r0", list(range(4))),
+                make_spec("r1", list(range(4, 8))),
+            ]
+        )
+        s.advance(
+            ExecutionEvent()
+            .add_event(PD.BootstrappedEvent("r0"))
+            .add_event(PD.BootstrappedEvent("r1"))
+        )
+
+        first_prefill = s.next_execution_plan()
+        assert first_prefill.forward[0].request_ids == ["r0", "r1"]
+        assert first_prefill.forward[0].num_extends() == 2
+
+        s.submit_requests([make_spec("r2", list(range(8, 12)))])
+        s.advance(ExecutionEvent().add_event(PD.BootstrappedEvent("r2")))
+
+        transfer_start = s.next_execution_plan()
+        assert transfer_start.forward[0].request_ids == ["r0", "r1"]
+        assert transfer_start.forward[0].num_extends() == 0
+        assert s.waiting_size() == 1
 
     def test_decode_batch_only_when_no_prefill_work(self):
         """Decode batch is only scheduled when there are no prefilling/submitted requests."""


### PR DESCRIPTION
## Problem

On the P node, completed prefills retain their KV pages until the P→D handoff is dispatched. Under sustained prefill load, `PrefillDone` requests could be delayed or mixed with normal prefill work, preventing the EventLoop from selecting the handoff path and eventually exhausting P-side KV capacity.

## Solution

Prioritize P-side `PrefillDone` requests and batch consecutive completed prefills into a pure handoff batch, ensuring KV transfers are dispatched promptly without processing them one at a time.

## Validation

Tested on B300 P8+D8 with the same long-context agentic workload.

- Before: the c24 workload stalled with no workload KV handoffs, and all 24 requests timed out.
- After: c24 completed all 282 API turns without failures, and c32 completed all 372 API turns without failures.