### PR TITLE
perf(v4): avoid prefill host synchronizations

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -986,14 +986,12 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     )
                     + query_lens_cpu[:prefix_count]
                 )
-        elif extend_seq_lens_cpu is not None and forward_mode is not None:
-            if forward_mode.is_extend():
-                seq_lens_cpu = extend_seq_lens_cpu[:bs].to(
-                    dtype=torch.int32,
-                    device="cpu",
-                )
-            elif forward_mode.is_mixed():
-                seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
+        elif (
+            extend_seq_lens_cpu is not None
+            and forward_mode is not None
+            and forward_mode.is_mixed()
+        ):
+            seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
         prefill_seq_lens: list[int] = []
         prefill_query_lens: list[int] = []
         if num_prefill_reqs:

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -960,7 +960,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         )
         seq_lens_cpu = None
         if extend_prefix_lens_cpu is not None and query_lens_cpu is not None:
-            seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
             prefix_count = min(
                 int(extend_prefix_lens_cpu.numel()),
                 (
@@ -969,6 +968,16 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     else bs
                 ),
             )
+            if prefix_count == bs:
+                seq_lens_cpu = (
+                    extend_prefix_lens_cpu[:bs].to(dtype=torch.int32, device="cpu")
+                    + query_lens_cpu[:bs]
+                )
+            else:
+                # Mixed decode rows do not have a complete host sequence-length
+                # mirror. Preserve their exact values for decode metadata while
+                # keeping the all-prefill path synchronization-free.
+                seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
             if prefix_count:
                 seq_lens_cpu[:prefix_count] = (
                     extend_prefix_lens_cpu[:prefix_count].to(
@@ -985,7 +994,46 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 )
             elif forward_mode.is_mixed():
                 seq_lens_cpu = seq_lens[:bs].to(dtype=torch.int32, device="cpu")
-        max_seq_len = int(seq_lens.max().item()) if bs else 0
+        prefill_seq_lens: list[int] = []
+        prefill_query_lens: list[int] = []
+        if num_prefill_reqs:
+            if (
+                seq_lens_cpu is None
+                or query_lens_cpu is None
+                or seq_lens_cpu.device.type != "cpu"
+                or query_lens_cpu.device.type != "cpu"
+                or seq_lens_cpu.numel() < num_prefill_reqs
+                or query_lens_cpu.numel() < num_prefill_reqs
+            ):
+                raise RuntimeError(
+                    "DeepSeek V4 prefill metadata requires complete CPU sequence "
+                    "and query length mirrors"
+                )
+            prefill_seq_lens = [
+                int(value) for value in seq_lens_cpu[:num_prefill_reqs].tolist()
+            ]
+            prefill_query_lens = [
+                int(value) for value in query_lens_cpu[:num_prefill_reqs].tolist()
+            ]
+            if any(
+                query_len < 0 or seq_len < query_len
+                for seq_len, query_len in zip(
+                    prefill_seq_lens, prefill_query_lens, strict=True
+                )
+            ):
+                raise RuntimeError(
+                    "DeepSeek V4 prefill CPU length mirrors contain an invalid "
+                    "sequence/query pair"
+                )
+
+        if num_prefill_reqs == bs:
+            max_seq_len = max(prefill_seq_lens, default=0)
+        elif bs:
+            # Preserve mixed/decode sizing semantics. Those paths do not have
+            # a complete CPU sequence-length mirror.
+            max_seq_len = int(seq_lens.max().item())
+        else:
+            max_seq_len = 0
         if forward_mode is not None and forward_mode.is_extend():
             max_seq_len += max(self.speculative_num_steps - 1, 0)
         if is_packed_decode:
@@ -1031,25 +1079,29 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             base_offsets_on_device,
         )
         req_ids = torch.arange(bs, device=device, dtype=torch.int32)
-        token_to_req = torch.repeat_interleave(req_ids, query_lens.clamp_min(0))
-        if (
-            forward_mode is not None
-            and forward_mode.is_mixed()
-            and num_tokens_arg is not None
-        ):
-            # numel() reads tensor shape metadata only. Reducing query_lens and
-            # calling .item() here would synchronize its CUDA stream on every
-            # eager mixed batch.
-            metadata_tokens = token_to_req.numel()
-            if metadata_tokens != num_tokens:
-                raise RuntimeError(
-                    "DeepSeek V4 mixed metadata token count mismatch: "
-                    f"query_lens describe {metadata_tokens} tokens, packed input has "
-                    f"{num_tokens}"
-                )
-        num_prefill_tokens = (
-            int(query_lens[:num_prefill_reqs].sum().item()) if num_prefill_reqs else 0
-        )
+        num_prefill_tokens = sum(prefill_query_lens)
+        if num_prefill_reqs == bs:
+            token_to_req = torch.repeat_interleave(
+                req_ids,
+                query_lens.clamp_min(0),
+                output_size=num_prefill_tokens,
+            )
+        else:
+            token_to_req = torch.repeat_interleave(req_ids, query_lens.clamp_min(0))
+            if (
+                forward_mode is not None
+                and forward_mode.is_mixed()
+                and num_tokens_arg is not None
+            ):
+                # numel() reads tensor shape metadata only. Reducing query_lens
+                # and calling .item() here would synchronize its CUDA stream.
+                metadata_tokens = token_to_req.numel()
+                if metadata_tokens != num_tokens:
+                    raise RuntimeError(
+                        "DeepSeek V4 mixed metadata token count mismatch: "
+                        f"query_lens describe {metadata_tokens} tokens, packed input "
+                        f"has {num_tokens}"
+                    )
         query_start_loc = torch.nn.functional.pad(
             torch.cumsum(query_lens.to(torch.int32), dim=0, dtype=torch.int32),
             (1, 0),
@@ -1590,14 +1642,17 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         if cache_metadata.swa_page_table is None:
             raise RuntimeError("DeepSeek V4 missing paged-cache block table for SWA KV")
         swa_page_table = cache_metadata.swa_page_table
-        max_gather_len = int(gather_lens.max().item()) if num_reqs else 1
         compressed_lens = (
             torch.div(metadata.seq_lens, compress_ratio, rounding_mode="floor")
             if compress_ratio > 1
             else torch.zeros_like(metadata.seq_lens)
         )
-        compressed_base = (
-            int(compressed_lens.max().item()) if compress_ratio > 1 and num_reqs else 0
+        max_gather_len, compressed_base = self._prefill_workspace_bounds(
+            metadata.seq_lens_cpu,
+            metadata.query_lens_cpu,
+            num_reqs=num_reqs,
+            window_size=window_size,
+            compress_ratio=compress_ratio,
         )
         workspace_width = max(1, compressed_base + max_gather_len)
         kv_workspace = self._get_prefill_workspace(
@@ -1716,6 +1771,54 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             compressed_base=compressed_base,
         )
         return kv_workspace, indices, lens
+
+    @staticmethod
+    def _prefill_workspace_bounds(
+        seq_lens_cpu: torch.Tensor | None,
+        query_lens_cpu: torch.Tensor | None,
+        *,
+        num_reqs: int,
+        window_size: int,
+        compress_ratio: int,
+    ) -> tuple[int, int]:
+        """Compute prefill allocation bounds without reading the CUDA stream."""
+        if num_reqs < 0:
+            raise ValueError(f"num_reqs must be non-negative, got {num_reqs}")
+        if num_reqs == 0:
+            return 1, 0
+        if (
+            seq_lens_cpu is None
+            or query_lens_cpu is None
+            or seq_lens_cpu.device.type != "cpu"
+            or query_lens_cpu.device.type != "cpu"
+            or seq_lens_cpu.numel() != num_reqs
+            or query_lens_cpu.numel() != num_reqs
+        ):
+            raise RuntimeError(
+                "DeepSeek V4 prefill workspace sizing requires matching CPU "
+                "sequence and query lengths"
+            )
+        seq_lens = [int(value) for value in seq_lens_cpu.tolist()]
+        query_lens = [int(value) for value in query_lens_cpu.tolist()]
+        if any(
+            query_len < 0 or seq_len < query_len
+            for seq_len, query_len in zip(seq_lens, query_lens, strict=True)
+        ):
+            raise RuntimeError(
+                "DeepSeek V4 prefill workspace CPU length mirrors contain an "
+                "invalid sequence/query pair"
+            )
+        gather_window = max(window_size - 1, 0)
+        max_gather_len = max(
+            query_len + min(seq_len - query_len, gather_window)
+            for seq_len, query_len in zip(seq_lens, query_lens, strict=True)
+        )
+        compressed_base = (
+            max(seq_len // compress_ratio for seq_len in seq_lens)
+            if compress_ratio > 1
+            else 0
+        )
+        return max_gather_len, compressed_base
 
     def _metadata_slice(
         self,
@@ -1929,10 +2032,23 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 topk_indices=topk_indices,
             )
 
-        token_offsets = [
-            int(x)
-            for x in metadata.query_start_loc[: num_reqs + 1].detach().cpu().tolist()
-        ]
+        query_lens_cpu = metadata.query_lens_cpu
+        if (
+            query_lens_cpu is None
+            or query_lens_cpu.device.type != "cpu"
+            or query_lens_cpu.numel() < num_reqs
+        ):
+            raise RuntimeError(
+                "DeepSeek V4 chunked prefill requires CPU query-length metadata"
+            )
+        token_offsets = [0]
+        for query_len in query_lens_cpu[:num_reqs].tolist():
+            token_offsets.append(token_offsets[-1] + int(query_len))
+        if token_offsets[-1] != q.shape[0]:
+            raise RuntimeError(
+                "DeepSeek V4 chunked prefill query lengths do not match token "
+                f"count: query_tokens={token_offsets[-1]}, q_tokens={q.shape[0]}"
+            )
         out = q.new_empty((q.shape[0], num_local_heads, head_dim))
         saved_metadata = self.forward_metadata
         try:

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -3098,6 +3098,257 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_extends=1,
             )
 
+    def test_deepseek_v4_prefill_metadata_uses_complete_cpu_mirrors(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                prefix_granularity=64,
+                kernel_page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+
+        backend.init_forward_metadata(
+            bs=2,
+            num_tokens=14,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+            seq_lens=torch.tensor([17, 65], dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            page_table=torch.zeros((2, 2), dtype=torch.int32),
+            extend_seq_lens_cpu=torch.tensor([5, 9], dtype=torch.int32),
+            extend_prefix_lens_cpu=torch.tensor([12, 56], dtype=torch.int32),
+            num_extends=2,
+        )
+
+        metadata = backend.forward_metadata
+        self.assertIsNotNone(metadata)
+        assert metadata is not None
+        self.assertEqual(metadata.seq_lens_cpu.tolist(), [17, 65])
+        self.assertEqual(metadata.query_lens_cpu.tolist(), [5, 9])
+        self.assertEqual(metadata.num_prefill_reqs, 2)
+        self.assertEqual(metadata.num_prefill_tokens, 14)
+        self.assertEqual(metadata.token_to_req_indices.tolist(), [0] * 5 + [1] * 9)
+
+    def test_deepseek_v4_prefill_metadata_requires_complete_cpu_mirrors(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                prefix_granularity=64,
+                kernel_page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "prefill metadata requires complete CPU sequence and query length mirrors",
+        ):
+            backend.init_forward_metadata(
+                bs=1,
+                num_tokens=3,
+                req_pool_indices=torch.tensor([0], dtype=torch.int64),
+                seq_lens=torch.tensor([5], dtype=torch.int32),
+                forward_mode=ForwardMode.EXTEND,
+                page_table=torch.zeros((1, 1), dtype=torch.int32),
+                extend_prefix_lens_cpu=torch.tensor([2], dtype=torch.int32),
+                num_extends=1,
+            )
+
+    def test_deepseek_v4_prefill_workspace_bounds_use_cpu_mirrors(self):
+        self.assertEqual(
+            DeepseekV4AttentionBackend._prefill_workspace_bounds(
+                torch.tensor([17, 65], dtype=torch.int32),
+                torch.tensor([5, 9], dtype=torch.int32),
+                num_reqs=2,
+                window_size=16,
+                compress_ratio=4,
+            ),
+            (24, 16),
+        )
+        self.assertEqual(
+            DeepseekV4AttentionBackend._prefill_workspace_bounds(
+                torch.tensor([17], dtype=torch.int32),
+                torch.tensor([5], dtype=torch.int32),
+                num_reqs=1,
+                window_size=16,
+                compress_ratio=1,
+            ),
+            (17, 0),
+        )
+        self.assertEqual(
+            DeepseekV4AttentionBackend._prefill_workspace_bounds(
+                None,
+                None,
+                num_reqs=0,
+                window_size=16,
+                compress_ratio=4,
+            ),
+            (1, 0),
+        )
+
+    def test_deepseek_v4_prefill_workspace_bounds_fail_closed(self):
+        invalid_cases = (
+            (
+                torch.tensor([17, 65], dtype=torch.int32),
+                torch.tensor([5], dtype=torch.int32),
+            ),
+            (
+                torch.tensor([4], dtype=torch.int32),
+                torch.tensor([5], dtype=torch.int32),
+            ),
+        )
+        for seq_lens_cpu, query_lens_cpu in invalid_cases:
+            with (
+                self.subTest(
+                    seq_lens=seq_lens_cpu.tolist(),
+                    query_lens=query_lens_cpu.tolist(),
+                ),
+                self.assertRaises(RuntimeError),
+            ):
+                DeepseekV4AttentionBackend._prefill_workspace_bounds(
+                    seq_lens_cpu,
+                    query_lens_cpu,
+                    num_reqs=2 if seq_lens_cpu.numel() == 2 else 1,
+                    window_size=16,
+                    compress_ratio=4,
+                )
+
+        for seq_lens_cpu, query_lens_cpu in (
+            (None, torch.tensor([5], dtype=torch.int32)),
+            (torch.tensor([17], dtype=torch.int32), None),
+            (
+                torch.tensor([17, 65], dtype=torch.int32),
+                torch.tensor([5, 9], dtype=torch.int32),
+            ),
+        ):
+            with (
+                self.subTest(
+                    seq_lens_missing=seq_lens_cpu is None,
+                    query_lens_missing=query_lens_cpu is None,
+                    seq_lens_count=(
+                        None if seq_lens_cpu is None else seq_lens_cpu.numel()
+                    ),
+                ),
+                self.assertRaises(RuntimeError),
+            ):
+                DeepseekV4AttentionBackend._prefill_workspace_bounds(
+                    seq_lens_cpu,
+                    query_lens_cpu,
+                    num_reqs=1,
+                    window_size=16,
+                    compress_ratio=4,
+                )
+
+        with self.assertRaisesRegex(ValueError, "num_reqs must be non-negative"):
+            DeepseekV4AttentionBackend._prefill_workspace_bounds(
+                None,
+                None,
+                num_reqs=-1,
+                window_size=16,
+                compress_ratio=4,
+            )
+
+    def test_deepseek_v4_chunked_prefill_uses_cpu_query_offsets(self):
+        backend = DeepseekV4AttentionBackend(
+            SimpleNamespace(
+                prefix_granularity=64,
+                kernel_page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+        backend.prefill_chunk_size = 2
+        backend.init_forward_metadata(
+            bs=3,
+            num_tokens=6,
+            req_pool_indices=torch.tensor([0, 1, 2], dtype=torch.int64),
+            seq_lens=torch.tensor([4, 7, 9], dtype=torch.int32),
+            forward_mode=ForwardMode.EXTEND,
+            page_table=torch.zeros((3, 1), dtype=torch.int32),
+            extend_seq_lens_cpu=torch.tensor([2, 1, 3], dtype=torch.int32),
+            extend_prefix_lens_cpu=torch.tensor([2, 6, 6], dtype=torch.int32),
+            num_extends=3,
+        )
+        metadata = backend.forward_metadata
+        assert metadata is not None
+        calls = []
+
+        def fake_prefill_chunk(**kwargs):
+            chunk_metadata = backend.forward_metadata
+            calls.append(
+                (
+                    kwargs["q"].shape[0],
+                    kwargs["positions"].tolist(),
+                    chunk_metadata.req_pool_indices.tolist(),
+                    chunk_metadata.query_lens_cpu.tolist(),
+                )
+            )
+            q = kwargs["q"]
+            return q.new_zeros((q.shape[0], 1, 2))
+
+        backend._forward_deepseek_v4_prefill_chunk = fake_prefill_chunk
+        q = torch.zeros((6, 1, 2), dtype=torch.float32)
+        common = {
+            "q": q,
+            "positions": torch.arange(6, dtype=torch.int32),
+            "token_to_kv_pool": SimpleNamespace(),
+            "layer_id": 0,
+            "kind": "mla",
+            "compress_ratio": 4,
+            "num_local_heads": 1,
+            "padded_heads": 1,
+            "head_dim": 2,
+            "window_size": 4,
+            "softmax_scale": 1.0,
+            "attn_sink": torch.zeros(1),
+            "topk_indices": None,
+        }
+        out = backend.forward_deepseek_v4_prefill(**common)
+
+        self.assertEqual(out.shape, (6, 1, 2))
+        self.assertEqual(
+            calls,
+            [
+                (3, [0, 1, 2], [0, 1], [2, 1]),
+                (3, [3, 4, 5], [2], [3]),
+            ],
+        )
+
+        metadata.query_lens_cpu = None
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "chunked prefill requires CPU query-length metadata",
+        ):
+            backend.forward_deepseek_v4_prefill(**common)
+
+        metadata.query_lens_cpu = torch.tensor([2, 1, 2], dtype=torch.int32)
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "chunked prefill query lengths do not match token count",
+        ):
+            backend.forward_deepseek_v4_prefill(**common)
+
     def test_deepseek_v4_draft_keeps_mixed_step0_and_decode_step_metadata(self):
         verify_width = 4
         backend = DeepseekV4AttentionBackend(
@@ -4923,6 +5174,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             seq_lens=seq_lens,
             forward_mode=ForwardMode.EXTEND,
             page_table=page_table,
+            extend_seq_lens_cpu=seq_lens.cpu(),
         )
         backend.init_forward_metadata(
             bs=1,

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -3168,6 +3168,21 @@ class TestDeepseekV4Config(unittest.TestCase):
                 num_extends=1,
             )
 
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "prefill metadata requires complete CPU sequence and query length mirrors",
+        ):
+            backend.init_forward_metadata(
+                bs=1,
+                num_tokens=3,
+                req_pool_indices=torch.tensor([0], dtype=torch.int64),
+                seq_lens=torch.tensor([131], dtype=torch.int32),
+                forward_mode=ForwardMode.EXTEND,
+                page_table=torch.zeros((1, 3), dtype=torch.int32),
+                extend_seq_lens_cpu=torch.tensor([3], dtype=torch.int32),
+                num_extends=1,
+            )
+
     def test_deepseek_v4_prefill_workspace_bounds_use_cpu_mirrors(self):
         self.assertEqual(
             DeepseekV4AttentionBackend._prefill_workspace_bounds(
@@ -5175,6 +5190,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             forward_mode=ForwardMode.EXTEND,
             page_table=page_table,
             extend_seq_lens_cpu=seq_lens.cpu(),
+            extend_prefix_lens_cpu=torch.zeros(1, dtype=torch.int32),
         )
         backend.init_forward_metadata(
             bs=1,


### PR DESCRIPTION
## Summary

- reuse existing CPU sequence and query length mirrors when preparing DeepSeek V4 prefill metadata
- avoid CUDA scalar reads for sequence bounds, prefill token counts, workspace sizing, and chunk offsets
- preserve mixed/decode behavior and fail closed when required CPU mirrors are incomplete
- add coverage for pure prefill, mixed/decode metadata, workspace bounds, and chunked prefill offsets

## Why

The long-prefill path performed several host-visible reads from CUDA tensors while preparing metadata and workspaces. Those reads serialized the host with the active CUDA stream before the prefill kernels could proceed.

## Validation

- focused DeepSeek V4 metadata tests: 10 passed
- full `test/runtime/test_deepseek_v4_config.py`: 161 passed, 1 skipped
- runtime Ruff undefined/unused/import checks
- test-file formatting check
- matched long-prefill validation on NVIDIA GB200 showed a repeatable improvement:
  on a GB200 node serving DeepSeek V4 Flash (TP4), a 58K-token single-request
  prefill benchmark with interleaved base/candidate arms (1 warmup + 12 measured
  requests per arm) showed median TTFT improving from ~4.49s to ~4.21s
  (**~6.2% faster**), with per-arm spread under 2%; decode and mixed batches
  keep their original code path

This remains a draft while review and repository CI complete.
