### PR TITLE
refactor(cache): one pipeline per model family — layers, group, pack, bind

### DIFF
--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -27,7 +27,7 @@ Two quantities anchor the vocabulary:
 
 `block_granularity` is the generic quantity; a group *declares* it through
 one of two family-specific shapes (Python
-`PagedCacheGroupSpec`):
+`CacheGroupSpec`):
 
 * **Row geometry** (`rows_per_page` × `entry_stride_tokens`, exposed as
   **`page_size`**) — for paged KV-cache consumers, whose blocks physically
@@ -65,8 +65,11 @@ A fourth quantity lives outside the logical world entirely:
   `prefix_granularity`. The V4 backend's scalar is therefore a true
   registry-sourced `kernel_page_size` (config-overridable), and the
   scheduler grain is free: any positive multiple of the kernel page is
-  accepted (asserted at backend construction and in the fields builder;
-  P defaults to the kernel page, `DEEPSEEK_V4_PREFIX_GRANULARITY`).
+  accepted (asserted at backend construction and in the recipe's
+  `check_layout`). The V4 architecture spec defaults P to exactly one kernel
+  page by naming `DEEPSEEK_V4_PAGE_SIZE` as its
+  `default_prefix_granularity` — the registry constant itself, not a second
+  copy of the number.
 
 ### Physical world (storage units)
 
@@ -97,10 +100,29 @@ showing up there means a paged-KV concept is leaking across the boundary;
 name it `block_granularity` (generic span), `prefix_granularity` (identity
 span), or keep it on the Python side where the page actually exists.
 
+**Nor does the word "paged" belong in cache-group type names, on either
+side of the bridge.** A cache group is not necessarily paged: a snapshot
+state group has no rows and no pages (see the two declaration shapes
+above), so a `Paged`-prefixed group type is a claim its own contents
+contradict. Three types carry one group across the boundary, and none of
+them says "paged":
+
+```
+Python  CacheGroupSpec     declaration shape (rows | checkpoint) + policy
+  ↓     pool_to_cache_groups                      the single folding point
+C++     CacheGroupConfig   boundary config, nanobind-exposed (SchedulerConfig.cache_groups)
+  ↓     MakeSpecsFromConfig
+C++     CacheGroupSpec     folded scheduling form (block_granularity only)
+```
+
+The first and third share a name and differ in fields, so always qualify
+which side you mean; `CacheGroupConfig` in between is the only one visible
+from both.
+
 The same boundary holds for `checkpoint_granularity`: the identifier never
 enters `tokenspeed-scheduler` at all. It is a Python-side *declaration
-shape* on `PagedCacheGroupSpec`, and the bridge
-(`scheduler_utils.pool_to_paged_cache_groups`) is the single folding point:
+shape* on `CacheGroupSpec`, and the bridge
+(`scheduler_utils.pool_to_cache_groups`) is the single folding point:
 a snapshot declaration folds to `(rows = checkpoint_granularity,
 stride = 1)` and crosses into C++ as `CacheGroupSpec.block_granularity` — so
 a snapshot group's `block_granularity` equals its `checkpoint_granularity`
@@ -111,8 +133,9 @@ Declaration-shape vocabulary stops at the bridge; only the generic span
 crosses it.
 
 `CacheGroupSpec.block_granularity` is **required and explicit**: a positive
-divisor of `prefix_granularity`, asserted at coordinator construction. There
-is no zero-means-default fallback — every group states its span.
+divisor of `prefix_granularity`, rejected by `SchedulerConfig::Validate()`
+before construction and asserted again at coordinator construction. There is
+no zero-means-default fallback — every group states its span.
 
 The block tables the scheduler emits are logically *indexed*: row *i* of a
 request's table covers tokens
@@ -135,14 +158,14 @@ value, that is a design smell to justify, not a default to reach for.
 
 Provenance discipline: each quantity is sourced from its own domain and never
 laundered through another's name. The contract's `prefix_granularity` comes
-from the memory plan, not read back out of pool state. The pool carries
-**two** scalars with distinct roles: `CachePool.prefix_granularity` is the
+from the memory plan, not read back out of pool state. The arena carries
+**two** scalars with distinct roles: `CacheArena.prefix_granularity` is the
 identity grain, used only for contract publication and plan-consistency
 checks — `prefix_granularity` exists to compute prefix hits, and runtime
-arithmetic must not reach for it; `CachePool.kv_page_size` is the KV arena
+arithmetic must not reach for it; `CacheArena.kv_page_size` is the KV arena
 page span that paged-KV geometry math (row views, slot↔page arithmetic,
-scale-tile branching) reads. The two are pinned 1:1 at construction — that
-assignment is the single point of the prefix-page ↔ KV-page convention.
+scale-tile branching) reads. Both derive from the one plan, which is the
+single point of the prefix-page ↔ KV-page convention.
 Neither is a statement about per-group CacheBlock geometry: group spans live
 in the specs as `block_granularity`, and blocks narrower than P (V4's SWA
 window, state checkpoints) are the norm, not the exception. A backend's
@@ -314,6 +337,62 @@ a closed prefix) until the plan fits; finally walk the victim list in reverse
 and restore every victim that is not strictly required, yielding a minimal
 eviction set.
 
+## The cache pipeline: layers → group → pack → bind
+
+Every model family's cache is built by the same four-stage pipeline, and the
+stage names are the vocabulary:
+
+```
+layers ──group──▶ groups ──pack──▶ CacheLayout ──bind──▶ CacheMemoryPlan
+```
+
+* **layers** — the family's layer vocabulary: a `layer_types` label and a
+  `group_ids` assignment per layer, target layers then draft layers.
+* **`group`** (`recipes/spec.py`) walks those layers **once** and returns
+  `(CacheGroupSpec, fields)` pairs — one per distinct group. The pairing is
+  the point: a group id is spelled exactly once, in its spec, next to the
+  fields that deposit bytes in it.
+* **`pack`** (`recipes/plan.py`) decides how one physical parent is laid out:
+  plane sizes, per-field offsets and page strides, and how many of each
+  group's CacheBlocks share a parent (`cache_blocks_per_lcm_block`). The
+  result, `CacheLayout`, is **capacity-independent** — it describes one
+  parent, not an allocation.
+* **`bind`** (`CacheLayout.bind(num_lcm_blocks)`) multiplies that parent out
+  by a count and yields the `CacheMemoryPlan` the arena allocates from and
+  the PD wire carries.
+
+`CacheRecipe` (`recipes/base.py`) is a template method: `setup()` is the one
+place the four stages appear in order, and a family fills in uniformly named
+seams — `layer_types`, `group_ids`, `fields_for_layer`, `prefix_granularity`,
+`alignment`, `max_padding_fraction`, `packing`, `check_layout`,
+`num_lcm_blocks`, `token_capacity`, `parents_needed`, `workspace_bytes`,
+`pool_options`. `groups()` itself is a seam for the two families whose groups
+are not per-layer (Inkling appends conv columns; V4 declares each group
+whole). No family restates the order of the stages, and `_RECIPES`
+(`recipes/setup.py`) is the single family → recipe map.
+
+**No round-trip reconciliation.** The pipeline is arranged so that the pairs
+that used to be cross-checked cannot differ:
+
+* the group set in the plan equals the declared one because `pack` consumes
+  the `(spec, fields)` pairs and `setup()` publishes the specs from those
+  same pairs;
+* a field cannot name a group the plan does not have, because it never names
+  one — `pack` carries the declaring group id alongside each field;
+* per-group packing is read from the layout, not recomputed, everywhere
+  downstream (the C++ bridge, the runtime contract, capacity math).
+
+If you find yourself writing a check that two derived views agree, the
+design is wrong: make one of them the source.
+
+Capacity has exactly two shapes, both on the base class. The default is the
+flat product (`parents × tightest packing × P`). Families whose per-group
+demand differs — K3's state groups riding inside MLA planes, V4's SWA and
+compressed chains — override `parents_needed` and get the inverse for free
+from `_capacity_from_parents`, one monotonic binary search shared by all.
+`scheduler_limits` is the single place a recipe reads the scheduler's
+concurrency, so demand and capacity cannot size against different numbers.
+
 ## Code placement
 
 * Prefix-matching code (prefix hashing, match/lookup, reuse boundaries) lives
@@ -374,7 +453,18 @@ Enforced since this round:
   `block_granularity` everywhere;
 * `CacheGroupSpec.block_granularity` is required and explicit — the
   zero-means-prefix-granularity fallback is deleted, and the coordinator
-  asserts a positive divisor of P at construction.
+  asserts a positive divisor of P at construction;
+* `SchedulerConfig::Validate()` is the **single** configuration gate: every
+  scheduler scalar, every `CacheGroupConfig::Validate()`, and the cross-checks
+  between them (P divisibility, PD transfer policy, one-cache-block chunks for
+  a recurrent-state group). The `Scheduler` runs it before constructing any
+  member, because the pools and the coordinator assert on the same fields and
+  would otherwise preempt the diagnostic. Consequently `MakeSpecsFromConfig`
+  is pure translation — it validates nothing;
+* the scheduler layer **transports** `cache_blocks_per_lcm_block` rather than
+  reasoning with it. It appears in `csrc/scheduler/` only as a config field
+  copied into the spec; capacity math stays in tokens and pages and folds to
+  LCM blocks inside `LcmBlocksNeededFor`.
 
 Note on naming: the capacity counts intentionally keep *LCM block* names. An
 LCM parent is a byte-uniform storage unit whose token span differs per group
@@ -434,7 +524,7 @@ view, mirrored by the host tier. Fixed on 2026-08-13:
   `contract.prefix_granularity`.
 * Spec geometry is shape-checked at construction: row geometry and
   `checkpoint_granularity` are mutually exclusive, both positive, and
-  family-gated (`PagedCacheGroupSpec.__post_init__`).
+  family-gated (`CacheGroupSpec.__post_init__`).
 
 Remaining known item (deliberate, separate project): the mapping *primitive*
 is single but the *owners* are four — MLA `CacheBatchMetadata.kernel_table`,
@@ -447,8 +537,29 @@ do it as its own milestone.
 ### Principle 6 — provenance discipline: fixed
 
 * The contract's `prefix_granularity` comes from the memory plan
-  (`kv_cache/base.py` builds the runtime contract from `plan.prefix_granularity`,
-  never from pool geometry). ✓
+  (`kv_cache/arena.py` builds the runtime contract from
+  `plan.prefix_granularity`, never from pool geometry). ✓
+* Field dtypes come from the memory plan. `CacheFieldSpec`/`CacheFieldLayout`
+  carry `dtype` (a name; `plan.py` stays torch-free because the plan travels
+  the PD wire) and `element_size` derives from it, so byte geometry and dtype
+  can no longer disagree. Recipes name each field's dtype where they already
+  know it, via `cache_dtype_name` or `scatter_stored_dtype_name` — the latter
+  encodes the one substitution rule that used to live in the pools: fp8
+  collapses to `uint8` for fields written by elementwise scatter, because
+  `index_put` has no fp8 kernel. Fields written through dtype-aware kernels
+  (MXFP8) keep their fp8 view. The PD wire string is unchanged by this move,
+  and `CacheTransferContract` no longer carries a parallel `field_dtypes`
+  tuple. ✓
+* The arena owns the allocation and materializes every planned field view in
+  its constructor, so `field(field_id)` is a lookup with no dtype argument and
+  no lazy-bind state. `CachePool.store_dtype` narrowed to what it always
+  should have been: how a pool reinterprets *input* tensors before a write.
+  A pool binds nothing — `_bind_layer_planes` walks `plan.fields` once and
+  arranges this view's layer window into the per-layer buffers its kernels
+  read, with each subclass declaring only its `layer_plane_bindings`. Which
+  planes a layer has is a fact of the plan (a state layer plans no `k`/`v`),
+  so pools no longer re-derive it from `layer_types` or V4 compression ratios,
+  and page contiguity stays a plan invariant (`exact_page_stride`). ✓
 * Every backend's `kernel_page_size` is registry- or config-sourced
   (`kernel_page_sizes.py`); the registry LCM validator checks explicitly
   configured values, and a backend that resolves its own registry default
@@ -458,8 +569,58 @@ do it as its own milestone.
   positive multiple of it (e2e-verified against the `bt_v4` baseline;
   GSM8K 1319-question sweep: nospec 0.9651, DSpark 0.9629). ✓
 * The former pool-scalar naming debt is paid by a role split:
-  `CachePool.prefix_granularity` (identity grain; contract publication and
-  plan checks only) and `CachePool.kv_page_size` (KV arena geometry, read by
-  row/slot/tile math in the paged pools and their consumers), pinned 1:1 at
-  construction. Prefix-hit computation is the only computational consumer of
+  `CacheArena.prefix_granularity` (identity grain; contract publication and
+  plan checks only) and `CacheArena.kv_page_size` (KV arena geometry, read by
+  row/slot/tile math in the paged pools and their consumers), both derived
+  from the plan. Prefix-hit computation is the only computational consumer of
   `prefix_granularity`.
+* Cache geometry has one owner and no mirrors. `CacheArena` holds the
+  allocation, the field views, the plan, the contract and the geometry
+  scalars; `CachePool` is a typed layer window that forwards nothing, so
+  consumers write `pool.arena.plan` and cannot read a stale copy off a view.
+  What stays per-view is what genuinely differs per view: the dtype these
+  bytes are read as (a bf16 draft head over an fp8 target is two views of
+  one arena), the layer-window offset, and the per-layer kernel buffers. ✓
+
+### Principle 7 — one pipeline, declared once (round of 2026-08-16)
+
+The recipe layer used to be ~26 family-prefixed free functions
+(`prepare_kimi_k3_cache`, `kimi_k3_token_capacity_for_cache_pool`,
+`build_v4_cache_specs`, …) whose call order each family restated. It is now
+one template method with uniformly named seams (see *The cache pipeline*
+above). What changed, and why each change is structural rather than a check:
+
+* `layers → group → pack → bind` is written once, in `CacheRecipe.setup()`.
+  `solve_cache_layout` → `pack` (it solves nothing when the recipe pins every
+  group) and `CacheLayout.with_num_lcm_blocks` → `bind`, so the stage names
+  and the function names are the same words.
+* `group` walks the layers once and returns `(spec, fields)` pairs. The
+  previous two-walk shape (`group_specs_from_layer_types` plus a separate
+  field builder, reconciled afterwards by `group_fields`) is gone, along with
+  its reconciliation: the group id exists in exactly one place per group.
+* `CacheGroupSpec` lost `cache_blocks_per_lcm_block` and `CacheFieldSpec` lost
+  `group_id` — packing is the layout's answer and the declaring group is
+  positional, so neither can be stated twice and disagree.
+* `CachePoolSpec.pool_size` is deleted: it was a fourth copy of
+  `num_lcm_blocks × max_packing × P`. The registry reads `arena.size` for
+  physical slots and the contract for admitted capacity, and the tautological
+  `pool_size <= 0` guard went with it. `create_attn_components` no longer
+  returns a token count at all — the caller overwrote it with
+  `geometry.token_capacity` on the next line.
+* Capacity is two shapes, not five: the flat product on the base class, and
+  `parents_needed` + one shared binary search for the families whose per-group
+  demand differs. `deepseek_v4_lcm_blocks_needed` and
+  `deepseek_v4_token_capacity_for_cache_pool` are gone; K3's own binary search
+  is gone.
+* `paged` is out of the group-type names on both sides of the bridge
+  (`CacheGroupSpec`, `CacheRuntimeContract`, `pool_to_cache_groups`,
+  `cache_group_page_counts`) — see the boundary section above for why. Names
+  are kept only where the consumer is genuinely paged KV.
+* `recipes/deepseek_v4_cache_spec.py` is split by dependency direction, not
+  merged: kernel byte geometry and the group-id vocabulary moved *up* to
+  `attention/deepseek_v4_geometry.py`, where the backends, ops, model and pool
+  already lived; only the recipe-side spec constructors moved *into*
+  `recipes/deepseek_v4.py`. The recipes package no longer sits underneath
+  kernel-facing code. Dead constants (`DEEPSEEK_V4_PREFIX_GRANULARITY`,
+  `DEEPSEEK_V4_FP8_BLOCK_SIZE`) and the duplicated compressor-state tables
+  went with the move.

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -371,8 +371,8 @@ are not per-layer (Inkling appends conv columns; V4 declares each group
 whole). No family restates the order of the stages, and `_RECIPES`
 (`recipes/setup.py`) is the single family → recipe map.
 
-**No round-trip reconciliation.** The pipeline is arranged so that the pairs
-that used to be cross-checked cannot differ:
+**No round-trip reconciliation.** The pipeline is arranged so that pairs which
+would otherwise need cross-checking cannot differ:
 
 * the group set in the plan equals the declared one because `pack` consumes
   the `(spec, fields)` pairs and `setup()` publishes the specs from those
@@ -542,24 +542,21 @@ do it as its own milestone.
 * Field dtypes come from the memory plan. `CacheFieldSpec`/`CacheFieldLayout`
   carry `dtype` (a name; `plan.py` stays torch-free because the plan travels
   the PD wire) and `element_size` derives from it, so byte geometry and dtype
-  can no longer disagree. Recipes name each field's dtype where they already
-  know it, via `cache_dtype_name` or `scatter_stored_dtype_name` — the latter
-  encodes the one substitution rule that used to live in the pools: fp8
-  collapses to `uint8` for fields written by elementwise scatter, because
-  `index_put` has no fp8 kernel. Fields written through dtype-aware kernels
-  (MXFP8) keep their fp8 view. The PD wire string is unchanged by this move,
-  and `CacheTransferContract` no longer carries a parallel `field_dtypes`
-  tuple. ✓
+  cannot disagree. Recipes name each field's dtype where they already know it,
+  via `cache_dtype_name` or `scatter_stored_dtype_name`; the latter holds the
+  one substitution rule — fp8 collapses to `uint8` for fields written by
+  elementwise scatter, because `index_put` has no fp8 kernel, while fields
+  written through dtype-aware kernels (MXFP8) keep their fp8 view. The
+  contract carries no parallel `field_dtypes` tuple. ✓
 * The arena owns the allocation and materializes every planned field view in
   its constructor, so `field(field_id)` is a lookup with no dtype argument and
-  no lazy-bind state. `CachePool.store_dtype` narrowed to what it always
-  should have been: how a pool reinterprets *input* tensors before a write.
-  A pool binds nothing — `_bind_layer_planes` walks `plan.fields` once and
-  arranges this view's layer window into the per-layer buffers its kernels
-  read, with each subclass declaring only its `layer_plane_bindings`. Which
-  planes a layer has is a fact of the plan (a state layer plans no `k`/`v`),
-  so pools no longer re-derive it from `layer_types` or V4 compression ratios,
-  and page contiguity stays a plan invariant (`exact_page_stride`). ✓
+  no lazy-bind state. `CachePool.store_dtype` means one thing: how a pool
+  reinterprets *input* tensors before a write. A pool allocates nothing —
+  `_bind_layer_planes` walks `plan.fields` once and arranges this view's layer
+  window into the per-layer buffers its kernels read, with each subclass
+  declaring only its `layer_plane_bindings`. Which planes a layer has is a
+  fact of the plan (a state layer plans no `k`/`v`), and page contiguity is a
+  plan invariant (`exact_page_stride`). ✓
 * Every backend's `kernel_page_size` is registry- or config-sourced
   (`kernel_page_sizes.py`); the registry LCM validator checks explicitly
   configured values, and a backend that resolves its own registry default
@@ -568,12 +565,11 @@ do it as its own milestone.
   build from `DEEPSEEK_V4_PAGE_SIZE`, and V4 accepts any P that is a
   positive multiple of it (e2e-verified against the `bt_v4` baseline;
   GSM8K 1319-question sweep: nospec 0.9651, DSpark 0.9629). ✓
-* The former pool-scalar naming debt is paid by a role split:
+* Two arena scalars, two roles, both derived from the plan:
   `CacheArena.prefix_granularity` (identity grain; contract publication and
   plan checks only) and `CacheArena.kv_page_size` (KV arena geometry, read by
-  row/slot/tile math in the paged pools and their consumers), both derived
-  from the plan. Prefix-hit computation is the only computational consumer of
-  `prefix_granularity`.
+  row/slot/tile math in the paged pools and their consumers). Prefix-hit
+  computation is the only computational consumer of `prefix_granularity`. ✓
 * Cache geometry has one owner and no mirrors. `CacheArena` holds the
   allocation, the field views, the plan, the contract and the geometry
   scalars; `CachePool` is a typed layer window that forwards nothing, so
@@ -582,45 +578,30 @@ do it as its own milestone.
   bytes are read as (a bf16 draft head over an fp8 target is two views of
   one arena), the layer-window offset, and the per-layer kernel buffers. ✓
 
-### Principle 7 — one pipeline, declared once (round of 2026-08-16)
+### Principle 7 — one pipeline, declared once: fixed
 
-The recipe layer used to be ~26 family-prefixed free functions
-(`prepare_kimi_k3_cache`, `kimi_k3_token_capacity_for_cache_pool`,
-`build_v4_cache_specs`, …) whose call order each family restated. It is now
-one template method with uniformly named seams (see *The cache pipeline*
-above). What changed, and why each change is structural rather than a check:
+* Every family's cache is built by `CacheRecipe.setup()`, the single place the
+  four stages appear in order (see *The cache pipeline* above). A family fills
+  in uniformly named seams and marks each with `@override`, so a renamed seam
+  fails type checking rather than silently taking the base default. ✓
+* The stage names and the function names are the same words: `group`, `pack`,
+  `bind`. `pack` is capacity-independent — it describes one physical parent —
+  and `bind` is the only place a parent count enters. ✓
+* A group id is written once, in its spec, next to the fields that deposit
+  bytes in it. `CacheFieldSpec` carries no `group_id` and `CacheGroupSpec` no
+  packing: the declaring group is positional, and packing is the layout's
+  answer, so neither can be stated twice and disagree. ✓
+* Capacity has two shapes and no more, and one place to read the scheduler's
+  concurrency (see *The cache pipeline* above). ✓
+* Kernel geometry does not live under the recipes package. DeepSeek V4's byte
+  formulas, cache layout and group-id vocabulary sit in
+  `attention/deepseek_v4_geometry.py`, which the backends, ops, model and pool
+  read directly; the recipe depends on it, not the reverse. ✓
+* One kernel layout has one definition. The interleaved mxfp8 KV-scale planes
+  come from `plan.mxfp8_kv_scale_fields`, which also owns the page-span and
+  head-dim constraints that layout imposes, so no recipe restates the shape or
+  re-checks the constraint. ✓
 
-* `layers → group → pack → bind` is written once, in `CacheRecipe.setup()`.
-  `solve_cache_layout` → `pack` (it solves nothing when the recipe pins every
-  group) and `CacheLayout.with_num_lcm_blocks` → `bind`, so the stage names
-  and the function names are the same words.
-* `group` walks the layers once and returns `(spec, fields)` pairs. The
-  previous two-walk shape (`group_specs_from_layer_types` plus a separate
-  field builder, reconciled afterwards by `group_fields`) is gone, along with
-  its reconciliation: the group id exists in exactly one place per group.
-* `CacheGroupSpec` lost `cache_blocks_per_lcm_block` and `CacheFieldSpec` lost
-  `group_id` — packing is the layout's answer and the declaring group is
-  positional, so neither can be stated twice and disagree.
-* `CachePoolSpec.pool_size` is deleted: it was a fourth copy of
-  `num_lcm_blocks × max_packing × P`. The registry reads `arena.size` for
-  physical slots and the contract for admitted capacity, and the tautological
-  `pool_size <= 0` guard went with it. `create_attn_components` no longer
-  returns a token count at all — the caller overwrote it with
-  `geometry.token_capacity` on the next line.
-* Capacity is two shapes, not five: the flat product on the base class, and
-  `parents_needed` + one shared binary search for the families whose per-group
-  demand differs. `deepseek_v4_lcm_blocks_needed` and
-  `deepseek_v4_token_capacity_for_cache_pool` are gone; K3's own binary search
-  is gone.
-* `paged` is out of the group-type names on both sides of the bridge
-  (`CacheGroupSpec`, `CacheRuntimeContract`, `pool_to_cache_groups`,
-  `cache_group_page_counts`) — see the boundary section above for why. Names
-  are kept only where the consumer is genuinely paged KV.
-* `recipes/deepseek_v4_cache_spec.py` is split by dependency direction, not
-  merged: kernel byte geometry and the group-id vocabulary moved *up* to
-  `attention/deepseek_v4_geometry.py`, where the backends, ops, model and pool
-  already lived; only the recipe-side spec constructors moved *into*
-  `recipes/deepseek_v4.py`. The recipes package no longer sits underneath
-  kernel-facing code. Dead constants (`DEEPSEEK_V4_PREFIX_GRANULARITY`,
-  `DEEPSEEK_V4_FP8_BLOCK_SIZE`) and the duplicated compressor-state tables
-  went with the move.
+Verified end to end for this round: DeepSeek V3.2, R1 and V4-Flash, each
+× {CUDA graph, eager} × {spec, no spec}, against pre-refactor baselines
+(accuracy equal or better; speculative accept length within noise).

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -415,13 +415,11 @@ concurrency, so demand and capacity cannot size against different numbers.
 4. New attention backends declare which view of `CacheBlock` they need
    (paged KV view or state view); they do not invent new table concepts.
 
-## Current state vs. principles (audit 2026-08-13, re-verified after the kernel-page round)
+## Current state vs. principles (audit 2026-08-16)
 
-A snapshot of where the code stands relative to each principle, after the
-2026-08-13 refactor series (prefix layer extraction, coordinator capacity
-API, table-naming cleanup, spec geometry shapes, kernel-page registry, and
-the V4 decoupling milestone). Every claim below was re-checked against the
-code at this date.
+Where the code stands relative to each principle. Every claim below was
+re-checked against the code at this date; a ✓ means the principle holds with
+no known exception, and the exceptions that remain say so explicitly.
 
 ### Principle 1 — prefix matching isolated from the allocator: fixed
 
@@ -442,17 +440,17 @@ Scheduling and FSM code do no geometry arithmetic. The coordinator exposes
 capacity views — `LcmBlocksNeededFor(group_pages)`,
 `NumActiveLcmBlocks(request_tables)`, `NumAvailableLcmBlocks`,
 `TotalLcmBlocks`, `GroupAvailablePages(group)` — and the scheduler treats the
-counts as opaque capacity units. `ForwardState::ActiveLcmBlockIds()` is gone;
-the null-page reservation lives in
-`SchedulerConfig::AllocatorConfig::NumUsableBlocks()`.
+counts as opaque capacity units. The null-page reservation lives in
+`SchedulerConfig::AllocatorConfig::NumUsableBlocks()`, and nothing outside the
+cache layer enumerates LCM block ids.
 
-Enforced since this round:
+Enforced:
 
 * the identifier `page_size` is grep-zero across `tokenspeed-scheduler`
   (csrc, tests, python bindings) — the slot span is spelled
   `block_granularity` everywhere;
-* `CacheGroupSpec.block_granularity` is required and explicit — the
-  zero-means-prefix-granularity fallback is deleted, and the coordinator
+* `CacheGroupSpec.block_granularity` is required and explicit: every group
+  states its span, with no zero-means-default fallback, and the coordinator
   asserts a positive divisor of P at construction;
 * `SchedulerConfig::Validate()` is the **single** configuration gate: every
   scheduler scalar, every `CacheGroupConfig::Validate()`, and the cross-checks
@@ -498,30 +496,31 @@ and never touches packing. No refactor needed here.
   `CacheGroupsMixin` docstring. Third-party kernel keyword names
   (`flash_mla`'s `block_table=`, TRT-LLM's `block_tables=`) are an external
   boundary and stay as the kernels spell them.
-* Former residues, both closed on 2026-08-13: the state backend's replay
-  hook no longer names a `page_table` parameter (the shared call's keyword
-  is absorbed unused via `**kwargs` — state attention has no page table),
-  and `input_buffer.py::fill_input_buffers` takes a unit-neutral
-  `out_loc_table` (the batch-ordered table `out_cache_loc` derives from:
-  scheduler full-history table on the target path, staged draft table on
-  the drafter path).
+* The state backend's replay hook names no `page_table` parameter — state
+  attention has no page table, so the shared call's keyword is absorbed unused
+  via `**kwargs`. And `input_buffer.py::fill_input_buffers` takes a
+  unit-neutral `out_loc_table`: the batch-ordered table `out_cache_loc`
+  derives from, which is the scheduler's full-history table on the target path
+  and the staged draft table on the drafter path.
 
 ### Principle 5 — Python perceives the logical quantities minimally: leaks fixed, mapping owners still four
 
 Compliant: the recipes/planner layer *owns* the vocabulary rather than
 leaking it; `expand_page_table` (`attention/page_table.py`) is the single
 expansion primitive; state attention and KV share one plan/arena/`CacheBlock`
-view, mirrored by the host tier. Fixed on 2026-08-13:
+view, mirrored by the host tier. Specifically:
 
-* The magic `prefix_granularity == 128` branches now name the real
-  constraint — `MXFP8_KV_SCALE_TILE_TOKENS` in `recipes/spec.py`, used by
-  `recipes/ordinary.py` and `pd/cache_protocol.py`.
-* glm5's private page→slot arithmetic moved to the mapping layer
-  (`attention/page_table.py::build_prefill_kv_workspace_slots`).
+* No magic `prefix_granularity == 128` branches: the constraint is named
+  `MXFP8_KV_SCALE_TILE_TOKENS`, defined in `recipes/plan.py` beside the scale
+  field geometry it fixes and re-exported from `recipes/spec.py` for callers
+  that read it as a token span.
+* glm5's page→slot arithmetic lives in the mapping layer
+  (`attention/page_table.py::build_prefill_kv_workspace_slots`), not in the
+  model.
 * The mamba backend derives its checkpoint span from the state group's
-  `spec.checkpoint_granularity` (snapshot-state groups declare it directly;
-  `page_size` no longer exists on them) instead of
-  `contract.prefix_granularity`.
+  `spec.checkpoint_granularity`, which snapshot-state groups declare directly
+  — asking such a group for `page_size` is a `TypeError`, since it has no
+  rows.
 * Spec geometry is shape-checked at construction: row geometry and
   `checkpoint_granularity` are mutually exclusive, both positive, and
   family-gated (`CacheGroupSpec.__post_init__`).

--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -549,7 +549,7 @@ flags above and add:
 With `--speculative-draft-model-path` omitted, V4 uses the same checkpoint as the
 draft source (`DeepseekV4ForCausalLMNextN`). MTP runs on the non-overlap
 scheduler — the runtime disables overlap scheduling automatically when
-speculative decoding and paged-cache groups are both active — and prefix caching
+speculative decoding and cache groups are both active — and prefix caching
 stays on by default. Add `--enable-metrics` to read `Decoded Tok/Iter` and the
 speculative accept rate from the run summary.
 

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -109,7 +109,7 @@ class L2CacheExecutor:
             draft_pool.cache_transfer_layout() if draft_pool is not None else None
         )
         scheduler_group_ids = tuple(
-            spec.group_id for spec in device_pool.paged_cache_group_specs
+            spec.group_id for spec in device_pool.arena.cache_group_specs
         )
         self.layout = combine_cache_transfer_layouts(
             target_layout,

--- a/python/tokenspeed/runtime/configs/inkling_config.py
+++ b/python/tokenspeed/runtime/configs/inkling_config.py
@@ -365,8 +365,8 @@ class InklingModelConfig(PretrainedConfig):
         return [i for i in range(self.num_hidden_layers) if i not in local]
 
     @property
-    def paged_cache_layer_types(self) -> list[str]:
-        """Per-layer paged-cache labels derived from ``local_layer_ids``.
+    def cache_layer_types(self) -> list[str]:
+        """Per-layer cache-group labels derived from ``local_layer_ids``.
 
         Deliberately NOT named ``layer_types``: transformers strictly
         validates that attribute against its own vocabulary
@@ -545,8 +545,8 @@ class InklingMMConfig(PretrainedConfig):
         return self.text_config
 
     @property
-    def paged_cache_layer_types(self) -> list[str]:
-        return self.text_config.paged_cache_layer_types
+    def cache_layer_types(self) -> list[str]:
+        return self.text_config.cache_layer_types
 
     @property
     def sliding_window(self) -> int:

--- a/python/tokenspeed/runtime/configs/kimi_k3_config.py
+++ b/python/tokenspeed/runtime/configs/kimi_k3_config.py
@@ -43,7 +43,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     LINEAR_ATTENTION,
 )
 
-# "linear_attention" comes from paged_cache_spec (the KV-cache label vocabulary
+# "linear_attention" comes from cache_spec (the KV-cache label vocabulary
 # the hybrid allocator keys on). "attention" is the value of
 # ``HybridLayerType.full_attention`` (configs/qwen3_5_text_base_config.py);
 # kept as a literal to avoid a cross-config import in the model-loading path.
@@ -278,7 +278,7 @@ class KimiLinearConfig(PretrainedConfig):
 
     @property
     def layer_types(self) -> list[str]:
-        """``layers_block_type`` translated to paged-cache labels."""
+        """``layers_block_type`` translated to cache-group labels."""
         return [
             FULL_ATTENTION if layer_type == _ATTENTION_LAYER else layer_type
             for layer_type in self.layers_block_type

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -32,6 +32,9 @@ import torch
 import yaml
 from transformers import PretrainedConfig
 
+from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
+    DEEPSEEK_V4_PAGE_SIZE,
+)
 from tokenspeed.runtime.layers.quantization import QUANTIZATION_METHODS
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.env import envs
@@ -234,7 +237,9 @@ _ATTENTION_FAMILY_SPECS = (
         architectures=_DEEPSEEK_V4_ARCHITECTURES,
         configure=configure_deepseek_v4_attention,
         supports_target_verify_forward_mode=True,
-        default_prefix_granularity=256,
+        # V4 kernels need P to be a multiple of their fixed page; default to
+        # exactly one page rather than restating the number.
+        default_prefix_granularity=DEEPSEEK_V4_PAGE_SIZE,
     ),
     _AttentionFamilySpec(
         name="GLM",

--- a/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
+++ b/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
@@ -277,10 +277,10 @@ class Qwen3_5BaseTextConfig(PretrainedConfig):
 
     @property
     def layer_types(self):
-        """Per-layer paged-cache labels: "full_attention" / "linear_attention".
+        """Per-layer cache-group labels: "full_attention" / "linear_attention".
 
         Same interleaving as ``layers_block_type``, translated to the label
-        vocabulary of ``paged_cache_spec`` (``HybridLayerType.full_attention``
+        vocabulary of ``cache_spec`` (``HybridLayerType.full_attention``
         serializes as the checkpoint's "attention", which the KV-cache layer
         has no retention entry for). A property rather than an ``__init__``
         attribute because NextN drafts overwrite ``full_attention_interval``

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -51,7 +51,7 @@ from tokenspeed.runtime.engine.scheduler_utils import (
     cache_sync_debug_enabled,
     log_gpu_memory_summary,
     make_config,
-    pool_to_paged_cache_groups,
+    pool_to_cache_groups,
     pop_common_cache_event_payloads,
     resolve_dspark_prefix_replay_tokens,
     scheduler_cache_geometry_from_pool,
@@ -242,7 +242,6 @@ class EventLoop:
             token_to_kv_pool,
             draft_attn_backend,
             draft_token_to_kv_pool,
-            self.max_total_num_tokens,
             self.cache_storage,
         ) = create_attn_components(
             server_args,
@@ -257,14 +256,13 @@ class EventLoop:
         )
 
         self._scheduler_cache_geometry = scheduler_cache_geometry_from_pool(
-            token_to_kv_pool,
-            fallback_token_capacity=self.max_total_num_tokens,
-            fallback_prefix_granularity=server_args.prefix_granularity,
+            token_to_kv_pool
         )
         geometry = self._scheduler_cache_geometry
+        # The contract is the one source of admitted capacity.
         self.max_total_num_tokens = geometry.token_capacity
         num_total_pages = geometry.num_device_pages
-        paged_cache_groups = pool_to_paged_cache_groups(token_to_kv_pool)
+        cache_groups = pool_to_cache_groups(token_to_kv_pool)
         # Resolve the scheduler limit before ModelExecutorConfig sizes input
         # buffers. Lowering the limit is safe; a configured chunk smaller than
         # one state checkpoint block is rejected by aligned_max_scheduled_tokens instead of
@@ -273,7 +271,7 @@ class EventLoop:
         if server_args.enable_prefix_caching:
             max_scheduled_tokens = aligned_max_scheduled_tokens(
                 server_args.chunked_prefill_size,
-                paged_cache_groups,
+                cache_groups,
             )
             if max_scheduled_tokens != server_args.chunked_prefill_size:
                 logger.warning(
@@ -379,7 +377,7 @@ class EventLoop:
             "decode",
         )
         if self._pd_cache_enabled:
-            if not token_to_kv_pool.supports_disaggregation:
+            if not token_to_kv_pool.arena.supports_disaggregation:
                 raise RuntimeError(
                     "PD disaggregation requires a unified cache contract"
                 )
@@ -418,7 +416,7 @@ class EventLoop:
                 )
         # Backend/pool compatibility is validated inside ModelExecutor
         # (validate_scheduler_config), before CUDA-graph capture.
-        self._paged_cache_groups = paged_cache_groups
+        self._cache_groups = cache_groups
         scheduler_cfg = make_config(
             num_device_pages=geometry.num_device_pages,
             max_scheduled_tokens=max_scheduled_tokens,
@@ -433,7 +431,7 @@ class EventLoop:
             overlap_schedule_depth=self.overlap_schedule_depth,
             disable_prefix_cache=not server_args.enable_prefix_caching,
             prefix_replay_tokens=prefix_replay_tokens,
-            paged_cache_groups=paged_cache_groups,
+            cache_groups=cache_groups,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
         )
         scheduler_cfg.enable_pd_cache = self._pd_cache_enabled
@@ -443,7 +441,7 @@ class EventLoop:
             "overlap_schedule_depth=%s disable_l2_cache=%s "
             "max_batch_size=%s (global max_num_seqs=%s, dp_size=%s) "
             "disable_prefix_cache=%s prefix_replay_tokens=%s "
-            "paged_cache_groups=%s",
+            "cache_groups=%s",
             scheduler_cfg.prefix_granularity,
             scheduler_cfg.num_device_pages,
             scheduler_cfg.max_scheduled_tokens,
@@ -455,7 +453,7 @@ class EventLoop:
             self.dp_size,
             scheduler_cfg.disable_prefix_cache,
             scheduler_cfg.prefix_replay_tokens,
-            [group.group_id for group in paged_cache_groups],
+            [group.group_id for group in cache_groups],
         )
         self.scheduler = Scheduler(scheduler_cfg)
         self.max_single_request_tokens = self.scheduler.max_single_request_tokens()
@@ -481,7 +479,7 @@ class EventLoop:
             self.max_model_len,
             self.max_req_input_len,
         )
-        token_to_kv_pool.bind_paged_cache_scheduler(self.scheduler)
+        token_to_kv_pool.bind_cache_scheduler(self.scheduler)
         if attn_tp_rank == 0:
             self.kv_event_publisher = EventPublisherFactory.create(
                 server_args.kv_events_config,

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -30,12 +30,12 @@ import numpy as np
 import torch
 from tokenspeed_scheduler import (
     Cache,
+    CacheGroupConfig,
+    CacheGroupFamily,
+    CacheRetention,
+    CacheTransferPolicy,
     ExecutionEvent,
     ForwardEvent,
-    PagedCacheGroupConfig,
-    PagedCacheGroupFamily,
-    PagedCacheRetention,
-    PagedCacheTransferPolicy,
     RequestSpec,
     SchedulerConfig,
 )
@@ -53,18 +53,18 @@ if hasattr(Cache, "LoadBackDoneEvent"):
     _CACHE_EVENT_TYPES["LoadBackDoneEvent"] = Cache.LoadBackDoneEvent
 _TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 
-# Pool-spec string -> scheduler enum (pool_to_paged_cache_groups).
+# Pool-spec string -> scheduler enum (pool_to_cache_groups).
 _RETENTION_MAP = {
-    "full_history": PagedCacheRetention.FullHistory,
-    "sliding_window": PagedCacheRetention.SlidingWindow,
+    "full_history": CacheRetention.FullHistory,
+    "sliding_window": CacheRetention.SlidingWindow,
 }
 _FAMILY_MAP = {
-    "history": PagedCacheGroupFamily.History,
-    "state": PagedCacheGroupFamily.State,
+    "history": CacheGroupFamily.History,
+    "state": CacheGroupFamily.State,
 }
 _TRANSFER_POLICY_MAP = {
-    "full_suffix": PagedCacheTransferPolicy.FullSuffix,
-    "latest_snapshot": PagedCacheTransferPolicy.LatestSnapshot,
+    "full_suffix": CacheTransferPolicy.FullSuffix,
+    "latest_snapshot": CacheTransferPolicy.LatestSnapshot,
 }
 
 
@@ -76,77 +76,29 @@ class SchedulerCacheGeometry:
     token_capacity: int
 
 
-def scheduler_cache_geometry_from_pool(
-    pool: Any,
-    *,
-    fallback_token_capacity: int,
-    fallback_prefix_granularity: int,
-) -> SchedulerCacheGeometry:
-    contract = getattr(pool, "runtime_contract", None)
-    num_lcm_blocks = getattr(pool, "num_lcm_blocks", None)
-    if num_lcm_blocks is not None:
-        num_lcm_blocks = require_positive_int("num_lcm_blocks", num_lcm_blocks)
-        if contract is not None and contract.num_lcm_blocks != num_lcm_blocks:
-            raise ValueError("pool and runtime contract disagree on num_lcm_blocks")
-        return SchedulerCacheGeometry(
-            prefix_granularity=require_positive_int(
-                (
-                    "contract.prefix_granularity"
-                    if contract is not None
-                    else "fallback_prefix_granularity"
-                ),
-                (
-                    contract.prefix_granularity
-                    if contract is not None
-                    else fallback_prefix_granularity
-                ),
-            ),
-            # Parent 0 is reserved as the null LCM block.
-            num_device_pages=num_lcm_blocks + 1,
-            num_usable_pages=num_lcm_blocks,
-            token_capacity=require_positive_int(
-                (
-                    "contract.token_capacity"
-                    if contract is not None
-                    else "fallback_token_capacity"
-                ),
-                (
-                    contract.token_capacity
-                    if contract is not None
-                    else fallback_token_capacity
-                ),
-            ),
-        )
-    if contract is not None:
-        num_lcm_blocks = require_positive_int(
-            "contract.num_lcm_blocks", contract.num_lcm_blocks
-        )
-        return SchedulerCacheGeometry(
-            prefix_granularity=contract.prefix_granularity,
-            num_device_pages=num_lcm_blocks + 1,
-            num_usable_pages=num_lcm_blocks,
-            token_capacity=contract.token_capacity,
-        )
-    if fallback_prefix_granularity <= 0 or fallback_token_capacity <= 0:
-        raise ValueError("fallback scheduler cache geometry must be positive")
-    if fallback_token_capacity % fallback_prefix_granularity:
-        raise ValueError(
-            "fallback token capacity must be divisible by the fallback prefix granularity"
-        )
-    pages = fallback_token_capacity // fallback_prefix_granularity
+def scheduler_cache_geometry_from_pool(pool: Any) -> SchedulerCacheGeometry:
+    """Project the arena's published contract onto scheduler page counts.
+
+    The contract is the only source: the arena publishes it for every pool,
+    so there is no pool-side copy to prefer and no server-args fallback to
+    reconcile against.
+    """
+    contract = pool.arena.runtime_contract
+    num_lcm_blocks = require_positive_int(
+        "contract.num_lcm_blocks", contract.num_lcm_blocks
+    )
     return SchedulerCacheGeometry(
-        prefix_granularity=fallback_prefix_granularity,
-        # Ordinary pools allocate page 0 separately from their profiled,
-        # usable token capacity, just like LCM pools reserve parent 0.
-        num_device_pages=pages + 1,
-        num_usable_pages=pages,
-        token_capacity=fallback_token_capacity,
+        prefix_granularity=contract.prefix_granularity,
+        # Parent 0 is reserved as the null LCM block.
+        num_device_pages=num_lcm_blocks + 1,
+        num_usable_pages=num_lcm_blocks,
+        token_capacity=contract.token_capacity,
     )
 
 
 def aligned_max_scheduled_tokens(
     max_scheduled_tokens: int,
-    paged_cache_groups,
+    cache_groups,
 ) -> int:
     """Floor ``max_scheduled_tokens`` to the state-snapshot grain, if any.
 
@@ -162,8 +114,8 @@ def aligned_max_scheduled_tokens(
     Args:
         max_scheduled_tokens: Requested per-step token budget
             (``--chunked-prefill-size``).
-        paged_cache_groups: Scheduler ``PagedCacheGroupConfig`` sequence, or
-            None/empty when the model declares no paged cache groups.
+        cache_groups: Scheduler ``CacheGroupConfig`` sequence, or
+            None/empty when the model declares no cache groups.
     Returns:
         ``max_scheduled_tokens`` floored to the LCM of the state groups'
         CacheBlock token spans. Returned unchanged when no such group exists
@@ -176,10 +128,10 @@ def aligned_max_scheduled_tokens(
     """
     require_positive_int("max_scheduled_tokens", max_scheduled_tokens)
     grain = 1
-    for group in paged_cache_groups or ():
-        if group.family != PagedCacheGroupFamily.State:
+    for group in cache_groups or ():
+        if group.family != CacheGroupFamily.State:
             continue
-        if group.retention == PagedCacheRetention.SlidingWindow:
+        if group.retention == CacheRetention.SlidingWindow:
             continue
         grain = math.lcm(
             grain,
@@ -216,7 +168,7 @@ def make_config(
     decode_input_tokens: int = 1,
     overlap_schedule_depth: int = 0,
     disable_prefix_cache: bool = False,
-    paged_cache_groups: Sequence["PagedCacheGroupConfig"] | None = None,
+    cache_groups: Sequence["CacheGroupConfig"] | None = None,
     enable_mixed_prefill_decode: bool = False,
     prefix_replay_tokens: int = 0,
 ) -> SchedulerConfig:
@@ -248,34 +200,31 @@ def make_config(
     cfg.disable_l2_cache = disable_l2_cache
 
     cfg.enable_mixed_prefill_decode = enable_mixed_prefill_decode
-    if paged_cache_groups:
-        cfg.paged_cache_groups = list(paged_cache_groups)
+    if cache_groups:
+        cfg.cache_groups = list(cache_groups)
     return cfg
 
 
-def pool_to_paged_cache_groups(pool: Any) -> list:
-    """Convert authoritative contract specs, or legacy pool properties."""
-    contract = getattr(pool, "runtime_contract", None)
-    if contract is not None:
-        specs = contract.group_specs
-        counts = contract.group_page_counts
-    else:
-        specs = pool.paged_cache_group_specs
-        counts = pool.paged_cache_group_page_counts
-    if not specs:
-        return []
+def pool_to_cache_groups(pool: Any) -> list:
+    """Convert a cache's published contract into scheduler group configs."""
+    # The arena is the sole publisher, so there is exactly one source here --
+    # no fallback to pool-side copies of the same specs.
+    contract = pool.arena.runtime_contract
+    specs = contract.group_specs
+    counts = contract.group_page_counts
+    packing = contract.group_packing
     out = []
     for spec in specs:
         retention = _RETENTION_MAP.get(spec.retention)
         if retention is None:
             raise ValueError(
-                f"pool_to_paged_cache_groups: unsupported retention "
+                f"pool_to_cache_groups: unsupported retention "
                 f"{spec.retention!r} for group {spec.group_id!r}"
             )
         family = _FAMILY_MAP.get(spec.family)
         if family is None:
             raise ValueError(
-                f"pool_to_paged_cache_groups: unsupported family "
+                f"pool_to_cache_groups: unsupported family "
                 f"{spec.family!r} for group {spec.group_id!r}"
             )
         # The C++ scheduler config only carries row geometry. A snapshot-state
@@ -294,22 +243,20 @@ def pool_to_paged_cache_groups(pool: Any) -> list:
             total_pages=int(counts[spec.group_id]),
             retention=retention,
             family=family,
-            cache_blocks_per_lcm_block=int(
-                getattr(spec, "cache_blocks_per_lcm_block", 1)
-            ),
+            cache_blocks_per_lcm_block=int(packing[spec.group_id]),
         )
-        transfer_policy = getattr(spec, "transfer_policy", None)
+        transfer_policy = spec.transfer_policy
         if transfer_policy is not None:
             mapped_policy = _TRANSFER_POLICY_MAP.get(transfer_policy)
             if mapped_policy is None:
                 raise ValueError(
-                    "pool_to_paged_cache_groups: unsupported transfer policy "
+                    "pool_to_cache_groups: unsupported transfer policy "
                     f"{transfer_policy!r} for group {spec.group_id!r}"
                 )
             kwargs["transfer_policy"] = mapped_policy
         if spec.retention == "sliding_window":
             kwargs["sliding_window_tokens"] = int(spec.sliding_window_tokens)
-        out.append(PagedCacheGroupConfig(**kwargs))
+        out.append(CacheGroupConfig(**kwargs))
     return out
 
 
@@ -640,10 +587,9 @@ def _classify_param(name: str) -> str:
 def _kv_pool_bytes(*pools) -> int:
     """Best-effort total KV-buffer bytes across the given pools, deduped.
 
-    A draft pool is a ``LayerMappedKVPool`` view of the target's merged pool
-    (draft KV lives in the target arena), and its ``get_kv_size_bytes`` forwards
-    to that same inner pool -- so counting target + draft naively would double
-    the KV. Dedupe by the underlying (unwrapped) pool identity first.
+    Target and draft are two compute views of the ONE arena (draft KV lives
+    in the target's arena), so counting both naively would double the KV.
+    Dedupe by arena identity -- the allocation each view reports on.
 
     Return types differ (int, or a tuple like MSA's (kv, index); a hybrid pool
     may nest several) -- sum any numeric leaves.
@@ -653,10 +599,10 @@ def _kv_pool_bytes(*pools) -> int:
     for pool in pools:
         if pool is None:
             continue
-        underlying = getattr(pool, "inner", pool)
-        if id(underlying) in seen:
+        arena = getattr(pool, "arena", pool)
+        if id(arena) in seen:
             continue
-        seen.add(id(underlying))
+        seen.add(id(arena))
         getter = getattr(pool, "get_kv_size_bytes", None)
         if getter is None:
             continue

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -239,12 +239,8 @@ class CudaGraphWrapper:
         init_backend_cuda_graph_state(
             attn_backend,
             self.max_bs,
-            paged_cache_group_specs=tuple(token_to_kv_pool.paged_cache_group_specs),
-            paged_cache_group_page_counts=getattr(
-                token_to_kv_pool,
-                "paged_cache_group_page_counts",
-                None,
-            ),
+            cache_group_specs=tuple(token_to_kv_pool.arena.cache_group_specs),
+            cache_group_page_counts=(token_to_kv_pool.arena.cache_group_page_counts),
             max_tokens_per_req=self.max_tokens_per_req,
             overlap_schedule_depth=self.overlap_schedule_depth,
         )
@@ -252,13 +248,9 @@ class CudaGraphWrapper:
             init_backend_cuda_graph_state(
                 draft_attn_backend,
                 self.max_bs,
-                paged_cache_group_specs=tuple(
-                    draft_token_to_kv_pool.paged_cache_group_specs
-                ),
-                paged_cache_group_page_counts=getattr(
-                    draft_token_to_kv_pool,
-                    "paged_cache_group_page_counts",
-                    None,
+                cache_group_specs=tuple(draft_token_to_kv_pool.arena.cache_group_specs),
+                cache_group_page_counts=(
+                    draft_token_to_kv_pool.arena.cache_group_page_counts
                 ),
                 max_tokens_per_req=self.max_tokens_per_req,
                 overlap_schedule_depth=self.overlap_schedule_depth,
@@ -614,7 +606,7 @@ class CudaGraphWrapper:
             _is_cuda_graph_phase = old_cuda_graph_phase
 
     def _capture_group_block_tables(self, bs: int, pool) -> dict | None:
-        specs = tuple(pool.paged_cache_group_specs)
+        specs = tuple(pool.arena.cache_group_specs)
         if not specs:
             return None
         out = {}
@@ -648,7 +640,7 @@ class CudaGraphWrapper:
         persistent per-group buffers."""
         if not getattr(self.attn_backend, "uses_cache_groups", False):
             return ()
-        return tuple(str(spec.group_id) for spec in pool.paged_cache_group_specs)
+        return tuple(str(spec.group_id) for spec in pool.arena.cache_group_specs)
 
     def _draft_cache_group_ids(self) -> tuple[str, ...]:
         """Per-group page tables consumed by the drafter.
@@ -680,17 +672,15 @@ class CudaGraphWrapper:
                 ("history",),
             )
         )
-        if self.draft_token_to_kv_pool is not None and getattr(
-            self.draft_token_to_kv_pool, "paged_cache_group_specs", ()
-        ):
+        draft_arena = getattr(self.draft_token_to_kv_pool, "arena", None)
+        draft_specs = getattr(draft_arena, "cache_group_specs", ())
+        if draft_specs:
             return tuple(
-                str(spec.group_id)
-                for spec in self.draft_token_to_kv_pool.paged_cache_group_specs
-                if spec.family in families
+                str(spec.group_id) for spec in draft_specs if spec.family in families
             )
         return tuple(
             str(spec.group_id)
-            for spec in self.token_to_kv_pool.paged_cache_group_specs
+            for spec in self.token_to_kv_pool.arena.cache_group_specs
             if spec.family in families
         )
 
@@ -704,7 +694,7 @@ class CudaGraphWrapper:
 
     def _init_capture_metadata(self, bs: int):
         capture_kwargs = {}
-        if self.attn_backend.uses_paged_cache_groups:
+        if self.attn_backend.needs_group_block_tables:
             group_block_tables = self._capture_group_block_tables(
                 bs,
                 self.token_to_kv_pool,
@@ -727,7 +717,7 @@ class CudaGraphWrapper:
             draft_kwargs = {}
             if (
                 self.draft_token_to_kv_pool is not None
-                and self.draft_attn_backend.uses_paged_cache_groups
+                and self.draft_attn_backend.needs_group_block_tables
             ):
                 draft_group_block_tables = self._capture_group_block_tables(
                     bs,
@@ -752,7 +742,7 @@ class CudaGraphWrapper:
         """Minimal per-group tables for the bs==0 idle replay: all rows are
         dummy rows, so one column of page-0 entries per group is valid.
         None when the pool publishes no groups."""
-        specs = tuple(self.token_to_kv_pool.paged_cache_group_specs)
+        specs = tuple(self.token_to_kv_pool.arena.cache_group_specs)
         if not specs:
             return None
         table = torch.zeros((padded_bs, 1), dtype=torch.int32, device=self.device)
@@ -842,13 +832,13 @@ class CudaGraphWrapper:
         group_placeholder_tables = kwargs.pop("group_placeholder_tables", None)
         block_table_base_offsets = kwargs.pop("block_table_base_offsets", None)
         block_tables = kwargs.pop("block_tables", None)
-        target_uses_paged_groups = getattr(
+        target_needs_group_tables = getattr(
             self.attn_backend,
-            "uses_paged_cache_groups",
+            "needs_group_block_tables",
             False,
         )
-        draft_uses_paged_groups = self.draft_attn_backend is not None and getattr(
-            self.draft_attn_backend, "uses_paged_cache_groups", False
+        draft_needs_group_tables = self.draft_attn_backend is not None and getattr(
+            self.draft_attn_backend, "needs_group_block_tables", False
         )
         target_uses_cache_groups = getattr(
             self.attn_backend,
@@ -861,7 +851,7 @@ class CudaGraphWrapper:
             False,
         )
         if group_placeholder_tables is not None and (
-            target_uses_paged_groups or draft_uses_paged_groups
+            target_needs_group_tables or draft_needs_group_tables
         ):
             table_bs = next(
                 (
@@ -882,7 +872,7 @@ class CudaGraphWrapper:
                     actual_bs=actual_bs,
                     padded_bs=padded_bs,
                 )
-            if target_uses_paged_groups:
+            if target_needs_group_tables:
                 kwargs["block_tables"] = group_placeholder_tables
                 if block_table_base_offsets is not None:
                     kwargs["block_table_base_offsets"] = block_table_base_offsets
@@ -918,7 +908,7 @@ class CudaGraphWrapper:
                 kwargs["block_tables"] = padded_block_tables
         if self.attn_backend.uses_padded_decode_token_mask:
             kwargs["actual_bs"] = actual_bs
-        if target_uses_paged_groups and getattr(self, "drafter", None) is not None:
+        if target_needs_group_tables and getattr(self, "drafter", None) is not None:
             kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
         self.attn_backend.init_forward_metadata_replay_cuda_graph(
             padded_bs,
@@ -930,7 +920,7 @@ class CudaGraphWrapper:
         )
         if self.draft_attn_backend is not None:
             draft_attn_kwargs = {}
-            if draft_uses_paged_groups and group_placeholder_tables is not None:
+            if draft_needs_group_tables and group_placeholder_tables is not None:
                 draft_attn_kwargs["block_tables"] = group_placeholder_tables
                 if block_table_base_offsets is not None:
                     draft_attn_kwargs["block_table_base_offsets"] = (
@@ -951,7 +941,7 @@ class CudaGraphWrapper:
             if draft_group_tables is not None:
                 draft_attn_kwargs["block_tables"] = draft_group_tables
             draft_forward_mode = ForwardMode.DECODE
-            if draft_uses_paged_groups:
+            if draft_needs_group_tables:
                 draft_attn_kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
             draft_seq_lens = self.drafter.draft_seq_lens_buf[:padded_bs]
             draft_seq_lens.copy_(seq_lens[:padded_bs])
@@ -977,7 +967,7 @@ class CudaGraphWrapper:
     ):
         """Eager path — allocate/refresh metadata for the upcoming forward."""
         if (
-            getattr(self.attn_backend, "uses_paged_cache_groups", False)
+            getattr(self.attn_backend, "needs_group_block_tables", False)
             and self.drafter is not None
             and forward_mode.is_decode()
         ):
@@ -993,7 +983,7 @@ class CudaGraphWrapper:
         )
         if self.draft_attn_backend is not None:
             draft_kwargs = {}
-            if getattr(self.draft_attn_backend, "uses_paged_cache_groups", False):
+            if getattr(self.draft_attn_backend, "needs_group_block_tables", False):
                 value = kwargs.get("block_table_base_offsets")
                 if value is not None:
                     draft_kwargs["block_table_base_offsets"] = value
@@ -1059,7 +1049,7 @@ class CudaGraphWrapper:
                     seq_lens if self.use_v4_mtp_paged_metadata else draft_seq_lens
                 )
                 draft_forward_mode = ForwardMode.DECODE
-                if getattr(self.draft_attn_backend, "uses_paged_cache_groups", False):
+                if getattr(self.draft_attn_backend, "needs_group_block_tables", False):
                     draft_kwargs["num_tokens"] = padded_bs * self.max_tokens_per_req
                 self.draft_attn_backend.init_forward_metadata(
                     bs=padded_bs,
@@ -1202,7 +1192,7 @@ class CudaGraphWrapper:
 
         if use_graph:
             group_placeholder_tables = None
-            if bs == 0 and self.attn_backend.uses_paged_cache_groups:
+            if bs == 0 and self.attn_backend.needs_group_block_tables:
                 group_placeholder_tables = self._capture_group_block_tables(
                     padded_bs,
                     self.token_to_kv_pool,
@@ -1261,19 +1251,19 @@ class CudaGraphWrapper:
                 and not ctx.forward_mode.is_idle()
                 and not block_tables
                 and getattr(self.attn_backend, "uses_cache_groups", False)
-                and len(self.token_to_kv_pool.paged_cache_group_specs) > 1
+                and len(self.token_to_kv_pool.arena.cache_group_specs) > 1
             ):
                 raise RuntimeError(
                     "CudaGraphWrapper eager forward: pool publishes "
-                    f"{len(self.token_to_kv_pool.paged_cache_group_specs)} "
-                    "paged cache groups and the backend consumes group tables, "
+                    f"{len(self.token_to_kv_pool.arena.cache_group_specs)} "
+                    "cache groups and the backend consumes group tables, "
                     f"but block_tables is missing/empty at bs={bs} "
                     f"({ctx.forward_mode.name}); the single-table fallback "
                     "would use one group's pages for all layers."
                 )
             metadata_num_tokens = (
                 {"num_tokens": ctx.input_num_tokens}
-                if self.attn_backend.uses_paged_cache_groups
+                if self.attn_backend.needs_group_block_tables
                 else {}
             )
             self._init_forward_metadata(
@@ -1299,7 +1289,7 @@ class CudaGraphWrapper:
                 ),
                 block_table_base_offsets=(
                     block_table_base_offsets
-                    if self.attn_backend.uses_paged_cache_groups
+                    if self.attn_backend.needs_group_block_tables
                     else None
                 ),
                 **cache_kwargs,

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -68,7 +68,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
 )
 from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
 from tokenspeed.runtime.layers.paged_attention import (
-    validate_paged_cache_group_ids,
+    validate_cache_group_ids,
 )
 from tokenspeed.runtime.sampling.backends.base import SamplingBackend
 from tokenspeed.runtime.sampling.dp_sampling_config import (
@@ -124,6 +124,14 @@ def _resolve_prefill_graph_max_tokens(server_args) -> int:
     if server_args.max_total_tokens:
         cap = min(cap, int(server_args.max_total_tokens))
     return cap
+
+
+def _cache_arena_attr(pool, name: str, default):
+    """Read one arena attribute off a cache view, tolerating fakes.
+
+    Every production pool is a view onto an arena; test doubles need not be.
+    """
+    return getattr(getattr(pool, "arena", None), name, default)
 
 
 @dataclass
@@ -317,7 +325,7 @@ class ModelExecutor:
             attn_backend=attn_backend,
             kv_pool=token_to_kv_pool,
         )
-        self._cache_runtime_contract = token_to_kv_pool.runtime_contract
+        self._cache_runtime_contract = token_to_kv_pool.arena.runtime_contract
 
         # The batch-ordered full-history table backs out_cache_loc and the
         # draft page table. First contract group with family=history and
@@ -335,8 +343,10 @@ class ModelExecutor:
         self._draft_final_step_counter = None
 
         # fill_input_buffers indexes the scheduler table in its own table pages; the drafter indexes draft_page_table in its backend's kernel pages.
+        # The grain comes off the draft view's arena (the plan's P), never from
+        # the view itself -- a recipe may pin a P the config never saw.
         self._block_granularity = int(
-            getattr(draft_token_to_kv_pool, "prefix_granularity", 0)
+            _cache_arena_attr(draft_token_to_kv_pool, "prefix_granularity", 0)
             or config.prefix_granularity
         )
         draft_kernel_page_size = getattr(draft_attn_backend, "kernel_page_size", None)
@@ -390,8 +400,8 @@ class ModelExecutor:
             max_num_tokens=config.chunked_prefill_size,
             # Indexes the scheduler's full-history table: scheduler-table page ids.
             page_size=self._block_granularity,
-            # token_to_kv_pool allocates size+page_size slots; index `size` is
-            # the reserved dummy slot (see MHATokenToKVPool._create_buffers).
+            # The cache arena reserves parent 0 as the null page, so slot 0
+            # is the dummy slot padded tokens write into.
             dummy_kv_slot=0,
             state_write_padding_pool_index=config.max_req_pool_size,
             device=self.device,
@@ -444,34 +454,30 @@ class ModelExecutor:
 
         attn_backend.configure_runtime(
             sliding_window_size=model_runner.sliding_window_size,
-            paged_cache_group_specs=tuple(token_to_kv_pool.paged_cache_group_specs),
-            paged_cache_group_page_counts=getattr(
-                token_to_kv_pool,
-                "paged_cache_group_page_counts",
-                None,
+            cache_group_specs=tuple(token_to_kv_pool.arena.cache_group_specs),
+            cache_group_page_counts=_cache_arena_attr(
+                token_to_kv_pool, "cache_group_page_counts", None
             ),
         )
         if draft_attn_backend is not None:
             draft_attn_backend.configure_runtime(
                 sliding_window_size=model_runner.sliding_window_size,
-                paged_cache_group_specs=tuple(
-                    getattr(draft_token_to_kv_pool, "paged_cache_group_specs", ())
+                cache_group_specs=tuple(
+                    _cache_arena_attr(draft_token_to_kv_pool, "cache_group_specs", ())
                 ),
-                paged_cache_group_page_counts=getattr(
-                    draft_token_to_kv_pool,
-                    "paged_cache_group_page_counts",
-                    None,
+                cache_group_page_counts=_cache_arena_attr(
+                    draft_token_to_kv_pool, "cache_group_page_counts", None
                 ),
             )
 
-        validate_paged_cache_group_ids(
+        validate_cache_group_ids(
             model_runner.model,
-            token_to_kv_pool.paged_cache_group_specs,
+            token_to_kv_pool.arena.cache_group_specs,
         )
         if draft_model_runner is not None and draft_token_to_kv_pool is not None:
-            validate_paged_cache_group_ids(
+            validate_cache_group_ids(
                 draft_model_runner.model,
-                draft_token_to_kv_pool.paged_cache_group_specs,
+                draft_token_to_kv_pool.arena.cache_group_specs,
             )
 
         self.dp_sampling_runtime_config = setup_dp_sampling(
@@ -1072,7 +1078,7 @@ class ModelExecutor:
                     gen_throughput,
                     num_queue_reqs,
                 )
-            self.token_to_kv_pool.maybe_log_paged_cache_group_pages()
+            self.token_to_kv_pool.maybe_log_cache_group_pages()
             self.num_generated_tokens = 0
             self.num_decode_steps = 0
             self.last_decode_stats_tic = now
@@ -1210,7 +1216,7 @@ class ModelExecutor:
                 )
                 zero_pages(page_ids)
                 return True
-            if getattr(pool, "paged_cache_requires_page_zeroing", False):
+            if getattr(pool, "requires_page_zeroing", False):
                 raise RuntimeError(
                     "scheduler emitted pages to zero but an active KV "
                     "pool does not implement physical-page sanitization"
@@ -1222,14 +1228,16 @@ class ModelExecutor:
             draft_pool = getattr(self, "draft_token_to_kv_pool", None)
             if draft_pool is not None and getattr(
                 draft_pool,
-                "paged_cache_requires_page_zeroing",
+                "requires_page_zeroing",
                 False,
             ):
                 draft_pages = pages
                 if isinstance(pages, Mapping):
                     draft_group_ids = {
                         str(spec.group_id)
-                        for spec in draft_pool.paged_cache_group_specs
+                        for spec in _cache_arena_attr(
+                            draft_pool, "cache_group_specs", ()
+                        )
                     }
                     draft_pages = {
                         group_id: page_ids

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -187,7 +187,7 @@ class PrefillGraph:
     A pure graph object -- :meth:`can_run` / :meth:`replay` -- holding no
     reference to any other component. The executor calls :meth:`capture` once
     kernel tuning has run, passing the decode wrapper transiently for its
-    capture stream and dummy paged-cache tables; it is not kept. The dispatch
+    capture stream and dummy cache-group tables; it is not kept. The dispatch
     checks :meth:`can_run` and calls :meth:`replay`; the eager path stays a
     direct ``model_runner.forward`` call at that call site. Capture failure
     degrades to eager -- world-agreed, so DP/TP ranks stay in lockstep.
@@ -272,7 +272,7 @@ class PrefillGraph:
         """Capture one breakable graph per token bucket (no-op when disabled).
 
         ``decode_wrapper`` supplies the shared capture stream and dummy
-        paged-cache block tables (used here only, not stored). Buckets share
+        cache-group block tables (used here only, not stored). Buckets share
         one PRIVATE mempool (first capture
         allocates it), so graph memory stays ~the largest bucket's peak --
         but never the decode graphs' pool: eager ops cache raw pointers to
@@ -425,14 +425,13 @@ class PrefillGraph:
         backend = self.attn_backend
         if not getattr(backend, "uses_cache_groups", False):
             return {}
-        specs = tuple(getattr(self.token_to_kv_pool, "paged_cache_group_specs", ()))
+        # The arena's specs are the source; the backend's state_group_ids is
+        # learned from these same specs, so consulting it as a second opinion
+        # could only ever return the same set.
+        specs = self.token_to_kv_pool.arena.cache_group_specs
         state_group_ids = {
-            str(spec.group_id)
-            for spec in specs
-            if getattr(spec, "family", "history") == "state"
+            str(spec.group_id) for spec in specs if spec.family == "state"
         }
-        if not state_group_ids:
-            state_group_ids = set(getattr(backend, "state_group_ids", frozenset()))
         # Composite wrappers hold the cache-group consumer as a child.
         if not hasattr(backend, "kernel_page_size") and hasattr(
             backend, "full_attn_backend"
@@ -534,7 +533,7 @@ class PrefillGraph:
             ctx.global_bs = [bs] * self.config.world_size
         extra_metadata_kwargs: dict = {}
         if (
-            getattr(self.attn_backend, "uses_paged_cache_groups", False)
+            getattr(self.attn_backend, "needs_group_block_tables", False)
             and decode_wrapper is not None
         ):
             tables = decode_wrapper._capture_group_block_tables(
@@ -546,24 +545,22 @@ class PrefillGraph:
             extra_metadata_kwargs["positions"] = ib.positions_buf[:num_tokens]
         group_tables = self._dummy_group_tables(max(seq_lens), bs)
         if group_tables:
-            contract = getattr(self.token_to_kv_pool, "runtime_contract", None)
-            if contract is not None:
-                arrays = {
-                    group_id: table.cpu().numpy()
-                    for group_id, table in group_tables.items()
-                }
-                dummy_forward_op = SimpleNamespace(block_tables_arrays=lambda: arrays)
-                cache_metadata = CacheBatchMetadata.from_forward_op(
-                    dummy_forward_op,
-                    device=self.config.device,
-                    contract=contract,
-                    num_requests=bs,
-                )
-                group_tables = dict(
-                    cache_metadata.tables(active_forward_op=dummy_forward_op)
-                )
-                extra_metadata_kwargs["cache_metadata"] = cache_metadata
-                extra_metadata_kwargs["forward_batch"] = dummy_forward_op
+            arrays = {
+                group_id: table.cpu().numpy()
+                for group_id, table in group_tables.items()
+            }
+            dummy_forward_op = SimpleNamespace(block_tables_arrays=lambda: arrays)
+            cache_metadata = CacheBatchMetadata.from_forward_op(
+                dummy_forward_op,
+                device=self.config.device,
+                contract=self.token_to_kv_pool.arena.runtime_contract,
+                num_requests=bs,
+            )
+            group_tables = dict(
+                cache_metadata.tables(active_forward_op=dummy_forward_op)
+            )
+            extra_metadata_kwargs["cache_metadata"] = cache_metadata
+            extra_metadata_kwargs["forward_batch"] = dummy_forward_op
             extra_metadata_kwargs["block_tables"] = group_tables
         self.attn_backend.init_forward_metadata(
             bs=bs,

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -45,7 +45,7 @@ def init_backend_cuda_graph_state(
     """Call ``backend.init_cuda_graph_state`` with only the kwargs its
     signature accepts (VAR_KEYWORD accepts all of them).
 
-    Signature-probe instead of try/except TypeError: paged_cache_group_specs
+    Signature-probe instead of try/except TypeError: cache_group_specs
     is load-bearing for the state shed, so a TypeError raised from inside the
     backend's body must propagate rather than silently retry without specs.
 
@@ -61,11 +61,15 @@ def init_backend_cuda_graph_state(
 class AttentionBackend(ABC):
     """The base class of attention backends"""
 
-    uses_paged_cache_groups: bool = False
-    # paged cache per-group block tables (absolute index, null hole = 0). A
-    # separate flag from uses_paged_cache_groups because the two mechanisms have
-    # different hole/index semantics; a group-aware backend sets
-    # this True. Default False keeps every existing backend on today's path.
+    # The graph capture/replay helpers must hand this backend per-group
+    # ``block_tables`` as a metadata kwarg; a backend that builds its own
+    # tables from the pool leaves this False.
+    needs_group_block_tables: bool = False
+    # This backend reads per-group cache block tables (absolute index, null
+    # hole = 0). A separate flag from needs_group_block_tables because that
+    # one is about who supplies the tables and this one about the index
+    # semantics the backend reads them with; a group-aware backend sets this
+    # True. Default False keeps every existing backend on today's path.
     uses_cache_groups: bool = False
     # True when authoritative per-group tables also replace the shared
     # full-history draft table for this backend. Keep this separate from

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_groups.py
@@ -71,7 +71,7 @@ class CacheGroupsMixin:
     cache_consumer_families = frozenset({"history"})
 
     # family="state" group ids (GDN/mamba state blocks); learned from the
-    # pool's specs in init_cuda_graph_state, shed from every table here.
+    # pool's specs in set_cache_pool, shed from every table here.
     state_group_ids: frozenset[str] = frozenset()
 
     # Wrapper-owned (Inkling conv) groups: mixin skips their write-loc math and capture buffers
@@ -175,26 +175,39 @@ class CacheGroupsMixin:
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        # Learned from the pool by _learn_cache_groups / set_cache_pool;
-        # init_cuda_graph_state is never reached under --enforce-eager, so
-        # establish the empty state at construction.
+        # Empty until the pool arrives; set_cache_pool runs before any
+        # metadata init, on both the eager and the CUDA-graph path.
         self.state_group_ids: frozenset[str] = frozenset()
         self.group_block_granularities: dict[str, int] = {}
         self.cache_pool: CachePool | None = None
 
-    def _learn_cache_groups(self, paged_cache_group_specs) -> None:
-        """Record the pool's family="state" group ids (see
-        state_group_ids) and per-group page sizes (heterogeneous block
-        sizes); called from init_cuda_graph_state, the one place the pool's
-        specs reach every backend."""
+    def set_cache_pool(self, cache_pool: CachePool) -> None:
+        """Bind the pool and learn its groups in one step.
+
+        The arena's published specs are the only source of group geometry, so
+        binding is also when learning happens -- no second seeding path that
+        could answer differently on the eager arm.
+        """
+        super().set_cache_pool(cache_pool)
+        self._learn_cache_groups(cache_pool.arena.cache_group_specs)
+
+    def _learn_cache_groups(self, cache_group_specs) -> None:
+        """Record the pool's family="state" group ids (see state_group_ids)
+        and per-group CacheBlock spans (heterogeneous block sizes).
+
+        Spans are read as ``block_granularity``, the shape-agnostic name: for
+        the row-geometry groups kept here it equals ``page_size`` by
+        definition, and asking a snapshot-state group for ``page_size`` is a
+        TypeError. State groups carry no span because they are shed before any
+        page-table or write-location math (_shed_state_groups); their blocks
+        hold state snapshots, not kernel pages.
+        """
         self.state_group_ids = frozenset(
-            str(spec.group_id)
-            for spec in paged_cache_group_specs
-            if spec.family == "state"
+            str(spec.group_id) for spec in cache_group_specs if spec.family == "state"
         )
         self.group_block_granularities = {
-            str(spec.group_id): spec.page_size
-            for spec in paged_cache_group_specs
+            str(spec.group_id): spec.block_granularity
+            for spec in cache_group_specs
             if spec.family != "state"
         }
 
@@ -504,8 +517,8 @@ class CacheGroupsMixin:
             if buf is None:
                 # Replay write locs are ALWAYS the fused triton launch over
                 # the stacked buffers; a group outside the stack could never
-                # get its locs filled. Groups must be declared (via
-                # group_block_granularities) before init_cuda_graph_state.
+                # get its locs filled. Every capture-visible group must be
+                # known (set_cache_pool) before init_cuda_graph_state.
                 raise RuntimeError(
                     f"cache group {gid!r} is not in the stacked CUDA-graph "
                     f"buffers (stack: {self._graph_group_ids}); declare every "

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_metadata.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_metadata.py
@@ -31,7 +31,7 @@ from tokenspeed.runtime.engine.scheduler_utils import (
     block_tables_from_forward_op,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.cache_runtime import (
-    PagedCacheRuntimeContract,
+    CacheRuntimeContract,
     require_positive_int,
 )
 from tokenspeed.runtime.layers.attention.page_table import expand_page_table
@@ -74,7 +74,7 @@ class CacheBatchMetadata:
         forward_op: Any,
         *,
         device: torch.device | str,
-        contract: PagedCacheRuntimeContract,
+        contract: CacheRuntimeContract,
         num_requests: int,
     ) -> CacheBatchMetadata:
         """Validate CPU exports, pack once, and retain operation provenance."""
@@ -201,7 +201,7 @@ class CacheBatchMetadata:
         try:
             return self._group_tables[group_id]
         except KeyError:
-            raise KeyError(f"missing paged cache group {group_id!r}") from None
+            raise KeyError(f"missing cache group {group_id!r}") from None
 
     def require_full_attention_table(self, *, active_forward_op: Any) -> torch.Tensor:
         """Return the unique full-history history-group table.

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -37,6 +37,13 @@ from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.deepseek_v4.metadata import (
     DeepseekV4ForwardMetadata,
 )
+from tokenspeed.runtime.layers.attention.deepseek_v4_geometry import (
+    DEEPSEEK_V4_SPARSE_PREFILL_TOPK_ALIGNMENT,
+    V4_KERNEL_BLOCK_ROWS,
+    deepseek_v4_swa_row_bytes,
+    first_v4_compressed_kv_group_id,
+    v4_compressed_kv_group_id,
+)
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_build_dense_prefill_local_compressed_indices,
     deepseek_v4_combine_dense_swa_indices,
@@ -52,15 +59,8 @@ from tokenspeed.runtime.layers.attention.kv_cache.hybrid_deepseek_v4 import (
     DeepseekV4CacheMetadata,
     _split_block_tables_into_v4_metadata,
 )
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec import (
-    DEEPSEEK_V4_SPARSE_PREFILL_TOPK_ALIGNMENT,
-    V4_KERNEL_BLOCK_ROWS,
-    deepseek_v4_swa_row_bytes,
-    first_v4_compressed_kv_group_id,
-    v4_compressed_kv_group_id,
-)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.utils.env import global_server_args_dict
@@ -245,7 +245,7 @@ def _refresh_decode_indexer_schedule_metadata(
 class DeepseekV4AttentionBackend(AttentionBackend):
     """Metadata owner for the model-local DeepSeek V4 attention path."""
 
-    uses_paged_cache_groups = True
+    needs_group_block_tables = True
     uses_cache_groups = True
     cache_group_tables_replace_draft_page_table = True
     cache_active_pages_must_be_real = True
@@ -338,10 +338,10 @@ class DeepseekV4AttentionBackend(AttentionBackend):
 
     def _configure_cache_group_contract(
         self,
-        paged_cache_group_specs=(),
-        paged_cache_group_page_counts=None,
+        cache_group_specs=(),
+        cache_group_page_counts=None,
     ) -> tuple[tuple[object, ...], dict[str, int]]:
-        specs = tuple(paged_cache_group_specs or ())
+        specs = tuple(cache_group_specs or ())
         group_ids = tuple(getattr(spec, "group_id", None) for spec in specs)
         if any(not isinstance(group_id, str) or not group_id for group_id in group_ids):
             raise RuntimeError(
@@ -349,7 +349,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             )
         if len(group_ids) != len(set(group_ids)):
             raise RuntimeError("DeepSeek V4 cache group specs contain duplicate IDs")
-        page_counts = dict(paged_cache_group_page_counts or {})
+        page_counts = dict(cache_group_page_counts or {})
         if not group_ids:
             if page_counts:
                 raise RuntimeError(
@@ -406,8 +406,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
 
     def configure_runtime(self, **kwargs) -> None:
         self._configure_cache_group_contract(
-            kwargs.pop("paged_cache_group_specs", ()),
-            kwargs.pop("paged_cache_group_page_counts", None),
+            kwargs.pop("cache_group_specs", ()),
+            kwargs.pop("cache_group_page_counts", None),
         )
 
     def _prepare_cache_group_tables(
@@ -592,7 +592,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
 
     def _cuda_graph_group_table_width(
         self,
-        spec: PagedCacheGroupSpec,
+        spec: CacheGroupSpec,
         *,
         max_tokens_per_req: int,
         overlap_schedule_depth: int,
@@ -1144,7 +1144,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
 
         cache_metadata = metadata.cache
         if cache_metadata.swa_page_table is None:
-            raise RuntimeError("DeepSeek V4 missing paged-cache block table for SWA KV")
+            raise RuntimeError("DeepSeek V4 missing cache-group block table for SWA KV")
         swa_page_table = cache_metadata.swa_page_table
         indices, lens = deepseek_v4_decode_swa_indices_and_lens(
             query_start_loc=metadata.query_start_loc,
@@ -1588,7 +1588,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             torch.full_like(prefix_lens, max(window_size - 1, 0)),
         )
         if cache_metadata.swa_page_table is None:
-            raise RuntimeError("DeepSeek V4 missing paged-cache block table for SWA KV")
+            raise RuntimeError("DeepSeek V4 missing cache-group block table for SWA KV")
         swa_page_table = cache_metadata.swa_page_table
         max_gather_len = int(gather_lens.max().item()) if num_reqs else 1
         compressed_lens = (
@@ -1977,8 +1977,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        paged_cache_group_specs=(),
-        paged_cache_group_page_counts=None,
+        cache_group_specs=(),
+        cache_group_page_counts=None,
         max_tokens_per_req: int = 1,
         overlap_schedule_depth: int = 0,
     ):
@@ -2041,8 +2041,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._cuda_graph_max_bs = max_bs
         self._cuda_graph_block_tables = {}
         specs, _ = self._configure_cache_group_contract(
-            paged_cache_group_specs,
-            paged_cache_group_page_counts,
+            cache_group_specs,
+            cache_group_page_counts,
         )
         group_ids = self._expected_cache_group_ids
         assert group_ids is not None
@@ -2097,14 +2097,14 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             if table is not None:
                 if int(table.shape[0]) < active_rows:
                     raise RuntimeError(
-                        "DeepSeek V4 CUDA graph paged cache table row count "
+                        "DeepSeek V4 CUDA graph cache-group table row count "
                         f"mismatch for {group_id!r}: got {int(table.shape[0])}, "
                         f"expected at least actual_bs {active_rows}"
                     )
                 cols = int(table.shape[1])
                 if cols > int(buf.shape[1]):
                     raise RuntimeError(
-                        "DeepSeek V4 CUDA graph paged cache table width "
+                        "DeepSeek V4 CUDA graph cache-group table width "
                         f"mismatch for {group_id!r}: got {cols}, capture "
                         f"buffer has {int(buf.shape[1])}"
                     )

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -532,7 +532,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         self.cuda_graph_seq_lens_k = torch.zeros(
             max_bs, dtype=torch.int32, device="cuda"
         )
-        # Paged cache contract: persistent write-location buffer whose address
+        # Cache contract: persistent write-location buffer whose address
         # the captured graph records; replay refreshes it in place from the
         # live full-history table. Only allocated when the backend is a cache
         # contract sub-backend.

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -313,7 +313,7 @@ class MambaAttnBackend(AttentionBackend):
     def set_kv_pool(self, kv_pool) -> None:
         """Bind a unified pool that publishes state groups and component views."""
         self.kv_pool = kv_pool
-        contract = kv_pool.runtime_contract
+        contract = kv_pool.arena.runtime_contract
         if contract is None:
             raise RuntimeError(
                 "MambaAttnBackend requires a KV pool with a runtime cache contract"
@@ -2016,7 +2016,7 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.linear_attn_backend.init_forward_metadata(*args, **kwargs)
 
     def init_cuda_graph_state(self, max_bs: int, **kwargs):
-        # kwargs (e.g. paged_cache_group_specs, so the full backend sheds
+        # kwargs (e.g. cache_group_specs, so the full backend sheds
         # state-family groups) are forwarded through the shared signature
         # filter: the full backend is user-selectable and may have a narrow
         # signature (e.g. TRTLLM MHA takes only (max_bs,)), and the mamba

--- a/python/tokenspeed/runtime/layers/attention/backends/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/inkling.py
@@ -233,8 +233,8 @@ class InklingAttnBackend(AttentionBackend):
 
     # Class-level flags on AttentionBackend would shadow __getattr__; mirror inner's explicitly.
     @property
-    def uses_paged_cache_groups(self):
-        return self.inner.uses_paged_cache_groups
+    def needs_group_block_tables(self):
+        return self.inner.needs_group_block_tables
 
     @property
     def uses_cache_groups(self):

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -173,11 +173,6 @@ class MHAAttnBackend(CacheGroupsMixin, AttentionBackend):
         self.forward_decode_metadata: MHADecodeMetadata | None = None
         self.forward_extend_metadata: MHAExtendMetadata | None = None
 
-        # family="state" ids (GDN/mamba) learned in init_cuda_graph_state; this backend sheds them
-        self.state_group_ids: frozenset[str] = frozenset()
-        # Group geometry is available to eager metadata before graph setup.
-        self.group_block_granularities = dict(config.group_block_granularities or {})
-
     # ------------------------------------------------------------------
     # Metadata initialization
     # ------------------------------------------------------------------
@@ -210,7 +205,7 @@ class MHAAttnBackend(CacheGroupsMixin, AttentionBackend):
             # Verify keeps [bs]-row tables; only DFLASH expands rows.
             assert not (
                 self.draft_block_decode and self.spec_num_tokens > 1
-            ), "paged cache groups are unsupported with DFLASH block decode"
+            ), "cache groups are unsupported with DFLASH block decode"
             # The cache path routes every read/write through the per-group
             # tables; a shared single page_table would be dead work.
             page_table = None
@@ -337,13 +332,13 @@ class MHAAttnBackend(CacheGroupsMixin, AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        paged_cache_group_specs: Sequence = (),
+        cache_group_specs: Sequence = (),
         **kwargs,
     ):
         # State-family groups (GDN/mamba pages) belong to the mamba backend;
         # learn their ids from the pool's specs so every table/location path
         # here (eager, capture, replay) sheds them.
-        self._learn_cache_groups(paged_cache_group_specs)
+        self._learn_cache_groups(cache_group_specs)
 
         self.cuda_graph_decode_metadata = {}
         # Per-group persistent buffers. parallels

--- a/python/tokenspeed/runtime/layers/attention/backends/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/msa.py
@@ -213,7 +213,7 @@ class MSAAttnBackend(CacheGroupsMixin, AttentionBackend):
             # Verify keeps [bs]-row tables; only DFLASH expands rows.
             assert not (
                 self.draft_block_decode and self.spec_num_tokens > 1
-            ), "paged cache groups are unsupported with DFLASH block decode"
+            ), "cache groups are unsupported with DFLASH block decode"
             # The cache path routes every read/write through the per-group
             # tables; a shared single page_table would be dead work.
             page_table = None
@@ -336,13 +336,13 @@ class MSAAttnBackend(CacheGroupsMixin, AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        paged_cache_group_specs: Sequence = (),
+        cache_group_specs: Sequence = (),
         **kwargs,
     ):
         # State-family groups (GDN/mamba pages) belong to the mamba backend;
         # learn their ids from the pool's specs so every table/location path
         # here (eager, capture, replay) sheds them.
-        self._learn_cache_groups(paged_cache_group_specs)
+        self._learn_cache_groups(cache_group_specs)
 
         self.cuda_graph_decode_metadata = {}
         # Per-group persistent buffers, lazily allocated at first

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -108,7 +108,7 @@ class CuteDSLMLABackend(AttentionBackend):
     _logged_decode = False
     _logged_prefill = False
 
-    # Paged cache contract capability: this backend consumes only history-family
+    # Cache contract capability: this backend consumes only history-family
     # (full-attention) tables; state groups belong to the linear sub-backend.
     cache_consumer_families = frozenset({"history"})
     draft_seq_lens_attr: str = "cuda_graph_seq_lens_buf"
@@ -117,7 +117,7 @@ class CuteDSLMLABackend(AttentionBackend):
         super().__init__(config)
 
         # Latched the first time paged cache metadata arrives. Once bound, a
-        # forward without cache metadata is a hard error: the paged-cache contract
+        # forward without cache metadata is a hard error: the cache contract
         # forbids falling back to legacy page_table metadata.
         self._cache_groups_bound = False
         # Set by the registry before graph capture; see mark_cache_contract.
@@ -191,7 +191,7 @@ class CuteDSLMLABackend(AttentionBackend):
         self.forward_prefill_metadata: CuteDSLMLAPrefillMetadata | None = None
         self.decode_cuda_graph_metadata: dict[int, CuteDSLMLADecodeMetadata] = {}
         self.decode_cuda_graph_kv_indices = None
-        # Paged cache contract decode graph: persistent write-location buffer whose
+        # Cache contract decode graph: persistent write-location buffer whose
         # address the captured graph records; replay refreshes it in place.
         # Allocated in init_cuda_graph_state only when _cache_contract_bound.
         self.decode_cuda_graph_group_out_cache_loc: torch.Tensor | None = None
@@ -210,7 +210,7 @@ class CuteDSLMLABackend(AttentionBackend):
         return buf
 
     def mark_cache_contract(self) -> None:
-        """Mark this MLA backend as a Kimi-K3 Paged cache contract sub-backend.
+        """Mark this MLA backend as a Kimi-K3 Cache contract sub-backend.
 
         Called by the registry when the backend is constructed for the
         Kimi-K3 LCM contract path. Enables grouped CUDA-graph
@@ -399,7 +399,7 @@ class CuteDSLMLABackend(AttentionBackend):
             # Missing Paged cache metadata must never select the legacy page_table
             # path after the backend is bound to the contract.
             raise RuntimeError(
-                "tokenspeed_mla is bound to the Paged cache contract but received "
+                "tokenspeed_mla is bound to the Cache contract but received "
                 "no paged cache metadata; refusing the legacy page_table path"
             )
 
@@ -680,7 +680,7 @@ class CuteDSLMLABackend(AttentionBackend):
                 raise RuntimeError(
                     "tokenspeed_mla Paged cache graph capture: the cache write-location "
                     "buffer is not allocated; init_cuda_graph_state ran before "
-                    "the backend was marked as the Paged cache contract sub-backend"
+                    "the backend was marked as the Cache contract sub-backend"
                 )
             # Placeholders resolve to the null page 0 until the first replay.
             block_kv_indices.zero_()

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -149,9 +149,6 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
             if config.kernel_page_size is not None
             else TRTLLM_MHA_PAGE_SIZE
         )
-        self.group_block_granularities = dict(
-            getattr(config, "group_block_granularities", None) or {}
-        )
         self.max_context_len = config.context_len
         self.kv_cache_dtype = config.kv_cache_dtype
         max_bs = config.max_bs
@@ -436,7 +433,7 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
             # Verify keeps [bs]-row tables; only DFLASH expands rows.
             assert not (
                 self.draft_block_decode and self.spec_num_tokens > 1
-            ), "paged cache groups are unsupported with DFLASH block decode"
+            ), "cache groups are unsupported with DFLASH block decode"
             if forward_mode.is_extend_or_mixed():
                 assert extend_prefix_lens_cpu is not None
                 assert extend_seq_lens_cpu is not None
@@ -747,14 +744,14 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
     def init_cuda_graph_state(
         self,
         max_bs: int,
-        paged_cache_group_specs: Sequence = (),
+        cache_group_specs: Sequence = (),
         **kwargs,
     ):
         self.cuda_graph_prefill_metadata = {}
         self.cuda_graph_decode_metadata = {}
         # Per-group persistent buffers + state-group shed; before the
         # DFLASH early return (replay reads the dict for the stale guard).
-        self._learn_cache_groups(paged_cache_group_specs)
+        self._learn_cache_groups(cache_group_specs)
         self._init_group_graph_buffers(max_bs)
         if self.draft_block_decode and self.spec_num_tokens > 1:
             # DFLASH draft block: spec_num_tokens decode rows per request. Unlike

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -432,7 +432,7 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
         self.decode_cuda_graph_kv_indices = torch.zeros(
             (max_bs, max_blocks), dtype=torch.int32, device=self.device
         )
-        # Paged cache contract: persistent write-location buffer whose address
+        # Cache contract: persistent write-location buffer whose address
         # the captured graph records; replay refreshes it in place. Target
         # verify records spec_num_tokens locations per request.
         if self._cache_contract_bound:

--- a/python/tokenspeed/runtime/layers/attention/configs/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mha.py
@@ -36,16 +36,13 @@ from tokenspeed.runtime.utils.server_args import ServerArgs
 @dataclass
 class MHAConfig(BaseAttnConfig):
     # Per-layer attention-type labels + window, forwarded to the KV pool for
-    # paged_cache_group_specs publication (empty -> single full-history group).
+    # cache_group_specs publication (empty -> single full-history group).
     layer_types: tuple[str, ...] = ()
     sliding_window_tokens: int | tuple[int | None, ...] | None = None
     max_scheduled_tokens: int = 0
     # True iff server_args.disaggregation_mode != "null"; cache recipes use
-    # it to stamp transfer policies onto the paged-cache group specs.
+    # it to stamp transfer policies onto the cache group specs.
     pd_disaggregation_enabled: bool = False
-    # Per-group scheduler page sizes, published by the registry for
-    # group-aware backends (backends/cache_groups.py).
-    group_block_granularities: dict[str, int] | None = None
     layer_kv_head_counts: tuple[int, ...] | None = None
 
     @classmethod
@@ -68,9 +65,9 @@ class MHAConfig(BaseAttnConfig):
             kv_cache_dtype = "bfloat16"
 
         hf_config = getattr(model_config, "hf_config", None)
-        # paged_cache_layer_types wins: it can carry labels outside transformers' ALLOWED_LAYER_TYPES
+        # cache_layer_types wins: it can carry labels outside transformers' ALLOWED_LAYER_TYPES
         layer_types = tuple(
-            getattr(hf_config, "paged_cache_layer_types", None)
+            getattr(hf_config, "cache_layer_types", None)
             or getattr(hf_config, "layer_types", None)
             or ()
         )

--- a/python/tokenspeed/runtime/layers/attention/configs/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mla.py
@@ -80,7 +80,7 @@ class MLAConfig(BaseAttnConfig):
             )
         hf_config = getattr(model_config, "hf_config", None)
         layer_types = tuple(
-            getattr(hf_config, "paged_cache_layer_types", None)
+            getattr(hf_config, "cache_layer_types", None)
             or getattr(hf_config, "layer_types", None)
             or ()
         )

--- a/python/tokenspeed/runtime/layers/attention/configs/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/msa.py
@@ -48,7 +48,7 @@ class MSAConfig(BaseAttnConfig):
     sliding_window_tokens: None = None
     max_scheduled_tokens: int = 0
     # True iff server_args.disaggregation_mode != "null"; cache recipes use
-    # it to stamp transfer policies onto the paged-cache group specs.
+    # it to stamp transfer policies onto the cache group specs.
     pd_disaggregation_enabled: bool = False
 
     index_head_dim: int = 0

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_geometry.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_geometry.py
@@ -12,39 +12,46 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DeepSeek V4 kernel cache geometry and cache-group vocabulary.
+
+Everything here is what the kernels, the model and the pool all have to agree
+on: how many bytes a row of each quantized cache costs, and what its cache
+group is called. It knows nothing about recipes, budgets or the scheduler --
+:mod:`tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4` builds
+the group specs on top of it, and depends on this module rather than the other
+way round.
+"""
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, replace
-from typing import Any
+from collections.abc import Iterable
+from dataclasses import dataclass
 
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     DEEPSEEK_V4_PAGE_SIZE,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
-    compute_paged_cache_group_page_counts,
 )
 
 V4_KERNEL_BLOCK_ROWS: int = 64
 V4_SWA_KV_GROUP_ID = "v4.swa_kv"
 V4_INDEXER_COMPRESSOR_STATE_GROUP_ID = "v4.c4a.indexer_compressor_state"
 DEEPSEEK_V4_FP8_MAX = 448.0
-DEEPSEEK_V4_FP8_BLOCK_SIZE = 128
 DEEPSEEK_V4_FP8_QUANT_BLOCK = 64
 DEEPSEEK_V4_FP8_INDEXER_BLOCK_SIZE = 128
 DEEPSEEK_V4_FP8_SCALE_BYTES = 4
 DEEPSEEK_V4_MXFP4_BLOCK_SIZE = 32
 DEEPSEEK_V4_MXFP4_SCALE_BYTES = 1
 DEEPSEEK_V4_SPARSE_PREFILL_TOPK_ALIGNMENT = 128
-# V4's default scheduler prefix granularity. Kernel geometry never derives
-# from it (that sources from DEEPSEEK_V4_PAGE_SIZE); any positive multiple of
-# the kernel page is a valid prefix granularity.
-DEEPSEEK_V4_PREFIX_GRANULARITY = DEEPSEEK_V4_PAGE_SIZE
-_COMPRESSOR_STATE_WINDOW_TOKENS = {4: 8, 128: 128}
-_COMPRESSOR_STATE_ROWS_PER_PAGE = {4: 4, 128: 8}
+# Per compression ratio: how long the compressor tail must be retained, and how
+# many rows of it share one cache block. Both the kernel cache layout and the
+# recipe's group specs read these, so the tables live here once.
+V4_COMPRESSOR_STATE_WINDOW_TOKENS = {4: 8, 128: 128}
+V4_COMPRESSOR_STATE_ROWS_PER_PAGE = {4: 4, 128: 8}
 
 
 def deepseek_v4_nope_dim(head_dim: int, rope_dim: int) -> int:
@@ -158,6 +165,17 @@ def deepseek_v4_indexer_fp8_layout_from_row_bytes(
     return index_head_dim, scale_bytes
 
 
+def v4_compressed_rows_per_page(ratio: int) -> int:
+    """Kernel rows one compressed-KV cache block holds.
+
+    Sources from the kernel-page registry constant, never from the scheduler
+    prefix granularity.
+    """
+    if ratio <= 1:
+        raise ValueError(f"ratio must be > 1, got {ratio}")
+    return max(1, DEEPSEEK_V4_PAGE_SIZE // ratio)
+
+
 @dataclass(frozen=True)
 class DeepseekV4CacheLayout:
     """Per-model cache geometry derived from the HF config: layer compress
@@ -191,15 +209,11 @@ class DeepseekV4CacheLayout:
 
     def storage_block_size(self, compress_ratio: int) -> int:
         if compress_ratio > 1:
-            return max(1, DEEPSEEK_V4_PAGE_SIZE // compress_ratio)
+            return v4_compressed_rows_per_page(compress_ratio)
         return self.page_size
 
     def compressor_state_block_size(self, compress_ratio: int) -> int:
-        if compress_ratio == 4:
-            return 4
-        if compress_ratio == 128:
-            return 8
-        return self.page_size
+        return V4_COMPRESSOR_STATE_ROWS_PER_PAGE.get(compress_ratio, self.page_size)
 
     @property
     def indexer_row_bytes(self) -> int:
@@ -298,247 +312,3 @@ def first_v4_compressed_kv_group_id(group_ids) -> str | None:
     if not ratios:
         return None
     return ratios[min(ratios)]
-
-
-def _compressed_kernel_block_size(ratio: int) -> int:
-    # Kernel geometry sources from the kernel-page registry constant, never
-    # from the scheduler prefix granularity.
-    if ratio <= 1:
-        raise ValueError(f"ratio must be > 1, got {ratio}")
-    return max(1, DEEPSEEK_V4_PAGE_SIZE // ratio)
-
-
-def _resolve_sliding_window(hf_config: Any) -> int:
-    for source in (hf_config, getattr(hf_config, "text_config", None)):
-        if source is None:
-            continue
-        if hasattr(source, "sliding_window"):
-            value = source.sliding_window
-            if value is None:
-                raise ValueError("DeepSeek V4 sliding_window is None")
-            window = int(value)
-            if window <= 0:
-                raise ValueError(f"sliding_window must be positive, got {value!r}")
-            return window
-    raise ValueError("DeepSeek V4 hf_config is missing sliding_window")
-
-
-def build_v4_cache_specs(
-    hf_config: Any,
-    *,
-    layer_ratio: Sequence[int],
-    cache_blocks_per_lcm_block: Mapping[str, int] | None = None,
-    decode_input_tokens: int = 1,
-) -> list[PagedCacheGroupSpec]:
-    if (
-        isinstance(decode_input_tokens, bool)
-        or not isinstance(decode_input_tokens, int)
-        or decode_input_tokens <= 0
-    ):
-        raise ValueError("decode_input_tokens must be a positive integer")
-    swa_window = _resolve_sliding_window(hf_config)
-    unique_compress_ratios = sorted({int(r) for r in layer_ratio if int(r) > 1})
-    # c4 compression consumes the prior four-token state plus every token in
-    # the target verify block. Preserve the historical eight-token window for
-    # verify widths <= 4 and grow it for wider block-speculative decoders.
-    c4_state_window = max(
-        _COMPRESSOR_STATE_WINDOW_TOKENS[4],
-        4 + decode_input_tokens,
-    )
-
-    specs: list[PagedCacheGroupSpec] = [
-        # SWA kv: trailing window only -> State family.
-        PagedCacheGroupSpec(
-            group_id=V4_SWA_KV_GROUP_ID,
-            retention="sliding_window",
-            rows_per_page=V4_KERNEL_BLOCK_ROWS,
-            entry_stride_tokens=1,
-            sliding_window_tokens=swa_window,
-            family="state",
-        ),
-    ]
-    for ratio in unique_compress_ratios:
-        if ratio not in _COMPRESSOR_STATE_WINDOW_TOKENS:
-            raise ValueError(f"unsupported DeepSeek V4 compress_ratio={ratio}")
-        # Compressor state: tail buffer -> State family.
-        specs.append(
-            PagedCacheGroupSpec(
-                group_id=v4_compressor_state_group_id(ratio),
-                retention="sliding_window",
-                rows_per_page=_COMPRESSOR_STATE_ROWS_PER_PAGE[ratio],
-                entry_stride_tokens=1,
-                sliding_window_tokens=(
-                    c4_state_window
-                    if ratio == 4
-                    else _COMPRESSOR_STATE_WINDOW_TOKENS[ratio]
-                ),
-                family="state",
-            )
-        )
-        # Compressed kv: full-history chain (indexer K shares this group).
-        specs.append(
-            PagedCacheGroupSpec(
-                group_id=v4_compressed_kv_group_id(ratio),
-                retention="full_history",
-                rows_per_page=_compressed_kernel_block_size(ratio),
-                entry_stride_tokens=ratio,
-                sliding_window_tokens=None,
-                family="history",
-            )
-        )
-    if 4 in unique_compress_ratios:
-        # Indexer compressor state: tail buffer -> State family.
-        specs.append(
-            PagedCacheGroupSpec(
-                group_id=V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
-                retention="sliding_window",
-                rows_per_page=_COMPRESSOR_STATE_ROWS_PER_PAGE[4],
-                entry_stride_tokens=1,
-                sliding_window_tokens=c4_state_window,
-                family="state",
-            )
-        )
-    if cache_blocks_per_lcm_block is None:
-        return specs
-
-    packing = dict(cache_blocks_per_lcm_block)
-    group_ids = {spec.group_id for spec in specs}
-    if set(packing) != group_ids:
-        raise ValueError(
-            "DeepSeek V4 LCM packing must contain exactly the cache groups"
-        )
-    if any(
-        isinstance(count, bool) or not isinstance(count, int) or count <= 0
-        for count in packing.values()
-    ):
-        raise ValueError("DeepSeek V4 LCM packing values must be positive integers")
-    return [
-        replace(
-            spec,
-            cache_blocks_per_lcm_block=packing[spec.group_id],
-        )
-        for spec in specs
-    ]
-
-
-def deepseek_v4_lcm_blocks_needed(
-    specs: Sequence[PagedCacheGroupSpec],
-    *,
-    prefix_granularity: int,
-    token_capacity: int,
-    max_live_requests: int,
-    max_scheduled_tokens: int,
-    max_context_len: int,
-    decode_input_tokens: int = 1,
-    overlap_schedule_depth: int = 0,
-) -> int:
-    """Return physical parents needed by per-group CacheBlock tables."""
-    if prefix_granularity <= 0:
-        raise ValueError("prefix_granularity must be positive")
-    if token_capacity <= 0:
-        raise ValueError("token_capacity must be positive")
-    for spec in specs:
-        if prefix_granularity % spec.block_granularity:
-            raise ValueError(
-                f"group {spec.group_id!r} cache block tokens must divide "
-                f"prefix_granularity={prefix_granularity}"
-            )
-    counts = compute_paged_cache_group_page_counts(
-        specs,
-        max_live_requests=max_live_requests,
-        max_scheduled_tokens=max_scheduled_tokens,
-        max_total_tokens=token_capacity,
-        max_context_len=max_context_len,
-        decode_input_tokens=decode_input_tokens,
-        overlap_schedule_depth=overlap_schedule_depth,
-    )
-    parents = 0
-    for spec in specs:
-        child_pages = counts[spec.group_id] - 1  # page 0 is the null page
-        packing = spec.cache_blocks_per_lcm_block
-        parents += (child_pages + packing - 1) // packing
-    return parents
-
-
-def deepseek_v4_token_capacity_for_cache_pool(
-    specs: Sequence[PagedCacheGroupSpec],
-    *,
-    prefix_granularity: int,
-    num_lcm_blocks: int,
-    max_live_requests: int,
-    max_scheduled_tokens: int,
-    max_context_len: int,
-    decode_input_tokens: int = 1,
-    overlap_schedule_depth: int = 0,
-    upper_bound_tokens: int,
-) -> int:
-    """Invert :func:`deepseek_v4_lcm_blocks_needed` monotonically."""
-    if num_lcm_blocks <= 0:
-        raise ValueError("num_lcm_blocks must be positive")
-    if upper_bound_tokens <= 0:
-        raise ValueError("upper_bound_tokens must be positive")
-    sizing = {
-        "prefix_granularity": prefix_granularity,
-        "max_live_requests": max_live_requests,
-        "max_scheduled_tokens": max_scheduled_tokens,
-        "max_context_len": max_context_len,
-        "decode_input_tokens": decode_input_tokens,
-        "overlap_schedule_depth": overlap_schedule_depth,
-    }
-    low, high = 0, upper_bound_tokens
-    while low < high:
-        candidate = (low + high + 1) // 2
-        if (
-            deepseek_v4_lcm_blocks_needed(
-                specs,
-                token_capacity=candidate,
-                **sizing,
-            )
-            <= num_lcm_blocks
-        ):
-            low = candidate
-        else:
-            high = candidate - 1
-    if low == 0:
-        raise ValueError(
-            f"num_lcm_blocks={num_lcm_blocks} cannot admit one token with "
-            "the configured DeepSeek V4 scheduler limits"
-        )
-    return low
-
-
-__all__ = [
-    "DEEPSEEK_V4_PREFIX_GRANULARITY",
-    "DEEPSEEK_V4_FP8_BLOCK_SIZE",
-    "DEEPSEEK_V4_FP8_INDEXER_BLOCK_SIZE",
-    "DEEPSEEK_V4_FP8_MAX",
-    "DEEPSEEK_V4_FP8_QUANT_BLOCK",
-    "DEEPSEEK_V4_FP8_SCALE_BYTES",
-    "DEEPSEEK_V4_MXFP4_BLOCK_SIZE",
-    "DEEPSEEK_V4_MXFP4_SCALE_BYTES",
-    "DEEPSEEK_V4_SPARSE_PREFILL_TOPK_ALIGNMENT",
-    "V4_INDEXER_COMPRESSOR_STATE_GROUP_ID",
-    "V4_KERNEL_BLOCK_ROWS",
-    "V4_SWA_KV_GROUP_ID",
-    "DeepseekV4CacheLayout",
-    "build_v4_cache_specs",
-    "deepseek_v4_cache_layout_from_config",
-    "deepseek_v4_indexer_fp8_layout_from_row_bytes",
-    "deepseek_v4_indexer_fp8_row_bytes",
-    "deepseek_v4_indexer_fp8_scale_bytes",
-    "deepseek_v4_indexer_mxfp4_layout_from_row_bytes",
-    "deepseek_v4_indexer_mxfp4_row_bytes",
-    "deepseek_v4_indexer_mxfp4_scale_dim",
-    "deepseek_v4_indexer_mxfp4_value_bytes",
-    "deepseek_v4_lcm_blocks_needed",
-    "deepseek_v4_nope_dim",
-    "deepseek_v4_swa_row_bytes",
-    "deepseek_v4_swa_scale_dim",
-    "deepseek_v4_swa_token_stride",
-    "deepseek_v4_token_capacity_for_cache_pool",
-    "first_v4_compressed_kv_group_id",
-    "parse_v4_compressed_kv_group_id",
-    "parse_v4_compressor_state_group_id",
-    "v4_compressed_kv_group_id",
-    "v4_compressor_state_group_id",
-]

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -60,7 +60,7 @@ from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
 )
 from tokenspeed_kernel.ops.transform import hadamard_transform
 
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec import (
+from tokenspeed.runtime.layers.attention.deepseek_v4_geometry import (
     DEEPSEEK_V4_FP8_MAX,
     DEEPSEEK_V4_FP8_QUANT_BLOCK,
     DEEPSEEK_V4_MXFP4_BLOCK_SIZE,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The one cache allocation every compute view is a window onto."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+from tokenspeed_kernel.ops.kvcache.triton import zero_byte_ranges
+
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.cache_runtime import (
+    CacheRuntimeContract,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    CacheGroupSpec,
+)
+from tokenspeed.runtime.utils import get_colorful_logger
+from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+
+logger = get_colorful_logger(__name__)
+
+
+class CacheArena:
+    """Own the cache allocation, its typed field views, and its contract.
+
+    One model, one arena. Every ``CachePool`` is a compute view onto an
+    arena and owns no memory of its own: target and draft views of one
+    merged plan share this object, so "who allocates" and "who may clear"
+    stop being per-pool modes and become properties of the single owner.
+
+    The arena is the sole publisher of the scheduler-facing runtime
+    contract, so a secondary view cannot republish or diverge from it.
+    Publication is unconditional: an arena without group specs would be an
+    arena no scheduler can address, and ModelExecutor rejects it anyway.
+    """
+
+    def __init__(
+        self,
+        plan: CacheMemoryPlan,
+        device: str,
+        *,
+        cache_group_specs: tuple[CacheGroupSpec, ...],
+        token_capacity: int | None = None,
+        enable_memory_saver: bool = False,
+    ):
+        if not cache_group_specs:
+            raise ValueError(
+                "cache arena requires at least one cache group spec to publish"
+            )
+        self.plan = plan
+        self.device = device
+        # One adapter for the whole arena. The allocation happens inside its
+        # region, so the sleep/wake lifetime is a property of the arena.
+        # Tag as "kv_cache", no CPU backup: cache bytes are discarded on
+        # sleep and rebuilt after wake (paging overwrites; clear() zeros the
+        # remapped pages).
+        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
+            enable=enable_memory_saver
+        )
+        with self.memory_saver_adapter.region(
+            tag="kv_cache", enable_cpu_backup=False
+        ):
+            self.buffer = torch.zeros(
+                plan.arena_bytes,
+                dtype=torch.uint8,
+                device=device,
+            )
+
+        # The plan names every field and its dtype
+        self._fields: dict[str, torch.Tensor] = {
+            field.field_id: self._bind(field) for field in plan.fields
+        }
+        # Publish the contract: the recipe's logical specs joined with the
+        # plan's physical facts for the same groups. Nothing is copied into
+        # the specs -- the plan owns page counts and LCM packing, the contract
+        # carries them beside the specs, so the two never need reconciling.
+        # That the two name the same groups needs no assertion here: the
+        # recipe packs the plan from the very (spec, fields) pairs it publishes
+        # these specs from, so one group id cannot reach only one of them.
+        plan_groups = {group.group_id: group for group in plan.groups}
+        self.runtime_contract = CacheRuntimeContract(
+            # The identity axis comes from the plan, never read back out of
+            # view state. Per-group CacheBlock spans live in the group specs
+            # as block_granularity.
+            prefix_granularity=plan.prefix_granularity,
+            num_lcm_blocks=plan.num_lcm_blocks,
+            token_capacity=(
+                token_capacity if token_capacity is not None else self.size
+            ),
+            group_specs=tuple(cache_group_specs),
+            group_page_counts={
+                spec.group_id: plan_groups[spec.group_id].page_count
+                for spec in cache_group_specs
+            },
+            group_packing={
+                spec.group_id: plan_groups[spec.group_id].cache_blocks_per_lcm_block
+                for spec in cache_group_specs
+            },
+        )
+        logger.info(
+            "Allocated cache arena: %d bytes, prefix_granularity=%d, num_lcm_blocks=%d, device %s",
+            plan.arena_bytes,
+            plan.prefix_granularity,
+            plan.num_lcm_blocks,
+            device,
+        )
+
+    @property
+    def cache_group_specs(self) -> tuple[CacheGroupSpec, ...]:
+        """The published group specs. Stored once, in the contract."""
+        return self.runtime_contract.group_specs
+
+    @property
+    def cache_group_page_counts(self) -> Mapping[str, int]:
+        """Per-group CacheBlock counts. Stored once, in the contract."""
+        return self.runtime_contract.group_page_counts
+
+    @property
+    def prefix_granularity(self) -> int:
+        """The identity grain, from the plan that defined this arena."""
+        return self.plan.prefix_granularity
+
+    @property
+    def kv_page_size(self) -> int:
+        """KV arena page span for paged consumers.
+
+        Pinned 1:1 to the identity grain -- this property is the single point
+        of the prefix-page <-> KV-page convention, and geometry math must read
+        it rather than ``prefix_granularity``.
+        """
+        return self.plan.prefix_granularity
+
+    @property
+    def size(self) -> int:
+        """Token slots the most finely packed group addresses.
+
+        The plan's parent count times the tightest packing. One definition
+        here, so compute views no longer re-derive it and disagree.
+        """
+        max_packing = max(group.cache_blocks_per_lcm_block for group in self.plan.groups)
+        return self.plan.num_lcm_blocks * max_packing * self.plan.prefix_granularity
+
+    def _bind(self, field) -> torch.Tensor:
+        """Stride one planned field's view over the arena bytes.
+
+        Pages are the physical unit, so the stride math is page-major; a
+        per-token field then folds that axis into its entries (see
+        :meth:`field` for why the planned shape decides).
+        """
+        dtype = getattr(torch, field.dtype)
+        group = self.plan.group(field.group_id)
+        element_strides = []
+        stride = 1
+        for extent in reversed(field.shape):
+            element_strides.append(stride)
+            stride *= extent
+        pages = self.buffer.view(dtype).as_strided(
+            (group.page_count, *field.shape),
+            (
+                field.page_stride_bytes // field.element_size,
+                *reversed(element_strides),
+            ),
+            self.field_block_byte_offset(field.field_id, 0) // field.element_size,
+        )
+        if field.shape[0] != self.plan.prefix_granularity:
+            return pages
+        return pages.view(-1, *field.shape[1:])
+
+    def field(self, field_id: str) -> torch.Tensor:
+        """Return one planned field's view into the arena.
+
+        The view is shaped the way the field is addressed. A field whose
+        planned shape leads with the identity grain stores one entry per
+        token, so its page axis is folded away and consumers index entries
+        directly; every other field (recurrent state, block-scaled scale
+        planes, V4's byte-shaped planes) is addressed per page and keeps its
+        planned shape. The plan decides which, so no compute view restates
+        its kernel's geometry, and the dtype likewise comes from the plan.
+
+        Args:
+            field_id: A field id named by the memory plan.
+
+        Returns:
+            The field's view over its arena bytes.
+
+        Raises:
+            ValueError: The plan does not name this field.
+        """
+        try:
+            return self._fields[field_id]
+        except KeyError:
+            raise ValueError(f"cache field {field_id!r} is not planned") from None
+
+    def field_ids(self) -> frozenset[str]:
+        """Every field the plan names, all of them materialized."""
+        return frozenset(self._fields)
+
+    def field_block_byte_offset(self, field_id: str, block_id: int) -> int:
+        return self.plan.field_page_byte_offset(field_id, block_id)
+
+    def zero_blocks(self, block_ids_by_group: dict[str, list[int]]) -> None:
+        """Clear selected CacheBlocks without interpreting their field types."""
+        segments = [
+            segment
+            for group_id, block_ids in block_ids_by_group.items()
+            for segment in self.block_byte_segments(group_id, block_ids)
+        ]
+        if segments:
+            zero_byte_ranges(self.buffer, segments)
+
+    def block_byte_segments(
+        self, group_id: str, block_ids: list[int]
+    ) -> list[tuple[int, int]]:
+        self.plan.group(group_id)
+        fields = [field for field in self.plan.fields if field.group_id == group_id]
+        return [
+            (
+                self.field_block_byte_offset(field.field_id, block_id),
+                field.payload_bytes,
+            )
+            for block_id in block_ids
+            for field in fields
+        ]
+
+    @property
+    def supports_disaggregation(self) -> bool:
+        """Whether the arena exposes complete inputs for cache transfer."""
+        return all(
+            spec.transfer_policy is not None for spec in self.cache_group_specs
+        )
+
+    def contract_binding(self) -> torch.Tensor:
+        """Return the arena buffer the cache contract is bound to.
+
+        Field dtypes are not returned: the plan carries them, and the PD
+        contract reads them from there.
+        """
+        if not self.supports_disaggregation:
+            raise RuntimeError(
+                "cache arena has no transfer policy in its runtime contract"
+            )
+        return self.buffer
+
+    @torch.no_grad()
+    def clear(self) -> None:
+        """Zero the arena after sleep/wake remaps its storage.
+
+        Exactly one owner, so callers may fan this out over every compute
+        view without double-clearing or needing a "views skip" rule.
+        """
+        self.buffer.zero_()

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
@@ -88,13 +88,12 @@ class CacheArena:
         self._fields: dict[str, torch.Tensor] = {
             field.field_id: self._bind(field) for field in plan.fields
         }
-        # Publish the contract: the recipe's logical specs joined with the
-        # plan's physical facts for the same groups. Nothing is copied into
-        # the specs -- the plan owns page counts and LCM packing, the contract
-        # carries them beside the specs, so the two never need reconciling.
-        # That the two name the same groups needs no assertion here: the
-        # recipe packs the plan from the very (spec, fields) pairs it publishes
-        # these specs from, so one group id cannot reach only one of them.
+        # The contract joins the recipe's logical specs with the plan's
+        # physical facts for the same groups. The plan owns page counts and
+        # packing; the contract carries them beside the specs rather than
+        # copying them in, and the recipe packs the plan from the same
+        # (spec, fields) pairs these specs come from, so both name one group
+        # set by construction.
         plan_groups = {group.group_id: group for group in plan.groups}
         self.runtime_contract = CacheRuntimeContract(
             # The identity axis comes from the plan, never read back out of

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -20,19 +20,13 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from typing import TYPE_CHECKING
+import re
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
-from tokenspeed_kernel.ops.kvcache.triton import zero_byte_ranges
 
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.cache_runtime import (
-    PagedCacheRuntimeContract,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
-)
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.paged_attention import PagedAttention
 from tokenspeed.runtime.utils import get_colorful_logger
 
@@ -41,234 +35,127 @@ if TYPE_CHECKING:
 
 logger = get_colorful_logger(__name__)
 
+_LAYER_FIELD = re.compile(r"^layer\.(\d+)\.(.+)$")
 
-class CachePool:
-    """Own page-backed cache memory and expose backend-specific views."""
+
+def _layer_plane(
+    field_id: str, first_layer: int, num_layers: int
+) -> tuple[int, str] | None:
+    """Split a planned field id into this view's local layer id and plane.
+
+    Returns None for fields outside the view's layer window, and for fields
+    that are not per-layer at all.
+    """
+    match = _LAYER_FIELD.match(field_id)
+    if match is None:
+        return None
+    global_layer = int(match.group(1))
+    local_layer = global_layer - first_layer
+    if not 0 <= local_layer < num_layers:
+        return None
+    return local_layer, match.group(2)
+
+
+class CachePool(ABC):
+    """One model's typed layer window onto a shared cache arena.
+
+    A pool owns no memory and no geometry: ``self.arena`` owns the
+    allocation, the field views, the plan and the scheduler contract, and
+    callers that want any of those ask the arena directly. What a pool
+    adds is per-view: the dtype its kernels read these bytes as, where its
+    layer window starts in the merged plan, and the per-layer buffers its
+    kernels index. Target and draft are therefore two pools over one
+    arena -- and may read it as different dtypes.
+    """
 
     # Pools that alias recurrent-state bytes and KV in one buffer must
     # zero physical pages on reuse to avoid poisoned tails. Pure-attention
     # pools do not alias state, so reused pages need no sanitization.
-    paged_cache_requires_page_zeroing: bool = False
+    requires_page_zeroing: bool = False
 
     def __init__(
         self,
-        size: int,
+        arena: CacheArena,
         dtype: torch.dtype,
-        device: str,
-        prefix_granularity: int,
         rank: int,
-        memory_plan: CacheMemoryPlan,
         *,
-        paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...] = (),
-        token_capacity: int | None = None,
-        backing_pool: CachePool | None = None,
         field_layer_offset: int = 0,
     ):
+        self.arena = arena
         self.dtype = dtype
         self.rank = rank
-        self.size = size
-        self.prefix_granularity = prefix_granularity
-        # KV arena page span for paged consumers. Pinned 1:1 to the identity
-        # grain at construction — this assignment is the single point of the
-        # prefix-page <-> KV-page convention; geometry math must read this,
-        # never prefix_granularity.
-        self.kv_page_size = prefix_granularity
         if dtype in (torch.float8_e5m2, torch.float8_e4m3fn):
             #  Store as torch.uint8 because Tensor.index_put is not implemented for torch.float8_e5m2
             self.store_dtype = torch.uint8
         else:
             self.store_dtype = dtype
-        self.device = device
-        self.plan = memory_plan
         self._field_layer_offset = int(field_layer_offset)
         if self._field_layer_offset < 0:
             raise ValueError("field_layer_offset must be non-negative")
-        # The cache recipe is the single source of the scheduler group specs
-        # (CachePoolSpec.paged_cache_group_specs); the pool aligns their
-        # physical fields with the memory plan and publishes the runtime
-        # contract from the pair. Pools constructed without specs (tests)
-        # publish no contract.
-        self.runtime_contract: PagedCacheRuntimeContract | None = None
-        self.paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...] = ()
-        self.paged_cache_group_page_counts: dict[str, int] = {}
-        if paged_cache_group_specs:
-            self._publish_runtime_contract(
-                paged_cache_group_specs,
-                token_capacity if token_capacity is not None else size,
-            )
-        # Allocate lazily when the first field is bound. Concrete pools do
-        # that inside their memory-saver region, so the shared buffer keeps
-        # the same sleep/wake lifetime as the former per-buffer allocations.
-        #
-        # A heterogeneous draft view (for example, an MHA Eagle3 head over an
-        # MLA target) binds its own field family but must not allocate another
-        # arena. Construction is deliberately target-first: the draft aliases
-        # the target's already-registered buffer and field registry. The
-        # registry also supplies the runtime dtypes for the PD contract.
-        self._backing_pool = backing_pool
-        if backing_pool is None:
-            self.buffer: torch.Tensor | None = None
-            self._fields: dict[str, torch.Tensor] = {}
-        else:
-            if backing_pool.plan != memory_plan:
-                raise ValueError("a cache view must share its backing pool's plan")
-            if backing_pool.buffer is None:
-                raise ValueError(
-                    "the backing cache pool must bind its fields before a view"
-                )
-            if paged_cache_group_specs:
-                raise ValueError(
-                    "a cache view must inherit, not republish, the runtime contract"
-                )
-            self.buffer = backing_pool.buffer
-            self._fields = backing_pool._fields
-            self.runtime_contract = backing_pool.runtime_contract
-            self.paged_cache_group_specs = backing_pool.paged_cache_group_specs
-            self.paged_cache_group_page_counts = (
-                backing_pool.paged_cache_group_page_counts
-            )
-
         # default state for optional layer-wise transfer control
         self.layerwise_load_tracker = None
         logger.info(
-            f"Initialized token to kv pool with size {size}, dtype {dtype}, device {device}, prefix granularity {prefix_granularity}, rank {rank}"
+            "Initialized cache view over %d slots as %s, layers from %d, rank %d",
+            arena.size,
+            dtype,
+            self._field_layer_offset,
+            rank,
         )
 
-    def _publish_runtime_contract(
-        self,
-        group_specs: tuple[PagedCacheGroupSpec, ...],
-        token_capacity: int,
-    ) -> None:
-        """Align recipe group specs with the memory plan and publish the
-        scheduler contract. The plan is the source of truth for per-group
-        packing and page counts, so every spec group must be planned."""
-        from dataclasses import replace
+    def _field_layer_id(self, layer_id: int) -> int:
+        """Map this compute view's local layer id into the merged plan.
 
-        plan_groups = {group.group_id: group for group in self.plan.groups}
-        aligned = []
-        counts: dict[str, int] = {}
-        for spec in group_specs:
-            if spec.group_id in counts:
-                raise ValueError(
-                    f"cache group {spec.group_id!r} is published more than once"
-                )
-            group = plan_groups.get(spec.group_id)
-            if group is None:
-                raise ValueError(
-                    f"cache group {spec.group_id!r} has no planned fields; "
-                    "every published group must appear in the memory plan"
-                )
-            aligned.append(
-                replace(
-                    spec,
-                    cache_blocks_per_lcm_block=group.cache_blocks_per_lcm_block,
-                )
+        Callers pass the id their own model numbers the layer with, which for a
+        draft view means ``0..num_draft_layers-1``. Reject anything outside the
+        window: a global id offset a second time would silently address another
+        model's planes.
+        """
+        if not 0 <= layer_id < self.layer_num:
+            raise ValueError(
+                f"layer {layer_id} is outside this cache view's window of "
+                f"{self.layer_num} layers (ids are local to the view)"
             )
-            counts[spec.group_id] = group.page_count
-        self.paged_cache_group_specs = tuple(aligned)
-        self.paged_cache_group_page_counts = counts
-        self.runtime_contract = PagedCacheRuntimeContract(
-            # The identity axis comes from the plan, never read back out of
-            # pool state. The pool's prefix_granularity scalar is pinned to
-            # it at construction; per-group CacheBlock spans live in the
-            # group specs as block_granularity.
-            prefix_granularity=self.plan.prefix_granularity,
-            num_lcm_blocks=self.plan.num_lcm_blocks,
-            token_capacity=token_capacity,
-            group_specs=self.paged_cache_group_specs,
-            group_page_counts=counts,
-        )
+        return self._field_layer_offset + layer_id
 
-    def field(self, field_id: str, dtype: torch.dtype) -> torch.Tensor:
-        """Return one typed field view into the shared cache buffer."""
-        buffer = self._ensure_buffer()
-        view = self._fields.get(field_id)
-        if view is not None:
-            if view.dtype != dtype:
-                raise ValueError(
-                    f"cache field {field_id!r} is already bound as {view.dtype}"
-                )
-            return view
-        try:
-            field = self.plan.field(field_id)
-        except KeyError as exc:
-            raise ValueError(f"cache field {field_id!r} is not planned") from exc
-        if torch.empty((), dtype=dtype).element_size() != field.element_size:
-            raise ValueError(f"field {field_id!r}: dtype itemsize does not match plan")
-        group = self.plan.group(field.group_id)
-        element_strides = []
-        stride = 1
-        for extent in reversed(field.shape):
-            element_strides.append(stride)
-            stride *= extent
-        view = buffer.view(dtype).as_strided(
-            (group.page_count, *field.shape),
-            (
-                field.page_stride_bytes // field.element_size,
-                *reversed(element_strides),
-            ),
-            self._field_block_byte_offset(field_id, 0) // field.element_size,
-        )
-        self._fields[field_id] = view
-        return view
+    # Per-layer plane name -> the attribute holding its per-layer list.
+    # Subclasses declare only the planes their kernels read; a plane they do
+    # not name is not this view's concern.
+    layer_plane_bindings: ClassVar[dict[str, str]] = {}
 
-    def zero_blocks(self, block_ids_by_group: dict[str, list[int]]) -> None:
-        """Clear selected CacheBlocks without interpreting their field types."""
-        buffer = self._ensure_buffer()
-        segments = [
-            segment
-            for group_id, block_ids in block_ids_by_group.items()
-            for segment in self._block_byte_segments(group_id, block_ids)
-        ]
-        if segments:
-            zero_byte_ranges(buffer, segments)
+    def _bind_layer_planes(self) -> None:
+        """Arrange this view's planned per-layer fields into kernel buffers.
 
-    @property
-    def supports_disaggregation(self) -> bool:
-        """Whether this pool exposes complete inputs for cache transfer."""
-        return bool(self.paged_cache_group_specs) and all(
-            spec.transfer_policy is not None for spec in self.paged_cache_group_specs
-        )
-
-    def _ensure_buffer(self) -> torch.Tensor:
-        if self._backing_pool is not None:
-            buffer = self._backing_pool.buffer
-            if buffer is None:
-                raise RuntimeError("the backing cache pool released its buffer")
-            self.buffer = buffer
-            return buffer
-        if self.buffer is None:
-            self.buffer = torch.zeros(
-                self.plan.arena_bytes,
-                dtype=torch.uint8,
-                device=self.device,
+        The plan names every field, its dtype, its shape and which layer it
+        belongs to, and the arena already materialized every view in the
+        shape it is addressed by. Walk the plan once, keep the fields inside
+        this view's layer window, and file each under the attribute its
+        kernels read.
+        """
+        lists = {
+            attribute: [None] * self.layer_num
+            for attribute in self.layer_plane_bindings.values()
+        }
+        for field in self.arena.plan.fields:
+            located = _layer_plane(
+                field.field_id, self._field_layer_offset, self.layer_num
             )
-        return self.buffer
-
-    def _field_block_byte_offset(self, field_id: str, block_id: int) -> int:
-        return self.plan.field_page_byte_offset(field_id, block_id)
-
-    def _block_byte_segments(
-        self, group_id: str, block_ids: list[int]
-    ) -> list[tuple[int, int]]:
-        self.plan.group(group_id)
-        fields = [field for field in self.plan.fields if field.group_id == group_id]
-        return [
-            (
-                self._field_block_byte_offset(field.field_id, block_id),
-                field.payload_bytes,
-            )
-            for block_id in block_ids
-            for field in fields
-        ]
+            if located is None:
+                continue
+            layer_id, plane = located
+            attribute = self.layer_plane_bindings.get(plane)
+            if attribute is None:
+                continue
+            lists[attribute][layer_id] = self.arena.field(field.field_id)
+        for attribute, values in lists.items():
+            setattr(self, attribute, values)
 
     def register_layerwise_load_tracker(
         self, layerwise_load_tracker: LayerwiseLoadTracker
     ) -> None:
         self.layerwise_load_tracker = layerwise_load_tracker
 
-    def bind_paged_cache_scheduler(self, scheduler: object) -> None:
-        """Optional hook for model-specific paged-cache diagnostics."""
+    def bind_cache_scheduler(self, scheduler: object) -> None:
+        """Optional hook for model-specific cache-group diagnostics."""
 
     def cache_transfer_layout(self):
         """Return the transfer layout consumed by this compute view."""
@@ -278,7 +165,7 @@ class CachePool:
 
         try:
             field_ids, consumers = select_layer_fields(
-                self.plan.fields,
+                self.arena.plan.fields,
                 first_layer=self._field_layer_offset,
                 num_layers=self.layer_num,
             )
@@ -286,38 +173,22 @@ class CachePool:
             raise RuntimeError(str(exc)) from exc
         return self._build_cache_transfer_layout(field_ids, consumers)
 
-    def cache_contract_binding(self) -> tuple[torch.Tensor, dict[str, str]]:
-        """Return the arena and field dtypes bound to the cache contract."""
-        if not self.supports_disaggregation:
-            raise RuntimeError(
-                "cache pool has no transfer policy in its runtime contract"
-            )
-        field_ids = {field.field_id for field in self.plan.fields}
-        missing = sorted(field_ids - set(self._fields))
-        if missing:
-            raise RuntimeError(f"cache fields have no runtime dtype: {missing}")
-        return self._ensure_buffer(), {
-            field_id: str(self._fields[field_id].dtype).removeprefix("torch.")
-            for field_id in field_ids
-        }
-
     def _build_cache_transfer_layout(self, field_ids, consumers):
         from tokenspeed.runtime.cache.transfer.layout import layout_from_lcm_plan
 
-        missing = sorted(set(field_ids) - set(self._fields))
-        if missing:
-            raise RuntimeError(f"cache fields have no runtime dtype: {missing}")
         local_group_ids = {
-            field.group_id for field in self.plan.fields if field.field_id in field_ids
+            field.group_id
+            for field in self.arena.plan.fields
+            if field.field_id in field_ids
         }
         scheduler_group_ids = tuple(
             spec.group_id
-            for spec in self.paged_cache_group_specs
+            for spec in self.arena.cache_group_specs
             if spec.group_id in local_group_ids
         )
         return layout_from_lcm_plan(
-            self.plan,
-            self._ensure_buffer(),
+            self.arena.plan,
+            self.arena.buffer,
             consumers=consumers,
             group_ids=scheduler_group_ids or None,
             field_ids=field_ids,
@@ -325,26 +196,32 @@ class CachePool:
 
     @torch.no_grad()
     def clear_kv_buffers(self) -> None:
-        """Zero the shared cache buffer after sleep/wake remaps its storage."""
-        # The event loop visits both target and draft pools. A draft view owns
-        # no allocation; the target clears their shared arena exactly once.
-        if self._backing_pool is not None:
-            return
-        if self.buffer is not None:
-            self.buffer.zero_()
+        """Zero the shared cache arena after sleep/wake remaps its storage."""
+        # The event loop visits both target and draft pools; both name the
+        # same arena, and zeroing it twice is harmless.
+        self.arena.clear()
 
-    def maybe_log_paged_cache_group_pages(self) -> None:
+    def maybe_log_cache_group_pages(self) -> None:
         return None
 
+    # ------------------------------------------------------------------
+    # What every cache view owes its kernels. Abstract, so a subclass that
+    # forgets one fails at construction instead of at the first write.
+    # ------------------------------------------------------------------
+
+    @abstractmethod
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
-        raise NotImplementedError()
+        """This layer's K plane, in the shape its kernels read."""
 
+    @abstractmethod
     def get_value_buffer(self, layer_id: int) -> torch.Tensor:
-        raise NotImplementedError()
+        """This layer's V plane, in the shape its kernels read."""
 
+    @abstractmethod
     def get_kv_buffer(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
-        raise NotImplementedError()
+        """Both of this layer's planes at once."""
 
+    @abstractmethod
     def set_kv_buffer(
         self,
         layer: PagedAttention,
@@ -352,127 +229,4 @@ class CachePool:
         cache_k: torch.Tensor,
         cache_v: torch.Tensor,
     ) -> None:
-        raise NotImplementedError()
-
-
-class LayerMappedKVPool:
-    """Wraps a KV pool to map the caller's layer IDs to inner pool indices.
-
-    Two callers, one mechanism — a dict from the id a model layer carries to
-    the index its plane occupies in the wrapped pool:
-
-    - Hybrid models: layers carry global sparse ids (e.g. 3, 7, 11) while the
-      inner pool holds compact full-attention planes (0, 1, 2); the map is
-      ``{global_id: pool_idx}`` (the default built from ``layer_ids``).
-    - Draft views of the ONE merged pool: draft layers carry LOCAL ids
-      (0..n-1) while their planes are the continuation range
-      ``num_target_layers..``; the map is ``{local: global}`` (pass
-      ``layer_map`` explicitly).
-    """
-
-    def __init__(
-        self,
-        inner_pool,
-        full_attention_layer_ids: list[int],
-        *,
-        layer_map: dict[int, int] | None = None,
-    ):
-        self.inner = inner_pool
-        self.layer_ids = list(full_attention_layer_ids)
-        self.layer_map = (
-            dict(layer_map)
-            if layer_map is not None
-            else {
-                global_id: pool_idx
-                for pool_idx, global_id in enumerate(full_attention_layer_ids)
-            }
-        )
-        # Expose the identity grain for the scheduler and the KV page span
-        # for paged consumers.
-        self.prefix_granularity = getattr(inner_pool, "prefix_granularity", 1)
-        self.kv_page_size = getattr(inner_pool, "kv_page_size", 1)
-
-    def _map(self, layer_id: int) -> int:
-        return self.layer_map.get(layer_id, layer_id)
-
-    @contextmanager
-    def _mapped(self, layer):
-        """Temporarily remap ``layer.layer_id`` to its inner-pool slot."""
-        orig = layer.layer_id
-        layer.layer_id = self._map(orig)
-        try:
-            yield
-        finally:
-            layer.layer_id = orig
-
-    def set_kv_buffer(
-        self,
-        layer,
-        out_cache_loc: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor | None,
-        k_scale: torch.Tensor | None = None,
-        v_scale: torch.Tensor | None = None,
-    ):
-        with self._mapped(layer):
-            self.inner.set_kv_buffer(layer, out_cache_loc, k, v, k_scale, v_scale)
-
-    def get_kv_buffer(self, layer_id: int):
-        return self.inner.get_kv_buffer(self._map(layer_id))
-
-    def get_key_buffer(self, layer_id: int):
-        return self.inner.get_key_buffer(self._map(layer_id))
-
-    def get_value_buffer(self, layer_id: int):
-        return self.inner.get_value_buffer(self._map(layer_id))
-
-    # MLA pools index their per-layer kv_buffer by ``layer.layer_id`` directly.
-    # In a hybrid model the inner MLA pool only holds the full-attention layers,
-    # so the global id must be mapped to its pool slot first (mirrors
-    # ``set_kv_buffer``). Reached via the DeepseekV3-style MLA chunked-prefill
-    # path (Kimi-K3).
-    def set_mla_kv_buffer(self, layer, loc, cache_k_nope, cache_k_rope, sanitize=True):
-        # Prefill breakable-graph padding contract: the dummy-batch capture (and
-        # bucket-padding rows) whose ``out_cache_loc`` is the reserved
-        # ``dummy_kv_slot`` can carry NaN into this fp8 KV write. The paged MLA
-        # decode kernel reads that shared dummy slot through the zero-padded
-        # block-table entries and computes ``q·k`` BEFORE applying the causal
-        # mask, so the NaN survives it (``NaN + -inf = NaN``) and poisons a live
-        # row's softmax -> NaN logits -> token 0. Eager prefill leaves the dummy
-        # slot finite (``q·0`` masks cleanly), which is why the bug only appears
-        # with the prefill graph on. Ask the cache writer to sanitize in-kernel
-        # so real rows stay bitwise unchanged without allocating two temporary
-        # tensors or launching two separate nan_to_num kernels.
-        with self._mapped(layer):
-            self.inner.set_mla_kv_buffer(
-                layer,
-                loc,
-                cache_k_nope,
-                cache_k_rope,
-                sanitize=sanitize,
-            )
-
-    def get_mla_kv_buffer(self, layer, loc, dst_dtype=None):
-        with self._mapped(layer):
-            return self.inner.get_mla_kv_buffer(layer, loc, dst_dtype)
-
-    # DSA/MSA index-key planes are layer-indexed like the KV planes; a draft
-    # view must map its local layer ids onto the continuation range here too
-    # (an unmapped pass-through would read/write the target's planes).
-    def get_index_k_buffer(self, layer_id: int):
-        return self.inner.get_index_k_buffer(self._map(layer_id))
-
-    def set_index_k_buffer(self, layer_id: int, loc, index_k):
-        self.inner.set_index_k_buffer(self._map(layer_id), loc, index_k)
-
-    def gather_index_k(self, layer_id: int, slots):
-        return self.inner.gather_index_k(self._map(layer_id), slots)
-
-    def kvconv_checkpoint_buffers(self, layer_id: int):
-        return self.inner.kvconv_checkpoint_buffers(self._map(layer_id))
-
-    def hiddenconv_checkpoint_buffer(self, layer_id: int, component: str):
-        return self.inner.hiddenconv_checkpoint_buffer(self._map(layer_id), component)
-
-    def __getattr__(self, name):
-        return getattr(self.inner, name)
+        """Scatter one forward pass's K/V into this layer's planes."""

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -33,7 +33,6 @@ from tokenspeed.runtime.layers.attention.kv_cache.mla import (
 )
 
 _INDEX_K_FP8_GROUP_SIZE = 128
-_INDEX_K_SCALE_BYTES = torch._utils._element_size(torch.float32)
 
 
 class DSATokenToKVPool(MLATokenToKVPool):
@@ -55,9 +54,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
     def get_kv_size_bytes(self):
         return super().get_kv_size_bytes() + _get_tensor_size_bytes(self.index_k_buffer)
 
-    def has_index_k_buffer(self) -> bool:
-        return True
-
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layerwise_load_tracker is not None:
             self.layerwise_load_tracker.wait_for_layer(layer_id)
@@ -73,80 +69,6 @@ class DSATokenToKVPool(MLATokenToKVPool):
             index_k = index_k.to(self.model_dtype)
         index_k = index_k.view(-1, self.index_head_dim)
         self._set_index_k_buffer(layer_id, loc, index_k)
-
-    def _index_k_block_views(
-        self, buf: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return per-page block-split views into a packed FP8 index-K buffer.
-
-        DeepGEMM's ``fp8_paged_mqa_logits`` expects each page of ``page_size``
-        tokens to be laid out as ``[page_size * head_dim FP8 values]`` followed
-        by ``[page_size * num_groups FP32 scales]`` (block-split), NOT a
-        per-token ``[fp8 | scale]`` interleave. The two ``as_strided`` views
-        below alias the same storage as ``buf`` so writes land in place.
-
-        Args:
-            buf: Packed FP8 index-K buffer of shape ``[num_slots, row_bytes]``
-                and dtype ``uint8``, where ``row_bytes == head_dim +
-                scale_bytes`` and ``num_slots`` is a multiple of
-                ``page_size``.
-
-        Returns:
-            ``(fp8_view, scale_view)`` where ``fp8_view`` has shape
-            ``[num_pages, page_size, head_dim]`` (FP8 e4m3) and ``scale_view``
-            has shape ``[num_pages, page_size, num_groups]`` (float32), both
-            indexed as ``view[page, slot_in_page]``.
-        """
-        # DSA requires kv_page_size == DSA_SPARSE_PAGE_SIZE (64), the only
-        # implemented sparse layout.
-        ps = self.arena.kv_page_size
-        hd = self.index_head_dim
-        ng = hd // _INDEX_K_FP8_GROUP_SIZE
-        row = hd + ng * _INDEX_K_SCALE_BYTES
-        num_pages = buf.shape[0] // ps
-        page_bytes = ps * row
-        flat = buf.reshape(-1)
-        fp8_view = torch.as_strided(
-            flat.view(torch.float8_e4m3fn),
-            (num_pages, ps, hd),
-            (page_bytes, hd, 1),
-        )
-        scale_view = torch.as_strided(
-            flat.view(torch.float32),
-            (num_pages, ps, ng),
-            (page_bytes // 4, ng, 1),
-            (ps * hd) // 4,
-        )
-        return fp8_view, scale_view
-
-    def gather_index_k(
-        self, layer_id: int, slots: torch.Tensor
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Gather per-token FP8 index-K values and scales from the cache.
-
-        The packed FP8 index-K buffer is stored block-split per page (see
-        :meth:`_index_k_block_views`), so the non-paged prefill
-        scoring kernel (``fp8_mqa_logits``), which consumes contiguous
-        ``(k_fp8, k_scale)`` tensors, must gather token rows through the
-        block-split views rather than indexing raw rows.
-
-        Args:
-            layer_id: Layer whose index-K cache to read.
-            slots: 1D int tensor of global token slot indices to gather.
-
-        Returns:
-            ``(k_fp8, k_scale)`` where ``k_fp8`` has shape
-            ``[num_slots, head_dim]`` (FP8 e4m3) and ``k_scale`` has shape
-            ``[num_slots, num_groups]`` (float32).
-        """
-        buf = self.get_index_k_buffer(layer_id)
-        fp8_view, scale_view = self._index_k_block_views(buf)
-        slots = slots.to(torch.long)
-        page = slots // self.arena.kv_page_size
-        slot_in_page = slots % self.arena.kv_page_size
-        k_fp8 = fp8_view[page, slot_in_page]
-        k_scale = scale_view[page, slot_in_page]
-        return k_fp8, k_scale
 
     def _set_index_k_buffer(
         self,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/dsa.py
@@ -20,6 +20,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import torch
 from tokenspeed_kernel.ops.kvcache.triton import index_k_block_split_scatter
 from tokenspeed_kernel.ops.quantization import quantize_fp8_with_scale
@@ -45,13 +47,10 @@ class DSATokenToKVPool(MLATokenToKVPool):
         self.index_k_row_bytes = dsa_index_k_row_bytes(self.index_head_dim)
         super().__init__(*args, **kwargs)
 
-        with self.memory_saver_adapter.region():
-            self.index_k_buffer = [
-                self.field(f"layer.{layer_id}.index_k", torch.uint8).view(
-                    -1, self.index_k_row_bytes
-                )
-                for layer_id in range(self.layer_num)
-            ]
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        **MLATokenToKVPool.layer_plane_bindings,
+        "index_k": "index_k_buffer",
+    }
 
     def get_kv_size_bytes(self):
         return super().get_kv_size_bytes() + _get_tensor_size_bytes(self.index_k_buffer)
@@ -100,7 +99,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
         """
         # DSA requires kv_page_size == DSA_SPARSE_PAGE_SIZE (64), the only
         # implemented sparse layout.
-        ps = self.kv_page_size
+        ps = self.arena.kv_page_size
         hd = self.index_head_dim
         ng = hd // _INDEX_K_FP8_GROUP_SIZE
         row = hd + ng * _INDEX_K_SCALE_BYTES
@@ -143,8 +142,8 @@ class DSATokenToKVPool(MLATokenToKVPool):
         buf = self.get_index_k_buffer(layer_id)
         fp8_view, scale_view = self._index_k_block_views(buf)
         slots = slots.to(torch.long)
-        page = slots // self.kv_page_size
-        slot_in_page = slots % self.kv_page_size
+        page = slots // self.arena.kv_page_size
+        slot_in_page = slots % self.arena.kv_page_size
         k_fp8 = fp8_view[page, slot_in_page]
         k_scale = scale_view[page, slot_in_page]
         return k_fp8, k_scale
@@ -169,7 +168,7 @@ class DSATokenToKVPool(MLATokenToKVPool):
             index_k_fp8,
             index_k_scale,
             loc,
-            page_size=self.kv_page_size,
+            page_size=self.arena.kv_page_size,
             head_dim=self.index_head_dim,
             group_size=_INDEX_K_FP8_GROUP_SIZE,
         )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
@@ -26,6 +26,39 @@ def create_cache_arena(
     )
 
 
+def _mha_pool_class(family: str, *, mxfp8: bool) -> type[CachePool]:
+    """The MHA-shaped pool for one family, in its plain or mxfp8 variant.
+
+    All three take the same arguments; only the recurrent-state aliasing (and
+    the scale planes) differ, which is the class's business, not the caller's.
+    """
+    from tokenspeed.runtime.layers.attention.kv_cache.hybrid_inkling import (
+        HybridInklingTokenToKVPool,
+        HybridInklingTokenToKVPoolMXFP8,
+    )
+    from tokenspeed.runtime.layers.attention.kv_cache.hybrid_mha import (
+        HybridMHATokenToKVPool,
+        HybridMHATokenToKVPoolMXFP8,
+    )
+    from tokenspeed.runtime.layers.attention.kv_cache.mha import (
+        MHATokenToKVPool,
+        MHATokenToKVPoolMXFP8,
+    )
+
+    by_family = {
+        "mha": (MHATokenToKVPool, MHATokenToKVPoolMXFP8),
+        "inkling": (HybridInklingTokenToKVPool, HybridInklingTokenToKVPoolMXFP8),
+        "qwen_gdn": (HybridMHATokenToKVPool, HybridMHATokenToKVPoolMXFP8),
+    }
+    try:
+        plain, scaled = by_family[family]
+    except KeyError:
+        raise TypeError(
+            f"cache family {family!r} is incompatible with MHAConfig"
+        ) from None
+    return scaled if mxfp8 else plain
+
+
 def create_cache_pool(
     spec: CachePoolSpec,
     config: BaseAttnConfig,
@@ -98,52 +131,7 @@ def create_cache_pool(
             field_layer_offset=field_layer_offset,
         )
     if isinstance(config, MHAConfig):
-        if spec.family == "mha":
-            from tokenspeed.runtime.layers.attention.kv_cache.mha import (
-                MHATokenToKVPool,
-                MHATokenToKVPoolMXFP8,
-            )
-
-            pool_cls = (
-                MHATokenToKVPoolMXFP8 if config.kv_cache_mxfp8 else MHATokenToKVPool
-            )
-            return pool_cls(
-                arena,
-                dtype=config.kv_cache_dtype,
-                head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
-                head_dim=config.head_dim,
-                layer_num=num_layers,
-                rank=rank,
-                layer_types=spec.layer_types,
-                layer_group_ids=spec.layer_group_ids,
-                field_layer_offset=field_layer_offset,
-            )
-        if spec.family == "inkling":
-            from tokenspeed.runtime.layers.attention.kv_cache.hybrid_inkling import (
-                HybridInklingTokenToKVPool,
-                HybridInklingTokenToKVPoolMXFP8,
-            )
-
-            pool_cls = (
-                HybridInklingTokenToKVPoolMXFP8
-                if config.kv_cache_mxfp8
-                else HybridInklingTokenToKVPool
-            )
-        elif spec.family == "qwen_gdn":
-            from tokenspeed.runtime.layers.attention.kv_cache.hybrid_mha import (
-                HybridMHATokenToKVPool,
-                HybridMHATokenToKVPoolMXFP8,
-            )
-
-            pool_cls = (
-                HybridMHATokenToKVPoolMXFP8
-                if config.kv_cache_mxfp8
-                else HybridMHATokenToKVPool
-            )
-        else:
-            raise TypeError(
-                f"cache family {spec.family!r} is incompatible with MHAConfig"
-            )
+        pool_cls = _mha_pool_class(spec.family, mxfp8=bool(config.kv_cache_mxfp8))
         return pool_cls(
             arena=arena,
             dtype=config.kv_cache_dtype,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
@@ -5,35 +5,42 @@ from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import CachePoolSpec
+
+
+def create_cache_arena(
+    spec: CachePoolSpec,
+    *,
+    device: str,
+    enable_memory_saver: bool,
+) -> CacheArena:
+    """Allocate the one arena every compute view of this spec shares."""
+    return CacheArena(
+        spec.memory_plan,
+        device,
+        cache_group_specs=spec.cache_group_specs,
+        token_capacity=spec.token_capacity,
+        enable_memory_saver=enable_memory_saver,
+    )
 
 
 def create_cache_pool(
     spec: CachePoolSpec,
     config: BaseAttnConfig,
+    arena: CacheArena,
     *,
     num_layers: int,
     rank: int,
-    enable_memory_saver: bool,
     field_layer_offset: int = 0,
-    backing_pool: CachePool | None = None,
 ) -> CachePool:
-    """Create the concrete compute interface for a prepared cache spec.
+    """Bind one model's compute views to an already-allocated arena.
 
-    The recipe's group specs, including PD transfer policies, and token
-    capacity travel via the spec; the pool base aligns the specs' physical
-    fields with the memory plan and publishes the runtime contract
-    (ModelExecutor fails fast without one).
+    ``field_layer_offset`` places this view's local layer ids onto the
+    merged plan's global layer window, so a draft view names the
+    continuation fields the target's plan already reserved.
     """
-    if (backing_pool is not None or field_layer_offset) and not (
-        (isinstance(config, MHAConfig) and spec.family == "mha")
-        or (type(config) is MLAConfig and spec.family == "mla")
-    ):
-        raise ValueError(
-            "backing cache views are only supported by ordinary MHA or MLA pools"
-        )
-    plan = spec.memory_plan
     if spec.family == "deepseek_v4":
         from tokenspeed.runtime.layers.attention.kv_cache.hybrid_deepseek_v4 import (
             HybridDeepseekV4TokenToKVPool,
@@ -46,16 +53,12 @@ def create_cache_pool(
         if not isinstance(options, DeepseekV4PoolOptions):
             raise TypeError("DeepSeek V4 cache spec is missing pool options")
         return HybridDeepseekV4TokenToKVPool(
-            size=spec.pool_size,
+            arena,
             model_dtype=config.dtype,
             layout=options.layout,
             layer_num=num_layers,
-            device=config.device,
-            enable_memory_saver=enable_memory_saver,
             rank=rank,
-            memory_plan=plan,
-            paged_cache_group_specs=spec.paged_cache_group_specs,
-            token_capacity=spec.token_capacity,
+            field_layer_offset=field_layer_offset,
         )
     if isinstance(config, DSAConfig):
         from tokenspeed.runtime.layers.attention.kv_cache.dsa import (
@@ -63,22 +66,17 @@ def create_cache_pool(
         )
 
         return DSATokenToKVPool(
-            size=spec.pool_size,
+            arena,
             dtype=config.kv_cache_dtype,
             model_dtype=config.dtype,
             quant_method=config.kv_cache_quant_method,
             kv_lora_rank=config.kv_lora_rank,
             qk_rope_head_dim=config.qk_rope_head_dim,
             layer_num=num_layers,
-            device=config.device,
-            enable_memory_saver=enable_memory_saver,
-            prefix_granularity=plan.prefix_granularity,
             rank=rank,
             index_head_dim=config.index_head_dim,
-            memory_plan=plan,
-            paged_cache_group_specs=spec.paged_cache_group_specs,
-            token_capacity=spec.token_capacity,
             layer_group_ids=spec.layer_group_ids,
+            field_layer_offset=field_layer_offset,
         )
     if isinstance(config, MSAConfig):
         from tokenspeed.runtime.layers.attention.kv_cache.msa import (
@@ -86,23 +84,18 @@ def create_cache_pool(
         )
 
         return MSATokenToKVPool(
-            size=spec.pool_size,
+            arena=arena,
             dtype=config.kv_cache_dtype,
             head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
             head_dim=config.head_dim,
             layer_num=num_layers,
-            device=config.device,
-            enable_memory_saver=enable_memory_saver,
-            prefix_granularity=plan.prefix_granularity,
             rank=rank,
             index_head_dim=config.index_head_dim,
             index_dtype=config.dtype,
             indexed_layer_ids=config.sparse_layer_ids,
             layer_types=spec.layer_types,
             layer_group_ids=spec.layer_group_ids,
-            memory_plan=plan,
-            paged_cache_group_specs=spec.paged_cache_group_specs,
-            token_capacity=spec.token_capacity,
+            field_layer_offset=field_layer_offset,
         )
     if isinstance(config, MHAConfig):
         if spec.family == "mha":
@@ -115,22 +108,15 @@ def create_cache_pool(
                 MHATokenToKVPoolMXFP8 if config.kv_cache_mxfp8 else MHATokenToKVPool
             )
             return pool_cls(
-                size=spec.pool_size,
+                arena,
                 dtype=config.kv_cache_dtype,
                 head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
                 head_dim=config.head_dim,
                 layer_num=num_layers,
-                device=config.device,
-                enable_memory_saver=enable_memory_saver,
-                prefix_granularity=plan.prefix_granularity,
                 rank=rank,
                 layer_types=spec.layer_types,
                 layer_group_ids=spec.layer_group_ids,
-                memory_plan=plan,
-                paged_cache_group_specs=spec.paged_cache_group_specs,
-                token_capacity=spec.token_capacity,
                 field_layer_offset=field_layer_offset,
-                backing_pool=backing_pool,
             )
         if spec.family == "inkling":
             from tokenspeed.runtime.layers.attention.kv_cache.hybrid_inkling import (
@@ -159,25 +145,17 @@ def create_cache_pool(
                 f"cache family {spec.family!r} is incompatible with MHAConfig"
             )
         return pool_cls(
-            size=spec.pool_size,
+            arena=arena,
             dtype=config.kv_cache_dtype,
             head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
             head_dim=config.head_dim,
             layer_num=num_layers,
-            device=config.device,
-            enable_memory_saver=enable_memory_saver,
-            prefix_granularity=plan.prefix_granularity,
             rank=rank,
             layer_types=spec.layer_types,
             layer_kv_head_counts=spec.layer_kv_head_counts,
             kv_alloc_head_count=config.num_kv_heads,
-            memory_plan=plan,
             layer_group_ids=spec.layer_group_ids,
-            state_field_dtypes=spec.state_field_dtypes,
-            paged_cache_group_specs=spec.paged_cache_group_specs,
-            token_capacity=spec.token_capacity,
             field_layer_offset=field_layer_offset,
-            backing_pool=backing_pool,
         )
     if isinstance(config, MLAConfig):
         if spec.family == "mla":
@@ -186,23 +164,16 @@ def create_cache_pool(
             )
 
             return MLATokenToKVPool(
-                size=spec.pool_size,
+                arena,
                 dtype=config.kv_cache_dtype,
                 model_dtype=config.dtype,
                 quant_method=config.kv_cache_quant_method,
                 kv_lora_rank=config.kv_lora_rank,
                 qk_rope_head_dim=config.qk_rope_head_dim,
                 layer_num=num_layers,
-                device=config.device,
-                enable_memory_saver=enable_memory_saver,
-                prefix_granularity=plan.prefix_granularity,
                 rank=rank,
-                memory_plan=plan,
-                paged_cache_group_specs=spec.paged_cache_group_specs,
-                token_capacity=spec.token_capacity,
                 layer_group_ids=spec.layer_group_ids,
                 field_layer_offset=field_layer_offset,
-                backing_pool=backing_pool,
             )
 
         if spec.family != "kimi_k3":
@@ -215,22 +186,16 @@ def create_cache_pool(
         )
 
         return HybridKDATokenToKVPool(
-            size=spec.pool_size,
+            arena=arena,
             dtype=config.kv_cache_dtype,
             model_dtype=config.dtype,
             quant_method=config.kv_cache_quant_method,
             kv_lora_rank=config.kv_lora_rank,
             qk_rope_head_dim=config.qk_rope_head_dim,
             layer_num=num_layers,
-            device=config.device,
-            enable_memory_saver=enable_memory_saver,
-            prefix_granularity=plan.prefix_granularity,
             rank=rank,
             layer_types=spec.layer_types,
             layer_group_ids=spec.layer_group_ids,
-            state_field_dtypes=spec.state_field_dtypes,
-            memory_plan=plan,
-            paged_cache_group_specs=spec.paged_cache_group_specs,
-            token_capacity=spec.token_capacity,
+            field_layer_offset=field_layer_offset,
         )
     raise TypeError(f"cache setup does not support config type {type(config).__name__}")

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
@@ -33,10 +33,6 @@ from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
 )
 from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    CacheGroupSpec,
-)
 from tokenspeed.runtime.utils import get_colorful_logger
 
 logger = get_colorful_logger(__name__)

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
@@ -15,14 +15,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 import torch
 
-from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
-    deepseek_v4_compressed_slot_mapping,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec import (
+from tokenspeed.runtime.layers.attention.deepseek_v4_geometry import (
     V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
     V4_KERNEL_BLOCK_ROWS,
     V4_SWA_KV_GROUP_ID,
@@ -31,12 +28,16 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec
     v4_compressed_kv_group_id,
     v4_compressor_state_group_id,
 )
+from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
+    deepseek_v4_compressed_slot_mapping,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
+from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 from tokenspeed.runtime.utils import get_colorful_logger
-from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = get_colorful_logger(__name__)
 
@@ -409,8 +410,8 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
     """DeepSeek V4 fp8_ds_mla cache pool.
 
     TokenSpeed keeps SWA, compressed, compressor-state, and CSA indexer caches
-    in dedicated per-group paged pools (see PagedCacheGroup* on the scheduler
-    side and ``build_v4_cache_specs`` here), keeping ordinary MLA models on
+    in dedicated per-group paged pools (see CacheGroup* on the scheduler
+    side and the V4 recipe here), keeping ordinary MLA models on
     their existing single-pool contract. The ``indexer_kv_buffer`` shares its
     page table and page-count budget with the ``v4.c{ratio}a.compressed_kv``
     group rather than owning a separate group of its own.
@@ -418,56 +419,44 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
 
     def __init__(
         self,
-        size: int,
+        arena: CacheArena,
         model_dtype: torch.dtype,
         layout: DeepseekV4CacheLayout,
         layer_num: int,
-        device: str,
-        enable_memory_saver: bool,
         rank: int,
-        memory_plan: CacheMemoryPlan,
-        paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...],
-        token_capacity: int,
+        field_layer_offset: int = 0,
     ) -> None:
-        if size <= 0:
-            raise ValueError(f"DeepSeek V4 KV pool size must be positive, got {size}")
+        # The layout is this view's own window (a draft view carries only its
+        # continuation layers' ratios), so it is indexed by local layer id.
         if layer_num != len(layout.layer_ratio):
             raise ValueError(
                 "DeepSeek V4 KV pool layer_num must match cache layout ratios: "
                 f"layer_num={layer_num}, ratios={len(layout.layer_ratio)}"
             )
-        prefix_granularity = memory_plan.prefix_granularity
         super().__init__(
-            size=size,
-            dtype=torch.uint8,
-            device=device,
-            prefix_granularity=prefix_granularity,
-            rank=rank,
-            memory_plan=memory_plan,
-            paged_cache_group_specs=paged_cache_group_specs,
-            token_capacity=token_capacity,
+            arena,
+            torch.uint8,
+            rank,
+            field_layer_offset=field_layer_offset,
         )
-        # Tag KV allocations as "kv_cache" (no CPU backup: discarded on sleep)
-        # so release/resume_memory_occupation frees them. See memory_occupation.py.
-        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
-            enable=enable_memory_saver
-        )
+        plan = self.arena.plan
+        prefix_granularity = self.arena.prefix_granularity
         self.model_dtype = model_dtype
         self.layout = layout
         self.layer_num = layer_num
-        self._paged_cache_group_specs_by_id = {
-            spec.group_id: spec for spec in self.paged_cache_group_specs
+        self._cache_group_specs_by_id = {
+            spec.group_id: spec for spec in self.arena.cache_group_specs
         }
-        self._paged_cache_scheduler: object | None = None
-        self._paged_cache_state_group_ids = tuple(
+        self._cache_scheduler: object | None = None
+        self._cache_state_group_ids = tuple(
             str(spec.group_id)
-            for spec in self.paged_cache_group_specs
+            for spec in self.arena.cache_group_specs
             if spec.family == "state"
         )
-        self.paged_cache_requires_page_zeroing = True
+        self.requires_page_zeroing = True
 
         def _group_rows(group_id: str, default: int) -> int:
-            spec = self._paged_cache_group_specs_by_id.get(group_id)
+            spec = self._cache_group_specs_by_id.get(group_id)
             return int(spec.rows_per_page) if spec is not None else int(default)
 
         self.swa_block_size = _group_rows(
@@ -506,72 +495,44 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
             )
             for ratio in layout.layer_ratio
         )
-        expected_size = (
-            memory_plan.num_lcm_blocks
-            * max(group.cache_blocks_per_lcm_block for group in memory_plan.groups)
-            * memory_plan.prefix_granularity
-        )
-        if size != expected_size:
-            raise ValueError(
-                f"DeepSeek V4 cache pool size {size} does not match {expected_size}"
-            )
-        with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
-            self._bind_planned_buffers()
+        self._bind_layer_planes()
 
         logger.info(
             "Initialized DeepSeek V4 cache pool: %d parents, P=%d, %d layers, "
             "fp4 indexer=%s, compressed block sizes=%s",
-            memory_plan.num_lcm_blocks,
-            memory_plan.prefix_granularity,
+            plan.num_lcm_blocks,
+            prefix_granularity,
             layer_num,
             layout.use_fp4_indexer_cache,
             self.compressed_block_sizes,
         )
 
-    def _bind_planned_buffers(self) -> None:
-        self.swa_kv_buffer = []
-        self.compressed_kv_buffer = []
-        self.compressor_state_buffer = []
-        self.indexer_kv_buffer = []
-        self.indexer_state_buffer = []
-        for layer_id, ratio in enumerate(self.layout.layer_ratio):
-            self.swa_kv_buffer.append(self.field(f"layer.{layer_id}.swa", torch.uint8))
-            if ratio <= 1:
-                self.compressed_kv_buffer.append(None)
-                self.compressor_state_buffer.append(None)
-                self.indexer_kv_buffer.append(None)
-                self.indexer_state_buffer.append(None)
-                continue
-            self.compressed_kv_buffer.append(
-                self.field(f"layer.{layer_id}.compressed_kv", torch.uint8)
-            )
-            self.compressor_state_buffer.append(
-                self.field(f"layer.{layer_id}.compressor_state", torch.float32)
-            )
-            if ratio == 4:
-                indexer_kv = self.field(f"layer.{layer_id}.indexer_kv", torch.uint8)
-                self.indexer_kv_buffer.append(indexer_kv.view(indexer_kv.shape[0], -1))
-                self.indexer_state_buffer.append(
-                    self.field(f"layer.{layer_id}.indexer_state", torch.float32)
-                )
-            else:
-                self.indexer_kv_buffer.append(None)
-                self.indexer_state_buffer.append(None)
+    # A ratio-1 layer plans no compressed/state planes and only ratio-4 plans
+    # indexer planes, so the plan's field list decides per layer -- the
+    # ratio branches this used to re-derive are the plan's own shape.
+    # Every V4 plane is read with the shape the plan gives it.
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        "swa": "swa_kv_buffer",
+        "compressed_kv": "compressed_kv_buffer",
+        "compressor_state": "compressor_state_buffer",
+        "indexer_kv": "indexer_kv_buffer",
+        "indexer_state": "indexer_state_buffer",
+    }
 
-    def bind_paged_cache_scheduler(self, scheduler: object) -> None:
-        self._paged_cache_scheduler = scheduler
+    def bind_cache_scheduler(self, scheduler: object) -> None:
+        self._cache_scheduler = scheduler
 
-    def maybe_log_paged_cache_group_pages(self) -> None:
-        scheduler = self._paged_cache_scheduler
-        if self.rank != 0 or scheduler is None or not self._paged_cache_state_group_ids:
+    def maybe_log_cache_group_pages(self) -> None:
+        scheduler = self._cache_scheduler
+        if self.rank != 0 or scheduler is None or not self._cache_state_group_ids:
             return
         if not logger.isEnabledFor(logging.DEBUG):
             return
 
         parts = []
-        for group_id in self._paged_cache_state_group_ids:
-            total = scheduler.paged_cache_group_total_pages(group_id)
-            available = scheduler.paged_cache_group_available_pages(group_id)
+        for group_id in self._cache_state_group_ids:
+            total = scheduler.cache_group_total_pages(group_id)
+            available = scheduler.cache_group_available_pages(group_id)
             parts.append(
                 f"{group_id}: used={total - available}/{total}, available={available}"
             )
@@ -662,8 +623,7 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
         )
 
     def get_kv_size_bytes(self) -> int:
-        assert self.buffer is not None
-        return int(self.buffer.nbytes)
+        return int(self.arena.buffer.nbytes)
 
     def zero_new_blocks(self, new_page_ids: dict[str, list[int]]) -> None:
-        self.zero_blocks(new_page_ids)
+        self.arena.zero_blocks(new_page_ids)

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
@@ -581,11 +581,6 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
     def get_compressor_state_buffer(self, layer_id: int) -> torch.Tensor:
         return self._require(self.compressor_state_buffer, layer_id, "compressor state")
 
-    def get_compressor_state_view(self, layer_id: int) -> torch.Tensor:
-        buf = self.get_compressor_state_buffer(layer_id)
-        block_size = self.get_compressor_state_block_size(layer_id)
-        return buf.view(-1, block_size, buf.shape[-1])
-
     def get_indexer_kv_buffer_2d(self, layer_id: int) -> torch.Tensor:
         return self._require(self.indexer_kv_buffer, layer_id, "indexer KV")
 
@@ -597,11 +592,6 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
 
     def get_indexer_state_buffer(self, layer_id: int) -> torch.Tensor:
         return self._require(self.indexer_state_buffer, layer_id, "indexer state")
-
-    def get_indexer_state_view(self, layer_id: int) -> torch.Tensor:
-        buf = self.get_indexer_state_buffer(layer_id)
-        block_size = self.get_indexer_state_block_size(layer_id)
-        return buf.view(-1, block_size, buf.shape[-1])
 
     def get_key_buffer(self, layer_id: int) -> torch.Tensor:
         return self.get_swa_kv_buffer(layer_id)

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
@@ -504,9 +504,8 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
         )
 
     # A ratio-1 layer plans no compressed/state planes and only ratio-4 plans
-    # indexer planes, so the plan's field list decides per layer -- the
-    # ratio branches this used to re-derive are the plan's own shape.
-    # Every V4 plane is read with the shape the plan gives it.
+    # indexer planes, so the plan's field list decides which planes a layer
+    # has, and each is read with the shape the plan gives it.
     layer_plane_bindings: ClassVar[dict[str, str]] = {
         "swa": "swa_kv_buffer",
         "compressed_kv": "compressed_kv_buffer",

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_inkling.py
@@ -22,8 +22,6 @@
 
 from __future__ import annotations
 
-import os
-
 import torch
 
 from tokenspeed.runtime.layers.attention.kv_cache.hybrid_mha import (
@@ -35,20 +33,13 @@ from tokenspeed.runtime.layers.attention.kv_cache.hybrid_mha import (
 class HybridInklingTokenToKVPool(HybridMHATokenToKVPool):
     """Hybrid MHA pool with Inkling ShortConv checkpoint views."""
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.conv_col_dtype = (
-            torch.bfloat16
-            if os.environ.get("INKLING_FP8_SCONV", "0") == "0"
-            else torch.float8_e5m2
-        )
-
     def kvconv_checkpoint_buffers(
         self, layer_id: int
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        field_layer = self._field_layer_id(layer_id)
         return (
-            self.field(f"layer.{layer_id}.kvconv_k", torch.bfloat16),
-            self.field(f"layer.{layer_id}.kvconv_v", torch.bfloat16),
+            self.arena.field(f"layer.{field_layer}.kvconv_k"),
+            self.arena.field(f"layer.{field_layer}.kvconv_v"),
         )
 
     def hiddenconv_checkpoint_buffer(
@@ -56,7 +47,7 @@ class HybridInklingTokenToKVPool(HybridMHATokenToKVPool):
     ) -> torch.Tensor:
         if component not in ("attnconv", "mlpconv"):
             raise ValueError(f"unknown Inkling hidden-conv component {component!r}")
-        return self.field(f"layer.{layer_id}.{component}", self.conv_col_dtype)
+        return self.arena.field(f"layer.{self._field_layer_id(layer_id)}.{component}")
 
 
 class HybridInklingTokenToKVPoolMXFP8(

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
@@ -22,13 +22,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from typing import ClassVar
 
-import numpy as np
 import torch
+from typing_extensions import override
 
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     STATE_LAYER_TYPES,
 )
@@ -40,18 +39,15 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
     def __init__(
         self,
         *,
-        memory_plan: CacheMemoryPlan,
         layer_group_ids: tuple[str, ...],
         layer_types: tuple[str, ...],
-        state_field_dtypes: Mapping[str, torch.dtype] | None = None,
         **kwargs,
     ):
         self._layer_types = tuple(layer_types)
         group_ids = tuple(layer_group_ids)
         self._group_ids_by_layer = dict(enumerate(group_ids))
-        self._state_field_dtypes = dict(state_field_dtypes or {})
         self._state_buffers_by_layer: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
-        self.paged_cache_requires_page_zeroing = True
+        self.requires_page_zeroing = True
 
         layer_num = kwargs["layer_num"]
         if len(self._layer_types) != layer_num:
@@ -60,65 +56,34 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
             raise ValueError("cache group ids must cover every model layer")
 
         super().__init__(
-            memory_plan=memory_plan,
             layer_group_ids=group_ids,
             **kwargs,
         )
 
-    def _create_buffers(self) -> None:
-        with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
-            self._bind_buffers()
+    # A KDA layer has conv/recurrent planes planned and an MLA layer has a
+    # latent plane; the plan's field list decides per layer. Latent-page
+    # contiguity is a plan invariant (exact_page_stride).
+    # State planes keep their planned shape: the KDA decode ABI reads them
+    # as the plan lays them out.
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        **MLATokenToKVPool.layer_plane_bindings,
+        "conv_state": "_conv_state",
+        "recurrent_state": "_recurrent_state",
+    }
 
-    def _bind_buffers(self) -> None:
+    def _bind_layer_planes(self) -> None:
         if self.quant_method == "per_token_head":
             raise ValueError("KDA cache does not support per-token-head KV")
-        if self.plan.prefix_granularity != self.prefix_granularity:
-            raise ValueError(
-                f"cache plan P={self.plan.prefix_granularity} does not match "
-                f"pool prefix_granularity={self.prefix_granularity}"
-            )
-        max_packing = max(
-            group.cache_blocks_per_lcm_block for group in self.plan.groups
-        )
-        expected_size = self.plan.num_lcm_blocks * max_packing * self.prefix_granularity
-        if self.size != expected_size:
-            raise ValueError(
-                f"cache pool size {self.size} does not match child capacity "
-                f"{expected_size}"
-            )
-        self.kv_buffer = [None] * self.layer_num
-        for layer_id, label in enumerate(self._layer_types):
-            if label in STATE_LAYER_TYPES:
-                conv_id = f"layer.{layer_id}.conv_state"
-                recurrent_id = f"layer.{layer_id}.recurrent_state"
-                try:
-                    conv_dtype = self._state_field_dtypes[conv_id]
-                    recurrent_dtype = self._state_field_dtypes[recurrent_id]
-                except KeyError as exc:
-                    raise ValueError(
-                        f"cache state field {exc.args[0]!r} has no dtype"
-                    ) from exc
-                conv = self.field(
-                    conv_id,
-                    conv_dtype,
-                )
-                recurrent = self.field(
-                    recurrent_id,
-                    recurrent_dtype,
-                )
-                self._state_buffers_by_layer[layer_id] = (conv, recurrent)
-                continue
-            latent = self.field(f"layer.{layer_id}.latent_kv", self.store_dtype)
-            page_elements = int(np.prod(latent.shape[1:]))
-            if latent.stride(0) != page_elements:
-                raise ValueError(
-                    f"layer {layer_id} latent pages have padding between pages"
-                )
-            self.kv_buffer[layer_id] = latent.view(-1, 1, self.kv_cache_dim)
+        super()._bind_layer_planes()
+        self._state_buffers_by_layer = {
+            layer_id: (self._conv_state[layer_id], self._recurrent_state[layer_id])
+            for layer_id, label in enumerate(self._layer_types)
+            if label in STATE_LAYER_TYPES
+        }
 
     @property
     def num_lcm_blocks(self) -> int:
-        return self.plan.num_lcm_blocks
+        return self.arena.plan.num_lcm_blocks
 
     @property
     def state_slabs(self) -> list[tuple[torch.Tensor, torch.Tensor]]:
@@ -130,14 +95,36 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
         except KeyError as exc:
             raise ValueError(f"layer {layer_id} has no cache group") from exc
 
+    @override
+    def set_mla_kv_buffer(
+        self,
+        layer,
+        loc: torch.Tensor,
+        cache_k_nope: torch.Tensor,
+        cache_k_rope: torch.Tensor,
+        sanitize: bool = True,
+    ):
+        """Latent write that sanitizes by default -- a fact of this cache.
+
+        Prefill breakable-graph padding contract: the dummy-batch capture (and
+        bucket-padding rows) whose ``out_cache_loc`` is the reserved
+        ``dummy_kv_slot`` can carry NaN into this fp8 KV write. The paged MLA
+        decode kernel reads that shared dummy slot through the zero-padded
+        block-table entries and computes ``q·k`` BEFORE applying the causal
+        mask, so the NaN survives it (``NaN + -inf = NaN``) and poisons a live
+        row's softmax -> NaN logits -> token 0. Eager prefill leaves the dummy
+        slot finite (``q·0`` masks cleanly), which is why the bug only appears
+        with the prefill graph on. Sanitizing in-kernel keeps real rows bitwise
+        unchanged without allocating two temporary tensors.
+        """
+        super().set_mla_kv_buffer(
+            layer, loc, cache_k_nope, cache_k_rope, sanitize=sanitize
+        )
+
     def get_component(self, layer_id: int, component_name: str) -> torch.Tensor:
+        """Return one KDA state plane. Latent KV is read via ``kv_buffer``."""
         if self.layerwise_load_tracker is not None:
             self.layerwise_load_tracker.wait_for_layer(layer_id)
-        if component_name == "latent_kv":
-            buffer = self.kv_buffer[layer_id]
-            if buffer is None:
-                raise ValueError(f"layer {layer_id} has no MLA latent cache")
-            return self.field(f"layer.{layer_id}.latent_kv", self.store_dtype)
         try:
             conv, recurrent = self._state_buffers_by_layer[layer_id]
         except KeyError as exc:
@@ -156,13 +143,7 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
 
     def zero_new_blocks(self, new_page_ids: dict[str, list[int]]) -> None:
         if new_page_ids:
-            self.zero_blocks(new_page_ids)
-
-    @torch.no_grad()
-    def clear_kv_buffers(self) -> None:
-        assert self.buffer is not None
-        self.buffer.zero_()
+            self.arena.zero_blocks(new_page_ids)
 
     def get_kv_size_bytes(self):
-        assert self.buffer is not None
-        return self.buffer.nbytes
+        return self.arena.buffer.nbytes

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
@@ -22,7 +22,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from typing import ClassVar
 
 import numpy as np
 import torch
@@ -31,7 +31,6 @@ from tokenspeed.runtime.layers.attention.kv_cache.mha import (
     MHATokenToKVPool,
     MHATokenToKVPoolMXFP8,
 )
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     STATE_LAYER_TYPES,
 )
@@ -43,14 +42,11 @@ class HybridMHATokenToKVPool(MHATokenToKVPool):
     def __init__(
         self,
         *,
-        memory_plan: CacheMemoryPlan,
         layer_group_ids: tuple[str, ...],
-        state_field_dtypes: Mapping[str, torch.dtype] | None = None,
         **kwargs,
     ):
         group_ids = tuple(layer_group_ids)
         self._group_ids_by_layer = dict(enumerate(group_ids))
-        self._state_field_dtypes = dict(state_field_dtypes or {})
         layer_types = tuple(kwargs.get("layer_types", ()))
         self._state_layer_ids = tuple(
             layer_id
@@ -58,79 +54,38 @@ class HybridMHATokenToKVPool(MHATokenToKVPool):
             if label in STATE_LAYER_TYPES
         )
         self._state_buffers_by_layer: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
-        self.paged_cache_requires_page_zeroing = True
+        self.requires_page_zeroing = True
 
         if len(group_ids) != kwargs["layer_num"]:
             raise ValueError("cache group ids must cover every model layer")
 
         super().__init__(
-            memory_plan=memory_plan,
             layer_group_ids=group_ids,
             **kwargs,
         )
 
-    def _create_buffers(self) -> None:
-        with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
-            self._bind_buffers()
+    # A state layer has no k/v field planned and an attention layer has no
+    # conv/ssm, so the plan's field list decides per layer -- no layer_types
+    # branch here. Contiguity is a plan invariant (exact_page_stride), already
+    # enforced by pack.
+    # State planes keep their planned shape: the GDN decode ABI reads them
+    # as the plan lays them out.
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        **MHATokenToKVPool.layer_plane_bindings,
+        "conv": "_conv_state",
+        "ssm": "_ssm_state",
+    }
 
-    def _bind_buffers(self) -> None:
-        if self.plan.prefix_granularity != self.prefix_granularity:
-            raise ValueError(
-                f"cache plan P={self.plan.prefix_granularity} does not match pool "
-                f"prefix_granularity={self.prefix_granularity}"
-            )
-        max_packing = max(
-            group.cache_blocks_per_lcm_block for group in self.plan.groups
-        )
-        expected_size = self.plan.num_lcm_blocks * max_packing * self.prefix_granularity
-        if self.size != expected_size:
-            raise ValueError(
-                f"cache pool size {self.size} does not match plan child capacity "
-                f"{expected_size}"
-            )
-
-        self.k_buffer = [None] * self.layer_num
-        self.v_buffer = [None] * self.layer_num
-        for layer_id, label in enumerate(self._layer_types):
-            if label in STATE_LAYER_TYPES:
-                conv_id = f"layer.{layer_id}.conv"
-                ssm_id = f"layer.{layer_id}.ssm"
-                try:
-                    conv_dtype = self._state_field_dtypes[conv_id]
-                    ssm_dtype = self._state_field_dtypes[ssm_id]
-                except KeyError as exc:
-                    raise ValueError(
-                        f"cache state field {exc.args[0]!r} has no dtype"
-                    ) from exc
-                conv = self.field(conv_id, conv_dtype)
-                ssm = self.field(ssm_id, ssm_dtype)
-                if ssm.stride(0) != int(np.prod(ssm.shape[1:])):
-                    raise ValueError(
-                        f"state plane for layer {layer_id} has padding "
-                        "between pages; the GDN decode ABI requires contiguous "
-                        "state block rows"
-                    )
-                self._state_buffers_by_layer[layer_id] = (conv, ssm)
-                continue
-
-            k_pages = self.field(f"layer.{layer_id}.k", self.store_dtype)
-            v_pages = self.field(f"layer.{layer_id}.v", self.store_dtype)
-            contiguous_page_elements = int(np.prod(k_pages.shape[1:]))
-            if (
-                k_pages.stride(0) != contiguous_page_elements
-                or v_pages.stride(0) != contiguous_page_elements
-            ):
-                raise ValueError(
-                    f"history plane for layer {layer_id} has padding "
-                    "between child pages; the attention ABI requires "
-                    "contiguous flattened page rows"
-                )
-            self.k_buffer[layer_id] = k_pages.view(-1, self.head_num, self.head_dim)
-            self.v_buffer[layer_id] = v_pages.view(-1, self.head_num, self.head_dim)
+    def _bind_layer_planes(self) -> None:
+        super()._bind_layer_planes()
+        self._state_buffers_by_layer = {
+            layer_id: (self._conv_state[layer_id], self._ssm_state[layer_id])
+            for layer_id in self._state_layer_ids
+        }
 
     @property
     def num_lcm_blocks(self) -> int:
-        return self.plan.num_lcm_blocks
+        return self.arena.plan.num_lcm_blocks
 
     @property
     def state_slabs(self) -> list[tuple[torch.Tensor, torch.Tensor]]:
@@ -164,37 +119,17 @@ class HybridMHATokenToKVPool(MHATokenToKVPool):
 
     def zero_new_blocks(self, new_page_ids: dict[str, list[int]]) -> None:
         if new_page_ids:
-            self.zero_blocks(new_page_ids)
-
-    @torch.no_grad()
-    def clear_kv_buffers(self) -> None:
-        assert self.buffer is not None
-        self.buffer.zero_()
+            self.arena.zero_blocks(new_page_ids)
 
 
 class HybridMHATokenToKVPoolMXFP8(
     HybridMHATokenToKVPool,
     MHATokenToKVPoolMXFP8,
 ):
-    def _create_buffers(self) -> None:
-        if self.head_dim % self.MXFP8_SCALE_BLOCK_SIZE != 0:
-            raise ValueError("MXFP8 head_dim must be divisible by 32")
-        self.store_dtype = torch.float8_e4m3fn
-        super()._create_buffers()
-        self.k_scale_buffer = [
-            self.field(
-                f"layer.{self._field_layer_id(layer_id)}.k_scale",
-                torch.float8_e8m0fnu,
-            )
-            for layer_id in range(self.layer_num)
-        ]
-        self.v_scale_buffer = [
-            self.field(
-                f"layer.{self._field_layer_id(layer_id)}.v_scale",
-                torch.float8_e8m0fnu,
-            )
-            for layer_id in range(self.layer_num)
-        ]
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        **HybridMHATokenToKVPool.layer_plane_bindings,
+        **MHATokenToKVPoolMXFP8.layer_plane_bindings,
+    }
 
     def _layer_page_tokens(self, layer_id: int) -> int:
-        return self.kv_page_size
+        return self.arena.kv_page_size

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
@@ -64,11 +64,9 @@ class HybridMHATokenToKVPool(MHATokenToKVPool):
         )
 
     # A state layer has no k/v field planned and an attention layer has no
-    # conv/ssm, so the plan's field list decides per layer -- no layer_types
-    # branch here. Contiguity is a plan invariant (exact_page_stride), already
-    # enforced by pack.
-    # State planes keep their planned shape: the GDN decode ABI reads them
-    # as the plan lays them out.
+    # conv/ssm, so the plan's field list decides which planes a layer has.
+    # State planes keep their planned shape: the GDN decode ABI reads them as
+    # the plan lays them out.
     layer_plane_bindings: ClassVar[dict[str, str]] = {
         **MHATokenToKVPool.layer_plane_bindings,
         "conv": "_conv_state",

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from typing import ClassVar
 
-import numpy as np
 import torch
 
 from tokenspeed.runtime.layers.attention.kv_cache.mha import (

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
@@ -20,6 +20,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import torch
 from tokenspeed_kernel.ops.kvcache.triton import (
     quantize_store_kv_mxfp8,
@@ -27,16 +29,14 @@ from tokenspeed_kernel.ops.kvcache.triton import (
     store_sf_interleaved,
 )
 
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     MXFP8_KV_SCALE_TILE_TOKENS,
-    PagedCacheGroupSpec,
 )
 from tokenspeed.runtime.layers.paged_attention import PagedAttention
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.pdl import pdl_enabled
-from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = get_colorful_logger(__name__)
 
@@ -47,41 +47,24 @@ GB = 1024 * 1024 * 1024
 class MHATokenToKVPool(CachePool):
     def __init__(
         self,
-        size: int,
+        arena: CacheArena,
         dtype: torch.dtype,
         head_num: int,
         head_dim: int,
         layer_num: int,
-        device: str,
-        enable_memory_saver: bool,
-        prefix_granularity: int,
         rank: int,
         *,
-        memory_plan: CacheMemoryPlan,
-        paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...] = (),
-        token_capacity: int | None = None,
         layer_types: tuple[str, ...] = (),
         layer_group_ids: tuple[str, ...] = (),
         layer_kv_head_counts: tuple[int, ...] | None = None,
         kv_alloc_head_count: int | None = None,
         field_layer_offset: int = 0,
-        backing_pool: CachePool | None = None,
     ):
         super().__init__(
-            size,
+            arena,
             dtype,
-            device,
-            prefix_granularity,
             rank,
-            memory_plan,
-            paged_cache_group_specs=paged_cache_group_specs,
-            token_capacity=token_capacity,
-            backing_pool=backing_pool,
             field_layer_offset=field_layer_offset,
-        )
-
-        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
-            enable=enable_memory_saver
         )
 
         self.head_num = head_num
@@ -115,7 +98,7 @@ class MHATokenToKVPool(CachePool):
                 "recipe must supply one group id per layer "
                 "(CachePoolSpec.layer_group_ids)"
             )
-        self._create_buffers()
+        self._bind_layer_planes()
 
         k_size, v_size = self.get_kv_size_bytes()
         logger.info(
@@ -124,33 +107,10 @@ class MHATokenToKVPool(CachePool):
             v_size / GB,
         )
 
-    def _field_layer_id(self, layer_id: int) -> int:
-        """Map this compute view's local layer id into the merged plan."""
-        return self._field_layer_offset + layer_id
-
-    def _create_kv_buffers(self):
-        self.k_buffer = [
-            self.field(
-                f"layer.{self._field_layer_id(layer_id)}.k", self.store_dtype
-            ).view(-1, self.head_num, self.head_dim)
-            for layer_id in range(self.layer_num)
-        ]
-        self.v_buffer = [
-            self.field(
-                f"layer.{self._field_layer_id(layer_id)}.v", self.store_dtype
-            ).view(-1, self.head_num, self.head_dim)
-            for layer_id in range(self.layer_num)
-        ]
-        logger.info(
-            "KV layout: one buffer with %d per-layer K/V views",
-            self.layer_num,
-        )
-
-    def _create_buffers(self):
-        # Tag as "kv_cache", no CPU backup: KV is discarded on sleep and rebuilt
-        # after wake (paging overwrites; clear_kv_buffers zeros the remapped pages).
-        with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
-            self._create_kv_buffers()
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        "k": "k_buffer",
+        "v": "v_buffer",
+    }
 
     def get_kv_size_bytes(self):
         assert hasattr(self, "k_buffer")
@@ -276,31 +236,27 @@ class MHATokenToKVPoolMXFP8(MHATokenToKVPool):
 
     MXFP8_SCALE_BLOCK_SIZE = 32
 
-    def _create_buffers(self):
-        assert self.head_dim % self.MXFP8_SCALE_BLOCK_SIZE == 0
+    # Scale planes stay page-major: the blockscaled kernels read them in the
+    # interleaved layout the plan already gives them.
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        **MHATokenToKVPool.layer_plane_bindings,
+        "k_scale": "k_scale_buffer",
+        "v_scale": "v_scale_buffer",
+    }
+
+    def _bind_layer_planes(self) -> None:
+        if self.head_dim % self.MXFP8_SCALE_BLOCK_SIZE:
+            raise ValueError("MXFP8 head_dim must be divisible by 32")
+        # These writes go through dtype-aware kernels, so the fp8 view the
+        # plan hands out is the one to keep for input reinterpretation too.
         self.store_dtype = torch.float8_e4m3fn
-        with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
-            self._create_kv_buffers()
-            self.k_scale_buffer = [
-                self.field(
-                    f"layer.{self._field_layer_id(layer_id)}.k_scale",
-                    torch.float8_e8m0fnu,
-                )
-                for layer_id in range(self.layer_num)
-            ]
-            self.v_scale_buffer = [
-                self.field(
-                    f"layer.{self._field_layer_id(layer_id)}.v_scale",
-                    torch.float8_e8m0fnu,
-                )
-                for layer_id in range(self.layer_num)
-            ]
+        super()._bind_layer_planes()
 
     def _layer_page_tokens(self, layer_id: int) -> int:
         """Tokens represented by one page id for this layer."""
         # Byte-uniform slots factor one id through the layer's head count.
         heads_l = self._layer_heads_per_rank(layer_id)
-        return self.kv_page_size * self.head_num // heads_l
+        return self.arena.kv_page_size * self.head_num // heads_l
 
     def _layer_scale_view(self, buf: torch.Tensor, layer_id: int) -> torch.Tensor:
         """(num_ids, heads_l, k_l, 32, 4, 4) view over a layer's SF slots
@@ -368,7 +324,7 @@ class MHATokenToKVPoolMXFP8(MHATokenToKVPool):
                 page_size=page_tokens,
                 enable_pdl=pdl_enabled(),
             )
-        elif self.kv_page_size == MXFP8_KV_SCALE_TILE_TOKENS:
+        elif self.arena.kv_page_size == MXFP8_KV_SCALE_TILE_TOKENS:
             store_sf_interleaved(
                 k_scale, self.k_scale_buffer[layer_id], loc, enable_pdl=pdl_enabled()
             )
@@ -399,7 +355,7 @@ class MHATokenToKVPoolMXFP8(MHATokenToKVPool):
         )
         if self._layer_kv_head_counts is not None:
             page_tokens = self._layer_page_tokens(layer_id)
-        elif self.kv_page_size == MXFP8_KV_SCALE_TILE_TOKENS:
+        elif self.arena.kv_page_size == MXFP8_KV_SCALE_TILE_TOKENS:
             page_tokens = MXFP8_KV_SCALE_TILE_TOKENS
         else:
             return False

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
@@ -20,6 +20,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import numpy as np
 import torch
 
@@ -27,15 +29,11 @@ from tokenspeed.runtime.cache.utils import (
     get_mla_kv_buffer_triton,
     set_mla_kv_buffer_triton,
 )
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
-)
 from tokenspeed.runtime.layers.paged_attention import PagedAttention
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.pdl import pdl_enabled
-from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = get_colorful_logger(__name__)
 
@@ -51,35 +49,22 @@ def _get_tensor_size_bytes(t: torch.Tensor | list[torch.Tensor]):
 class MLATokenToKVPool(CachePool):
     def __init__(
         self,
-        size: int,
+        arena: CacheArena,
         model_dtype: torch.dtype,
         dtype: torch.dtype,
         quant_method: str,
         kv_lora_rank: int,
         qk_rope_head_dim: int,
         layer_num: int,
-        device: str,
-        enable_memory_saver: bool,
-        prefix_granularity: int,
         rank: int,
         *,
-        memory_plan: CacheMemoryPlan,
-        paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...] = (),
-        token_capacity: int | None = None,
         layer_group_ids: tuple[str, ...] = (),
         field_layer_offset: int = 0,
-        backing_pool: CachePool | None = None,
     ):
         super().__init__(
-            size,
+            arena,
             dtype,
-            device,
-            prefix_granularity,
             rank,
-            memory_plan,
-            paged_cache_group_specs=paged_cache_group_specs,
-            token_capacity=token_capacity,
-            backing_pool=backing_pool,
             field_layer_offset=field_layer_offset,
         )
         self.model_dtype = model_dtype
@@ -100,45 +85,26 @@ class MLATokenToKVPool(CachePool):
                 "recipe must supply one group id per layer "
                 "(CachePoolSpec.layer_group_ids)"
             )
-        self.memory_saver_adapter = TorchMemorySaverAdapter.create(
-            enable=enable_memory_saver
-        )
+        self._bind_layer_planes()
 
-        self._create_buffers()
+    # Quantized MLA splits one logical cache into three planes, so its
+    # per-layer entry is a tuple; the plain path is a single latent plane.
+    # Either way each plane is reshaped into the token rows its kernel reads.
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        "latent_kv": "_latent_kv",
+        "latent_scale": "_latent_scale",
+        "rope_k": "_rope_k",
+    }
 
-    def _field_layer_id(self, layer_id: int) -> int:
-        """Map this compute view's local layer id into the merged plan."""
-        return self._field_layer_offset + layer_id
-
-    def _create_buffers(self) -> None:
-        with self.memory_saver_adapter.region(tag="kv_cache", enable_cpu_backup=False):
-            # The padded page 0 is used for writing dummy outputs from padded tokens.
-            if self.quant_method == "per_token_head":
-                self.kv_buffer = [
-                    (
-                        self.field(
-                            f"layer.{self._field_layer_id(layer_id)}.latent_kv",
-                            self.store_dtype,
-                        ).view(-1, 1, self.kv_lora_rank),
-                        self.field(
-                            f"layer.{self._field_layer_id(layer_id)}.latent_scale",
-                            torch.float32,
-                        ).view(-1, 1, 1),
-                        self.field(
-                            f"layer.{self._field_layer_id(layer_id)}.rope_k",
-                            self.model_dtype,
-                        ).view(-1, 1, self.qk_rope_head_dim),
-                    )
-                    for layer_id in range(self.layer_num)
-                ]
-            else:
-                self.kv_buffer = [
-                    self.field(
-                        f"layer.{self._field_layer_id(layer_id)}.latent_kv",
-                        self.store_dtype,
-                    ).view(-1, 1, self.kv_cache_dim)
-                    for layer_id in range(self.layer_num)
-                ]
+    def _bind_layer_planes(self) -> None:
+        super()._bind_layer_planes()
+        # The padded page 0 is used for writing dummy outputs from padded tokens.
+        if self.quant_method == "per_token_head":
+            self.kv_buffer = list(
+                zip(self._latent_kv, self._latent_scale, self._rope_k, strict=True)
+            )
+        else:
+            self.kv_buffer = self._latent_kv
 
     def get_kv_size_bytes(self):
         assert hasattr(self, "kv_buffer")

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
@@ -5,10 +5,12 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 import torch
 
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
 
 
 class MSATokenToKVPool(MHATokenToKVPool):
@@ -17,54 +19,48 @@ class MSATokenToKVPool(MHATokenToKVPool):
     def __init__(
         self,
         *,
-        size: int,
+        arena: CacheArena,
         dtype: torch.dtype,
         head_num: int,
         head_dim: int,
         layer_num: int,
-        device: str,
-        enable_memory_saver: bool,
-        prefix_granularity: int,
         rank: int,
         index_head_dim: int,
         index_dtype: torch.dtype,
         indexed_layer_ids: frozenset[int],
-        memory_plan: CacheMemoryPlan,
-        paged_cache_group_specs: tuple = (),
-        token_capacity: int | None = None,
         layer_types: tuple[str, ...] = (),
         layer_group_ids: tuple[str, ...] = (),
+        field_layer_offset: int = 0,
     ) -> None:
         self.index_head_dim = index_head_dim
         self.index_dtype = index_dtype
         self.indexed_layer_ids = frozenset(indexed_layer_ids)
-        self.index_k_buffer: dict[int, torch.Tensor] = {}
         super().__init__(
-            size=size,
-            dtype=dtype,
+            arena,
+            dtype,
             head_num=head_num,
             head_dim=head_dim,
             layer_num=layer_num,
-            device=device,
-            enable_memory_saver=enable_memory_saver,
-            prefix_granularity=prefix_granularity,
             rank=rank,
             layer_types=layer_types,
             layer_group_ids=layer_group_ids,
-            memory_plan=memory_plan,
-            paged_cache_group_specs=paged_cache_group_specs,
-            token_capacity=token_capacity,
+            field_layer_offset=field_layer_offset,
         )
-        with self.memory_saver_adapter.region(
-            tag="kv_cache",
-            enable_cpu_backup=False,
-        ):
-            self.index_k_buffer = {
-                layer_id: self.field(
-                    f"layer.{layer_id}.index_k", self.index_dtype
-                ).view(-1, self.index_head_dim)
-                for layer_id in sorted(self.indexed_layer_ids)
-            }
+
+    layer_plane_bindings: ClassVar[dict[str, str]] = {
+        **MHATokenToKVPool.layer_plane_bindings,
+        "index_k": "_index_k",
+    }
+
+    def _bind_layer_planes(self) -> None:
+        super()._bind_layer_planes()
+        # Only sparse layers plan an index plane, so the list is holey; the
+        # kernel-facing surface is a dict keyed by the layers that have one.
+        self.index_k_buffer = {
+            layer_id: plane
+            for layer_id, plane in enumerate(self._index_k)
+            if plane is not None
+        }
 
     def get_index_k_buffer(self, layer_id: int) -> torch.Tensor:
         if self.layerwise_load_tracker is not None:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
@@ -1,0 +1,367 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The cache pipeline every model family runs: layers, group, pack, bind."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from functools import cached_property
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING
+
+from tokenspeed.runtime.layers.attention.kv_cache.recipes import (
+    configured_token_limit,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+    CacheFieldSpec,
+    CacheLayout,
+    pack,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    CacheGroupSpec,
+    compute_cache_group_page_counts,
+    group,
+)
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
+        CacheModelFamily,
+        CacheSetup,
+    )
+
+# One declared cache group: what the scheduler is told, and the bytes it costs.
+CacheGroupDeclaration = tuple[CacheGroupSpec, tuple[CacheFieldSpec, ...]]
+
+
+class CacheRecipe(ABC):
+    """One model family's cache recipe.
+
+    The pipeline is the same for every family and lives once, in :meth:`setup`:
+
+    ``layers -> group -> pack -> bind``
+
+    A family fills in the seams -- which layers exist and how they collapse
+    into groups, what bytes each layer costs, how tightly groups pack into a
+    physical parent, and how many parents the budget affords. It never
+    restates the order of the stages.
+    """
+
+    # Set as a class attribute by every subclass; OrdinaryRecipe takes it per
+    # instance because its four families differ by nothing else.
+    family: CacheModelFamily
+
+    def __init__(
+        self,
+        *,
+        server_args,
+        model_config,
+        attn_config,
+        draft_model_config,
+        draft_attn_config,
+        cache_budget_bytes: int,
+        decode_input_tokens: int,
+        overlap_schedule_depth: int,
+    ) -> None:
+        self.server_args = server_args
+        self.model_config = model_config
+        self.attn_config = attn_config
+        self.draft_model_config = draft_model_config
+        self.draft_attn_config = draft_attn_config
+        self.cache_budget_bytes = cache_budget_bytes
+        self.decode_input_tokens = decode_input_tokens
+        self.overlap_schedule_depth = overlap_schedule_depth
+
+    # ------------------------------------------------------------------
+    # The pipeline. One place, one order.
+    # ------------------------------------------------------------------
+
+    def setup(self) -> CacheSetup:
+        """Run the pipeline for this family and bind it to the budget."""
+        from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
+            CachePoolSpec,
+            CacheSetup,
+        )
+
+        groups = self.groups()
+        layout = pack(
+            groups,
+            prefix_granularity=self.prefix_granularity,
+            cache_blocks_per_lcm_block=self.packing(groups),
+            alignment=self.alignment,
+            max_padding_fraction=self.max_padding_fraction,
+        )
+        self.check_layout(layout)
+        num_lcm_blocks = self.num_lcm_blocks(layout)
+        return CacheSetup(
+            spec=CachePoolSpec(
+                family=self.family,
+                memory_plan=layout.bind(num_lcm_blocks),
+                layer_types=self.layer_types,
+                layer_group_ids=self.group_ids,
+                # The same declarations the layout was packed from, so plan and
+                # specs cannot name different groups.
+                cache_group_specs=tuple(spec for spec, _ in groups),
+                token_capacity=self.token_capacity(layout, num_lcm_blocks),
+                layer_kv_head_counts=self.layer_kv_head_counts,
+                pool_options=self.pool_options(),
+            ),
+            num_draft_layers=self.num_draft_layers,
+            cache_budget_bytes=self.cache_budget_bytes,
+            fixed_workspace_bytes=self.workspace_bytes(),
+        )
+
+    # ------------------------------------------------------------------
+    # Seams: the layer vocabulary
+    #
+    # Subclasses mark every seam they fill with @override, so a renamed or
+    # mistyped seam fails type checking instead of silently falling back to
+    # the default below. The two abstract seams are the exception: ABC
+    # already refuses to instantiate a subclass that misses them.
+    # ------------------------------------------------------------------
+
+    @property
+    @abstractmethod
+    def layer_types(self) -> tuple[str, ...]:
+        """Per-layer cache-group label, target layers then draft layers."""
+
+    @property
+    @abstractmethod
+    def group_ids(self) -> tuple[str, ...]:
+        """Per-layer cache group id, target layers then draft layers."""
+
+    @property
+    def num_target_layers(self) -> int:
+        """Leading layers that belong to the target model."""
+        return self.model_config.num_attention_layers
+
+    @property
+    def num_draft_layers(self) -> int:
+        """Trailing layers that belong to the draft model."""
+        return 0
+
+    @property
+    def layer_kv_head_counts(self) -> tuple[int, ...] | None:
+        """Per-layer KV head count, when a family's layers differ."""
+        return None
+
+    # ------------------------------------------------------------------
+    # Seams: geometry knobs
+    # ------------------------------------------------------------------
+
+    @property
+    def prefix_granularity(self) -> int:
+        """Scheduler-wide identity grain in tokens."""
+        return int(self.attn_config.prefix_granularity)
+
+    @property
+    def alignment(self) -> int:
+        """Byte alignment for plane sizes."""
+        return 256
+
+    @property
+    def max_padding_fraction(self) -> float:
+        """Padding budget a group may waste inside its parent."""
+        return 0.25
+
+    @cached_property
+    def token_limit(self) -> int | None:
+        """The configured token cap, if any: --max-total-tokens or the CI cap."""
+        return configured_token_limit(self.server_args)
+
+    @property
+    def pd_disaggregation_enabled(self) -> bool:
+        return bool(getattr(self.attn_config, "pd_disaggregation_enabled", False))
+
+    # ------------------------------------------------------------------
+    # Seams: groups
+    # ------------------------------------------------------------------
+
+    def fields_for_layer(
+        self, layer_id: int, group_id: str, occurrence: int
+    ) -> tuple[CacheFieldSpec, ...]:
+        """The bytes this layer costs its group.
+
+        ``occurrence`` is the layer's slot in its group's plane numbering.
+        Families whose groups are not per-layer override :meth:`groups`
+        instead and need not implement this.
+        """
+        raise NotImplementedError
+
+    def groups(self) -> tuple[CacheGroupDeclaration, ...]:
+        """Declare this family's cache groups, spec and fields together.
+
+        The default walks the layers once (:func:`spec.group`). Families with
+        groups that are not per-layer either append whole-group declarations
+        here or replace the walk entirely.
+        """
+        return group(
+            layer_types=self.layer_types,
+            group_ids=self.group_ids,
+            sliding_window_tokens=getattr(
+                self.attn_config, "sliding_window_tokens", None
+            ),
+            prefix_granularity=self.prefix_granularity,
+            fields_for_layer=self.fields_for_layer,
+            pd_disaggregation_enabled=self.pd_disaggregation_enabled,
+        )
+
+    def check_layout(self, layout: CacheLayout) -> None:
+        """Assert whatever this family requires of the packed parent.
+
+        Runs once, between pack and bind: the layout is final but nothing has
+        been sized or allocated yet.
+        """
+
+    def packing(
+        self, groups: Sequence[CacheGroupDeclaration]
+    ) -> Mapping[str, int] | None:
+        """How many of each group's CacheBlocks share one physical parent.
+
+        ``None`` lets :func:`plan.pack` derive it from byte ratios and the
+        exact-page-stride constraints the fields impose.
+        """
+        return None
+
+    # ------------------------------------------------------------------
+    # Seams: capacity
+    # ------------------------------------------------------------------
+
+    def num_lcm_blocks(self, layout: CacheLayout) -> int:
+        """Physical parents to allocate, excluding the reserved null parent.
+
+        The budget minus this family's fixed workspace, capped by the
+        configured token limit.
+        """
+        usable_bytes = self.cache_budget_bytes - self.workspace_bytes()
+        return self._capped_parents(
+            usable_bytes // layout.lcm_block_bytes - 1,
+            parent_tokens=self._max_packing(layout) * layout.prefix_granularity,
+        )
+
+    def _capped_parents(self, budgeted: int, *, parent_tokens: int) -> int:
+        """Trim a budget-derived parent count to the configured token limit.
+
+        The one place the token limit turns into a parent count, so a family
+        that sizes its budget differently still reads the limit the same way.
+        """
+        if budgeted < 1:
+            raise ValueError(
+                f"{self.family} cache budget must hold a null parent and one "
+                "usable LCM parent"
+            )
+        if self.token_limit is None:
+            return budgeted
+        requested = self.token_limit // parent_tokens
+        if requested < 1:
+            raise ValueError(
+                "the configured token limit must hold at least one LCM parent "
+                f"({parent_tokens} child tokens)"
+            )
+        return min(budgeted, requested)
+
+    def token_capacity(self, layout: CacheLayout, num_lcm_blocks: int) -> int:
+        """Tokens the scheduler may admit against these parents.
+
+        The one definition of child-token capacity: parents times the tightest
+        packing times the identity grain.
+        """
+        return num_lcm_blocks * self._max_packing(layout) * layout.prefix_granularity
+
+    @cached_property
+    def scheduler_limits(self) -> dict[str, int]:
+        """The concurrency the cache has to hold at once.
+
+        The one place a recipe reads the scheduler's limits, so per-group page
+        demand and the capacity search cannot size against different numbers.
+        """
+        return {
+            "max_live_requests": self.attn_config.max_bs,
+            "max_scheduled_tokens": max(0, int(self.server_args.chunked_prefill_size)),
+            "max_context_len": self.attn_config.context_len,
+            "decode_input_tokens": self.decode_input_tokens,
+            "overlap_schedule_depth": self.overlap_schedule_depth,
+        }
+
+    def parents_needed(self, layout: CacheLayout, token_capacity: int) -> int:
+        """Physical parents this capacity needs at the configured concurrency.
+
+        Reads only capacity-independent facts of the layout, so it can probe a
+        layout directly instead of binding a stand-in plan first. Families
+        whose per-group demand is not the contract's own page-count formula
+        override this.
+        """
+        counts = compute_cache_group_page_counts(
+            self._group_specs,
+            max_total_tokens=token_capacity,
+            **self.scheduler_limits,
+        )
+        parents = 0
+        for group_id, packing in layout.group_packing:
+            child_pages = counts[group_id] - 1  # page 0 is the reserved null page
+            parents += (child_pages + packing - 1) // packing
+        return parents
+
+    def _capacity_from_parents(
+        self, layout: CacheLayout, num_lcm_blocks: int, *, upper_bound: int
+    ) -> int:
+        """Largest capacity these parents admit, by monotonic binary search.
+
+        The inverse of :meth:`parents_needed`, for families that size parents
+        from per-group demand instead of the flat packing product.
+        """
+        if num_lcm_blocks <= 0:
+            raise ValueError("num_lcm_blocks must be positive")
+        if upper_bound <= 0:
+            raise ValueError("upper_bound must be positive")
+        low, high = 0, upper_bound
+        while low < high:
+            candidate = (low + high + 1) // 2
+            if self.parents_needed(layout, candidate) <= num_lcm_blocks:
+                low = candidate
+            else:
+                high = candidate - 1
+        if low == 0:
+            raise ValueError(
+                f"num_lcm_blocks={num_lcm_blocks} cannot admit one token with "
+                f"the configured {self.family} cache scheduler limits"
+            )
+        return low
+
+    @cached_property
+    def _group_specs(self) -> tuple[CacheGroupSpec, ...]:
+        return tuple(spec for spec, _ in self.groups())
+
+    @staticmethod
+    def _max_packing(layout: CacheLayout) -> int:
+        """CacheBlocks per parent of the most finely packed group."""
+        return max(count for _, count in layout.group_packing)
+
+    # ------------------------------------------------------------------
+    # Seams: extras
+    # ------------------------------------------------------------------
+
+    def workspace_bytes(self) -> int:
+        """Cache-adjacent fixed allocation this family also needs."""
+        return 0
+
+    def pool_options(self) -> object | None:
+        """Family-specific options the pool constructor needs."""
+        return None

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
@@ -154,8 +154,15 @@ class CacheRecipe(ABC):
 
     @property
     def num_draft_layers(self) -> int:
-        """Trailing layers that belong to the draft model."""
-        return 0
+        """Trailing layers that belong to the draft model, zero without one.
+
+        A draft's layers are continuation layers of the merged plan, so their
+        count is a fact of the draft config -- override this only to constrain
+        it further, never to restate it.
+        """
+        if self.draft_attn_config is None:
+            return 0
+        return self.draft_model_config.num_attention_layers
 
     @property
     def layer_kv_head_counts(self) -> tuple[int, ...] | None:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/cache_runtime.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/cache_runtime.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from types import MappingProxyType
 
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 
 
@@ -54,12 +54,15 @@ def require_positive_int(name: str, value: object) -> int:
 
 
 @dataclass(frozen=True)
-class PagedCacheRuntimeContract:
+class CacheRuntimeContract:
     prefix_granularity: int
     num_lcm_blocks: int
     token_capacity: int
-    group_specs: tuple[PagedCacheGroupSpec, ...]
+    group_specs: tuple[CacheGroupSpec, ...]
+    # Both projected from the memory plan, which owns physical geometry: how
+    # many CacheBlocks each group has, and how many share one LCM parent.
     group_page_counts: Mapping[str, int]
+    group_packing: Mapping[str, int]
 
     def __post_init__(self) -> None:
         prefix_granularity = require_positive_int(
@@ -69,8 +72,8 @@ class PagedCacheRuntimeContract:
         token_capacity = require_positive_int("token_capacity", self.token_capacity)
         if not isinstance(self.group_specs, tuple) or not self.group_specs:
             raise ValueError("group_specs must be a non-empty tuple")
-        if any(not isinstance(spec, PagedCacheGroupSpec) for spec in self.group_specs):
-            raise ValueError("group_specs must contain PagedCacheGroupSpec values")
+        if any(not isinstance(spec, CacheGroupSpec) for spec in self.group_specs):
+            raise ValueError("group_specs must contain CacheGroupSpec values")
         group_ids = tuple(spec.group_id for spec in self.group_specs)
         if len(group_ids) != len(set(group_ids)):
             raise ValueError("group_specs contain duplicate group IDs")
@@ -89,14 +92,24 @@ class PagedCacheRuntimeContract:
             )
             for group_id in group_ids
         }
-        expected_counts = {
-            spec.group_id: num_lcm_blocks
-            * require_positive_int(
-                f"cache_blocks_per_lcm_block for {spec.group_id!r}",
-                spec.cache_blocks_per_lcm_block,
+        packing = dict(self.group_packing)
+        if set(packing) != expected_group_ids:
+            raise ValueError(
+                "group_packing keys must match group_specs: "
+                f"missing={sorted(expected_group_ids - set(packing))} "
+                f"extra={sorted(set(packing) - expected_group_ids)}"
             )
-            + 1
-            for spec in self.group_specs
+        packing = {
+            group_id: require_positive_int(
+                f"cache_blocks_per_lcm_block for {group_id!r}", packing[group_id]
+            )
+            for group_id in group_ids
+        }
+        # Both sides come from the plan, so this checks the plan's own
+        # arithmetic: every group's blocks are its packing per parent times
+        # the parent count, plus the reserved null block.
+        expected_counts = {
+            group_id: num_lcm_blocks * packing[group_id] + 1 for group_id in group_ids
         }
         if counts != expected_counts:
             raise ValueError(
@@ -110,3 +123,4 @@ class PagedCacheRuntimeContract:
                 "token_capacity exceeds the largest group's child-page capacity"
             )
         object.__setattr__(self, "group_page_counts", MappingProxyType(counts))
+        object.__setattr__(self, "group_packing", MappingProxyType(packing))

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
@@ -1,246 +1,457 @@
-"""DeepSeek V4 cache field recipe."""
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""DeepSeek V4 cache recipe: SWA window, compressed chains, compressor state.
+
+V4 is the one family whose groups are not per-layer: a single layer costs bytes
+in three or four groups at once, and their retention comes from the compression
+ratio rather than an attention label. So each group is declared whole -- its id
+written once, in its spec, next to the fields the layers deposit in it.
+"""
+
+from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from functools import cached_property
 
+from typing_extensions import override
+
+from tokenspeed.runtime.layers.attention.deepseek_v4_geometry import (
+    V4_COMPRESSOR_STATE_ROWS_PER_PAGE,
+    V4_COMPRESSOR_STATE_WINDOW_TOKENS,
+    V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+    V4_KERNEL_BLOCK_ROWS,
+    V4_SWA_KV_GROUP_ID,
+    DeepseekV4CacheLayout,
+    deepseek_v4_cache_layout_from_config,
+    v4_compressed_kv_group_id,
+    v4_compressed_rows_per_page,
+    v4_compressor_state_group_id,
+)
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     DEEPSEEK_V4_PAGE_SIZE,
 )
-from tokenspeed.runtime.layers.attention.kv_cache.recipes import (
-    configured_token_limit,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec import (
-    DEEPSEEK_V4_PREFIX_GRANULARITY,
-    V4_KERNEL_BLOCK_ROWS,
-    DeepseekV4CacheLayout,
-    build_v4_cache_specs,
-    deepseek_v4_cache_layout_from_config,
-    deepseek_v4_lcm_blocks_needed,
-    deepseek_v4_token_capacity_for_cache_pool,
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
+    CacheGroupDeclaration,
+    CacheRecipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
-    solve_cache_layout,
+    CacheLayout,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    CacheGroupSpec,
     apply_pd_transfer_policies,
 )
 
 _MAX_PADDING_FRACTION = 2.0
 
 
+def v4_c4_state_window(decode_input_tokens: int) -> int:
+    """Tokens the ratio-4 compressor state must retain.
+
+    c4 compression consumes the prior four-token state plus every token in the
+    target verify block. Preserve the historical eight-token window for verify
+    widths <= 4 and grow it for wider block-speculative decoders.
+    """
+    if (
+        isinstance(decode_input_tokens, bool)
+        or not isinstance(decode_input_tokens, int)
+        or decode_input_tokens <= 0
+    ):
+        raise ValueError("decode_input_tokens must be a positive integer")
+    return max(V4_COMPRESSOR_STATE_WINDOW_TOKENS[4], 4 + decode_input_tokens)
+
+
+def v4_swa_kv_spec(hf_config) -> CacheGroupSpec:
+    """SWA kv: trailing window only, so State family."""
+    return CacheGroupSpec(
+        group_id=V4_SWA_KV_GROUP_ID,
+        retention="sliding_window",
+        rows_per_page=V4_KERNEL_BLOCK_ROWS,
+        entry_stride_tokens=1,
+        sliding_window_tokens=_resolve_sliding_window(hf_config),
+        family="state",
+    )
+
+
+def v4_compressor_state_spec(ratio: int, *, c4_state_window: int) -> CacheGroupSpec:
+    """Compressor state for one ratio: tail buffer, so State family."""
+    _check_ratio(ratio)
+    return CacheGroupSpec(
+        group_id=v4_compressor_state_group_id(ratio),
+        retention="sliding_window",
+        rows_per_page=V4_COMPRESSOR_STATE_ROWS_PER_PAGE[ratio],
+        entry_stride_tokens=1,
+        sliding_window_tokens=(
+            c4_state_window if ratio == 4 else V4_COMPRESSOR_STATE_WINDOW_TOKENS[ratio]
+        ),
+        family="state",
+    )
+
+
+def v4_compressed_kv_spec(ratio: int) -> CacheGroupSpec:
+    """Compressed kv for one ratio: full-history chain (indexer K shares it)."""
+    _check_ratio(ratio)
+    return CacheGroupSpec(
+        group_id=v4_compressed_kv_group_id(ratio),
+        retention="full_history",
+        rows_per_page=v4_compressed_rows_per_page(ratio),
+        entry_stride_tokens=ratio,
+        sliding_window_tokens=None,
+        family="history",
+    )
+
+
+def v4_indexer_state_spec(*, c4_state_window: int) -> CacheGroupSpec:
+    """Indexer compressor state: tail buffer, so State family."""
+    return CacheGroupSpec(
+        group_id=V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+        retention="sliding_window",
+        rows_per_page=V4_COMPRESSOR_STATE_ROWS_PER_PAGE[4],
+        entry_stride_tokens=1,
+        sliding_window_tokens=c4_state_window,
+        family="state",
+    )
+
+
+def _check_ratio(ratio: int) -> None:
+    if ratio not in V4_COMPRESSOR_STATE_WINDOW_TOKENS:
+        raise ValueError(f"unsupported DeepSeek V4 compress_ratio={ratio}")
+
+
+def _resolve_sliding_window(hf_config) -> int:
+    for source in (hf_config, getattr(hf_config, "text_config", None)):
+        if source is None:
+            continue
+        if hasattr(source, "sliding_window"):
+            value = source.sliding_window
+            if value is None:
+                raise ValueError("DeepSeek V4 sliding_window is None")
+            window = int(value)
+            if window <= 0:
+                raise ValueError(f"sliding_window must be positive, got {value!r}")
+            return window
+    raise ValueError("DeepSeek V4 hf_config is missing sliding_window")
+
+
 @dataclass(frozen=True)
 class DeepseekV4PoolOptions:
+    """What the V4 pool needs beyond the plan: its kernel cache layout."""
+
     layout: DeepseekV4CacheLayout
 
+    def layer_view(self, *, first_layer: int, num_layers: int):
+        """Narrow the layout to one compute view's layer window.
 
-def build_deepseek_v4_cache_fields(
-    layout: DeepseekV4CacheLayout,
-    *,
-    sliding_window: int,
-    prefix_granularity: int = DEEPSEEK_V4_PREFIX_GRANULARITY,
-):
-    """Build DSV4 fields for one scheduler-wide prefix granularity."""
-    if sliding_window <= 0 or prefix_granularity % sliding_window:
-        raise ValueError(
-            "DeepSeek V4 sliding_window must divide the prefix granularity"
-        )
-    if sliding_window % V4_KERNEL_BLOCK_ROWS:
-        raise ValueError(
-            "DeepSeek V4 sliding_window must be divisible by the SWA kernel page"
-        )
-
-    compressed_shapes = {
-        ratio: (layout.swa_block_bytes(layout.storage_block_size(ratio)),)
-        for ratio in set(layout.layer_ratio)
-        if ratio > 1
-    }
-    compressor_state_shapes = {
-        ratio: (
-            layout.compressor_state_block_size(ratio),
-            layout.head_dim * (2 if ratio == 4 else 1) * 2,
-        )
-        for ratio in set(layout.layer_ratio)
-        if ratio > 1
-    }
-    return deepseek_v4_cache_fields(
-        layer_ratios=layout.layer_ratio,
-        prefix_granularity=prefix_granularity,
-        swa_shape=(layout.swa_block_bytes(V4_KERNEL_BLOCK_ROWS),),
-        compressed_shapes=compressed_shapes,
-        compressor_state_shapes=compressor_state_shapes,
-        indexer_kv_shape=(V4_KERNEL_BLOCK_ROWS, layout.indexer_row_bytes),
-        indexer_state_shape=(
-            layout.compressor_state_block_size(4),
-            layout.index_head_dim * 2 * 2,
-        ),
-        kv_page_stride_alignment_bytes=layout.swa_token_stride,
-    )
-
-
-def solve_deepseek_v4_memory_layout(
-    fields: list[CacheFieldSpec],
-    prefix_granularity: int = DEEPSEEK_V4_PREFIX_GRANULARITY,
-):
-    """Solve DSV4's power-of-two group packing for one physical parent."""
-    raw_bytes: dict[str, int] = {}
-    for field in fields:
-        raw_bytes[field.group_id] = (
-            raw_bytes.get(field.group_id, 0) + field.payload_bytes
-        )
-    largest_group = max(raw_bytes.values())
-    # Power-of-two packing keeps every field stride naturally aligned. Using
-    # exact byte ratios would inflate a parent through their large common LCM.
-    packing = {
-        group_id: 1 << max(0, (largest_group // group_bytes).bit_length() - 1)
-        for group_id, group_bytes in raw_bytes.items()
-    }
-    return solve_cache_layout(
-        fields,
-        prefix_granularity=prefix_granularity,
-        cache_blocks_per_lcm_block=packing,
-        alignment=256,
-        max_padding_fraction=_MAX_PADDING_FRACTION,
-    )
-
-
-def deepseek_v4_cache_fields(
-    *,
-    layer_ratios: Sequence[int],
-    prefix_granularity: int,
-    swa_shape: Sequence[int],
-    compressed_shapes: Mapping[int, tuple[int, ...]],
-    compressor_state_shapes: Mapping[int, tuple[int, ...]],
-    indexer_kv_shape: Sequence[int],
-    indexer_state_shape: Sequence[int],
-    kv_page_stride_alignment_bytes: int,
-) -> tuple[CacheFieldSpec, ...]:
-    """Describe DSV4 history pages and bounded live-tail state."""
-    if prefix_granularity <= 0 or prefix_granularity % DEEPSEEK_V4_PAGE_SIZE:
-        raise ValueError(
-            "DeepSeek V4 prefix granularity must be a positive multiple of "
-            f"the kernel page ({DEEPSEEK_V4_PAGE_SIZE}), got {prefix_granularity}"
-        )
-    ratios = tuple(int(ratio) for ratio in layer_ratios)
-    if any(ratio not in (1, 4, 128) for ratio in ratios):
-        raise ValueError("DeepSeek V4 layer ratios must be 1, 4, or 128")
-
-    fields: list[CacheFieldSpec] = []
-    ratio_counts = Counter(ratios)
-    occurrences: dict[str, int] = {}
-    for layer_id, ratio in enumerate(ratios):
-        swa_group = "v4.swa_kv"
-        swa_slot = occurrences.get(swa_group, 0)
-        occurrences[swa_group] = swa_slot + 1
-        fields.append(
-            CacheFieldSpec(
-                swa_group,
-                f"layer.{layer_id}.swa",
-                f"unit.{swa_slot}",
-                tuple(swa_shape),
-                1,
-                exact_page_stride=False,
-                page_stride_alignment_bytes=kv_page_stride_alignment_bytes,
+        The layout's ``layer_ratio`` is per-layer and the pool indexes it by
+        its own local layer id, so a draft view carries only its own ratios.
+        """
+        ratios = self.layout.layer_ratio[first_layer : first_layer + num_layers]
+        if len(ratios) != num_layers:
+            raise ValueError(
+                f"DeepSeek V4 cache layout has no ratios for layers "
+                f"[{first_layer}, {first_layer + num_layers})"
             )
-        )
-        if ratio == 1:
-            continue
+        return DeepseekV4PoolOptions(layout=replace(self.layout, layer_ratio=ratios))
 
-        compressed_group = f"v4.c{ratio}a.compressed_kv"
-        state_group = f"v4.c{ratio}a.compressor_state"
-        try:
-            compressed_shape = tuple(compressed_shapes[ratio])
-            state_shape = tuple(compressor_state_shapes[ratio])
-        except KeyError as exc:
-            raise ValueError(f"missing DeepSeek V4 ratio-{ratio} geometry") from exc
-        compressed_slot = occurrences.get(compressed_group, 0)
-        occurrences[compressed_group] = compressed_slot + 1
-        state_slot = occurrences.get(state_group, 0)
-        occurrences[state_group] = state_slot + 1
-        fields.extend(
+
+class DeepseekV4Recipe(CacheRecipe):
+    """DeepSeek V4: one arena for SWA, compressed chains and indexer state.
+
+    The MTP layer already is a continuation layer of the target config
+    (``compress_ratios`` carries ``num_hidden_layers + num_nextn`` entries), so
+    one pass over the full layer range builds the merged plan.
+    """
+
+    family = "deepseek_v4"
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        if self.pd_disaggregation_enabled and (
+            getattr(self.server_args, "speculative_algorithm", None) is not None
+            or self.draft_model_config is not None
+            or self.draft_attn_config is not None
+            or self.decode_input_tokens != 1
+        ):
+            raise NotImplementedError(
+                "DeepSeek V4 PD supports target-only decoding; speculative/MTP "
+                "cache transfer is not implemented"
+            )
+
+    # ---- layer vocabulary ----
+
+    @property
+    @override
+    def num_draft_layers(self) -> int:
+        if self.draft_attn_config is None:
+            return 0
+        return self.draft_model_config.num_attention_layers
+
+    @cached_property
+    def _cache_layout(self) -> DeepseekV4CacheLayout:
+        """Kernel cache geometry over target and draft layers together."""
+        source = (
+            self.draft_model_config.hf_config
+            if self.draft_attn_config is not None
+            else self.model_config.hf_config
+        )
+        return deepseek_v4_cache_layout_from_config(
+            source,
+            page_size=DEEPSEEK_V4_PAGE_SIZE,
+            use_fp4_indexer_cache=self._use_fp4_indexer(source),
+            layer_indices=range(self.num_target_layers + self.num_draft_layers),
+        )
+
+    @cached_property
+    def layer_types(self) -> tuple[str, ...]:
+        """The compression ratio per layer -- V4's own layer vocabulary."""
+        return tuple(str(ratio) for ratio in self._cache_layout.layer_ratio)
+
+    @cached_property
+    def group_ids(self) -> tuple[str, ...]:
+        """The group a layer's own attention reads: SWA, or its chain."""
+        return tuple(
             (
+                v4_compressed_kv_spec(ratio).group_id
+                if ratio > 1
+                else v4_swa_kv_spec(self.model_config.hf_config).group_id
+            )
+            for ratio in self._cache_layout.layer_ratio
+        )
+
+    # ---- geometry ----
+
+    @property
+    @override
+    def max_padding_fraction(self) -> float:
+        return _MAX_PADDING_FRACTION
+
+    # ---- groups: declared whole, one walk over the layers ----
+
+    @override
+    def groups(self) -> tuple[CacheGroupDeclaration, ...]:
+        layout = self._cache_layout
+        sliding_window = int(
+            (
+                self.draft_model_config.hf_config
+                if self.draft_attn_config is not None
+                else self.model_config.hf_config
+            ).sliding_window
+        )
+        if sliding_window <= 0 or self.prefix_granularity % sliding_window:
+            raise ValueError(
+                "DeepSeek V4 sliding_window must divide the prefix granularity"
+            )
+        if sliding_window % V4_KERNEL_BLOCK_ROWS:
+            raise ValueError(
+                "DeepSeek V4 sliding_window must be divisible by the SWA kernel page"
+            )
+        ratios = tuple(int(ratio) for ratio in layout.layer_ratio)
+        if any(ratio not in (1, 4, 128) for ratio in ratios):
+            raise ValueError("DeepSeek V4 layer ratios must be 1, 4, or 128")
+
+        c4_window = v4_c4_state_window(self.decode_input_tokens)
+        swa_bytes = layout.swa_block_bytes(V4_KERNEL_BLOCK_ROWS)
+        stride_alignment = layout.swa_token_stride
+        ratio_counts = Counter(ratios)
+        declared: dict[str, tuple[CacheGroupSpec, tuple[CacheFieldSpec, ...]]] = {}
+        # A group's plane numbering: one plane per layer that stores in it.
+        occurrences: Counter[str] = Counter()
+
+        def declare(spec: CacheGroupSpec, *fields: CacheFieldSpec) -> None:
+            """Add fields to a group, creating it the first time it is named.
+
+            The group id is written once -- in ``spec`` -- right where its
+            fields are added, so the two halves cannot drift apart.
+            """
+            existing = declared.get(spec.group_id)
+            declared[spec.group_id] = (
+                spec if existing is None else existing[0],
+                (() if existing is None else existing[1]) + fields,
+            )
+
+        swa_spec = v4_swa_kv_spec(self.model_config.hf_config)
+        for layer_id, ratio in enumerate(ratios):
+            swa_slot = occurrences[swa_spec.group_id]
+            occurrences[swa_spec.group_id] += 1
+            declare(
+                swa_spec,
                 CacheFieldSpec(
-                    compressed_group,
+                    f"layer.{layer_id}.swa",
+                    f"unit.{swa_slot}",
+                    (swa_bytes,),
+                    "uint8",
+                    exact_page_stride=False,
+                    page_stride_alignment_bytes=stride_alignment,
+                ),
+            )
+            if ratio == 1:
+                continue
+
+            compressed_spec = v4_compressed_kv_spec(ratio)
+            state_spec = v4_compressor_state_spec(ratio, c4_state_window=c4_window)
+            compressed_slot = occurrences[compressed_spec.group_id]
+            occurrences[compressed_spec.group_id] += 1
+            state_slot = occurrences[state_spec.group_id]
+            occurrences[state_spec.group_id] += 1
+            declare(
+                compressed_spec,
+                CacheFieldSpec(
                     f"layer.{layer_id}.compressed_kv",
                     f"unit.{compressed_slot}",
-                    compressed_shape,
-                    1,
+                    (layout.swa_block_bytes(layout.storage_block_size(ratio)),),
+                    "uint8",
                     exact_page_stride=False,
-                    page_stride_alignment_bytes=kv_page_stride_alignment_bytes,
+                    page_stride_alignment_bytes=stride_alignment,
                 ),
+            )
+            declare(
+                state_spec,
                 CacheFieldSpec(
-                    state_group,
                     f"layer.{layer_id}.compressor_state",
                     f"unit.{state_slot}",
-                    state_shape,
-                    4,
+                    (
+                        layout.compressor_state_block_size(ratio),
+                        layout.head_dim * (2 if ratio == 4 else 1) * 2,
+                    ),
+                    "float32",
                     exact_page_stride=False,
                 ),
             )
-        )
-        if ratio != 4:
-            continue
-        indexer_state_group = "v4.c4a.indexer_compressor_state"
-        indexer_state_slot = occurrences.get(indexer_state_group, 0)
-        occurrences[indexer_state_group] = indexer_state_slot + 1
-        fields.extend(
-            (
+            if ratio != 4:
+                continue
+
+            # The indexer's K shares the compressed chain's group but sits on
+            # planes after every compressed tenant; its state is its own group.
+            indexer_state_spec = v4_indexer_state_spec(c4_state_window=c4_window)
+            indexer_state_slot = occurrences[indexer_state_spec.group_id]
+            occurrences[indexer_state_spec.group_id] += 1
+            declare(
+                compressed_spec,
                 CacheFieldSpec(
-                    compressed_group,
                     f"layer.{layer_id}.indexer_kv",
                     f"unit.{ratio_counts[4] + compressed_slot}",
-                    tuple(indexer_kv_shape),
-                    1,
-                    exact_page_stride=False,
-                ),
-                CacheFieldSpec(
-                    indexer_state_group,
-                    f"layer.{layer_id}.indexer_state",
-                    f"unit.{indexer_state_slot}",
-                    tuple(indexer_state_shape),
-                    4,
+                    (V4_KERNEL_BLOCK_ROWS * layout.indexer_row_bytes,),
+                    "uint8",
                     exact_page_stride=False,
                 ),
             )
-        )
-    return tuple(fields)
+            declare(
+                indexer_state_spec,
+                CacheFieldSpec(
+                    f"layer.{layer_id}.indexer_state",
+                    f"unit.{indexer_state_slot}",
+                    (
+                        layout.compressor_state_block_size(4),
+                        layout.index_head_dim * 2 * 2,
+                    ),
+                    "float32",
+                    exact_page_stride=False,
+                ),
+            )
 
-
-def prepare_deepseek_v4_cache(
-    *,
-    server_args,
-    model_config,
-    attn_config,
-    draft_model_config,
-    draft_attn_config,
-    cache_budget_bytes: int,
-    decode_input_tokens: int,
-    overlap_schedule_depth: int,
-):
-    """Build target and draft cache specs for DeepSeek V4."""
-    pd_enabled = bool(attn_config.pd_disaggregation_enabled)
-    if pd_enabled and (
-        getattr(server_args, "speculative_algorithm", None) is not None
-        or draft_model_config is not None
-        or draft_attn_config is not None
-        or decode_input_tokens != 1
-    ):
-        raise NotImplementedError(
-            "DeepSeek V4 PD supports target-only decoding; speculative/MTP "
-            "cache transfer is not implemented"
+        groups = tuple(declared.values())
+        if not self.pd_disaggregation_enabled:
+            return groups
+        policies = apply_pd_transfer_policies(tuple(spec for spec, _ in groups))
+        return tuple(
+            (spec, fields) for spec, (_, fields) in zip(policies, groups, strict=True)
         )
 
-    # Deferred: setup.py imports this recipe at module load.
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
-        CachePoolSpec,
-        CacheSetup,
-    )
+    # ---- packing: powers of two so every field stride stays aligned ----
 
-    def use_fp4_indexer(hf_config) -> bool:
-        override = getattr(server_args, "attention_use_fp4_indexer_cache", None)
-        if override is not None:
-            return bool(override)
+    @override
+    def packing(self, groups: tuple[CacheGroupDeclaration, ...]) -> Mapping[str, int]:
+        raw_bytes = {
+            spec.group_id: sum(field.payload_bytes for field in fields)
+            for spec, fields in groups
+        }
+        largest = max(raw_bytes.values())
+        # Exact byte ratios would inflate a parent through their large common
+        # LCM; powers of two keep every field stride naturally aligned.
+        return {
+            group_id: 1 << max(0, (largest // group_bytes).bit_length() - 1)
+            for group_id, group_bytes in raw_bytes.items()
+        }
+
+    @override
+    def check_layout(self, layout: CacheLayout) -> None:
+        """Every group's CacheBlock span must divide the identity grain.
+
+        A page id is derived by dividing a prefix-granularity token offset by
+        the group's block span; a remainder would put two different token
+        ranges on one page id.
+        """
+        for spec in self._group_specs:
+            if layout.prefix_granularity % spec.block_granularity:
+                raise ValueError(
+                    f"group {spec.group_id!r} cache block tokens must divide "
+                    f"prefix_granularity={layout.prefix_granularity}"
+                )
+
+    # ---- capacity: per-group demand at the configured concurrency ----
+
+    @override
+    def num_lcm_blocks(self, layout: CacheLayout) -> int:
+        """Parents the per-group demand needs, not what the budget affords.
+
+        The budget only bounds the search: V4 sizes from what each group
+        demands at the configured concurrency, and the token limit enters
+        through :meth:`token_capacity`'s upper bound rather than as a cap on
+        parents (a V4 parent spans the kernel page, not the prefix grain).
+        """
+        budgeted = self.cache_budget_bytes // layout.lcm_block_bytes - 1
+        if budgeted < 1:
+            raise ValueError(
+                "DeepSeek V4 cache budget must hold a null parent and one "
+                "usable parent"
+            )
+        return self.parents_needed(layout, self.token_capacity(layout, budgeted))
+
+    @override
+    def token_capacity(self, layout: CacheLayout, num_lcm_blocks: int) -> int:
+        return self._capacity_from_parents(
+            layout,
+            num_lcm_blocks,
+            upper_bound=(
+                self.token_limit
+                if self.token_limit is not None
+                # Tokens per parent = packing x the group block span (kernel
+                # page), independent of the scheduler prefix granularity.
+                else num_lcm_blocks * self._max_packing(layout) * DEEPSEEK_V4_PAGE_SIZE
+            ),
+        )
+
+    # ---- extras ----
+
+    @override
+    def pool_options(self) -> DeepseekV4PoolOptions:
+        return DeepseekV4PoolOptions(layout=self._cache_layout)
+
+    def _use_fp4_indexer(self, hf_config) -> bool:
+        forced = getattr(self.server_args, "attention_use_fp4_indexer_cache", None)
+        if forced is not None:
+            return bool(forced)
         attention_config = getattr(hf_config, "attention_config", None)
         if isinstance(attention_config, dict):
             configured = attention_config.get("use_fp4_indexer_cache", None)
@@ -253,107 +464,3 @@ def prepare_deepseek_v4_cache(
         from tokenspeed_kernel.platform import current_platform
 
         return current_platform().arch_version.major >= 10
-
-    def layout_and_fields(config, runtime_config, *, layer_indices=None):
-        # Kernel geometry sources from the kernel-page registry; the scheduler
-        # prefix granularity only has to be a positive multiple of it.
-        layout = deepseek_v4_cache_layout_from_config(
-            config,
-            page_size=DEEPSEEK_V4_PAGE_SIZE,
-            use_fp4_indexer_cache=use_fp4_indexer(config),
-            layer_indices=layer_indices,
-        )
-        fields = build_deepseek_v4_cache_fields(
-            layout,
-            sliding_window=int(config.sliding_window),
-            prefix_granularity=runtime_config.prefix_granularity,
-        )
-        return layout, fields
-
-    # One big model, one solve, one spec: V4's MTP layer already IS a
-    # continuation layer of the target config (compress_ratios carries
-    # num_hidden_layers + num_nextn entries, the draft layer indexed after
-    # the target's) — build the merged fields in one pass over the full
-    # layer range.
-    num_target_layers = model_config.num_attention_layers
-    num_draft_layers = (
-        draft_model_config.num_attention_layers if draft_attn_config is not None else 0
-    )
-    merged_source = (
-        draft_model_config.hf_config
-        if draft_attn_config is not None
-        else model_config.hf_config
-    )
-    merged_layout, merged_fields = layout_and_fields(
-        merged_source,
-        attn_config,
-        layer_indices=range(num_target_layers + num_draft_layers),
-    )
-    merged_layout_plan = solve_deepseek_v4_memory_layout(
-        merged_fields, attn_config.prefix_granularity
-    )
-    packing = dict(merged_layout_plan.group_packing)
-
-    num_lcm_blocks = cache_budget_bytes // merged_layout_plan.lcm_block_bytes - 1
-    if num_lcm_blocks < 1:
-        raise ValueError(
-            "DeepSeek V4 cache budget must hold a null parent and one usable parent"
-        )
-
-    specs = tuple(
-        build_v4_cache_specs(
-            model_config.hf_config,
-            layer_ratio=merged_layout.layer_ratio,
-            cache_blocks_per_lcm_block=packing,
-            decode_input_tokens=decode_input_tokens,
-        )
-    )
-    if pd_enabled:
-        specs = tuple(apply_pd_transfer_policies(specs))
-    max_packing = max(packing.values())
-    token_limit = configured_token_limit(server_args)
-    upper_bound = (
-        token_limit
-        if token_limit is not None
-        # Tokens per parent = packing x the group block span (kernel page),
-        # independent of the scheduler prefix granularity.
-        else num_lcm_blocks * max_packing * DEEPSEEK_V4_PAGE_SIZE
-    )
-    sizing = {
-        "prefix_granularity": attn_config.prefix_granularity,
-        "max_live_requests": attn_config.max_bs,
-        "max_scheduled_tokens": max(0, int(server_args.chunked_prefill_size)),
-        "max_context_len": attn_config.context_len,
-        "decode_input_tokens": decode_input_tokens,
-        "overlap_schedule_depth": overlap_schedule_depth,
-    }
-    token_capacity = deepseek_v4_token_capacity_for_cache_pool(
-        specs,
-        num_lcm_blocks=num_lcm_blocks,
-        upper_bound_tokens=upper_bound,
-        **sizing,
-    )
-    num_lcm_blocks = deepseek_v4_lcm_blocks_needed(
-        specs,
-        token_capacity=token_capacity,
-        **sizing,
-    )
-
-    return CacheSetup(
-        spec=CachePoolSpec(
-            family="deepseek_v4",
-            memory_plan=merged_layout_plan.with_num_lcm_blocks(num_lcm_blocks),
-            layer_types=tuple(str(ratio) for ratio in merged_layout.layer_ratio),
-            layer_group_ids=tuple(
-                (f"v4.c{ratio}a.compressed_kv" if ratio > 1 else "v4.swa_kv")
-                for ratio in merged_layout.layer_ratio
-            ),
-            paged_cache_group_specs=specs,
-            state_field_dtypes={},
-            token_capacity=token_capacity,
-            pool_options=DeepseekV4PoolOptions(layout=merged_layout),
-        ),
-        num_draft_layers=num_draft_layers,
-        cache_budget_bytes=cache_budget_bytes,
-        fixed_workspace_bytes=0,
-    )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
@@ -200,13 +200,6 @@ class DeepseekV4Recipe(CacheRecipe):
 
     # ---- layer vocabulary ----
 
-    @property
-    @override
-    def num_draft_layers(self) -> int:
-        if self.draft_attn_config is None:
-            return 0
-        return self.draft_model_config.num_attention_layers
-
     @cached_property
     def _cache_layout(self) -> DeepseekV4CacheLayout:
         """Kernel cache geometry over target and draft layers together."""

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
@@ -1,153 +1,320 @@
-"""Inkling cache recipe."""
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Inkling cache recipe: attention pages plus paged ShortConv checkpoints.
+
+Every attention layer costs bytes in three groups -- its own attention group
+and the two conv checkpoint columns -- so the conv groups are declared whole
+(spec and fields together) rather than derived from a layer label.
+"""
+
+from __future__ import annotations
 
 import os
+from functools import cached_property
 
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-    build_hybrid_cache_setup,
+import torch
+from typing_extensions import override
+
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
+    CacheGroupDeclaration,
+    CacheRecipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
-    merge_continuation_layers,
+    cache_dtype_bytes,
+    cache_dtype_name,
+    scatter_stored_dtype_name,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     MXFP8_KV_SCALE_TILE_TOKENS,
+    CacheGroupSpec,
+    apply_pd_transfer_policies,
 )
 
+_INKLING_PREFIX_GRANULARITY = 128
 
-def inkling_cache_fields(
-    *,
-    layer_group_ids,
-    prefix_granularity,
-    layer_kv_heads,
-    head_dim,
-    kv_element_size,
-    hidden_size,
-    checkpoint_rows,
-    kvconv_element_size,
-    hiddenconv_element_size,
-    kv_scale_block_size=0,
-    kv_scale_element_size=0,
-) -> tuple[CacheFieldSpec, ...]:
-    """Describe Inkling attention pages and ShortConv checkpoints."""
-    if len(layer_group_ids) != len(layer_kv_heads):
-        raise ValueError(
-            f"layer_group_ids has {len(layer_group_ids)} entries but "
-            f"layer_kv_heads has {len(layer_kv_heads)}"
-        )
-    if bool(kv_scale_block_size) != bool(kv_scale_element_size):
-        raise ValueError(
-            "kv_scale_block_size and kv_scale_element_size must both be zero "
-            "or both be positive"
-        )
-    if kv_scale_block_size and head_dim % kv_scale_block_size:
-        raise ValueError("head_dim must be divisible by kv_scale_block_size")
-    if kv_scale_block_size and (
-        prefix_granularity % 128 or head_dim != 128 or kv_scale_block_size != 32
-    ):
-        raise ValueError(
-            "Inkling MXFP8 scale fields require P divisible by 128, "
-            "head_dim 128 and scale block size 32"
-        )
+# The ShortConv checkpoint groups. Named once: the field builder and the
+# whole-group declaration below both reference these.
+KVCONV_GROUP_ID = "kvconv"
+HIDDENCONV_GROUP_ID = "hiddenconv"
 
-    occurrences: dict[str, int] = {}
-    fields = []
-    for layer_id, (group_id, kv_heads) in enumerate(
-        zip(layer_group_ids, layer_kv_heads)
-    ):
-        unit = occurrences.get(group_id, 0)
-        occurrences[group_id] = unit + 1
-        k_plane = f"unit.{unit}.k"
-        v_plane = f"unit.{unit}.v"
-        if hiddenconv_element_size > 1:
-            hidden_k_plane = f"unit.{unit}.hidden_k"
-            hidden_v_plane = f"unit.{unit}.hidden_v"
-        else:
-            hidden_k_plane = k_plane
-            hidden_v_plane = v_plane
-        kv_shape = (prefix_granularity, kv_heads, head_dim)
-        kvconv_shape = (checkpoint_rows, kv_heads * head_dim)
-        hiddenconv_shape = (checkpoint_rows, hidden_size)
-        fields.extend(
+
+class InklingRecipe(CacheRecipe):
+    """Inkling: MHA pages plus per-layer ShortConv state checkpoints."""
+
+    family = "inkling"
+
+    # ---- layer vocabulary ----
+
+    @property
+    @override
+    def num_target_layers(self) -> int:
+        return len(self.attn_config.layer_types)
+
+    @property
+    @override
+    def num_draft_layers(self) -> int:
+        if self.draft_attn_config is None:
+            return 0
+        num_layers = self.draft_model_config.num_attention_layers
+        num_steps = self.server_args.speculative_num_steps
+        if num_steps > num_layers:
+            raise ValueError(
+                f"Inkling MTP has {num_layers} depth layers; "
+                f"--speculative-num-steps {num_steps} would wrap depths "
+                "with no trained meaning."
+            )
+        return num_layers
+
+    @cached_property
+    def layer_types(self) -> tuple[str, ...]:
+        target = tuple(self.attn_config.layer_types)
+        if self.draft_attn_config is None:
+            return target
+        return target + tuple(self.draft_attn_config.layer_types)
+
+    @property
+    def group_ids(self) -> tuple[str, ...]:
+        """Inkling groups by label: the label *is* the attention group."""
+        return self.layer_types
+
+    @cached_property
+    @override
+    def layer_kv_head_counts(self) -> tuple[int, ...]:
+        counts = inkling_layer_kv_head_counts(self.model_config)
+        if self.draft_attn_config is None:
+            return counts
+        return counts + inkling_layer_kv_head_counts(self.draft_model_config)
+
+    # ---- geometry ----
+
+    @property
+    @override
+    def prefix_granularity(self) -> int:
+        return _INKLING_PREFIX_GRANULARITY
+
+    @property
+    @override
+    def max_padding_fraction(self) -> float:
+        # The bf16 conv columns are narrow next to the KV pages they alias;
+        # the fp8 variant tightens the binding enough to bound it.
+        return float("inf") if not _fp8_sconv() else 1.0
+
+    # ---- groups: the layer walk, plus the two conv columns ----
+
+    @override
+    def groups(self) -> tuple[CacheGroupDeclaration, ...]:
+        """The attention groups from the layer walk, plus both conv columns."""
+        conv = tuple(
             (
-                CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.k",
-                    k_plane,
-                    kv_shape,
-                    kv_element_size,
+                CacheGroupSpec(
+                    group_id=group_id,
+                    retention="full_history",
+                    sliding_window_tokens=None,
+                    family="state",
+                    checkpoint_granularity=self.prefix_granularity,
                 ),
+                fields,
+            )
+            for group_id, fields in self._conv_columns().items()
+        )
+        if self.pd_disaggregation_enabled:
+            # The layer walk already stamped the attention groups.
+            policies = apply_pd_transfer_policies(tuple(spec for spec, _ in conv))
+            conv = tuple(
+                (spec, fields) for spec, (_, fields) in zip(policies, conv, strict=True)
+            )
+        return super().groups() + conv
+
+    @override
+    def fields_for_layer(
+        self, layer_id: int, group_id: str, occurrence: int
+    ) -> tuple[CacheFieldSpec, ...]:
+        """This layer's attention pages. Its conv checkpoints are columns."""
+        config = self._layer_config(layer_id)
+        mxfp8 = bool(config.kv_cache_mxfp8)
+        if mxfp8 and (self.prefix_granularity % 128 or config.head_dim != 128):
+            raise ValueError(
+                "Inkling MXFP8 scale fields require P divisible by 128 and "
+                "head_dim 128"
+            )
+        kv_heads = self._layer_kv_heads(layer_id)
+        kv_shape = (self.prefix_granularity, kv_heads, config.head_dim)
+        kv_dtype = (
+            cache_dtype_name(torch.float8_e4m3fn)
+            if mxfp8
+            else scatter_stored_dtype_name(config.kv_cache_dtype)
+        )
+        fields = (
+            CacheFieldSpec(
+                f"layer.{layer_id}.k",
+                f"unit.{occurrence}.k",
+                kv_shape,
+                kv_dtype,
+            ),
+            CacheFieldSpec(
+                f"layer.{layer_id}.v",
+                f"unit.{occurrence}.v",
+                kv_shape,
+                kv_dtype,
+            ),
+        )
+        if not mxfp8:
+            return fields
+        scale_dim = config.head_dim // 32
+        scale_shape = (
+            kv_heads,
+            self.prefix_granularity // MXFP8_KV_SCALE_TILE_TOKENS,
+            32,
+            scale_dim,
+            scale_dim,
+        )
+        scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
+        return fields + (
+            CacheFieldSpec(
+                f"layer.{layer_id}.k_scale",
+                f"unit.{occurrence}.k_scale",
+                scale_shape,
+                scale_dtype,
+            ),
+            CacheFieldSpec(
+                f"layer.{layer_id}.v_scale",
+                f"unit.{occurrence}.v_scale",
+                scale_shape,
+                scale_dtype,
+            ),
+        )
+
+    def _conv_columns(self) -> dict[str, tuple[CacheFieldSpec, ...]]:
+        """Both ShortConv checkpoint columns, one entry per attention layer.
+
+        The checkpoints alias their layer's KV planes, so they reuse the plane
+        ids -- which means reproducing the group's plane numbering here. It is
+        the same rule the layer walk applies (a group's Nth layer takes plane
+        N) and Inkling's layers all declare fields, so the two agree.
+        """
+        columns = {KVCONV_GROUP_ID: (), HIDDENCONV_GROUP_ID: ()}
+        occurrences: dict[str, int] = {}
+        hiddenconv_dtype = cache_dtype_name(
+            torch.float8_e5m2 if _fp8_sconv() else torch.bfloat16
+        )
+        wide_hidden = cache_dtype_bytes(hiddenconv_dtype) > 1
+        for layer_id, group_id in enumerate(self.group_ids):
+            occurrence = occurrences.get(group_id, 0)
+            occurrences[group_id] = occurrence + 1
+            text_config = self._layer_model_config(layer_id).hf_config.get_text_config()
+            checkpoint_rows = text_config.sconv_kernel_size - 1
+            kv_row = (
+                self._layer_kv_heads(layer_id) * self._layer_config(layer_id).head_dim
+            )
+            k_plane = f"unit.{occurrence}.k"
+            v_plane = f"unit.{occurrence}.v"
+            columns[KVCONV_GROUP_ID] += (
                 CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.v",
-                    v_plane,
-                    kv_shape,
-                    kv_element_size,
-                ),
-                CacheFieldSpec(
-                    "kvconv",
                     f"layer.{layer_id}.kvconv_k",
                     k_plane,
-                    kvconv_shape,
-                    kvconv_element_size,
+                    (checkpoint_rows, kv_row),
+                    cache_dtype_name(torch.bfloat16),
                     exact_page_stride=False,
                 ),
                 CacheFieldSpec(
-                    "kvconv",
                     f"layer.{layer_id}.kvconv_v",
                     v_plane,
-                    kvconv_shape,
-                    kvconv_element_size,
+                    (checkpoint_rows, kv_row),
+                    cache_dtype_name(torch.bfloat16),
                     exact_page_stride=False,
                 ),
+            )
+            columns[HIDDENCONV_GROUP_ID] += (
                 CacheFieldSpec(
-                    "hiddenconv",
                     f"layer.{layer_id}.attnconv",
-                    hidden_k_plane,
-                    hiddenconv_shape,
-                    hiddenconv_element_size,
+                    f"unit.{occurrence}.hidden_k" if wide_hidden else k_plane,
+                    (checkpoint_rows, text_config.hidden_size),
+                    hiddenconv_dtype,
                     exact_page_stride=False,
                 ),
                 CacheFieldSpec(
-                    "hiddenconv",
                     f"layer.{layer_id}.mlpconv",
-                    hidden_v_plane,
-                    hiddenconv_shape,
-                    hiddenconv_element_size,
+                    f"unit.{occurrence}.hidden_v" if wide_hidden else v_plane,
+                    (checkpoint_rows, text_config.hidden_size),
+                    hiddenconv_dtype,
                     exact_page_stride=False,
                 ),
             )
+        return columns
+
+    def _layer_config(self, layer_id: int):
+        return (
+            self.attn_config
+            if layer_id < self.num_target_layers
+            else self.draft_attn_config
         )
-        if kv_scale_block_size:
-            scale_dim = head_dim // kv_scale_block_size
-            scale_shape = (
-                kv_heads,
-                prefix_granularity // MXFP8_KV_SCALE_TILE_TOKENS,
-                32,
-                scale_dim,
-                scale_dim,
+
+    def _layer_model_config(self, layer_id: int):
+        return (
+            self.model_config
+            if layer_id < self.num_target_layers
+            else self.draft_model_config
+        )
+
+    def _layer_kv_heads(self, layer_id: int) -> int:
+        config = self._layer_config(layer_id)
+        return max(1, self.layer_kv_head_counts[layer_id] // config.attn_tp_size)
+
+    # ---- extras ----
+
+    @override
+    def workspace_bytes(self) -> int:
+        """The conv ring both models stage their checkpoints through."""
+        draft_tokens = (
+            int(self.server_args.speculative_num_draft_tokens)
+            if self.draft_attn_config is not None
+            else 0
+        )
+        text_config = self.model_config.hf_config.get_text_config()
+        total = _conv_ring_bytes(
+            text_config=text_config,
+            attn_config=self.attn_config,
+            num_layers=text_config.num_hidden_layers,
+            spec_tokens=draft_tokens,
+        )
+        if self.draft_attn_config is not None:
+            total += _conv_ring_bytes(
+                text_config=self.draft_model_config.hf_config.get_text_config(),
+                attn_config=self.draft_attn_config,
+                num_layers=self.num_draft_layers,
+                spec_tokens=draft_tokens,
             )
-            fields.extend(
-                (
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.k_scale",
-                        f"unit.{unit}.k_scale",
-                        scale_shape,
-                        kv_scale_element_size,
-                    ),
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.v_scale",
-                        f"unit.{unit}.v_scale",
-                        scale_shape,
-                        kv_scale_element_size,
-                    ),
-                )
-            )
-    return tuple(fields)
+        return total
+
+
+def _fp8_sconv() -> bool:
+    return os.environ.get("INKLING_FP8_SCONV", "0") != "0"
 
 
 def inkling_layer_kv_head_counts(model_config) -> tuple[int, ...]:
+    """Per-layer global KV head count, before TP sharding.
+
+    Also read by the PD field-partition logic, which needs the global width.
+    """
     from tokenspeed.runtime.configs.inkling_config import inkling_kv_heads_for_layer
 
     text_config = model_config.hf_config.get_text_config()
@@ -157,59 +324,7 @@ def inkling_layer_kv_head_counts(model_config) -> tuple[int, ...]:
     )
 
 
-def _inkling_fields(attn_config, model_config, prefix_granularity: int):
-    text_config = model_config.hf_config.get_text_config()
-    layer_kv_head_counts = inkling_layer_kv_head_counts(model_config)
-    per_rank_heads = tuple(
-        max(1, heads // attn_config.attn_tp_size) for heads in layer_kv_head_counts
-    )
-    hiddenconv_element_size = (
-        2 if os.environ.get("INKLING_FP8_SCONV", "0") == "0" else 1
-    )
-    fields = inkling_cache_fields(
-        layer_group_ids=attn_config.layer_types,
-        prefix_granularity=prefix_granularity,
-        layer_kv_heads=per_rank_heads,
-        head_dim=attn_config.head_dim,
-        kv_element_size=attn_config.kv_cache_dtype.itemsize,
-        hidden_size=text_config.hidden_size,
-        checkpoint_rows=text_config.sconv_kernel_size - 1,
-        kvconv_element_size=2,
-        hiddenconv_element_size=hiddenconv_element_size,
-        kv_scale_block_size=32 if attn_config.kv_cache_mxfp8 else 0,
-        kv_scale_element_size=1 if attn_config.kv_cache_mxfp8 else 0,
-    )
-    return fields, layer_kv_head_counts
-
-
-def _checkpoint_groups(prefix_granularity: int):
-    # Physical packing is aligned with the memory plan by the pool at
-    # construction; the recipe only declares the scheduler semantics.
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        PagedCacheGroupSpec,
-    )
-
-    return tuple(
-        PagedCacheGroupSpec(
-            group_id=group_id,
-            retention="full_history",
-            sliding_window_tokens=None,
-            family="state",
-            checkpoint_granularity=prefix_granularity,
-        )
-        for group_id in ("kvconv", "hiddenconv")
-    )
-
-
-def _workspace_bytes(
-    *,
-    text_config,
-    attn_config,
-    num_layers: int,
-    spec_tokens: int = 1,
-) -> int:
-    import torch
-
+def _conv_ring_bytes(*, text_config, attn_config, num_layers: int, spec_tokens: int):
     from tokenspeed.runtime.configs.inkling_config import inkling_conv_total_dim
 
     rows = int(attn_config.max_bs) + 2
@@ -220,121 +335,8 @@ def _workspace_bytes(
         int(text_config.sconv_kernel_size) - 1 + spec_tokens + max(spec_tokens - 2, 0)
     )
     conv_dim = inkling_conv_total_dim(text_config, attn_config.attn_tp_size)
-    element_size = torch.bfloat16.itemsize
     pending_bytes = rows * torch.bool.itemsize
-    return num_layers * rows * ring_rows * conv_dim * element_size + pending_bytes
-
-
-def prepare_inkling_cache(
-    *,
-    server_args,
-    model_config,
-    attn_config,
-    draft_model_config,
-    draft_attn_config,
-    cache_budget_bytes: int,
-    decode_input_tokens: int,
-    overlap_schedule_depth: int,
-):
-    """Build target and optional draft cache specs for Inkling."""
-    prefix_granularity = 128
-    fields, layer_kv_head_counts = _inkling_fields(
-        attn_config, model_config, prefix_granularity
-    )
-    layer_types = tuple(attn_config.layer_types)
-    text_config = model_config.hf_config.get_text_config()
-    draft_tokens = (
-        int(server_args.speculative_num_draft_tokens)
-        if draft_attn_config is not None
-        else 0
-    )
-    fixed_workspace_bytes = _workspace_bytes(
-        text_config=text_config,
-        attn_config=attn_config,
-        num_layers=text_config.num_hidden_layers,
-        spec_tokens=draft_tokens,
-    )
-
-    draft_fields = None
-    draft_layer_types = ()
-    draft_group_ids = ()
-    draft_layer_kv_head_counts = None
-    if draft_attn_config is not None:
-        draft_num_layers = draft_model_config.num_attention_layers
-        num_steps = server_args.speculative_num_steps
-        if num_steps > draft_num_layers:
-            raise ValueError(
-                f"Inkling MTP has {draft_num_layers} depth layers; "
-                f"--speculative-num-steps {num_steps} would wrap depths "
-                "with no trained meaning."
-            )
-        draft_layer_types = tuple(draft_attn_config.layer_types)
-        draft_group_ids = draft_layer_types
-        # Same recipe as the target: the depth layers get kvconv/hiddenconv
-        # checkpoint fields as continuation tenants of the existing groups,
-        # so the draft conv ring gains the same publish/restore bridges.
-        draft_fields, draft_layer_kv_head_counts = _inkling_fields(
-            draft_attn_config, draft_model_config, prefix_granularity
-        )
-        fixed_workspace_bytes += _workspace_bytes(
-            text_config=draft_model_config.hf_config.get_text_config(),
-            attn_config=draft_attn_config,
-            num_layers=draft_num_layers,
-            spec_tokens=draft_tokens,
-        )
-
-    max_padding_fraction = (
-        float("inf") if os.environ.get("INKLING_FP8_SCONV", "0") == "0" else 1.0
-    )
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        apply_pd_transfer_policies,
-        build_paged_cache_group_specs,
-    )
-
-    (
-        merged_fields,
-        merged_layer_types,
-        merged_group_ids,
-        merged_head_counts,
-        num_draft_layers,
-    ) = merge_continuation_layers(
-        fields=fields,
-        layer_types=layer_types,
-        group_ids=layer_types,
-        layer_kv_head_counts=layer_kv_head_counts,
-        draft_fields=draft_fields,
-        draft_layer_types=draft_layer_types,
-        draft_group_ids=draft_group_ids,
-        draft_layer_kv_head_counts=draft_layer_kv_head_counts,
-    )
-    # ONE spec derivation over the merged layers (shared groups validate
-    # for consistent policy), plus the paged sconv checkpoint groups
-    # (per-layer state columns outside the layer-type vocabulary); PD
-    # policies stamp the complete tuple. Target and draft share the
-    # sliding window width by construction (same architecture family).
-    group_specs = (
-        *build_paged_cache_group_specs(
-            layer_types=merged_layer_types,
-            group_ids=merged_group_ids,
-            sliding_window_tokens=attn_config.sliding_window_tokens,
-            prefix_granularity=prefix_granularity,
-        ),
-        *_checkpoint_groups(prefix_granularity),
-    )
-    if attn_config.pd_disaggregation_enabled:
-        group_specs = tuple(apply_pd_transfer_policies(group_specs))
-    return build_hybrid_cache_setup(
-        family="inkling",
-        server_args=server_args,
-        fields=merged_fields,
-        layer_types=merged_layer_types,
-        group_ids=merged_group_ids,
-        group_specs=group_specs,
-        state_dtypes={},
-        layer_kv_head_counts=merged_head_counts,
-        num_draft_layers=num_draft_layers,
-        cache_budget_bytes=cache_budget_bytes,
-        fixed_workspace_bytes=fixed_workspace_bytes,
-        prefix_granularity=prefix_granularity,
-        max_padding_fraction=max_padding_fraction,
+    return (
+        num_layers * rows * ring_rows * conv_dim * torch.bfloat16.itemsize
+        + pending_bytes
     )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
@@ -41,10 +41,10 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
     cache_dtype_bytes,
     cache_dtype_name,
+    mxfp8_kv_scale_fields,
     scatter_stored_dtype_name,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    MXFP8_KV_SCALE_TILE_TOKENS,
     CacheGroupSpec,
     apply_pd_transfer_policies,
 )
@@ -72,11 +72,10 @@ class InklingRecipe(CacheRecipe):
     @property
     @override
     def num_draft_layers(self) -> int:
-        if self.draft_attn_config is None:
-            return 0
-        num_layers = self.draft_model_config.num_attention_layers
+        """The base count, plus the one constraint Inkling's depths impose."""
+        num_layers = super().num_draft_layers
         num_steps = self.server_args.speculative_num_steps
-        if num_steps > num_layers:
+        if num_layers and num_steps > num_layers:
             raise ValueError(
                 f"Inkling MTP has {num_layers} depth layers; "
                 f"--speculative-num-steps {num_steps} would wrap depths "
@@ -150,12 +149,9 @@ class InklingRecipe(CacheRecipe):
     ) -> tuple[CacheFieldSpec, ...]:
         """This layer's attention pages. Its conv checkpoints are columns."""
         config = self._layer_config(layer_id)
+        # mxfp8_kv_scale_fields owns the page-span and head-dim constraints the
+        # interleaved scale layout imposes.
         mxfp8 = bool(config.kv_cache_mxfp8)
-        if mxfp8 and (self.prefix_granularity % 128 or config.head_dim != 128):
-            raise ValueError(
-                "Inkling MXFP8 scale fields require P divisible by 128 and "
-                "head_dim 128"
-            )
         kv_heads = self._layer_kv_heads(layer_id)
         kv_shape = (self.prefix_granularity, kv_heads, config.head_dim)
         kv_dtype = (
@@ -179,28 +175,12 @@ class InklingRecipe(CacheRecipe):
         )
         if not mxfp8:
             return fields
-        scale_dim = config.head_dim // 32
-        scale_shape = (
-            kv_heads,
-            self.prefix_granularity // MXFP8_KV_SCALE_TILE_TOKENS,
-            32,
-            scale_dim,
-            scale_dim,
-        )
-        scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
-        return fields + (
-            CacheFieldSpec(
-                f"layer.{layer_id}.k_scale",
-                f"unit.{occurrence}.k_scale",
-                scale_shape,
-                scale_dtype,
-            ),
-            CacheFieldSpec(
-                f"layer.{layer_id}.v_scale",
-                f"unit.{occurrence}.v_scale",
-                scale_shape,
-                scale_dtype,
-            ),
+        return fields + mxfp8_kv_scale_fields(
+            layer_id=layer_id,
+            occurrence=occurrence,
+            kv_heads=kv_heads,
+            head_dim=config.head_dim,
+            prefix_granularity=self.prefix_granularity,
         )
 
     def _conv_columns(self) -> dict[str, tuple[CacheFieldSpec, ...]]:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
@@ -1,24 +1,55 @@
-"""Kimi K3 cache layout, capacity, and setup recipe."""
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Kimi-K3 cache recipe: MLA latents plus KDA recurrent state groups.
+
+The MLA layers and the KDA state layers live in one arena at P=128. MLA pages
+are dense and pin a 12:1 packing; the state groups pack to match the MLA
+plane's byte width so no parent is wasted.
+"""
 
 from __future__ import annotations
 
 import math
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from functools import cached_property
 
 import torch
+from typing_extensions import override
 
-from tokenspeed.runtime.layers.attention.kv_cache.recipes import (
-    configured_token_limit,
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
+    CacheGroupDeclaration,
+    CacheRecipe,
 )
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-    mla_cache_fields,
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.cache_runtime import (
+    require_positive_int,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
-    CacheMemoryPlan,
-    continue_layer_fields,
-    solve_cache_layout,
+    CacheLayout,
+    cache_dtype_name,
+    scatter_stored_dtype_name,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    FULL_ATTENTION,
+    LINEAR_ATTENTION,
 )
 
 _KIMI_K3_LAYERS = 93
@@ -27,23 +58,6 @@ _KIMI_K3_MLA_LAYERS = 24
 _KIMI_K3_PREFIX_GRANULARITY = 128
 _KIMI_K3_STATE_GROUPS = 3
 _KIMI_K3_MLA_PACKING = 12
-FULL_ATTENTION = "full_attention"
-LINEAR_ATTENTION = "linear_attention"
-
-if TYPE_CHECKING:
-    from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
-
-
-def _require_positive_int(name: str, value: int) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise ValueError(f"{name} must be a positive integer, got {value!r}")
-    return value
-
-
-def _require_non_negative_int(name: str, value: int) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
-    return value
 
 
 def _one_based_layers(value: object, name: str, num_layers: int) -> tuple[int, ...]:
@@ -59,459 +73,281 @@ def _one_based_layers(value: object, name: str, num_layers: int) -> tuple[int, .
     return tuple(sorted(layers))
 
 
-def kimi_k3_layer_group_ids(text_config: KimiLinearConfig) -> tuple[str, ...]:
-    """Map every Kimi-K3 layer to one full-attention or KDA cache group."""
-    num_layers = _require_positive_int(
-        "num_hidden_layers", text_config.num_hidden_layers
-    )
-    linear = text_config.linear_attn_config
-    if not isinstance(linear, Mapping):
-        raise TypeError("linear_attn_config must be a mapping")
-    kda_layers = _one_based_layers(
-        linear.get("kda_layers"), "linear_attn_config.kda_layers", num_layers
-    )
-    kda_layer_ids = tuple(layer - 1 for layer in kda_layers)
-    kda_layer_id_set = set(kda_layer_ids)
-    full_layer_ids = tuple(
-        layer_id for layer_id in range(num_layers) if layer_id not in kda_layer_id_set
-    )
-    if not kda_layer_ids or not full_layer_ids:
-        raise ValueError(
-            "Kimi-K3 cache requires both KDA and full-attention layers, got "
-            f"{len(kda_layer_ids)} and {len(full_layer_ids)}"
+class KimiK3Recipe(CacheRecipe):
+    """Kimi-K3: MLA full-attention layers plus three KDA state groups.
+
+    Draft MLA layers are continuation layers of the one big model and join the
+    target's full-attention group, sharing its packing and page-id space.
+    """
+
+    family = "kimi_k3"
+
+    # ---- layer vocabulary ----
+
+    @cached_property
+    def _text_config(self):
+        hf_config = self.model_config.hf_config
+        return getattr(hf_config, "text_config", hf_config)
+
+    @cached_property
+    def target_group_ids(self) -> tuple[str, ...]:
+        """Map every target layer to one full-attention or KDA cache group."""
+        num_layers = require_positive_int(
+            "num_hidden_layers", self._text_config.num_hidden_layers
         )
-    if num_layers == _KIMI_K3_LAYERS and (
-        len(kda_layer_ids) != _KIMI_K3_KDA_LAYERS
-        or len(full_layer_ids) != _KIMI_K3_MLA_LAYERS
-    ):
-        raise ValueError(
-            "93-layer Kimi-K3 requires 69 KDA and 24 MLA layers, got "
-            f"{len(kda_layer_ids)} and {len(full_layer_ids)}"
+        linear = self._text_config.linear_attn_config
+        if not isinstance(linear, Mapping):
+            raise TypeError("linear_attn_config must be a mapping")
+        kda_layers = _one_based_layers(
+            linear.get("kda_layers"), "linear_attn_config.kda_layers", num_layers
         )
-    if len(kda_layer_ids) % _KIMI_K3_STATE_GROUPS:
-        raise ValueError(
-            "Kimi-K3 cache requires the KDA layer count to divide into "
-            f"{_KIMI_K3_STATE_GROUPS} state groups, got {len(kda_layer_ids)}"
+        kda_layer_ids = tuple(layer - 1 for layer in kda_layers)
+        kda_layer_id_set = set(kda_layer_ids)
+        full_layer_ids = tuple(
+            layer_id
+            for layer_id in range(num_layers)
+            if layer_id not in kda_layer_id_set
         )
-    if "full_attn_layers" in linear:
-        declared = [
-            layer
-            for layer in linear["full_attn_layers"]
-            if not (isinstance(layer, int) and layer > num_layers)
-        ]
-        declared_full = _one_based_layers(
-            declared,
-            "linear_attn_config.full_attn_layers",
-            num_layers,
-        )
-        if declared_full != tuple(layer_id + 1 for layer_id in full_layer_ids):
+        if not kda_layer_ids or not full_layer_ids:
             raise ValueError(
-                "linear_attn_config.full_attn_layers must equal the "
-                "kda_layers complement"
+                "Kimi-K3 cache requires both KDA and full-attention layers, got "
+                f"{len(kda_layer_ids)} and {len(full_layer_ids)}"
             )
+        if num_layers == _KIMI_K3_LAYERS and (
+            len(kda_layer_ids) != _KIMI_K3_KDA_LAYERS
+            or len(full_layer_ids) != _KIMI_K3_MLA_LAYERS
+        ):
+            raise ValueError(
+                "93-layer Kimi-K3 requires 69 KDA and 24 MLA layers, got "
+                f"{len(kda_layer_ids)} and {len(full_layer_ids)}"
+            )
+        if len(kda_layer_ids) % _KIMI_K3_STATE_GROUPS:
+            raise ValueError(
+                "Kimi-K3 cache requires the KDA layer count to divide into "
+                f"{_KIMI_K3_STATE_GROUPS} state groups, got {len(kda_layer_ids)}"
+            )
+        if "full_attn_layers" in linear:
+            declared = [
+                layer
+                for layer in linear["full_attn_layers"]
+                if not (isinstance(layer, int) and layer > num_layers)
+            ]
+            declared_full = _one_based_layers(
+                declared,
+                "linear_attn_config.full_attn_layers",
+                num_layers,
+            )
+            if declared_full != tuple(layer_id + 1 for layer_id in full_layer_ids):
+                raise ValueError(
+                    "linear_attn_config.full_attn_layers must equal the "
+                    "kda_layers complement"
+                )
 
-    group_ids = [FULL_ATTENTION] * num_layers
-    per_group = len(kda_layer_ids) // _KIMI_K3_STATE_GROUPS
-    for index, layer_id in enumerate(kda_layer_ids):
-        group_ids[layer_id] = f"{LINEAR_ATTENTION}_{index // per_group}"
-    return tuple(group_ids)
+        group_ids = [FULL_ATTENTION] * num_layers
+        per_group = len(kda_layer_ids) // _KIMI_K3_STATE_GROUPS
+        for index, layer_id in enumerate(kda_layer_ids):
+            group_ids[layer_id] = f"{LINEAR_ATTENTION}_{index // per_group}"
+        return tuple(group_ids)
 
+    @property
+    @override
+    def num_target_layers(self) -> int:
+        return len(self.target_group_ids)
 
-def kimi_k3_cache_fields(
-    *,
-    layer_group_ids,
-    prefix_granularity,
-    latent_width,
-    mla_element_size,
-    conv_shape,
-    conv_element_size,
-    recurrent_shape,
-    recurrent_element_size,
-) -> tuple[CacheFieldSpec, ...]:
-    """Describe Kimi-K3 full-attention MLA KV and KDA state."""
-    if prefix_granularity <= 0 or latent_width <= 0 or mla_element_size <= 0:
-        raise ValueError("Kimi-K3 MLA geometry must be positive")
-    if (
-        not conv_shape
-        or not recurrent_shape
-        or conv_element_size <= 0
-        or recurrent_element_size <= 0
-    ):
-        raise ValueError("Kimi-K3 KDA state geometry must be positive")
-    occurrences: dict[str, int] = {}
-    fields = []
-    for layer_id, group_id in enumerate(layer_group_ids):
-        slot = occurrences.get(group_id, 0)
-        occurrences[group_id] = slot + 1
-        plane_id = f"slot.{slot}"
-        if group_id == "full_attention":
-            fields.append(
+    @property
+    @override
+    def num_draft_layers(self) -> int:
+        if self.draft_attn_config is None:
+            return 0
+        return self.draft_model_config.num_attention_layers
+
+    @cached_property
+    def group_ids(self) -> tuple[str, ...]:
+        return self.target_group_ids + (FULL_ATTENTION,) * self.num_draft_layers
+
+    @cached_property
+    def layer_types(self) -> tuple[str, ...]:
+        return tuple(
+            FULL_ATTENTION if group_id == FULL_ATTENTION else LINEAR_ATTENTION
+            for group_id in self.group_ids
+        )
+
+    # ---- geometry ----
+
+    @property
+    @override
+    def prefix_granularity(self) -> int:
+        return _KIMI_K3_PREFIX_GRANULARITY
+
+    @property
+    @override
+    def max_padding_fraction(self) -> float:
+        # A draft adds MLA planes of its own; the target-only bound would
+        # reject the wider arena they imply.
+        return float("inf") if self.num_draft_layers else 0.25
+
+    # ---- fields ----
+
+    @cached_property
+    def _kda_shapes(self):
+        """(conv shape, recurrent shape) per rank, validated against tp size."""
+        tp_size = self.attn_config.attn_tp_size
+        if tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {tp_size}")
+        cache_dtype = self.attn_config.kv_cache_dtype
+        if cache_dtype not in (torch.float8_e4m3fn, torch.bfloat16):
+            raise ValueError(
+                "Kimi-K3 cache requires mla_cache_dtype in "
+                f"{{torch.float8_e4m3fn, torch.bfloat16}}, got {cache_dtype}"
+            )
+        if self.attn_config.kv_cache_quant_method == "per_token_head":
+            raise ValueError("Kimi-K3 cache does not support per_token_head MLA cache")
+        if getattr(self._text_config, "mla_use_nope", None) is not True:
+            raise ValueError("Kimi-K3 cache requires mla_use_nope=True")
+        linear = self._text_config.linear_attn_config
+        num_heads = int(linear["num_heads"])
+        head_dim = int(linear["head_dim"])
+        kernel_size = int(linear["short_conv_kernel_size"])
+        if num_heads % tp_size:
+            raise ValueError(
+                f"KDA num_heads={num_heads} must be divisible by tp_size={tp_size}"
+            )
+        return (
+            (3 * num_heads * head_dim // tp_size, kernel_size - 1),
+            (num_heads // tp_size, head_dim, head_dim),
+        )
+
+    @override
+    def fields_for_layer(
+        self, layer_id: int, group_id: str, occurrence: int
+    ) -> tuple[CacheFieldSpec, ...]:
+        plane_id = f"slot.{occurrence}"
+        if group_id == FULL_ATTENTION:
+            config = (
+                self.attn_config
+                if layer_id < self.num_target_layers
+                else self.draft_attn_config
+            )
+            latent_width = config.kv_lora_rank + config.qk_rope_head_dim
+            return (
                 CacheFieldSpec(
-                    group_id,
                     f"layer.{layer_id}.latent_kv",
                     plane_id,
-                    (prefix_granularity, 1, latent_width),
-                    mla_element_size,
+                    (self.prefix_granularity, 1, latent_width),
+                    scatter_stored_dtype_name(config.kv_cache_dtype),
+                ),
+            )
+        conv_shape, recurrent_shape = self._kda_shapes
+        return (
+            CacheFieldSpec(
+                f"layer.{layer_id}.conv_state",
+                plane_id,
+                conv_shape,
+                cache_dtype_name(torch.bfloat16),
+                exact_page_stride=False,
+            ),
+            CacheFieldSpec(
+                f"layer.{layer_id}.recurrent_state",
+                plane_id,
+                recurrent_shape,
+                cache_dtype_name(torch.float32),
+                exact_page_stride=False,
+            ),
+        )
+
+    # ---- packing: state groups match the MLA plane's byte width ----
+
+    @override
+    def packing(self, groups: tuple[CacheGroupDeclaration, ...]) -> Mapping[str, int]:
+        fields_by_group = {spec.group_id: fields for spec, fields in groups}
+        mla_plane_bytes = _KIMI_K3_MLA_PACKING * next(
+            field.payload_bytes for field in fields_by_group[FULL_ATTENTION]
+        )
+        first_state = f"{LINEAR_ATTENTION}_0"
+        linear_plane_bytes = sum(
+            field.payload_bytes
+            for field in fields_by_group[first_state]
+            if field.plane_id == "slot.0"
+        )
+        linear_packing = max(1, mla_plane_bytes // linear_plane_bytes)
+        return {
+            spec.group_id: (
+                _KIMI_K3_MLA_PACKING
+                if spec.group_id == FULL_ATTENTION
+                else linear_packing
+            )
+            for spec, _ in groups
+        }
+
+    @override
+    def check_layout(self, layout: CacheLayout) -> None:
+        """One plane per MLA layer, plus one per draft layer -- no more.
+
+        The KDA state groups pack to the MLA plane's byte width precisely so
+        they ride inside those planes; a plane of their own means the packing
+        did not divide and the parent grew.
+        """
+        num_mla_layers = sum(
+            group_id == FULL_ATTENTION for group_id in self.target_group_ids
+        )
+        expected = num_mla_layers + self.num_draft_layers
+        if len(layout.plane_bytes) != expected:
+            raise ValueError(
+                f"Kimi-K3 LCM requires {num_mla_layers} target planes (one per "
+                f"MLA layer) plus {self.num_draft_layers} draft planes, got "
+                f"{len(layout.plane_bytes)}"
+            )
+
+    # ---- capacity: the scheduler's concurrency decides, then a search ----
+
+    @override
+    def num_lcm_blocks(self, layout: CacheLayout) -> int:
+        num_lcm_blocks = super().num_lcm_blocks(layout)
+        token_limit = self.token_limit
+        if token_limit is None:
+            return num_lcm_blocks
+        return min(num_lcm_blocks, self.parents_needed(layout, token_limit))
+
+    @override
+    def token_capacity(self, layout: CacheLayout, num_lcm_blocks: int) -> int:
+        upper = self.token_limit
+        if upper is None:
+            full_packing = dict(layout.group_packing)[FULL_ATTENTION]
+            upper = num_lcm_blocks * full_packing * layout.prefix_granularity
+        return self._capacity_from_parents(layout, num_lcm_blocks, upper_bound=upper)
+
+    @override
+    def parents_needed(self, layout: CacheLayout, token_capacity: int) -> int:
+        """Physical parents this capacity needs at the configured concurrency.
+
+        K3's KDA state rides inside the MLA planes, so its demand is a pair of
+        closed forms (history pages for MLA, a fixed working set for the state
+        groups) rather than the contract's per-retention page-count formula.
+        """
+        page_tokens = layout.prefix_granularity
+        limits = self.scheduler_limits
+        max_live_requests = limits["max_live_requests"]
+        depth = limits["overlap_schedule_depth"]
+        if depth not in (0, 1):
+            raise ValueError(f"overlap_schedule_depth must be 0 or 1, got {depth}")
+        if depth and limits["decode_input_tokens"] == 0:
+            raise ValueError("overlapped cache sizing requires decode_input_tokens > 0")
+        protected_pages = max_live_requests * math.ceil(
+            depth * limits["decode_input_tokens"] / page_tokens
+        )
+        scheduled_pages = math.ceil(
+            min(limits["max_scheduled_tokens"], token_capacity) / page_tokens
+        )
+        parents = 0
+        for group_id, packing in layout.group_packing:
+            if group_id == FULL_ATTENTION:
+                child_pages = (
+                    math.ceil(token_capacity / page_tokens)
+                    + max_live_requests
+                    - 1
+                    + protected_pages
                 )
-            )
-            continue
-        fields.extend(
-            (
-                CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.conv_state",
-                    plane_id,
-                    tuple(conv_shape),
-                    conv_element_size,
-                    exact_page_stride=False,
-                ),
-                CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.recurrent_state",
-                    plane_id,
-                    tuple(recurrent_shape),
-                    recurrent_element_size,
-                    exact_page_stride=False,
-                ),
-            )
-        )
-    return tuple(fields)
-
-
-def build_kimi_k3_cache_fields(
-    text_config: KimiLinearConfig,
-    *,
-    tp_size: int,
-    mla_cache_dtype: torch.dtype,
-    mla_quant_method: str | None,
-) -> tuple[CacheFieldSpec, ...]:
-    """Build target fields from the Kimi-K3 model configuration."""
-    tp_size = _require_positive_int("tp_size", tp_size)
-    # fp8_e4m3 is the memory-lean default (matches the Blackwell tokenspeed_mla
-    # kernels). bf16 is the Hopper path: FlashMLA has no SM90 dense-fp8 MLA
-    # kernel, so on SM90 the MLA layers run bf16 (flashinfer ragged prefill +
-    # bf16 FlashMLA decode), mirroring how vLLM/sglang serve K3 on Hopper.
-    if mla_cache_dtype not in (torch.float8_e4m3fn, torch.bfloat16):
-        raise ValueError(
-            "Kimi-K3 cache requires mla_cache_dtype in "
-            "{torch.float8_e4m3fn, torch.bfloat16}, got "
-            f"{mla_cache_dtype}"
-        )
-    if mla_quant_method == "per_token_head":
-        raise ValueError("Kimi-K3 cache does not support per_token_head MLA cache")
-    if getattr(text_config, "mla_use_nope", None) is not True:
-        raise ValueError("Kimi-K3 cache requires mla_use_nope=True")
-
-    linear = text_config.linear_attn_config
-    num_heads = _require_positive_int(
-        "linear_attn_config.num_heads", linear.get("num_heads")
-    )
-    head_dim = _require_positive_int(
-        "linear_attn_config.head_dim", linear.get("head_dim")
-    )
-    kernel_size = _require_positive_int(
-        "linear_attn_config.short_conv_kernel_size",
-        linear.get("short_conv_kernel_size"),
-    )
-    if num_heads % tp_size:
-        raise ValueError(
-            f"KDA num_heads={num_heads} must be divisible by tp_size={tp_size}"
-        )
-    kv_lora_rank = _require_positive_int("kv_lora_rank", text_config.kv_lora_rank)
-    rope_dim = _require_positive_int("qk_rope_head_dim", text_config.qk_rope_head_dim)
-    return kimi_k3_cache_fields(
-        layer_group_ids=kimi_k3_layer_group_ids(text_config),
-        prefix_granularity=_KIMI_K3_PREFIX_GRANULARITY,
-        latent_width=kv_lora_rank + rope_dim,
-        mla_element_size=mla_cache_dtype.itemsize,
-        conv_shape=(3 * num_heads * head_dim // tp_size, kernel_size - 1),
-        conv_element_size=torch.bfloat16.itemsize,
-        recurrent_shape=(num_heads // tp_size, head_dim, head_dim),
-        recurrent_element_size=torch.float32.itemsize,
-    )
-
-
-def solve_kimi_k3_cache_layout(
-    text_config: KimiLinearConfig,
-    *,
-    tp_size: int,
-    mla_cache_dtype: torch.dtype,
-    mla_quant_method: str | None,
-    draft_fields=None,
-    draft_layer_count: int = 0,
-):
-    """Solve Kimi-K3's capacity-independent P=128 LCM layout.
-
-    ``draft_fields`` join the same solve as continuation layers of the one
-    big model: their field ids are renumbered after the target's 93 layers
-    (``layer.93``, ``layer.94``, ...) so they share the full-attention
-    group's packing and page-id space with globally unique ids.
-    """
-    fields = build_kimi_k3_cache_fields(
-        text_config,
-        tp_size=tp_size,
-        mla_cache_dtype=mla_cache_dtype,
-        mla_quant_method=mla_quant_method,
-    )
-    layer_group_ids = kimi_k3_layer_group_ids(text_config)
-    if (
-        isinstance(draft_layer_count, bool)
-        or not isinstance(draft_layer_count, int)
-        or draft_layer_count < 0
-    ):
-        raise ValueError("draft_layer_count must be a non-negative integer")
-    num_draft_layers = 0
-    if draft_fields is not None:
-        draft_fields = tuple(draft_fields)
-        if not draft_fields:
-            raise ValueError("draft_fields must not be empty")
-        if draft_layer_count < 1:
-            raise ValueError("draft_fields require a positive draft_layer_count")
-        num_draft_layers = draft_layer_count
-        continued = continue_layer_fields(
-            draft_fields,
-            first_layer_id=len(layer_group_ids),
-        )
-        fields += continued
-    elif draft_layer_count:
-        raise ValueError("draft_layer_count requires draft_fields")
-    mla_plane_bytes = _KIMI_K3_MLA_PACKING * next(
-        field.payload_bytes for field in fields if field.group_id == FULL_ATTENTION
-    )
-    linear_plane_bytes = sum(
-        field.payload_bytes
-        for field in fields
-        if field.group_id == f"{LINEAR_ATTENTION}_0" and field.plane_id == "slot.0"
-    )
-    linear_packing = max(1, mla_plane_bytes // linear_plane_bytes)
-    packing = {
-        FULL_ATTENTION: _KIMI_K3_MLA_PACKING,
-        f"{LINEAR_ATTENTION}_0": linear_packing,
-        f"{LINEAR_ATTENTION}_1": linear_packing,
-        f"{LINEAR_ATTENTION}_2": linear_packing,
-    }
-
-    max_padding_fraction = float("inf") if num_draft_layers else 0.25
-    layout = solve_cache_layout(
-        fields,
-        prefix_granularity=_KIMI_K3_PREFIX_GRANULARITY,
-        cache_blocks_per_lcm_block=packing,
-        alignment=256,
-        max_padding_fraction=max_padding_fraction,
-    )
-    if dict(layout.group_packing) != packing:
-        raise ValueError(
-            f"Kimi-K3 LCM packing must be {packing}, got {dict(layout.group_packing)}"
-        )
-    num_mla_layers = sum(gid == FULL_ATTENTION for gid in layer_group_ids)
-    if len(layout.plane_bytes) != num_mla_layers + num_draft_layers:
-        raise ValueError(
-            f"Kimi-K3 LCM requires {num_mla_layers} target planes (one per "
-            f"MLA layer) plus {num_draft_layers} draft planes, got "
-            f"{len(layout.plane_bytes)}"
-        )
-    return layout
-
-
-def kimi_k3_lcm_blocks_needed(
-    plan: CacheMemoryPlan,
-    *,
-    token_capacity: int,
-    max_scheduled_tokens: int,
-    max_live_requests: int,
-    decode_input_tokens: int = 1,
-    overlap_schedule_depth: int = 0,
-) -> int:
-    """Return physical LCM parents needed at the configured concurrency."""
-    _require_positive_int("plan.prefix_granularity", plan.prefix_granularity)
-    _require_positive_int("token_capacity", token_capacity)
-    _require_non_negative_int("max_scheduled_tokens", max_scheduled_tokens)
-    _require_positive_int("max_live_requests", max_live_requests)
-    _require_non_negative_int("decode_input_tokens", decode_input_tokens)
-    if overlap_schedule_depth not in (0, 1):
-        raise ValueError(
-            f"overlap_schedule_depth must be 0 or 1, got {overlap_schedule_depth}"
-        )
-    if overlap_schedule_depth and decode_input_tokens == 0:
-        raise ValueError("overlapped cache sizing requires decode_input_tokens > 0")
-
-    page_tokens = plan.prefix_granularity
-    protected_pages = max_live_requests * math.ceil(
-        overlap_schedule_depth * decode_input_tokens / page_tokens
-    )
-    scheduled_pages = math.ceil(min(max_scheduled_tokens, token_capacity) / page_tokens)
-    total_lcm_blocks = 0
-    for group in plan.groups:
-        if group.group_id == FULL_ATTENTION:
-            child_pages = (
-                math.ceil(token_capacity / page_tokens)
-                + max_live_requests
-                - 1
-                + protected_pages
-            )
-        else:
-            child_pages = 2 * max_live_requests + scheduled_pages + protected_pages
-        total_lcm_blocks += math.ceil(child_pages / group.cache_blocks_per_lcm_block)
-    return total_lcm_blocks
-
-
-def kimi_k3_token_capacity_for_cache_pool(
-    plan: CacheMemoryPlan,
-    *,
-    num_lcm_blocks: int,
-    max_scheduled_tokens: int,
-    max_live_requests: int,
-    decode_input_tokens: int = 1,
-    overlap_schedule_depth: int = 0,
-    upper_bound_tokens: int | None = None,
-) -> int:
-    """Invert :func:`kimi_k3_lcm_blocks_needed` by monotonic binary search."""
-    _require_positive_int("num_lcm_blocks", num_lcm_blocks)
-    if upper_bound_tokens is None:
-        full_group = plan.group(FULL_ATTENTION)
-        upper_bound_tokens = (
-            num_lcm_blocks
-            * full_group.cache_blocks_per_lcm_block
-            * plan.prefix_granularity
-        )
-    _require_positive_int("upper_bound_tokens", upper_bound_tokens)
-
-    low, high = 0, upper_bound_tokens
-    while low < high:
-        candidate = (low + high + 1) // 2
-        required = kimi_k3_lcm_blocks_needed(
-            plan,
-            token_capacity=candidate,
-            max_scheduled_tokens=max_scheduled_tokens,
-            max_live_requests=max_live_requests,
-            decode_input_tokens=decode_input_tokens,
-            overlap_schedule_depth=overlap_schedule_depth,
-        )
-        if required <= num_lcm_blocks:
-            low = candidate
-        else:
-            high = candidate - 1
-    if low == 0:
-        raise ValueError(
-            f"num_lcm_blocks={num_lcm_blocks} cannot admit one token with "
-            "the configured Kimi-K3 cache scheduler limits"
-        )
-    return low
-
-
-def prepare_kimi_k3_cache(
-    *,
-    server_args,
-    model_config,
-    attn_config,
-    draft_model_config,
-    draft_attn_config,
-    cache_budget_bytes: int,
-    decode_input_tokens: int,
-    overlap_schedule_depth: int,
-):
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
-        CachePoolSpec,
-        CacheSetup,
-    )
-
-    text_config = getattr(model_config.hf_config, "text_config", model_config.hf_config)
-    group_ids = kimi_k3_layer_group_ids(text_config)
-    layer_types = tuple(
-        FULL_ATTENTION if group_id == FULL_ATTENTION else LINEAR_ATTENTION
-        for group_id in group_ids
-    )
-    _, _, conv_dtype, recurrent_dtype, _ = text_config.mamba2_cache_params
-    state_dtypes = {
-        f"layer.{layer_id}.conv_state": conv_dtype
-        for layer_id, layer_type in enumerate(layer_types)
-        if layer_type == LINEAR_ATTENTION
-    } | {
-        f"layer.{layer_id}.recurrent_state": recurrent_dtype
-        for layer_id, layer_type in enumerate(layer_types)
-        if layer_type == LINEAR_ATTENTION
-    }
-    # One big model, one solve, one spec: draft MLA layers continue the
-    # target's layer numbering and join the same solve, sharing the
-    # full-attention group's packing and page-id space.
-    draft_fields = None
-    draft_layer_types = ()
-    num_draft_layers = 0
-    if draft_attn_config is not None:
-        num_draft_layers = draft_model_config.num_attention_layers
-        draft_layer_types = (FULL_ATTENTION,) * num_draft_layers
-        draft_fields = mla_cache_fields(
-            layer_group_ids=draft_layer_types,
-            prefix_granularity=_KIMI_K3_PREFIX_GRANULARITY,
-            latent_width=(
-                draft_attn_config.kv_lora_rank + draft_attn_config.qk_rope_head_dim
-            ),
-            element_size=draft_attn_config.kv_cache_dtype.itemsize,
-        )
-    merged_layout = solve_kimi_k3_cache_layout(
-        text_config,
-        tp_size=attn_config.attn_tp_size,
-        mla_cache_dtype=attn_config.kv_cache_dtype,
-        mla_quant_method=attn_config.kv_cache_quant_method or None,
-        draft_fields=draft_fields,
-        draft_layer_count=num_draft_layers,
-    )
-    reference_plan = merged_layout.with_num_lcm_blocks(1)
-
-    num_lcm_blocks = cache_budget_bytes // merged_layout.lcm_block_bytes - 1
-    if num_lcm_blocks < 1:
-        raise ValueError(
-            "Kimi-K3 cache budget must hold a null parent and one usable LCM parent"
-        )
-
-    token_limit = configured_token_limit(server_args)
-    sizing = {
-        "max_scheduled_tokens": server_args.chunked_prefill_size,
-        "max_live_requests": attn_config.max_bs,
-        "decode_input_tokens": decode_input_tokens,
-        "overlap_schedule_depth": overlap_schedule_depth,
-    }
-    if token_limit is not None:
-        num_lcm_blocks = min(
-            num_lcm_blocks,
-            kimi_k3_lcm_blocks_needed(
-                reference_plan,
-                token_capacity=token_limit,
-                **sizing,
-            ),
-        )
-    admitted_tokens = kimi_k3_token_capacity_for_cache_pool(
-        reference_plan,
-        num_lcm_blocks=num_lcm_blocks,
-        upper_bound_tokens=token_limit,
-        **sizing,
-    )
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        build_paged_cache_group_specs,
-    )
-
-    merged_plan = merged_layout.with_num_lcm_blocks(num_lcm_blocks)
-    # ONE spec derivation over the merged layers (draft MLA layers all
-    # join the shared full-attention group).
-    merged_layer_types = layer_types + draft_layer_types
-    merged_group_ids = group_ids + draft_layer_types
-    return CacheSetup(
-        spec=CachePoolSpec(
-            family="kimi_k3",
-            memory_plan=merged_plan,
-            layer_types=merged_layer_types,
-            layer_group_ids=merged_group_ids,
-            paged_cache_group_specs=build_paged_cache_group_specs(
-                layer_types=merged_layer_types,
-                group_ids=merged_group_ids,
-                sliding_window_tokens=None,
-                prefix_granularity=merged_plan.prefix_granularity,
-                pd_disaggregation_enabled=attn_config.pd_disaggregation_enabled,
-            ),
-            state_field_dtypes=state_dtypes,
-            token_capacity=admitted_tokens,
-        ),
-        num_draft_layers=num_draft_layers,
-        cache_budget_bytes=cache_budget_bytes,
-        fixed_workspace_bytes=0,
-    )
+            else:
+                child_pages = 2 * max_live_requests + scheduled_pages + protected_pages
+            parents += math.ceil(child_pages / packing)
+        return parents

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
@@ -154,13 +154,6 @@ class KimiK3Recipe(CacheRecipe):
     def num_target_layers(self) -> int:
         return len(self.target_group_ids)
 
-    @property
-    @override
-    def num_draft_layers(self) -> int:
-        if self.draft_attn_config is None:
-            return 0
-        return self.draft_model_config.num_attention_layers
-
     @cached_property
     def group_ids(self) -> tuple[str, ...]:
         return self.target_group_ids + (FULL_ATTENTION,) * self.num_draft_layers

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
@@ -41,6 +41,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
     CacheLayout,
     cache_dtype_name,
+    mxfp8_kv_scale_fields,
     scatter_stored_dtype_name,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
@@ -64,13 +65,6 @@ class OrdinaryRecipe(CacheRecipe):
         self.family = family
 
     # ---- layer vocabulary ----
-
-    @property
-    @override
-    def num_draft_layers(self) -> int:
-        if self.draft_attn_config is None:
-            return 0
-        return self.draft_model_config.num_attention_layers
 
     @cached_property
     def group_ids(self) -> tuple[str, ...]:
@@ -240,22 +234,12 @@ def _mha_layer_fields(config, layer_id: int, occurrence: int):
     )
     if not mxfp8:
         return fields
-    scale_dim = head_dim // 32
-    scale_shape = (kv_heads, 32, scale_dim, scale_dim)
-    scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
-    return fields + (
-        CacheFieldSpec(
-            f"layer.{layer_id}.k_scale",
-            f"unit.{occurrence}.k_scale",
-            scale_shape,
-            scale_dtype,
-        ),
-        CacheFieldSpec(
-            f"layer.{layer_id}.v_scale",
-            f"unit.{occurrence}.v_scale",
-            scale_shape,
-            scale_dtype,
-        ),
+    return fields + mxfp8_kv_scale_fields(
+        layer_id=layer_id,
+        occurrence=occurrence,
+        kv_heads=kv_heads,
+        head_dim=head_dim,
+        prefix_granularity=config.prefix_granularity,
     )
 
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
@@ -1,340 +1,166 @@
-"""Full-attention cache recipes shared by MHA and MLA models."""
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The four ordinary cache families: MHA, MLA, DSA, MSA.
+
+One recipe serves all four, and a heterogeneous draft too: what a layer costs
+is dispatched on the attention config that owns it, so an MLA target with an
+MHA draft is just layers with two different geometries in one plan.
+"""
 
 from __future__ import annotations
 
-from tokenspeed.runtime.layers.attention.kv_cache.recipes import (
-    configured_token_limit,
+from collections.abc import Mapping
+from functools import cached_property
+
+import torch
+from typing_extensions import override
+
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
+    CacheGroupDeclaration,
+    CacheRecipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
-    merge_continuation_layers,
-    solve_cache_layout,
+    CacheLayout,
+    cache_dtype_name,
+    scatter_stored_dtype_name,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    FULL_ATTENTION,
     MXFP8_KV_SCALE_TILE_TOKENS,
+    hybrid_slab_group_size,
+    layer_group_ids,
 )
 
 
-def mla_cache_fields(
-    *,
-    layer_group_ids,
-    prefix_granularity,
-    latent_width,
-    element_size,
-) -> tuple[CacheFieldSpec, ...]:
-    """Describe MLA full-attention cache fields."""
-    if prefix_granularity <= 0 or latent_width <= 0 or element_size <= 0:
-        raise ValueError("MLA full-attention geometry must be positive")
-    occurrences: dict[str, int] = {}
-    fields = []
-    for layer_id, group_id in enumerate(layer_group_ids):
-        slot = occurrences.get(group_id, 0)
-        occurrences[group_id] = slot + 1
-        fields.append(
-            CacheFieldSpec(
-                group_id,
-                f"layer.{layer_id}.latent_kv",
-                f"slot.{slot}",
-                (prefix_granularity, 1, latent_width),
-                element_size,
-            )
-        )
-    return tuple(fields)
+class OrdinaryRecipe(CacheRecipe):
+    """MHA / MLA / DSA / MSA: one cache group per attention structure.
 
-
-def mha_cache_fields(
-    *,
-    layer_group_ids,
-    prefix_granularity,
-    kv_heads,
-    head_dim,
-    kv_element_size,
-    kv_scale_block_size=0,
-    kv_scale_element_size=0,
-) -> tuple[CacheFieldSpec, ...]:
-    """Describe fixed per-layer MHA views and their physical placement."""
-    if prefix_granularity <= 0 or kv_heads <= 0 or head_dim <= 0:
-        raise ValueError("MHA full-attention geometry must be positive")
-    if kv_element_size <= 0:
-        raise ValueError("MHA KV element size must be positive")
-    if bool(kv_scale_block_size) != bool(kv_scale_element_size):
-        raise ValueError(
-            "kv_scale_block_size and kv_scale_element_size must both be zero "
-            "or both be positive"
-        )
-    if kv_scale_block_size and head_dim % kv_scale_block_size:
-        raise ValueError("head_dim must be divisible by kv_scale_block_size")
-
-    occurrences: dict[str, int] = {}
-    fields = []
-    for layer_id, group_id in enumerate(layer_group_ids):
-        unit = occurrences.get(group_id, 0)
-        occurrences[group_id] = unit + 1
-        shape = (prefix_granularity, kv_heads, head_dim)
-        fields.extend(
-            (
-                CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.k",
-                    f"unit.{unit}.k",
-                    shape,
-                    kv_element_size,
-                ),
-                CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.v",
-                    f"unit.{unit}.v",
-                    shape,
-                    kv_element_size,
-                ),
-            )
-        )
-        if kv_scale_block_size:
-            scale_dim = head_dim // kv_scale_block_size
-            scale_shape = (
-                (kv_heads, 32, scale_dim, scale_dim)
-                if prefix_granularity == MXFP8_KV_SCALE_TILE_TOKENS
-                else (prefix_granularity, kv_heads, scale_dim)
-            )
-            fields.extend(
-                (
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.k_scale",
-                        f"unit.{unit}.k_scale",
-                        scale_shape,
-                        kv_scale_element_size,
-                    ),
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.v_scale",
-                        f"unit.{unit}.v_scale",
-                        scale_shape,
-                        kv_scale_element_size,
-                    ),
-                )
-            )
-    return tuple(fields)
-
-
-def draft_cache_fields(
-    *,
-    layer_group_ids,
-    enabled_layer_ids,
-    prefix_granularity,
-    layer_kv_heads,
-    head_dim,
-    kv_element_size,
-    kv_scale_block_size=0,
-    kv_scale_element_size=0,
-) -> tuple[CacheFieldSpec, ...]:
-    """Describe the enabled draft model's full-attention cache fields."""
-    if len(layer_group_ids) != len(layer_kv_heads):
-        raise ValueError(
-            f"layer_group_ids has {len(layer_group_ids)} entries but "
-            f"layer_kv_heads has {len(layer_kv_heads)}"
-        )
-    if prefix_granularity <= 0 or head_dim <= 0 or kv_element_size <= 0:
-        raise ValueError("draft full-attention geometry must be positive")
-    if bool(kv_scale_block_size) != bool(kv_scale_element_size):
-        raise ValueError(
-            "kv_scale_block_size and kv_scale_element_size must both be zero "
-            "or both be positive"
-        )
-    if kv_scale_block_size and (
-        prefix_granularity % MXFP8_KV_SCALE_TILE_TOKENS
-        or head_dim % kv_scale_block_size
-        or kv_scale_block_size <= 0
-    ):
-        raise ValueError("draft scale geometry is incompatible with the KV shape")
-
-    enabled_layer_ids = tuple(enabled_layer_ids)
-    if len(set(enabled_layer_ids)) != len(enabled_layer_ids) or any(
-        isinstance(layer_id, bool)
-        or not isinstance(layer_id, int)
-        or layer_id < 0
-        or layer_id >= len(layer_group_ids)
-        for layer_id in enabled_layer_ids
-    ):
-        raise ValueError("enabled draft layer ids must be unique valid layer ids")
-
-    occurrences: dict[str, int] = {}
-    fields = []
-    for layer_id in enabled_layer_ids:
-        group_id = layer_group_ids[layer_id]
-        kv_heads = layer_kv_heads[layer_id]
-        if kv_heads <= 0:
-            raise ValueError("draft layer KV heads must be positive")
-        unit = occurrences.get(group_id, 0)
-        occurrences[group_id] = unit + 1
-        kv_shape = (prefix_granularity, kv_heads, head_dim)
-        fields.extend(
-            (
-                CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.k",
-                    f"unit.{unit}.k",
-                    kv_shape,
-                    kv_element_size,
-                ),
-                CacheFieldSpec(
-                    group_id,
-                    f"layer.{layer_id}.v",
-                    f"unit.{unit}.v",
-                    kv_shape,
-                    kv_element_size,
-                ),
-            )
-        )
-        if kv_scale_block_size:
-            scale_dim = head_dim // kv_scale_block_size
-            scale_shape = (
-                kv_heads,
-                prefix_granularity // MXFP8_KV_SCALE_TILE_TOKENS,
-                32,
-                scale_dim,
-                scale_dim,
-            )
-            fields.extend(
-                (
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.k_scale",
-                        f"unit.{unit}.k_scale",
-                        scale_shape,
-                        kv_scale_element_size,
-                    ),
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.v_scale",
-                        f"unit.{unit}.v_scale",
-                        scale_shape,
-                        kv_scale_element_size,
-                    ),
-                )
-            )
-    return tuple(fields)
-
-
-def build_hybrid_cache_setup(
-    *,
-    family: str,
-    server_args,
-    fields,
-    layer_types: tuple[str, ...],
-    group_ids: tuple[str, ...],
-    group_specs: tuple,
-    state_dtypes,
-    layer_kv_head_counts: tuple[int, ...] | None,
-    num_draft_layers: int,
-    cache_budget_bytes: int,
-    fixed_workspace_bytes: int,
-    prefix_granularity: int,
-    max_padding_fraction: float,
-):
-    """Bind one hybrid cache layout to a capacity.
-
-    One big model: every parameter is already merged over target AND draft
-    layers (see ``merge_continuation_layers``) — the builder itself is
-    draft-oblivious. The recipe owns the complete published specs
-    (``group_specs``, incl. groups outside the layer-type vocabulary and
-    PD transfer policies). ``num_draft_layers`` is carried through to the
-    setup for wiring time.
+    Capacity comes from the profiled bytes-per-token rather than the parent
+    size, and every group packs one CacheBlock per parent -- the identity
+    grain is the block span.
     """
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
-        CachePoolSpec,
-        CacheSetup,
-    )
 
-    merged_fields = tuple(fields)
-    merged_layer_types = tuple(layer_types)
-    merged_group_ids = tuple(group_ids)
-    merged_specs = tuple(group_specs)
-    merged_head_counts = layer_kv_head_counts
-    merged_layout = solve_cache_layout(
-        merged_fields,
-        prefix_granularity=prefix_granularity,
-        alignment=256,
-        max_padding_fraction=max_padding_fraction,
-    )
-    packing = dict(merged_layout.group_packing)
+    def __init__(self, *, family, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.family = family
 
-    usable_cache_bytes = cache_budget_bytes - fixed_workspace_bytes
-    num_lcm_blocks = usable_cache_bytes // merged_layout.lcm_block_bytes - 1
-    if num_lcm_blocks < 1:
-        raise ValueError(
-            "cache budget must hold a null parent and one usable LCM parent"
+    # ---- layer vocabulary ----
+
+    @property
+    @override
+    def num_draft_layers(self) -> int:
+        if self.draft_attn_config is None:
+            return 0
+        return self.draft_model_config.num_attention_layers
+
+    @cached_property
+    def group_ids(self) -> tuple[str, ...]:
+        ids = _config_group_ids(self.attn_config, self.num_target_layers)
+        if self.draft_attn_config is None:
+            return ids
+        if self.draft_attn_config.prefix_granularity != self.prefix_granularity:
+            raise ValueError("target and draft cache page sizes must match")
+        return ids + _config_group_ids(self.draft_attn_config, self.num_draft_layers)
+
+    @cached_property
+    def layer_types(self) -> tuple[str, ...]:
+        """Merged labels, or empty when they cannot align per layer.
+
+        A NextN draft inherits the target hf_config's ``layer_types`` (one
+        draft layer against 61 target labels), so misaligned labels degrade to
+        full-history rather than mislabeling a group.
+        """
+        target = tuple(getattr(self.attn_config, "layer_types", ()))
+        if len(target) != self.num_target_layers:
+            target = ()
+        if self.draft_attn_config is None:
+            return target if target else ()
+        draft = tuple(getattr(self.draft_attn_config, "layer_types", ()))
+        if len(draft) != self.num_draft_layers:
+            draft = (FULL_ATTENTION,) * self.num_draft_layers
+        merged = target + draft
+        return merged if len(merged) == len(self.group_ids) else ()
+
+    # ---- geometry ----
+
+    @property
+    @override
+    def alignment(self) -> int:
+        return 1
+
+    @property
+    @override
+    def max_padding_fraction(self) -> float:
+        return 1.0
+
+    @override
+    def packing(self, groups: tuple[CacheGroupDeclaration, ...]) -> Mapping[str, int]:
+        """One CacheBlock per parent: the block span is the identity grain."""
+        return {spec.group_id: 1 for spec, _ in groups}
+
+    # ---- fields ----
+
+    @override
+    def fields_for_layer(
+        self, layer_id: int, group_id: str, occurrence: int
+    ) -> tuple[CacheFieldSpec, ...]:
+        if layer_id < self.num_target_layers:
+            config, local_layer_id = self.attn_config, layer_id
+        else:
+            config = self.draft_attn_config
+            local_layer_id = layer_id - self.num_target_layers
+        return _config_layer_fields(
+            config,
+            layer_id=layer_id,
+            local_layer_id=local_layer_id,
+            occurrence=occurrence,
         )
 
-    max_packing = max(packing.values())
-    token_limit = configured_token_limit(server_args)
-    if token_limit is not None:
-        requested = token_limit // prefix_granularity // max_packing
-        if requested < 1:
-            raise ValueError(
-                "the configured token limit must hold at least one LCM parent "
-                f"({prefix_granularity * max_packing} child tokens)"
+    # ---- capacity: profiled bytes per token, not parent size ----
+
+    @override
+    def num_lcm_blocks(self, layout: CacheLayout) -> int:
+        bytes_per_token = self.attn_config.cache_cell_size() * _storage_layers(
+            self.attn_config, self.num_target_layers
+        )
+        if self.draft_attn_config is not None:
+            bytes_per_token += (
+                self.draft_attn_config.cache_cell_size()
+                * _storage_layers(self.draft_attn_config, self.num_draft_layers)
             )
-        num_lcm_blocks = min(num_lcm_blocks, requested)
-
-    return CacheSetup(
-        spec=CachePoolSpec(
-            family=family,
-            memory_plan=merged_layout.with_num_lcm_blocks(num_lcm_blocks),
-            layer_types=merged_layer_types,
-            layer_group_ids=merged_group_ids,
-            paged_cache_group_specs=merged_specs,
-            state_field_dtypes=state_dtypes,
-            token_capacity=(num_lcm_blocks * max_packing * prefix_granularity),
-            layer_kv_head_counts=merged_head_counts,
-        ),
-        num_draft_layers=num_draft_layers,
-        cache_budget_bytes=cache_budget_bytes,
-        fixed_workspace_bytes=fixed_workspace_bytes,
-    )
-
-
-def _profiled_pages(
-    *,
-    cache_budget_bytes: int,
-    bytes_per_token: int,
-    prefix_granularity: int,
-    max_total_tokens: int | None,
-) -> int:
-    """Return usable pages while keeping the reserved null page in budget."""
-    if bytes_per_token <= 0:
-        raise ValueError(f"KV cache cell size must be positive, got {bytes_per_token}")
-    bytes_per_page = bytes_per_token * prefix_granularity
-    num_pages = cache_budget_bytes // bytes_per_page - 1
-    if max_total_tokens is not None:
-        requested_pages = max_total_tokens // prefix_granularity
-        if requested_pages < 1:
+        if bytes_per_token <= 0:
             raise ValueError(
-                f"max_total_tokens={max_total_tokens} must contain at least "
-                f"one full prefix page (prefix_granularity={prefix_granularity})"
+                f"KV cache cell size must be positive, got {bytes_per_token}"
             )
-        num_pages = min(num_pages, requested_pages)
-
-    from tokenspeed.runtime.utils.env import envs
-
-    ci_size = envs.TOKENSPEED_CI_SMALL_KV_SIZE.get_set_value_or(None)
-    if ci_size is not None and int(ci_size) > 0:
-        ci_tokens = int(ci_size)
-        if ci_tokens % prefix_granularity:
-            raise ValueError(
-                "TOKENSPEED_CI_SMALL_KV_SIZE must be divisible by prefix_granularity"
-            )
-        num_pages = min(num_pages, ci_tokens // prefix_granularity)
-    if num_pages < 1:
-        raise ValueError("KV cache token pool size must be positive")
-    return num_pages
+        # Every group packs one CacheBlock per parent, so a parent spans the
+        # identity grain and profiled bytes/token size it directly.
+        page_size = self.prefix_granularity
+        return self._capped_parents(
+            self.cache_budget_bytes // (bytes_per_token * page_size) - 1,
+            parent_tokens=page_size,
+        )
 
 
 def _storage_layers(config, num_layers: int) -> int:
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        hybrid_slab_group_size,
-    )
-
     group_size = hybrid_slab_group_size(
         getattr(config, "layer_types", None),
         sliding_window_tokens=getattr(config, "sliding_window_tokens", None),
@@ -342,287 +168,155 @@ def _storage_layers(config, num_layers: int) -> int:
     return group_size if group_size is not None else num_layers
 
 
-def _ordinary_setup(
-    *,
-    family: str,
-    server_args,
-    model_config,
-    attn_config,
-    target_fields,
-    target_group_ids: tuple[str, ...],
-    draft_model_config,
-    draft_attn_config,
-    draft_fields,
-    draft_group_ids: tuple[str, ...],
-    cache_budget_bytes: int,
-):
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
-        CachePoolSpec,
-        CacheSetup,
-    )
+def _config_group_ids(config, num_layers: int) -> tuple[str, ...]:
+    """Per-layer group ids for one ordinary attention config."""
+    from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
+    from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
 
-    page_size = int(attn_config.prefix_granularity)
-    target_layers = model_config.num_attention_layers
-    bytes_per_token = attn_config.cache_cell_size() * _storage_layers(
-        attn_config, target_layers
-    )
-    if draft_attn_config is not None:
-        if draft_attn_config.prefix_granularity != page_size:
-            raise ValueError("target and draft cache page sizes must match")
-        bytes_per_token += draft_attn_config.cache_cell_size() * _storage_layers(
-            draft_attn_config,
-            draft_model_config.num_attention_layers,
-        )
-    num_pages = _profiled_pages(
-        cache_budget_bytes=cache_budget_bytes,
-        bytes_per_token=bytes_per_token,
-        prefix_granularity=page_size,
-        max_total_tokens=server_args.max_total_tokens,
-    )
-    # One merged solve, one spec (see build_hybrid_cache_setup): draft
-    # layers continue the target's numbering; packing is uniformly 1 on
-    # this profiled path. Labels not aligned per-layer degrade to
-    # full-history: a NextN draft inherits the target hf_config's
-    # layer_types (1 draft layer vs 61 target labels).
-    target_layer_types = tuple(getattr(attn_config, "layer_types", ()))
-    if len(target_layer_types) != len(target_group_ids):
-        target_layer_types = ()
-    draft_layer_types = ()
-    if draft_fields is not None:
-        draft_layer_types = tuple(getattr(draft_attn_config, "layer_types", ()))
-        if len(draft_layer_types) != len(draft_group_ids):
-            draft_layer_types = ("full_attention",) * len(draft_group_ids)
-    (
-        merged_fields,
-        merged_layer_types,
-        merged_group_ids,
-        _,
-        num_draft_layers,
-    ) = merge_continuation_layers(
-        fields=target_fields,
-        layer_types=target_layer_types,
-        group_ids=target_group_ids,
-        draft_fields=draft_fields,
-        draft_layer_types=draft_layer_types,
-        draft_group_ids=draft_group_ids,
-    )
-    # Empty-or-aligned invariant: with an unlabeled target the merged
-    # labels cannot align; every merged group publishes full-history.
-    if len(merged_layer_types) != len(merged_group_ids):
-        merged_layer_types = ()
-    merged_layout = solve_cache_layout(
-        merged_fields,
-        prefix_granularity=page_size,
-        cache_blocks_per_lcm_block={field.group_id: 1 for field in merged_fields},
-        alignment=1,
-        max_padding_fraction=1.0,
-    )
-    token_capacity = num_pages * page_size
-
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        build_paged_cache_group_specs,
-    )
-
-    return CacheSetup(
-        spec=CachePoolSpec(
-            family=family,
-            memory_plan=merged_layout.with_num_lcm_blocks(num_pages),
-            layer_types=merged_layer_types,
-            layer_group_ids=merged_group_ids,
-            # ONE spec derivation over the merged layers: a draft-only
-            # group is planned AND published (planned-but-unallocated is
-            # not a state the scheduler can represent).
-            paged_cache_group_specs=build_paged_cache_group_specs(
-                layer_types=merged_layer_types,
-                group_ids=merged_group_ids,
-                sliding_window_tokens=getattr(
-                    attn_config, "sliding_window_tokens", None
-                ),
-                prefix_granularity=page_size,
-                pd_disaggregation_enabled=getattr(
-                    attn_config, "pd_disaggregation_enabled", False
-                ),
-            ),
-            state_field_dtypes={},
-            token_capacity=token_capacity,
-        ),
-        num_draft_layers=num_draft_layers,
-        cache_budget_bytes=cache_budget_bytes,
-        fixed_workspace_bytes=0,
-    )
+    if isinstance(config, MHAConfig | MSAConfig):
+        layer_types = tuple(config.layer_types)
+        if layer_types:
+            ids = tuple(
+                layer_group_ids(
+                    layer_types=layer_types,
+                    sliding_window_tokens=config.sliding_window_tokens,
+                )
+            )
+            if len(ids) != num_layers:
+                raise ValueError("cache group ids must cover every layer")
+            return ids
+    return (FULL_ATTENTION,) * num_layers
 
 
-def _ordinary_fields(config, num_layers: int):
-    """Return the fields and group ids for one ordinary attention config."""
+def _config_layer_fields(
+    config, *, layer_id: int, local_layer_id: int, occurrence: int
+) -> tuple[CacheFieldSpec, ...]:
+    """What one layer costs, dispatched on the config that owns the layer."""
     from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
     from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
     from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
 
     if isinstance(config, DSAConfig):
-        return _dsa_fields(config, num_layers), ("full_attention",) * num_layers
+        return _mla_layer_fields(config, layer_id, occurrence) + (
+            _index_k_field(config, layer_id),
+        )
     if isinstance(config, MSAConfig):
-        return _msa_fields(config, num_layers)
+        fields = _mha_layer_fields(config, layer_id, occurrence)
+        if local_layer_id in config.sparse_layer_ids:
+            fields += (_index_k_field(config, layer_id),)
+        return fields
     if isinstance(config, MLAConfig):
-        return _mla_fields(config, num_layers), ("full_attention",) * num_layers
+        return _mla_layer_fields(config, layer_id, occurrence)
     if isinstance(config, MHAConfig):
-        return _mha_fields(config, num_layers)
+        return _mha_layer_fields(config, layer_id, occurrence)
     raise TypeError(f"no ordinary cache recipe for {type(config).__name__}")
 
 
-def _mha_fields(config, num_layers: int):
-    import torch
-
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes import spec
-
-    if config.kv_cache_mxfp8:
-        assert config.prefix_granularity == MXFP8_KV_SCALE_TILE_TOKENS, (
+def _mha_layer_fields(config, layer_id: int, occurrence: int):
+    """One MHA layer's K/V pages, with mxfp8 scale planes when enabled."""
+    mxfp8 = bool(config.kv_cache_mxfp8)
+    if mxfp8 and config.prefix_granularity != MXFP8_KV_SCALE_TILE_TOKENS:
+        raise AssertionError(
             "mxfp8 KV cache requires --prefix-granularity "
             f"{MXFP8_KV_SCALE_TILE_TOKENS} (the attention kernel consumes "
             "the interleaved paged scale layout)"
         )
-    layer_types = tuple(config.layer_types)
-    group_ids = (
-        tuple(
-            spec.layer_group_ids(
-                layer_types=layer_types,
-                sliding_window_tokens=config.sliding_window_tokens,
-            )
-        )
-        if layer_types
-        else ("full_attention",) * num_layers
+    kv_heads = max(config.num_kv_heads // config.attn_tp_size, 1)
+    head_dim = config.head_dim
+    if config.prefix_granularity <= 0 or kv_heads <= 0 or head_dim <= 0:
+        raise ValueError("MHA full-attention geometry must be positive")
+    shape = (config.prefix_granularity, kv_heads, head_dim)
+    kv_dtype = (
+        # MXFP8 writes go through dtype-aware kernels, so the arena keeps the
+        # fp8 view; the scatter-written paths fall back to uint8.
+        cache_dtype_name(torch.float8_e4m3fn)
+        if mxfp8
+        else scatter_stored_dtype_name(config.kv_cache_dtype)
     )
-    if len(group_ids) != num_layers:
-        raise ValueError("cache group ids must cover every MHA layer")
-    fields = mha_cache_fields(
-        layer_group_ids=group_ids,
-        prefix_granularity=config.prefix_granularity,
-        kv_heads=max(config.num_kv_heads // config.attn_tp_size, 1),
-        head_dim=config.head_dim,
-        kv_element_size=(
-            1
-            if config.kv_cache_mxfp8
-            else torch.empty((), dtype=config.kv_cache_dtype).element_size()
+    fields = (
+        CacheFieldSpec(f"layer.{layer_id}.k", f"unit.{occurrence}.k", shape, kv_dtype),
+        CacheFieldSpec(f"layer.{layer_id}.v", f"unit.{occurrence}.v", shape, kv_dtype),
+    )
+    if not mxfp8:
+        return fields
+    scale_dim = head_dim // 32
+    scale_shape = (kv_heads, 32, scale_dim, scale_dim)
+    scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
+    return fields + (
+        CacheFieldSpec(
+            f"layer.{layer_id}.k_scale",
+            f"unit.{occurrence}.k_scale",
+            scale_shape,
+            scale_dtype,
         ),
-        kv_scale_block_size=32 if config.kv_cache_mxfp8 else 0,
-        kv_scale_element_size=1 if config.kv_cache_mxfp8 else 0,
+        CacheFieldSpec(
+            f"layer.{layer_id}.v_scale",
+            f"unit.{occurrence}.v_scale",
+            scale_shape,
+            scale_dtype,
+        ),
     )
-    return fields, group_ids
 
 
-def prepare_ordinary_cache(
-    *,
-    family: str,
-    server_args,
-    model_config,
-    attn_config,
-    draft_model_config,
-    draft_attn_config,
-    cache_budget_bytes: int,
-    decode_input_tokens: int,
-    overlap_schedule_depth: int,
-):
-    """Build an ordinary-family setup using the legacy capacity formula.
-
-    ``_ordinary_fields`` dispatches on the config type for target and draft
-    alike, so the four ordinary families (mha/mla/dsa/msa) share this one
-    entry point.
-    """
-    target_fields, target_group_ids = _ordinary_fields(
-        attn_config, model_config.num_attention_layers
-    )
-    draft_fields = None
-    draft_group_ids = ()
-    if draft_attn_config is not None:
-        draft_fields, draft_group_ids = _ordinary_fields(
-            draft_attn_config, draft_model_config.num_attention_layers
+def _mla_layer_fields(config, layer_id: int, occurrence: int):
+    """One MLA layer's latent page, split into planes when quantized."""
+    if config.prefix_granularity <= 0:
+        raise ValueError("MLA full-attention geometry must be positive")
+    if config.kv_cache_quant_method != "per_token_head":
+        latent_width = config.kv_lora_rank + config.qk_rope_head_dim
+        return (
+            CacheFieldSpec(
+                f"layer.{layer_id}.latent_kv",
+                f"slot.{occurrence}",
+                (config.prefix_granularity, 1, latent_width),
+                scatter_stored_dtype_name(config.kv_cache_dtype),
+            ),
         )
-    return _ordinary_setup(
-        family=family,
-        server_args=server_args,
-        model_config=model_config,
-        attn_config=attn_config,
-        target_fields=target_fields,
-        target_group_ids=target_group_ids,
-        draft_model_config=draft_model_config,
-        draft_attn_config=draft_attn_config,
-        draft_fields=draft_fields,
-        draft_group_ids=draft_group_ids,
-        cache_budget_bytes=cache_budget_bytes,
+    return tuple(
+        CacheFieldSpec(
+            f"layer.{layer_id}.{name}",
+            f"layer.{layer_id}.{name}",
+            shape,
+            dtype,
+        )
+        for name, shape, dtype in (
+            (
+                "latent_kv",
+                (config.prefix_granularity, 1, config.kv_lora_rank),
+                scatter_stored_dtype_name(config.kv_cache_dtype),
+            ),
+            (
+                "latent_scale",
+                (config.prefix_granularity, 1, 1),
+                cache_dtype_name(torch.float32),
+            ),
+            (
+                "rope_k",
+                (config.prefix_granularity, 1, config.qk_rope_head_dim),
+                cache_dtype_name(config.dtype),
+            ),
+        )
     )
 
 
-def _mla_fields(config, num_layers: int):
-    import torch
-
-    if config.kv_cache_quant_method == "per_token_head":
-        fields = []
-        for layer_id in range(num_layers):
-            for name, shape, dtype in (
-                (
-                    "latent_kv",
-                    (config.prefix_granularity, 1, config.kv_lora_rank),
-                    config.kv_cache_dtype,
-                ),
-                ("latent_scale", (config.prefix_granularity, 1, 1), torch.float32),
-                (
-                    "rope_k",
-                    (config.prefix_granularity, 1, config.qk_rope_head_dim),
-                    config.dtype,
-                ),
-            ):
-                fields.append(
-                    CacheFieldSpec(
-                        "full_attention",
-                        f"layer.{layer_id}.{name}",
-                        f"layer.{layer_id}.{name}",
-                        shape,
-                        torch.empty((), dtype=dtype).element_size(),
-                    )
-                )
-        return tuple(fields)
-    return mla_cache_fields(
-        layer_group_ids=("full_attention",) * num_layers,
-        prefix_granularity=config.prefix_granularity,
-        latent_width=config.kv_lora_rank + config.qk_rope_head_dim,
-        element_size=torch.empty((), dtype=config.kv_cache_dtype).element_size(),
-    )
-
-
-def _dsa_fields(config, num_layers: int):
-    fields = list(_mla_fields(config, num_layers))
+def _index_k_field(config, layer_id: int) -> CacheFieldSpec:
+    """The sparse indexer's key row for one layer (DSA bytes, MSA elements)."""
     from tokenspeed.runtime.layers.attention.configs.dsa import (
+        DSAConfig,
         dsa_index_k_row_bytes,
     )
 
-    index_row_bytes = dsa_index_k_row_bytes(config.index_head_dim)
-    fields.extend(
-        CacheFieldSpec(
-            "full_attention",
+    if isinstance(config, DSAConfig):
+        return CacheFieldSpec(
             f"layer.{layer_id}.index_k",
             f"layer.{layer_id}.index_k",
-            (config.prefix_granularity, index_row_bytes),
-            1,
+            (config.prefix_granularity, dsa_index_k_row_bytes(config.index_head_dim)),
+            "uint8",
         )
-        for layer_id in range(num_layers)
+    return CacheFieldSpec(
+        f"layer.{layer_id}.index_k",
+        f"layer.{layer_id}.index_k",
+        (config.prefix_granularity, config.index_head_dim),
+        cache_dtype_name(config.dtype),
     )
-    return tuple(fields)
-
-
-def _msa_fields(config, num_layers: int):
-    import torch
-
-    fields, group_ids = _mha_fields(config, num_layers)
-    fields = list(fields)
-    element_size = torch.empty((), dtype=config.dtype).element_size()
-    fields.extend(
-        CacheFieldSpec(
-            "full_attention",
-            f"layer.{layer_id}.index_k",
-            f"layer.{layer_id}.index_k",
-            (config.prefix_granularity, config.index_head_dim),
-            element_size,
-        )
-        for layer_id in sorted(config.sparse_layer_ids)
-    )
-    return tuple(fields), group_ids

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
@@ -23,7 +23,6 @@
 from __future__ import annotations
 
 import math
-import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
@@ -29,6 +29,8 @@ from dataclasses import dataclass
 from itertools import pairwise
 from typing import TYPE_CHECKING
 
+import torch
+
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
         CacheGroupSpec,
@@ -113,6 +115,13 @@ def cache_dtype_bytes(dtype_name: str) -> int:
         return _CACHE_DTYPE_BYTES[dtype_name]
     except KeyError:
         raise ValueError(f"unsupported cache dtype {dtype_name!r}") from None
+
+
+# Token span of one interleaved mxfp8 KV-scale tile, and the head-dim block a
+# single e8m0 scale covers. Both are properties of the fused FP8 attention
+# kernels, so the shape they imply is built here once.
+MXFP8_KV_SCALE_TILE_TOKENS = 128
+MXFP8_SCALE_BLOCK_SIZE = 32
 
 
 def cache_field_layer_id(field_id: str) -> int:
@@ -355,6 +364,53 @@ class CacheFieldSpec:
     @property
     def payload_bytes(self) -> int:
         return math.prod(self.shape) * self.element_size
+
+
+def mxfp8_kv_scale_fields(
+    *,
+    layer_id: int,
+    occurrence: int,
+    kv_heads: int,
+    head_dim: int,
+    prefix_granularity: int,
+) -> tuple[CacheFieldSpec, ...]:
+    """The k_scale/v_scale planes of one mxfp8 KV layer.
+
+    One kernel layout, one definition: the fused FP8 attention kernels read
+    scales as ``(num_ids, heads, tiles, 32, sf, sf)`` where a tile spans
+    ``MXFP8_KV_SCALE_TILE_TOKENS`` tokens, so the per-page shape a recipe
+    declares is fixed by the page's token span and the head count. Recipes
+    differ in how they arrive at those two numbers, never in the shape.
+    """
+    if prefix_granularity % MXFP8_KV_SCALE_TILE_TOKENS or kv_heads <= 0:
+        raise ValueError(
+            "mxfp8 KV scales need a page span that is a positive multiple of "
+            f"{MXFP8_KV_SCALE_TILE_TOKENS} and at least one KV head, got "
+            f"{prefix_granularity} and {kv_heads}"
+        )
+    if head_dim % MXFP8_SCALE_BLOCK_SIZE:
+        raise ValueError(
+            f"mxfp8 head_dim must be a multiple of {MXFP8_SCALE_BLOCK_SIZE}, "
+            f"got {head_dim}"
+        )
+    scale_dim = head_dim // MXFP8_SCALE_BLOCK_SIZE
+    shape = (
+        kv_heads,
+        prefix_granularity // MXFP8_KV_SCALE_TILE_TOKENS,
+        32,
+        scale_dim,
+        scale_dim,
+    )
+    dtype = cache_dtype_name(torch.float8_e8m0fnu)
+    return tuple(
+        CacheFieldSpec(
+            f"layer.{layer_id}.{plane}_scale",
+            f"unit.{occurrence}.{plane}_scale",
+            shape,
+            dtype,
+        )
+        for plane in ("k", "v")
+    )
 
 
 @dataclass(frozen=True)

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
@@ -25,13 +25,95 @@ from __future__ import annotations
 import math
 import re
 from collections import defaultdict
-from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from itertools import pairwise
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+        CacheGroupSpec,
+    )
 
 # Planner/runtime limits, not model layout inputs.
 _MAX_LCM_BLOCK_BYTES = (1 << 63) - 1
 _MAX_KERNEL_PAGE_ID = (1 << 31) - 1
+
+# Byte width per cache dtype name. This module stays torch-free (pure integer
+# geometry, and the plan travels the PD wire as JSON), so dtypes are named by
+# string and their widths live in this table.
+_CACHE_DTYPE_BYTES = {
+    "uint8": 1,
+    "int8": 1,
+    "float8_e4m3fn": 1,
+    "float8_e5m2": 1,
+    "float8_e8m0fnu": 1,
+    "bfloat16": 2,
+    "float16": 2,
+    "int32": 4,
+    "float32": 4,
+    "int64": 8,
+    "float64": 8,
+}
+
+# Elementwise scatter (Tensor.index_put) has no fp8 kernel, so pools that
+# write KV that way view the bytes as uint8 instead. Pools whose writes go
+# through a dtype-aware kernel (MXFP8, via store_sf_interleaved and
+# quantize_store_kv_mxfp8) keep the fp8 view.
+_INDEX_PUT_UNSUPPORTED = ("float8_e5m2", "float8_e4m3fn")
+
+
+def cache_dtype_name(dtype) -> str:
+    """Return the plan-facing name of the dtype the arena views bytes as.
+
+    Args:
+        dtype: A ``torch.dtype`` or an already-normalized dtype name.
+
+    Returns:
+        The dtype name to record in the plan.
+
+    Raises:
+        ValueError: The dtype has no cache representation.
+    """
+    name = str(dtype).removeprefix("torch.")
+    if name not in _CACHE_DTYPE_BYTES:
+        raise ValueError(f"unsupported cache dtype {name!r}")
+    return name
+
+
+def scatter_stored_dtype_name(dtype) -> str:
+    """Plan dtype for a field whose pool writes it with elementwise scatter.
+
+    fp8 collapses to ``uint8`` because ``index_put`` has no fp8 kernel --
+    the same substitution the pools applied before the plan owned dtypes,
+    so the PD wire string is unchanged.
+
+    Args:
+        dtype: A ``torch.dtype`` or an already-normalized dtype name.
+
+    Returns:
+        The dtype name to record in the plan.
+    """
+    name = cache_dtype_name(dtype)
+    return "uint8" if name in _INDEX_PUT_UNSUPPORTED else name
+
+
+def cache_dtype_bytes(dtype_name: str) -> int:
+    """Return the byte width of one element of a plan dtype name.
+
+    Args:
+        dtype_name: A name produced by :func:`cache_dtype_name`.
+
+    Returns:
+        Bytes per element.
+
+    Raises:
+        ValueError: The name is not a known cache dtype.
+    """
+    try:
+        return _CACHE_DTYPE_BYTES[dtype_name]
+    except KeyError:
+        raise ValueError(f"unsupported cache dtype {dtype_name!r}") from None
 
 
 @dataclass(frozen=True)
@@ -54,9 +136,18 @@ class CacheFieldLayout:
     field_id: str
     plane_id: str
     shape: tuple[int, ...]
-    element_size: int
+    # The dtype the arena views these bytes as -- the plan is the single
+    # source, so no consumer has to supply it a second time.
+    dtype: str
     field_offset_bytes: int
     page_stride_bytes: int
+
+    def __post_init__(self) -> None:
+        cache_dtype_bytes(self.dtype)
+
+    @property
+    def element_size(self) -> int:
+        return cache_dtype_bytes(self.dtype)
 
     @property
     def payload_bytes(self) -> int:
@@ -219,11 +310,20 @@ class CacheMemoryPlan:
 
 @dataclass(frozen=True)
 class CacheFieldSpec:
-    group_id: str
+    """One field a cache group declares, without naming that group.
+
+    A field belongs to whichever group lists it in the ``{spec: fields}``
+    mapping handed to :func:`pack`, so a group id is written
+    once -- in its spec -- instead of once per field.
+    """
+
     field_id: str
     plane_id: str
     shape: tuple[int, ...]
-    element_size: int
+    # The dtype the arena views these bytes as. Recipes know this when they
+    # build the spec, so it travels with the geometry instead of being
+    # re-supplied at bind time.
+    dtype: str
     # True when the field's kernel walks pages by an implicit payload-sized
     # stride. False when the kernel consumes the tensor's runtime stride.
     exact_page_stride: bool = True
@@ -231,6 +331,13 @@ class CacheFieldSpec:
     # stride to satisfy an alignment constraint (for example, a TMA row
     # stride). The planner applies this in bytes after group packing.
     page_stride_alignment_bytes: int = 1
+
+    def __post_init__(self) -> None:
+        cache_dtype_bytes(self.dtype)
+
+    @property
+    def element_size(self) -> int:
+        return cache_dtype_bytes(self.dtype)
 
     @property
     def payload_bytes(self) -> int:
@@ -247,7 +354,7 @@ class CacheLayout:
     plane_bytes: tuple[tuple[str, int], ...]
     fields: tuple[CacheFieldLayout, ...]
 
-    def with_num_lcm_blocks(self, num_lcm_blocks: int) -> CacheMemoryPlan:
+    def bind(self, num_lcm_blocks: int) -> CacheMemoryPlan:
         if (
             isinstance(num_lcm_blocks, bool)
             or not isinstance(num_lcm_blocks, int)
@@ -292,106 +399,22 @@ class CacheLayout:
         )
 
 
-def merge_continuation_layers(
-    *,
-    fields,
-    layer_types: tuple[str, ...],
-    group_ids: tuple[str, ...],
-    layer_kv_head_counts: tuple[int, ...] | None = None,
-    draft_fields=None,
-    draft_layer_types: tuple[str, ...] = (),
-    draft_group_ids: tuple[str, ...] = (),
-    draft_layer_kv_head_counts: tuple[int, ...] | None = None,
-) -> tuple:
-    """Merge a draft model's per-layer vectors after the target's.
-
-    One big model: the draft's fields renumber via
-    :func:`continue_layer_fields`; every other per-layer vector is plain
-    concatenation. Returns ``(fields, layer_types, group_ids,
-    layer_kv_head_counts, num_draft_layers)`` — all target-shaped, so
-    downstream builders stay draft-oblivious.
-    """
-    merged_fields = tuple(fields)
-    merged_layer_types = tuple(layer_types)
-    merged_group_ids = tuple(group_ids)
-    merged_head_counts = layer_kv_head_counts
-    num_draft_layers = 0
-    if draft_fields is not None:
-        num_target_layers = len(merged_group_ids)
-        num_draft_layers = len(draft_group_ids)
-        if len(draft_layer_types) != num_draft_layers:
-            raise ValueError(
-                f"draft layer_types has {len(draft_layer_types)} entries but "
-                f"draft group_ids has {num_draft_layers}"
-            )
-        merged_fields += continue_layer_fields(
-            draft_fields, first_layer_id=num_target_layers
-        )
-        merged_layer_types += tuple(draft_layer_types)
-        merged_group_ids += tuple(draft_group_ids)
-        if bool(layer_kv_head_counts) != bool(draft_layer_kv_head_counts):
-            raise ValueError(
-                "layer_kv_head_counts must be supplied for both sides or neither"
-            )
-        if layer_kv_head_counts is not None:
-            merged_head_counts = tuple(layer_kv_head_counts) + tuple(
-                draft_layer_kv_head_counts
-            )
-    return (
-        merged_fields,
-        merged_layer_types,
-        merged_group_ids,
-        merged_head_counts,
-        num_draft_layers,
-    )
-
-
-def continue_layer_fields(
-    fields,
-    *,
-    first_layer_id: int,
-) -> tuple[CacheFieldSpec, ...]:
-    """Renumber per-layer fields as continuation layers of one big model.
-
-    Draft layers join the target's ``solve_cache_layout`` as ordinary
-    layers of the ONE merged model:
-    a draft model's local ``layer.{i}...`` field/plane ids become the
-    global ``layer.{first_layer_id + i}...``. Group ids are untouched: a
-    draft layer in a target group shares its page-id space and packing by
-    construction. No draft-specific namespace exists — the merged plan is
-    simply a model with more layers.
-    """
-    renumber = re.compile(r"^(?P<head>layer|unit|slot)\.(?P<idx>\d+)")
-
-    def _shift(identifier: str) -> str:
-        return renumber.sub(
-            lambda m: f"{m.group('head')}.{int(m.group('idx')) + first_layer_id}",
-            identifier,
-        )
-
-    return tuple(
-        replace(
-            field,
-            field_id=_shift(field.field_id),
-            plane_id=_shift(field.plane_id),
-        )
-        for field in fields
-    )
-
-
 def _align_up(value: int, alignment: int) -> int:
     return ((value + alignment - 1) // alignment) * alignment
 
 
 def _solve_packing(fields):
-    """Derive per-group cache blocks per LCM block from exact field ratios."""
+    """Derive per-group cache blocks per LCM block from exact field ratios.
+
+    ``fields`` are ``(group_id, CacheFieldSpec)`` pairs.
+    """
     exact_by_plane: dict[str, dict[str, int]] = {}
     groups = set()
-    for field in fields:
-        groups.add(field.group_id)
+    for group_id, field in fields:
+        groups.add(group_id)
         if field.exact_page_stride:
             plane = exact_by_plane.setdefault(field.plane_id, {})
-            plane[field.group_id] = plane.get(field.group_id, 0) + field.payload_bytes
+            plane[group_id] = plane.get(group_id, 0) + field.payload_bytes
 
     # ratio[g] = (num, den) expressing K_g as a multiple of its component root.
     root = {group_id: group_id for group_id in groups}
@@ -454,15 +477,16 @@ def _packing_by_group_ratio(raw_by_group):
 
 
 def _check_exact_page_strides(fields, plane_bytes, packing):
-    for field in fields:
+    """``fields`` are ``(group_id, CacheFieldSpec)`` pairs."""
+    for group_id, field in fields:
         if not field.exact_page_stride:
             continue
-        stride = plane_bytes[field.plane_id] // packing[field.group_id]
+        stride = plane_bytes[field.plane_id] // packing[group_id]
         if stride != field.payload_bytes:
             widest = max(
                 (
-                    (other.payload_bytes * packing[other.group_id], other.field_id)
-                    for other in fields
+                    (other.payload_bytes * packing[other_group], other.field_id)
+                    for other_group, other in fields
                     if other.plane_id == field.plane_id
                 ),
                 default=(0, ""),
@@ -477,15 +501,41 @@ def _check_exact_page_strides(fields, plane_bytes, packing):
             )
 
 
-def solve_cache_layout(
-    fields,
+def pack(
+    groups: Sequence[tuple[CacheGroupSpec, tuple[CacheFieldSpec, ...]]],
     *,
     prefix_granularity,
     cache_blocks_per_lcm_block: Mapping[str, int] | None = None,
     alignment=1,
     max_padding_fraction=0.25,
 ):
-    """Solve one capacity-independent, plane-major LCM block layout."""
+    """Pack declared cache groups into one capacity-independent LCM block.
+
+    The second stage of the pipeline: ``group`` says which groups exist and
+    what bytes they need, this says how those bytes sit inside one physical
+    parent (plane sizes, per-field offsets and page strides), and
+    :meth:`CacheLayout.bind` later multiplies it out by a parent count.
+
+    Args:
+        groups: ``(group spec, its declared fields)`` pairs. The pairing is
+            the whole point: a group id is spelled once, in its spec, so the
+            planned group set equals the declared one by construction.
+        prefix_granularity: Scheduler-wide identity grain in tokens.
+        cache_blocks_per_lcm_block: How many of each group's CacheBlocks share
+            one parent. A recipe that owns this policy pins every group and
+            nothing is derived here; groups left unpinned are derived from
+            byte ratios plus the exact-page-stride constraints their fields
+            impose.
+        alignment: Byte alignment for plane sizes.
+        max_padding_fraction: Padding budget per group.
+
+    Returns:
+        The packed :class:`CacheLayout`.
+
+    Raises:
+        ValueError: No group declared, duplicate field ids, invalid geometry,
+            or packing pinned for a group outside the declaration.
+    """
     if prefix_granularity <= 0:
         raise ValueError("prefix_granularity must be > 0")
     if alignment <= 0:
@@ -493,68 +543,72 @@ def solve_cache_layout(
     if max_padding_fraction < 0:
         raise ValueError("max_padding_fraction must be >= 0")
 
+    groups = tuple(groups)
+    declared_ids = [spec.group_id for spec, _ in groups]
+    if len(declared_ids) != len(set(declared_ids)):
+        raise ValueError(f"cache group declared more than once: {declared_ids}")
+    empty = sorted(spec.group_id for spec, fields in groups if not fields)
+    if empty:
+        raise ValueError(
+            f"cache groups {empty} declare no fields; a group with no bytes "
+            "cannot be addressed"
+        )
+    # Each field carries its declaring group id from here on: the planner
+    # works in (group_id, field) pairs so nothing can rebind a field.
     ordered_fields = tuple(
         sorted(
-            fields,
-            key=lambda field: (field.plane_id, field.group_id, field.field_id),
+            ((spec.group_id, field) for spec, fields in groups for field in fields),
+            key=lambda entry: (entry[1].plane_id, entry[0], entry[1].field_id),
         )
     )
     if not ordered_fields:
-        raise ValueError("at least one cache field is required")
-    if len({field.field_id for field in ordered_fields}) != len(ordered_fields):
+        raise ValueError("at least one cache group is required")
+    if len({field.field_id for _, field in ordered_fields}) != len(ordered_fields):
         raise ValueError("cache field ids must be unique")
 
     raw_by_group: dict[str, int] = {}
-    for field in ordered_fields:
-        if not field.group_id or not field.field_id or not field.plane_id:
-            raise ValueError(
-                "cache field group_id, field_id and plane_id must be non-empty"
-            )
+    for group_id, field in ordered_fields:
+        if not group_id or not field.field_id or not field.plane_id:
+            raise ValueError("cache group id, field id and plane id must be non-empty")
         if (
-            field.element_size <= 0
-            or not field.shape
+            not field.shape
             or any(extent <= 0 for extent in field.shape)
             or isinstance(field.page_stride_alignment_bytes, bool)
             or not isinstance(field.page_stride_alignment_bytes, int)
             or field.page_stride_alignment_bytes <= 0
         ):
             raise ValueError(f"cache field {field.field_id!r} has invalid geometry")
-        raw_by_group[field.group_id] = (
-            raw_by_group.get(field.group_id, 0) + field.payload_bytes
-        )
+        raw_by_group[group_id] = raw_by_group.get(group_id, 0) + field.payload_bytes
 
     ordered_group_ids = tuple(sorted(raw_by_group))
-    has_explicit_packing = cache_blocks_per_lcm_block is not None
-    if has_explicit_packing:
-        unknown = set(cache_blocks_per_lcm_block) - set(ordered_group_ids)
-        if unknown:
-            raise ValueError(
-                "cache_blocks_per_lcm_block names groups outside the plan: "
-                f"{sorted(unknown)}"
-            )
-        if any(
-            isinstance(count, bool) or not isinstance(count, int) or count < 1
-            for count in cache_blocks_per_lcm_block.values()
-        ):
-            raise ValueError("cache group packing must be a positive integer")
-        # Pinned groups take the caller's count; groups the caller leaves
-        # unpinned pack by their byte ratio as in the unpinned solve.
-        packing = _packing_by_group_ratio(raw_by_group)
-        constrained = _solve_packing(ordered_fields)
-        if constrained is not None:
-            packing.update(constrained)
-        packing.update(cache_blocks_per_lcm_block)
+    pinned = dict(cache_blocks_per_lcm_block or {})
+    unknown = set(pinned) - set(ordered_group_ids)
+    if unknown:
+        raise ValueError(
+            "cache_blocks_per_lcm_block names groups outside the plan: "
+            f"{sorted(unknown)}"
+        )
+    if any(
+        isinstance(count, bool) or not isinstance(count, int) or count < 1
+        for count in pinned.values()
+    ):
+        raise ValueError("cache group packing must be a positive integer")
+    if set(pinned) == set(ordered_group_ids):
+        # The recipe owns the policy for every group; deriving one here only
+        # to overwrite it would be wasted work.
+        packing = pinned
     else:
         packing = _packing_by_group_ratio(raw_by_group)
         constrained = _solve_packing(ordered_fields)
         if constrained is not None:
             packing.update(constrained)
+        packing.update(pinned)
 
     plane_fields: dict[str, dict[str, list[CacheFieldSpec]]] = {}
-    for field in ordered_fields:
-        plane_fields.setdefault(field.plane_id, {}).setdefault(
-            field.group_id, []
-        ).append(field)
+    for group_id, field in ordered_fields:
+        plane_fields.setdefault(field.plane_id, {}).setdefault(group_id, []).append(
+            field
+        )
 
     field_offsets: dict[str, int] = {}
     group_plane_bytes: dict[str, dict[str, int]] = defaultdict(dict)
@@ -570,10 +624,10 @@ def solve_cache_layout(
     # Flexible fields consume explicit strides and can use slack left by exact
     # fields, but their K must divide every plane they occupy.
     exact_groups = {
-        field.group_id for field in ordered_fields if field.exact_page_stride
+        group_id for group_id, field in ordered_fields if field.exact_page_stride
     }
     flexible_groups = set(ordered_group_ids) - exact_groups
-    if flexible_groups and not has_explicit_packing:
+    if flexible_groups and not pinned:
         fixed_plane_bytes = {}
         for plane_id, by_group in plane_fields.items():
             fixed_alignment = alignment
@@ -682,17 +736,16 @@ def solve_cache_layout(
             )
 
     field_layouts = []
-    for field in ordered_fields:
+    for group_id, field in ordered_fields:
         field_layouts.append(
             CacheFieldLayout(
-                group_id=field.group_id,
+                group_id=group_id,
                 field_id=field.field_id,
                 plane_id=field.plane_id,
                 shape=field.shape,
-                element_size=field.element_size,
+                dtype=field.dtype,
                 field_offset_bytes=field_offsets[field.field_id],
-                page_stride_bytes=plane_bytes[field.plane_id]
-                // packing[field.group_id],
+                page_stride_bytes=plane_bytes[field.plane_id] // packing[group_id],
             )
         )
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen35.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen35.py
@@ -1,234 +1,230 @@
-"""Qwen3.5 cache field recipe."""
+"""Qwen3.5 cache recipe: full-attention KV plus GDN recurrent checkpoints."""
 
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-    build_hybrid_cache_setup,
-    draft_cache_fields,
-)
+from __future__ import annotations
+
+from functools import cached_property
+
+import torch
+from typing_extensions import override
+
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecipe
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
-    merge_continuation_layers,
+    cache_dtype_name,
+    scatter_stored_dtype_name,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    FULL_ATTENTION,
+    LINEAR_ATTENTION,
+    MXFP8_KV_SCALE_TILE_TOKENS,
+    split_recurrent_state_groups,
 )
 
+_QWEN_GDN_PREFIX_GRANULARITY = 128
 
-def qwen_gdn_max_padding_fraction(*, layer_types, num_draft_layers: int) -> float:
-    """Allow the structural K/V planes added by a Qwen MTP draft.
 
-    Args:
-        layer_types: Target-only attention labels, before merging draft layers.
-        num_draft_layers: Number of full-attention MTP layers being merged.
+class QwenGDNRecipe(CacheRecipe):
+    """Qwen3.5: MHA full-attention layers interleaved with GDN state layers.
 
-    Returns:
-        The Qwen-specific upper bound on unified-arena padding.
-
-    Raises:
-        ValueError: If the target has no full-attention layers.
+    Draft (MTP) layers are full-attention continuation layers of the one big
+    model, so they join the target's full-attention group.
     """
-    num_full_attention_layers = sum(
-        layer_type == "full_attention" for layer_type in layer_types
-    )
-    if num_full_attention_layers == 0:
-        raise ValueError("Qwen3.5 cache requires at least one full-attention layer")
 
-    # If target-only recurrent padding is p <= 1, each mirrored draft layer's
-    # K/V planes increase it by (1 + p) / num_full_attention_layers.  Bound
-    # that increase by 2 without relaxing the original limit when no draft is
-    # present.  The derivation margin is intentionally the only headroom: if
-    # future cache geometry trips the guard, re-derive this bound rather than
-    # adding an epsilon or silently accepting an unbounded binding hole.
-    return 1.0 + 2.0 * num_draft_layers / num_full_attention_layers
+    family = "qwen_gdn"
 
-
-def qwen_gdn_cache_fields(
-    *,
-    layer_types,
-    layer_group_ids,
-    prefix_granularity,
-    kv_shape,
-    kv_element_size,
-    conv_shape,
-    conv_element_size,
-    ssm_shape,
-    ssm_element_size,
-) -> tuple[CacheFieldSpec, ...]:
-    """Describe Qwen3.5 full-attention KV and recurrent checkpoints."""
-    if len(layer_types) != len(layer_group_ids):
-        raise ValueError(
-            f"layer_types has {len(layer_types)} entries but layer_group_ids "
-            f"has {len(layer_group_ids)}"
-        )
-    if next(iter(kv_shape)) != prefix_granularity:
-        raise ValueError("kv_shape must start with prefix_granularity")
-    occurrences: dict[str, int] = {}
-    fields = []
-    for layer_id, (label, group_id) in enumerate(zip(layer_types, layer_group_ids)):
-        unit = occurrences.get(group_id, 0)
-        occurrences[group_id] = unit + 1
-        if label == "linear_attention":
-            fields.extend(
-                (
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.ssm",
-                        f"unit.{unit}.a",
-                        tuple(ssm_shape),
-                        ssm_element_size,
-                    ),
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.conv",
-                        f"unit.{unit}.b",
-                        tuple(conv_shape),
-                        conv_element_size,
-                        exact_page_stride=False,
-                    ),
-                )
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        if self.attn_config.kv_cache_mxfp8:
+            raise RuntimeError(
+                "Qwen cache buffer does not yet support the MXFP8 interleaved "
+                "scale layout"
             )
-        else:
-            fields.extend(
-                (
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.k",
-                        f"unit.{unit}.a",
-                        tuple(kv_shape),
-                        kv_element_size,
-                    ),
-                    CacheFieldSpec(
-                        group_id,
-                        f"layer.{layer_id}.v",
-                        f"unit.{unit}.b",
-                        tuple(kv_shape),
-                        kv_element_size,
-                    ),
-                )
-            )
-    return tuple(fields)
 
+    # ---- layer vocabulary ----
 
-def prepare_qwen35_cache(
-    *,
-    server_args,
-    model_config,
-    attn_config,
-    draft_model_config,
-    draft_attn_config,
-    cache_budget_bytes: int,
-    decode_input_tokens: int,
-    overlap_schedule_depth: int,
-):
-    """Build target and optional draft cache specs for Qwen3.5."""
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        FULL_ATTENTION,
-        LINEAR_ATTENTION,
-        build_paged_cache_group_specs,
-        split_recurrent_state_groups,
-    )
+    @cached_property
+    def target_layer_types(self) -> tuple[str, ...]:
+        return tuple(self.attn_config.layer_types)
 
-    if attn_config.kv_cache_mxfp8:
-        raise RuntimeError(
-            "Qwen cache buffer does not yet support the MXFP8 interleaved scale layout"
+    @property
+    @override
+    def num_draft_layers(self) -> int:
+        if self.draft_attn_config is None:
+            return 0
+        return self.draft_model_config.num_attention_layers
+
+    @cached_property
+    def layer_types(self) -> tuple[str, ...]:
+        return self.target_layer_types + (FULL_ATTENTION,) * self.num_draft_layers
+
+    @cached_property
+    def group_ids(self) -> tuple[str, ...]:
+        # Recurrent state splits into its own groups; draft layers land in the
+        # target's full-attention group.
+        return (
+            tuple(split_recurrent_state_groups(self.target_layer_types))
+            + (FULL_ATTENTION,) * self.num_draft_layers
         )
-    prefix_granularity = 128
-    text_config = getattr(model_config.hf_config, "text_config", model_config.hf_config)
-    conv_shape, ssm_shape, conv_dtype, ssm_dtype, _ = text_config.mamba2_cache_params
-    layer_types = tuple(attn_config.layer_types)
-    group_ids = tuple(split_recurrent_state_groups(layer_types))
-    fields = qwen_gdn_cache_fields(
-        layer_types=layer_types,
-        layer_group_ids=group_ids,
-        prefix_granularity=prefix_granularity,
-        kv_shape=(
-            prefix_granularity,
-            max(attn_config.num_kv_heads // attn_config.attn_tp_size, 1),
-            attn_config.head_dim,
-        ),
-        kv_element_size=attn_config.kv_cache_dtype.itemsize,
-        conv_shape=conv_shape,
-        conv_element_size=conv_dtype.itemsize,
-        ssm_shape=ssm_shape,
-        ssm_element_size=ssm_dtype.itemsize,
-    )
-    state_dtypes = {
-        f"layer.{layer_id}.conv": conv_dtype
-        for layer_id, layer_type in enumerate(layer_types)
-        if layer_type == LINEAR_ATTENTION
-    } | {
-        f"layer.{layer_id}.ssm": ssm_dtype
-        for layer_id, layer_type in enumerate(layer_types)
-        if layer_type == LINEAR_ATTENTION
-    }
 
-    draft_fields = None
-    draft_layer_types = ()
-    draft_group_ids = ()
-    fixed_workspace_bytes = 0
-    if draft_attn_config is not None:
-        draft_num_layers = draft_model_config.num_attention_layers
-        draft_layer_types = (FULL_ATTENTION,) * draft_num_layers
-        draft_group_ids = draft_layer_types
-        per_rank_heads = (
-            max(
-                draft_attn_config.num_kv_heads // draft_attn_config.attn_tp_size,
-                1,
+    # ---- geometry ----
+
+    @property
+    @override
+    def prefix_granularity(self) -> int:
+        return _QWEN_GDN_PREFIX_GRANULARITY
+
+    @property
+    @override
+    def max_padding_fraction(self) -> float:
+        """Allow the structural K/V planes added by a Qwen MTP draft.
+
+        If target-only recurrent padding is p <= 1, each mirrored draft
+        layer's K/V planes increase it by (1 + p) / num_full_attention_layers.
+        Bound that increase by 2 without relaxing the original limit when no
+        draft is present. The derivation margin is intentionally the only
+        headroom: if future cache geometry trips the guard, re-derive this
+        bound rather than adding an epsilon or silently accepting an unbounded
+        binding hole.
+        """
+        num_full_attention = sum(
+            layer_type == FULL_ATTENTION for layer_type in self.target_layer_types
+        )
+        if num_full_attention == 0:
+            raise ValueError("Qwen3.5 cache requires at least one full-attention layer")
+        return 1.0 + 2.0 * self.num_draft_layers / num_full_attention
+
+    # ---- fields ----
+
+    @cached_property
+    def _state_shapes(self):
+        text_config = getattr(
+            self.model_config.hf_config, "text_config", self.model_config.hf_config
+        )
+        conv_shape, ssm_shape, conv_dtype, ssm_dtype, _ = (
+            text_config.mamba2_cache_params
+        )
+        return (
+            tuple(conv_shape),
+            cache_dtype_name(conv_dtype),
+            tuple(ssm_shape),
+            cache_dtype_name(ssm_dtype),
+        )
+
+    @cached_property
+    def _kv_shape(self) -> tuple[int, ...]:
+        return (
+            self.prefix_granularity,
+            max(self.attn_config.num_kv_heads // self.attn_config.attn_tp_size, 1),
+            self.attn_config.head_dim,
+        )
+
+    @cached_property
+    def _draft_kv_shape(self) -> tuple[int, ...]:
+        config = self.draft_attn_config
+        return (
+            self.prefix_granularity,
+            max(config.num_kv_heads // config.attn_tp_size, 1),
+            config.head_dim,
+        )
+
+    @override
+    def fields_for_layer(
+        self, layer_id: int, group_id: str, occurrence: int
+    ) -> tuple[CacheFieldSpec, ...]:
+        if layer_id >= len(self.target_layer_types):
+            return self._draft_fields(layer_id, occurrence)
+        conv_shape, conv_dtype, ssm_shape, ssm_dtype = self._state_shapes
+        if self.layer_types[layer_id] == LINEAR_ATTENTION:
+            return (
+                CacheFieldSpec(
+                    f"layer.{layer_id}.ssm",
+                    f"unit.{occurrence}.a",
+                    ssm_shape,
+                    ssm_dtype,
+                ),
+                CacheFieldSpec(
+                    f"layer.{layer_id}.conv",
+                    f"unit.{occurrence}.b",
+                    conv_shape,
+                    conv_dtype,
+                    exact_page_stride=False,
+                ),
+            )
+        kv_dtype = scatter_stored_dtype_name(self.attn_config.kv_cache_dtype)
+        return (
+            CacheFieldSpec(
+                f"layer.{layer_id}.k", f"unit.{occurrence}.a", self._kv_shape, kv_dtype
             ),
-        ) * draft_num_layers
-        draft_fields = draft_cache_fields(
-            layer_group_ids=draft_group_ids,
-            enabled_layer_ids=range(draft_num_layers),
-            prefix_granularity=prefix_granularity,
-            layer_kv_heads=per_rank_heads,
-            head_dim=draft_attn_config.head_dim,
-            kv_element_size=draft_attn_config.kv_cache_dtype.itemsize,
-            kv_scale_block_size=32 if draft_attn_config.kv_cache_mxfp8 else 0,
-            kv_scale_element_size=1 if draft_attn_config.kv_cache_mxfp8 else 0,
+            CacheFieldSpec(
+                f"layer.{layer_id}.v", f"unit.{occurrence}.b", self._kv_shape, kv_dtype
+            ),
         )
-        verify_rows = attn_config.max_bs * (
-            int(server_args.speculative_num_draft_tokens) + 1
+
+    def _draft_fields(
+        self, layer_id: int, occurrence: int
+    ) -> tuple[CacheFieldSpec, ...]:
+        """One MTP draft layer's full-attention KV, mxfp8 scales included."""
+        config = self.draft_attn_config
+        mxfp8 = bool(config.kv_cache_mxfp8)
+        kv_dtype = (
+            cache_dtype_name(torch.float8_e4m3fn)
+            if mxfp8
+            else scatter_stored_dtype_name(config.kv_cache_dtype)
         )
-        fixed_workspace_bytes = verify_rows * sum(
+        fields = (
+            CacheFieldSpec(
+                f"layer.{layer_id}.k",
+                f"unit.{occurrence}.a",
+                self._draft_kv_shape,
+                kv_dtype,
+            ),
+            CacheFieldSpec(
+                f"layer.{layer_id}.v",
+                f"unit.{occurrence}.b",
+                self._draft_kv_shape,
+                kv_dtype,
+            ),
+        )
+        if not mxfp8:
+            return fields
+        kv_heads = self._draft_kv_shape[1]
+        scale_dim = config.head_dim // 32
+        scale_shape = (
+            kv_heads,
+            self.prefix_granularity // MXFP8_KV_SCALE_TILE_TOKENS,
+            32,
+            scale_dim,
+            scale_dim,
+        )
+        scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
+        return fields + (
+            CacheFieldSpec(
+                f"layer.{layer_id}.k_scale",
+                f"unit.{occurrence}.k_scale",
+                scale_shape,
+                scale_dtype,
+            ),
+            CacheFieldSpec(
+                f"layer.{layer_id}.v_scale",
+                f"unit.{occurrence}.v_scale",
+                scale_shape,
+                scale_dtype,
+            ),
+        )
+
+    # ---- extras ----
+
+    @override
+    def workspace_bytes(self) -> int:
+        """Verify-window staging for the recurrent state, when drafting."""
+        if not self.num_draft_layers:
+            return 0
+        verify_rows = self.attn_config.max_bs * (
+            int(self.server_args.speculative_num_draft_tokens) + 1
+        )
+        return verify_rows * sum(
             field.payload_bytes
+            for _, fields in self.groups()
             for field in fields
             if field.field_id.endswith((".conv", ".ssm"))
         )
-
-    (
-        merged_fields,
-        merged_layer_types,
-        merged_group_ids,
-        _,
-        num_draft_layers,
-    ) = merge_continuation_layers(
-        fields=fields,
-        layer_types=layer_types,
-        group_ids=group_ids,
-        draft_fields=draft_fields,
-        draft_layer_types=draft_layer_types,
-        draft_group_ids=draft_group_ids,
-    )
-    # ONE spec derivation over the merged layers: shared groups validate
-    # for consistent policy instead of the draft's being silently dropped.
-    group_specs = build_paged_cache_group_specs(
-        layer_types=merged_layer_types,
-        group_ids=merged_group_ids,
-        sliding_window_tokens=None,
-        prefix_granularity=prefix_granularity,
-        pd_disaggregation_enabled=attn_config.pd_disaggregation_enabled,
-    )
-    return build_hybrid_cache_setup(
-        family="qwen_gdn",
-        server_args=server_args,
-        fields=merged_fields,
-        layer_types=merged_layer_types,
-        group_ids=merged_group_ids,
-        group_specs=group_specs,
-        state_dtypes=state_dtypes,
-        layer_kv_head_counts=None,
-        num_draft_layers=num_draft_layers,
-        cache_budget_bytes=cache_budget_bytes,
-        fixed_workspace_bytes=fixed_workspace_bytes,
-        prefix_granularity=prefix_granularity,
-        max_padding_fraction=qwen_gdn_max_padding_fraction(
-            layer_types=layer_types,
-            num_draft_layers=num_draft_layers,
-        ),
-    )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen35.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen35.py
@@ -11,12 +11,12 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecip
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
     cache_dtype_name,
+    mxfp8_kv_scale_fields,
     scatter_stored_dtype_name,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     FULL_ATTENTION,
     LINEAR_ATTENTION,
-    MXFP8_KV_SCALE_TILE_TOKENS,
     split_recurrent_state_groups,
 )
 
@@ -48,13 +48,6 @@ class QwenGDNRecipe(CacheRecipe):
     @cached_property
     def target_layer_types(self) -> tuple[str, ...]:
         return tuple(self.attn_config.layer_types)
-
-    @property
-    @override
-    def num_draft_layers(self) -> int:
-        if self.draft_attn_config is None:
-            return 0
-        return self.draft_model_config.num_attention_layers
 
     @cached_property
     def layer_types(self) -> tuple[str, ...]:
@@ -190,29 +183,12 @@ class QwenGDNRecipe(CacheRecipe):
         )
         if not mxfp8:
             return fields
-        kv_heads = self._draft_kv_shape[1]
-        scale_dim = config.head_dim // 32
-        scale_shape = (
-            kv_heads,
-            self.prefix_granularity // MXFP8_KV_SCALE_TILE_TOKENS,
-            32,
-            scale_dim,
-            scale_dim,
-        )
-        scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
-        return fields + (
-            CacheFieldSpec(
-                f"layer.{layer_id}.k_scale",
-                f"unit.{occurrence}.k_scale",
-                scale_shape,
-                scale_dtype,
-            ),
-            CacheFieldSpec(
-                f"layer.{layer_id}.v_scale",
-                f"unit.{occurrence}.v_scale",
-                scale_shape,
-                scale_dtype,
-            ),
+        return fields + mxfp8_kv_scale_fields(
+            layer_id=layer_id,
+            occurrence=occurrence,
+            kv_heads=self._draft_kv_shape[1],
+            head_dim=config.head_dim,
+            prefix_granularity=self.prefix_granularity,
         )
 
     # ---- extras ----

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
@@ -22,32 +22,31 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from functools import partial
 from typing import Literal
 
-import torch
-
 from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecipe
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4 import (
-    prepare_deepseek_v4_cache,
+    DeepseekV4Recipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.inkling import (
-    prepare_inkling_cache,
+    InklingRecipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.kimi_k3 import (
-    prepare_kimi_k3_cache,
+    KimiK3Recipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-    prepare_ordinary_cache,
+    OrdinaryRecipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import CacheMemoryPlan
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.qwen35 import (
-    prepare_qwen35_cache,
+    QwenGDNRecipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 
 CacheModelFamily = Literal[
@@ -70,25 +69,13 @@ class CachePoolSpec:
     memory_plan: CacheMemoryPlan
     layer_types: tuple[str, ...]
     layer_group_ids: tuple[str, ...]
-    # Scheduler group specs, computed once by the recipe. The pool aligns
-    # their physical fields (packing) with the memory plan and publishes the
-    # runtime contract from the pair.
-    paged_cache_group_specs: tuple[PagedCacheGroupSpec, ...]
-    state_field_dtypes: Mapping[str, torch.dtype]
+    # Scheduler group specs. The recipe declared these next to the fields the
+    # plan was packed from (CacheRecipe.groups), so the plan and the specs name
+    # the same groups by construction -- there is nothing to cross-check.
+    cache_group_specs: tuple[CacheGroupSpec, ...]
     token_capacity: int
     layer_kv_head_counts: tuple[int, ...] | None = None
     pool_options: object | None = None
-
-    @property
-    def pool_size(self) -> int:
-        max_packing = max(
-            group.cache_blocks_per_lcm_block for group in self.memory_plan.groups
-        )
-        return (
-            self.memory_plan.num_lcm_blocks
-            * max_packing
-            * self.memory_plan.prefix_granularity
-        )
 
     def layer_view(
         self,
@@ -96,13 +83,13 @@ class CachePoolSpec:
         first_layer: int,
         num_layers: int,
         family: CacheModelFamily | None = None,
-        publish_runtime_contract: bool = True,
     ) -> CachePoolSpec:
         """Describe one concrete compute view over this spec's shared arena.
 
-        The memory plan and scheduler geometry stay merged. Only per-layer
-        compute metadata is sliced; a secondary view inherits the target's
-        published contract instead of publishing the same groups again.
+        The memory plan and scheduler geometry stay merged, group specs
+        included: publication is not a view's concern. Only per-layer compute
+        metadata is sliced. The arena publishes the contract once, from the
+        merged spec, so no view can republish or diverge from it.
         """
         total_layers = len(self.layer_group_ids)
         if first_layer < 0 or num_layers < 0:
@@ -119,6 +106,10 @@ class CachePoolSpec:
             len(self.layer_kv_head_counts) != total_layers
         ):
             raise ValueError("cache KV head counts must cover every layer")
+        # A family whose pool options are themselves per-layer (V4's kernel
+        # cache layout) narrows them to the same window; anything else is a
+        # whole-pool fact and travels unchanged.
+        narrow_options = getattr(self.pool_options, "layer_view", None)
         return replace(
             self,
             family=family or self.family,
@@ -131,8 +122,10 @@ class CachePoolSpec:
                 if self.layer_kv_head_counts is not None
                 else None
             ),
-            paged_cache_group_specs=(
-                self.paged_cache_group_specs if publish_runtime_contract else ()
+            pool_options=(
+                narrow_options(first_layer=first_layer, num_layers=num_layers)
+                if narrow_options is not None
+                else self.pool_options
             ),
         )
 
@@ -160,15 +153,18 @@ class CacheSetup:
         return len(self.spec.layer_group_ids) - self.num_draft_layers
 
 
-_PREPARE_CACHE = {
-    "mha": partial(prepare_ordinary_cache, family="mha"),
-    "mla": partial(prepare_ordinary_cache, family="mla"),
-    "dsa": partial(prepare_ordinary_cache, family="dsa"),
-    "msa": partial(prepare_ordinary_cache, family="msa"),
-    "qwen_gdn": prepare_qwen35_cache,
-    "inkling": prepare_inkling_cache,
-    "kimi_k3": prepare_kimi_k3_cache,
-    "deepseek_v4": prepare_deepseek_v4_cache,
+# family -> how to build its recipe. Every family runs the one pipeline in
+# CacheRecipe.setup(); the class only fills in that family's seams, and the
+# four ordinary families differ by nothing but the family label.
+_RECIPES: dict[CacheModelFamily, Callable[..., CacheRecipe]] = {
+    "mha": partial(OrdinaryRecipe, family="mha"),
+    "mla": partial(OrdinaryRecipe, family="mla"),
+    "dsa": partial(OrdinaryRecipe, family="dsa"),
+    "msa": partial(OrdinaryRecipe, family="msa"),
+    "qwen_gdn": QwenGDNRecipe,
+    "inkling": InklingRecipe,
+    "kimi_k3": KimiK3Recipe,
+    "deepseek_v4": DeepseekV4Recipe,
 }
 
 
@@ -185,10 +181,10 @@ def prepare_cache_setup(
     overlap_schedule_depth: int,
 ) -> CacheSetup:
     """Apply one model recipe and size target/draft arenas from one budget."""
-    prepare = _PREPARE_CACHE.get(family)
-    if prepare is None:
+    recipe = _RECIPES.get(family)
+    if recipe is None:
         raise ValueError(f"unsupported cache model family: {family}")
-    return prepare(
+    return recipe(
         server_args=server_args,
         model_config=model_config,
         attn_config=attn_config,
@@ -197,4 +193,4 @@ def prepare_cache_setup(
         cache_budget_bytes=cache_budget_bytes,
         decode_input_tokens=decode_input_tokens,
         overlap_schedule_depth=overlap_schedule_depth,
-    )
+    ).setup()

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
@@ -69,9 +69,8 @@ class CachePoolSpec:
     memory_plan: CacheMemoryPlan
     layer_types: tuple[str, ...]
     layer_group_ids: tuple[str, ...]
-    # Scheduler group specs. The recipe declared these next to the fields the
-    # plan was packed from (CacheRecipe.groups), so the plan and the specs name
-    # the same groups by construction -- there is nothing to cross-check.
+    # Scheduler group specs, declared next to the fields the plan was packed
+    # from (CacheRecipe.groups), so the plan and the specs name one group set.
     cache_group_specs: tuple[CacheGroupSpec, ...]
     token_capacity: int
     layer_kv_head_counts: tuple[int, ...] | None = None

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
@@ -20,6 +20,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Literal
 
+from tokenspeed.runtime.layers.attention.kv_cache.recipes import plan
+
 Retention = Literal["full_history", "sliding_window"]
 Family = Literal["history", "state"]
 TransferPolicy = Literal["full_suffix", "latest_snapshot"]
@@ -111,10 +113,10 @@ class CacheGroupSpec:
 
 _CACHE_GROUP_DUMMY_PAGES = 1
 
-# Token span of one interleaved mxfp8 KV-scale tile. The fused FP8 attention
-# kernels store k_scale/v_scale in tiles of this many tokens, which changes
-# both the scale field shape and its head-partition axis.
-MXFP8_KV_SCALE_TILE_TOKENS = 128
+# The scale-tile span lives with the field geometry it defines (plan.py); it is
+# re-exported here because scheduler-side callers reason about the tile as a
+# token span, not as a shape.
+MXFP8_KV_SCALE_TILE_TOKENS = plan.MXFP8_KV_SCALE_TILE_TOKENS
 
 
 def _ceil_div(dividend: int, divisor: int) -> int:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
@@ -26,7 +26,7 @@ TransferPolicy = Literal["full_suffix", "latest_snapshot"]
 
 
 @dataclass(frozen=True)
-class PagedCacheGroupSpec:
+class CacheGroupSpec:
     """One cache group's scheduler-facing layout.
 
     A spec declares exactly one geometry shape:
@@ -51,8 +51,6 @@ class PagedCacheGroupSpec:
     # History stores token history; State stores recurrent state. Retention
     # determines whether either family is full-history or sliding.
     family: Family = "history"
-    # Physical child CacheBlocks packed into one shared LCM parent.
-    cache_blocks_per_lcm_block: int = 1
     # None preserves standalone/non-PD behavior; PD plans set this explicitly.
     transfer_policy: TransferPolicy | None = None
     # Snapshot-state shape: raw-token span between two state checkpoints.
@@ -111,7 +109,7 @@ class PagedCacheGroupSpec:
         return self.page_size
 
 
-_PAGED_CACHE_GROUP_DUMMY_PAGES = 1
+_CACHE_GROUP_DUMMY_PAGES = 1
 
 # Token span of one interleaved mxfp8 KV-scale tile. The fused FP8 attention
 # kernels store k_scale/v_scale in tiles of this many tokens, which changes
@@ -123,7 +121,7 @@ def _ceil_div(dividend: int, divisor: int) -> int:
     return (dividend + divisor - 1) // divisor
 
 
-# Paged-cache label vocabulary (NOT the HF checkpoint's serialized enum:
+# Cache-group label vocabulary (NOT the HF checkpoint's serialized enum:
 # Qwen3.5 checkpoints spell full attention "attention").
 FULL_ATTENTION = "full_attention"
 LINEAR_ATTENTION = "linear_attention"
@@ -154,11 +152,12 @@ def validate_scheduler_config(
             dying on a capture-path assert at best and silently reading the
             wrong pages at worst.
     """
-    contract = getattr(kv_pool, "runtime_contract", None)
+    arena = getattr(kv_pool, "arena", None)
+    contract = getattr(arena, "runtime_contract", None)
     if contract is None:
         raise RuntimeError(
             f"KV pool {type(kv_pool).__name__} publishes no "
-            "PagedCacheRuntimeContract. Every pool must be built from a "
+            "CacheRuntimeContract. Every pool must be built from a "
             "cache recipe (kv_cache.recipes.setup.prepare_cache_setup)."
         )
     required_families = frozenset(spec.family for spec in contract.group_specs)
@@ -166,15 +165,15 @@ def validate_scheduler_config(
     missing_families = required_families - supported_families
     if missing_families:
         raise RuntimeError(
-            "paged cache pool requires consumer families "
+            "cache pool requires consumer families "
             f"{sorted(required_families)}, but backend "
             f"{type(attn_backend).__name__} is missing "
             f"{sorted(missing_families)}"
         )
 
 
-def compute_paged_cache_group_page_counts(
-    specs: Sequence[PagedCacheGroupSpec],
+def compute_cache_group_page_counts(
+    specs: Sequence[CacheGroupSpec],
     *,
     max_live_requests: int,
     max_scheduled_tokens: int,
@@ -201,9 +200,7 @@ def compute_paged_cache_group_page_counts(
             f"overlap_schedule_depth must be 0 or 1, got {overlap_schedule_depth}"
         )
     if overlap_schedule_depth > 0 and decode_input_tokens == 0:
-        raise ValueError(
-            "overlapped paged-cache sizing requires decode_input_tokens > 0"
-        )
+        raise ValueError("overlapped cache sizing requires decode_input_tokens > 0")
     if safety_margin < 0:
         raise ValueError(f"safety_margin must be >= 0, got {safety_margin}")
 
@@ -224,14 +221,14 @@ def compute_paged_cache_group_page_counts(
                 _ceil_div(max_total_tokens, block_granularity)
                 + max_live_requests
                 + protected_pages
-                + _PAGED_CACHE_GROUP_DUMMY_PAGES
+                + _CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )
             state_total = (
                 max_live_requests * 2
                 + max_total_tokens // block_granularity
                 + protected_pages
-                + _PAGED_CACHE_GROUP_DUMMY_PAGES
+                + _CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )
             total = min(state_total, full_history_total)
@@ -241,14 +238,14 @@ def compute_paged_cache_group_page_counts(
                 full_pages
                 + max_live_requests
                 + protected_pages
-                + _PAGED_CACHE_GROUP_DUMMY_PAGES
+                + _CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )
         elif spec.retention == "sliding_window":
             window = spec.sliding_window_tokens
             if window is None or window <= 0:
                 raise ValueError(
-                    f"PagedCacheGroupSpec {spec.group_id}: sliding group missing "
+                    f"CacheGroupSpec {spec.group_id}: sliding group missing "
                     "positive sliding_window_tokens"
                 )
             # Capacity tracks resident history before the next token.
@@ -263,12 +260,12 @@ def compute_paged_cache_group_page_counts(
                 + scheduled_pages
                 + max_live_requests
                 + protected_pages
-                + _PAGED_CACHE_GROUP_DUMMY_PAGES
+                + _CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )
         else:
             raise ValueError(
-                f"PagedCacheGroupSpec {spec.group_id}: unsupported retention "
+                f"CacheGroupSpec {spec.group_id}: unsupported retention "
                 f"{spec.retention!r}"
             )
         counts[spec.group_id] = int(total)
@@ -276,13 +273,13 @@ def compute_paged_cache_group_page_counts(
 
 
 def compute_max_logical_pages_for_capture(
-    spec: PagedCacheGroupSpec,
+    spec: CacheGroupSpec,
     *,
     max_context_len: int,
     max_tokens_per_req: int = 1,
     overlap_schedule_depth: int = 0,
 ) -> int:
-    """Return CUDA Graph block-table width for one paged-cache group.
+    """Return CUDA Graph block-table width for one cache group.
 
     Decode admission reserves the current verify span plus one span for each
     overlapped schedule.  Include that complete reservation horizon here: a
@@ -291,7 +288,7 @@ def compute_max_logical_pages_for_capture(
     truncated by the request-length limit.
 
     Args:
-        spec: Paged-cache group layout and retention policy.
+        spec: Cache group layout and retention policy.
         max_context_len: Maximum accepted raw-token context length.
         max_tokens_per_req: Runtime decode/verify width.
         overlap_schedule_depth: Number of additionally in-flight decode steps.
@@ -313,7 +310,7 @@ def compute_max_logical_pages_for_capture(
         window = spec.sliding_window_tokens
         if window is None or window <= 0:
             raise ValueError(
-                f"PagedCacheGroupSpec {spec.group_id}: sliding group missing "
+                f"CacheGroupSpec {spec.group_id}: sliding group missing "
                 "positive sliding_window_tokens"
             )
         # Capture uses a conservative metadata bound; it does not change the
@@ -325,7 +322,7 @@ def compute_max_logical_pages_for_capture(
         live_tokens = max_context_len + reservation_horizon
         return _ceil_div(live_tokens, block_granularity)
     raise ValueError(
-        f"PagedCacheGroupSpec {spec.group_id}: unsupported retention {spec.retention!r}"
+        f"CacheGroupSpec {spec.group_id}: unsupported retention {spec.retention!r}"
     )
 
 
@@ -377,8 +374,7 @@ def hybrid_slab_group_size(
     group shares slab i), or None when the model cannot share slabs.
 
     Single source (canonical) for both the sizing divisor (registry KV
-    profile) and the buffer layout (_create_buffers) -- the two must never
-    disagree. The scheduler's single BlockPool owns each page id by at most
+    profile) and the planned field layout -- the two must never disagree. The scheduler's single BlockPool owns each page id by at most
     one group, so paired layers' live rows never overlap. Unknown labels
     degrade to None -- the predicate gates an optimization, so it must not
     raise.
@@ -491,7 +487,7 @@ def layer_group_ids(
     layer_types: Sequence[str],
     sliding_window_tokens: int | Sequence[int | None] | None,
 ) -> list[str]:
-    """Per-layer paged-cache group id — the single derivation the recipes
+    """Per-layer cache group id — the single derivation the recipes
     and multi-window models assign ``PagedAttention(group_id=...)`` from
     (today gpt_oss.py assigns group_id=layer_type, identical in the
     single-window case), so ``block_tables`` keys line up with the
@@ -532,16 +528,27 @@ def split_recurrent_state_groups(layer_types: Sequence[str]) -> list[str]:
     return group_ids
 
 
-def group_specs_from_layer_types(
+def group(
     *,
     layer_types: Sequence[str],
     group_ids: Sequence[str],
     sliding_window_tokens: int | Sequence[int | None] | None,
     prefix_granularity: int,
+    fields_for_layer,
     page_sizes: Mapping[str, int] | None = None,
-    cache_blocks_per_lcm_block: Mapping[str, int] | None = None,
-) -> list[PagedCacheGroupSpec]:
-    """Derive paged-cache group specs from per-layer attention types.
+    pd_disaggregation_enabled: bool = False,
+) -> tuple[tuple[CacheGroupSpec, tuple], ...]:
+    """Walk the layers once, building each group whole.
+
+    A cache group has two halves -- the scheduler-facing spec and the bytes
+    its fields occupy -- and one walk produces both: every layer contributes
+    its retention/family policy to its group's spec and its fields to that
+    same group's field list, keyed by the one ``group_id`` variable. There is
+    no second enumeration to disagree with, so nothing needs cross-checking.
+
+    Physical packing is deliberately absent from the specs: how many of a
+    group's CacheBlocks share one LCM parent is solved by the memory plan and
+    published by the arena.
 
     vLLM-style spec-value grouping: layers collapse into one group per
     distinct group id. Group order = first-appearance order.
@@ -550,7 +557,8 @@ def group_specs_from_layer_types(
         layer_types: Per-layer labels: "full_attention" / "sliding_attention"
             (or sliding sub-group labels "sliding_attention_<k>") /
             "linear_attention" (state-family, e.g. Qwen3.5 GDN). Retention
-            and family always come from these labels.
+            and family always come from these labels. Empty means every layer
+            is full-history.
         group_ids: Physical group id per layer. The cache recipe is the
             single source of these ids: derive them with ``layer_group_ids``
             for label-equivalent grouping, or supply a finer split (hybrid
@@ -560,17 +568,41 @@ def group_specs_from_layer_types(
             scalar), or a per-layer sequence (multi-window models; full-layer
             positions must be None).
         prefix_granularity: Scheduler-wide prefix granularity in tokens.
+        fields_for_layer: ``(layer_id, group_id, occurrence) -> fields``. The
+            occurrence is how many layers of this group already declared
+            fields, i.e. this layer's slot in the group's plane numbering; a
+            layer that declares nothing does not consume a slot.
         page_sizes: Per-group page sizes keyed by group id (heterogeneous
-            block sizes); values must be positive multiples of prefix_granularity.
-            Groups not listed use prefix_granularity.
-        cache_blocks_per_lcm_block: Per-group physical packing. Omitted groups
-            use one CacheBlock per physical parent.
+            block sizes); values must be positive multiples of
+            prefix_granularity. Groups not listed use prefix_granularity.
+        pd_disaggregation_enabled: Stamp PD transfer policies on the specs.
+
+    Returns:
+        ``(spec, fields)`` pairs in first-appearance order, ready for
+        ``pack``.
 
     Raises:
         ValueError: unknown label; window sequence length mismatch; sliding
             layer without a positive window; full layer carrying a window;
-            group id shared across incompatible layer policies.
+            group id shared across incompatible layer policies; a group whose
+            layers declare no fields.
     """
+    resolved_group_ids = tuple(group_ids)
+    if not resolved_group_ids:
+        raise ValueError(
+            "group requires per-layer group_ids; the "
+            "cache recipe is their single source: derive them with "
+            "layer_group_ids(...) and carry them via "
+            "CachePoolSpec.layer_group_ids"
+        )
+    resolved_layer_types = tuple(layer_types) or (FULL_ATTENTION,) * len(
+        resolved_group_ids
+    )
+    if len(resolved_group_ids) != len(resolved_layer_types):
+        raise ValueError(
+            f"group_ids has {len(resolved_group_ids)} entries but layer_types "
+            f"has {len(resolved_layer_types)}"
+        )
     sizes = dict(page_sizes or {})
     for gid, ps in sizes.items():
         if ps <= 0 or ps % prefix_granularity:
@@ -578,75 +610,94 @@ def group_specs_from_layer_types(
                 f"page_sizes[{gid!r}] = {ps} must be a positive "
                 f"multiple of prefix_granularity {prefix_granularity}"
             )
-    packing = dict(cache_blocks_per_lcm_block or {})
-    for gid, count in packing.items():
-        if isinstance(count, bool) or not isinstance(count, int) or count <= 0:
-            raise ValueError(
-                f"cache_blocks_per_lcm_block[{gid!r}] = {count!r} must be "
-                "a positive int"
-            )
-    layer_specs = _layer_retention_windows(layer_types, sliding_window_tokens)
-    resolved_group_ids = list(group_ids)
-    if len(resolved_group_ids) != len(layer_types):
-        raise ValueError(
-            f"group_ids has {len(resolved_group_ids)} entries but layer_types "
-            f"has {len(layer_types)}"
-        )
+    layer_policies = _layer_retention_windows(
+        resolved_layer_types, sliding_window_tokens
+    )
 
-    specs: list[PagedCacheGroupSpec] = []
-    seen: dict[str, tuple[Retention, int | None, Family]] = {}
+    specs: dict[str, CacheGroupSpec] = {}
+    fields: dict[str, tuple] = {}
+    occurrences: dict[str, int] = {}
     for layer_id, ((retention, window), gid) in enumerate(
-        zip(layer_specs, resolved_group_ids)
+        zip(layer_policies, resolved_group_ids)
     ):
         if not gid:
             raise ValueError(f"group_ids[{layer_id}] must be non-empty")
         family: Family = (
-            "state" if layer_types[layer_id] in STATE_LAYER_TYPES else "history"
+            "state"
+            if resolved_layer_types[layer_id] in STATE_LAYER_TYPES
+            else "history"
         )
-        if gid in seen:
-            if seen[gid] != (retention, window, family):
+        if gid in specs:
+            existing = specs[gid]
+            if (
+                existing.retention,
+                existing.sliding_window_tokens,
+                existing.family,
+            ) != (
+                retention,
+                window,
+                family,
+            ):
                 raise ValueError(f"group_id {gid!r} mixes incompatible layer policies")
-            continue
-        seen[gid] = (retention, window, family)
-        ps = sizes.pop(gid, None) or prefix_granularity
-        group_packing = packing.pop(gid, 1)
-        if family == "state":
-            # Snapshot-state groups have no rows: one CacheBlock holds one
-            # recurrent-state checkpoint taken every `ps` tokens.
-            specs.append(
-                PagedCacheGroupSpec(
-                    group_id=gid,
-                    retention=retention,
-                    sliding_window_tokens=window,
-                    family=family,
-                    cache_blocks_per_lcm_block=group_packing,
-                    checkpoint_granularity=ps,
-                )
-            )
-            continue
-        specs.append(
-            PagedCacheGroupSpec(
+        else:
+            specs[gid] = _layer_group_spec(
                 group_id=gid,
                 retention=retention,
-                rows_per_page=ps,
-                entry_stride_tokens=1,
-                sliding_window_tokens=window,
+                window=window,
                 family=family,
-                cache_blocks_per_lcm_block=group_packing,
+                block_tokens=sizes.pop(gid, None) or prefix_granularity,
             )
-        )
+        occurrence = occurrences.get(gid, 0)
+        declared = tuple(fields_for_layer(layer_id, gid, occurrence))
+        if declared:
+            occurrences[gid] = occurrence + 1
+            fields[gid] = fields.get(gid, ()) + declared
     if sizes:
         raise ValueError(f"page_sizes for unknown groups: {sorted(sizes)}")
-    if packing:
+    barren = sorted(set(specs) - set(fields))
+    if barren:
         raise ValueError(
-            f"cache_blocks_per_lcm_block for unknown groups: {sorted(packing)}"
+            f"cache groups {barren} declare no fields; a group with no bytes "
+            "cannot be addressed"
         )
-    return specs
+    published = specs.values()
+    if pd_disaggregation_enabled:
+        published = apply_pd_transfer_policies(tuple(published))
+    return tuple((spec, fields[spec.group_id]) for spec in published)
+
+
+def _layer_group_spec(
+    *,
+    group_id: str,
+    retention: Retention,
+    window: int | None,
+    family: Family,
+    block_tokens: int,
+) -> CacheGroupSpec:
+    """One group's spec in the shape its family declares."""
+    if family == "state":
+        # Snapshot-state groups have no rows: one CacheBlock holds one
+        # recurrent-state checkpoint taken every `block_tokens` tokens.
+        return CacheGroupSpec(
+            group_id=group_id,
+            retention=retention,
+            sliding_window_tokens=window,
+            family=family,
+            checkpoint_granularity=block_tokens,
+        )
+    return CacheGroupSpec(
+        group_id=group_id,
+        retention=retention,
+        rows_per_page=block_tokens,
+        entry_stride_tokens=1,
+        sliding_window_tokens=window,
+        family=family,
+    )
 
 
 def apply_pd_transfer_policies(
-    specs: Sequence[PagedCacheGroupSpec],
-) -> list[PagedCacheGroupSpec]:
+    specs: Sequence[CacheGroupSpec],
+) -> list[CacheGroupSpec]:
     """Stamp PD-disaggregation transfer policies onto group specs.
 
     Full-history state groups transfer only their trailing snapshot. Sliding
@@ -668,68 +719,16 @@ def apply_pd_transfer_policies(
     ]
 
 
-def build_paged_cache_group_specs(
-    *,
-    layer_types: Sequence[str],
-    group_ids: Sequence[str],
-    sliding_window_tokens: int | Sequence[int | None] | None,
-    prefix_granularity: int,
-    cache_blocks_per_lcm_block: Mapping[str, int] | None = None,
-    pd_disaggregation_enabled: bool = False,
-) -> tuple[PagedCacheGroupSpec, ...]:
-    """Build the scheduler group specs one cache recipe publishes.
-
-    The recipe computes these once and carries them via
-    ``CachePoolSpec.paged_cache_group_specs``; page counts always come from
-    the memory plan (the pool binds both into the runtime contract).
-    Groups outside the layer-type vocabulary (e.g. Inkling's paged sconv
-    columns) are plain tuple concatenation on the result — the pool
-    validates uniqueness and planning for every group the same way.
-
-    Args:
-        layer_types: Per-layer paged-cache labels (empty -> every layer in
-            ``group_ids`` is full-history).
-        group_ids: Physical group id per layer, from the cache recipe
-            (``CachePoolSpec.layer_group_ids``). Must line up 1:1 with
-            layer_types when both are non-empty.
-        sliding_window_tokens / prefix_granularity / cache_blocks_per_lcm_block:
-            Forwarded to group_specs_from_layer_types.
-        pd_disaggregation_enabled: Stamp PD transfer policies on the specs.
-    """
-    resolved_group_ids = tuple(group_ids)
-    if not resolved_group_ids:
-        raise ValueError(
-            "build_paged_cache_group_specs requires per-layer group_ids; the "
-            "cache recipe is their single source: derive them with "
-            "layer_group_ids(...) and carry them via "
-            "CachePoolSpec.layer_group_ids"
-        )
-    resolved_layer_types = tuple(layer_types) or (FULL_ATTENTION,) * len(
-        resolved_group_ids
-    )
-    specs = group_specs_from_layer_types(
-        layer_types=resolved_layer_types,
-        group_ids=resolved_group_ids,
-        sliding_window_tokens=sliding_window_tokens,
-        prefix_granularity=prefix_granularity,
-        cache_blocks_per_lcm_block=cache_blocks_per_lcm_block,
-    )
-    if pd_disaggregation_enabled:
-        specs = apply_pd_transfer_policies(specs)
-    return tuple(specs)
-
-
 __all__ = [
     "FULL_ATTENTION",
     "LINEAR_ATTENTION",
-    "PagedCacheGroupSpec",
+    "CacheGroupSpec",
     "Retention",
     "STATE_LAYER_TYPES",
     "apply_pd_transfer_policies",
-    "build_paged_cache_group_specs",
+    "group",
     "compute_max_logical_pages_for_capture",
-    "compute_paged_cache_group_page_counts",
-    "group_specs_from_layer_types",
+    "compute_cache_group_page_counts",
     "hybrid_slab_group_size",
     "layer_group_ids",
     "split_recurrent_state_groups",

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -35,11 +35,14 @@ from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import (
     MSAConfig,
 )
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.attention.kv_cache.base import (
     CachePool,
-    LayerMappedKVPool,
 )
-from tokenspeed.runtime.layers.attention.kv_cache.factory import create_cache_pool
+from tokenspeed.runtime.layers.attention.kv_cache.factory import (
+    create_cache_arena,
+    create_cache_pool,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
     CacheModelFamily,
     CachePoolSpec,
@@ -96,14 +99,13 @@ def _resolve_heterogeneous_draft_family(
     return draft_family
 
 
-def _pool_allocated_bytes(pool) -> int:
-    buffer = getattr(pool, "buffer", None)
-    if buffer is not None:
-        return int(buffer.nbytes)
-    sizes = pool.get_kv_size_bytes()
-    if isinstance(sizes, tuple):
-        return sum(int(size) for size in sizes)
-    return int(sizes)
+def _arena_allocated_bytes(arena) -> int:
+    """Bytes this model's cache actually occupies: the one arena allocation.
+
+    Summing a pool's per-layer view sizes would answer a different question
+    (and double-count aliased views), so read the owner directly.
+    """
+    return int(arena.buffer.nbytes)
 
 
 def _cache_storage_report(
@@ -113,19 +115,16 @@ def _cache_storage_report(
     fixed_workspace_bytes: int = 0,
 ) -> dict:
     """Describe cache storage from allocated tensors, not scheduler counts."""
-    plan = getattr(pool, "plan", None)
+    arena = getattr(pool, "arena", None)
+    plan = getattr(arena, "plan", None)
     if plan is None:
         raise RuntimeError("cache pool has no memory plan; every pool is LCM-planned")
     packing = {
         group.group_id: int(group.cache_blocks_per_lcm_block) for group in plan.groups
     }
-    physical_token_capacity = (
-        int(plan.num_lcm_blocks) * max(packing.values()) * int(plan.prefix_granularity)
-    )
-    if physical_token_capacity != int(pool.size):
-        raise RuntimeError(
-            "LCM geometry capacity does not match the allocated pool size"
-        )
+    # The arena is the one definition of child-token capacity; re-deriving it
+    # here only to compare against itself is what this report used to do.
+    physical_token_capacity = int(arena.size)
     geometry = {
         "prefix_granularity": int(plan.prefix_granularity),
         "num_lcm_blocks": int(plan.num_lcm_blocks),
@@ -141,7 +140,7 @@ def _cache_storage_report(
 
     # One pool: the draft "pool" is a layer-mapped view of the same buffer,
     # so the one allocation already covers both models' layers.
-    arena_bytes = _pool_allocated_bytes(pool)
+    arena_bytes = _arena_allocated_bytes(arena)
     allocated_cache_bytes = arena_bytes + fixed_workspace_bytes
     if allocated_cache_bytes > configured_cache_bytes:
         raise RuntimeError(
@@ -263,26 +262,6 @@ def _validate_lcm_page_size(
             "prefix granularity must be a positive multiple of kernel page "
             f"size, got {prefix_granularity} and {kernel_page_size}"
         )
-
-
-def _set_cache_group_block_granularities(
-    config: BaseAttnConfig, spec: CachePoolSpec
-) -> None:
-    """Publish each group's scheduler table grain to group-aware backends.
-
-    This seed must be per-group: under --enforce-eager the backend never runs
-    _learn_cache_groups (a CUDA-graph hook), so whatever is published here is
-    what group-table expansion uses.
-    """
-    if not hasattr(config, "group_block_granularities"):
-        return
-    grain_by_group = {
-        group_spec.group_id: group_spec.block_granularity
-        for group_spec in spec.paged_cache_group_specs
-    }
-    config.group_block_granularities = {
-        group_id: grain_by_group[group_id] for group_id in spec.layer_group_ids
-    }
 
 
 # ---------- arch -> config class ----------
@@ -416,7 +395,7 @@ def _create_hybrid_linear_attn_backend(
     )
 
     if is_kda:
-        # Paged cache contract: see CuteDSLMLABackend.mark_cache_contract.
+        # Cache contract: see CuteDSLMLABackend.mark_cache_contract.
         mark_cache_contract = getattr(full_attn_backend, "mark_cache_contract", None)
         if mark_cache_contract is not None:
             mark_cache_contract()
@@ -527,11 +506,11 @@ def _wrap_inkling_backend(
 
 def _inkling_conv_columns(pool, text_config):
     """Return the ShortConv checkpoint groups backed by the cache plan."""
-    layer_labels = text_config.paged_cache_layer_types
-    prefix_granularity = pool.plan.prefix_granularity
+    layer_labels = text_config.cache_layer_types
+    prefix_granularity = pool.arena.plan.prefix_granularity
     # The checkpoint grain belongs to the conv groups' own specs; P is only
     # the fallback when a group is absent from the plan.
-    specs_by_id = {spec.group_id: spec for spec in pool.paged_cache_group_specs}
+    specs_by_id = {spec.group_id: spec for spec in pool.arena.cache_group_specs}
 
     def conv_grain(group_id):
         spec = specs_by_id.get(group_id)
@@ -547,12 +526,12 @@ def _inkling_conv_columns(pool, text_config):
         },
         "pd_endpoint_snapshots": all(
             spec.transfer_policy == "latest_snapshot"
-            for spec in pool.paged_cache_group_specs
+            for spec in pool.arena.cache_group_specs
             if spec.group_id in ("kvconv", "hiddenconv")
         )
         and any(
             spec.group_id in ("kvconv", "hiddenconv")
-            for spec in pool.paged_cache_group_specs
+            for spec in pool.arena.cache_group_specs
         ),
     }
     logger.info(
@@ -616,39 +595,33 @@ def _create_target_components(
     model_config,
     config,
     cache_spec: CachePoolSpec,
+    arena: CacheArena,
     rank: int,
-    enable_memory_saver: bool,
     full_attn_backend_name: str | None,
     is_hybrid_linear: bool,
     is_kda: bool,
     is_inkling: bool,
 ):
-    """The ONE cache pool (target + draft continuation layers) + target backend."""
-    # The merged spec includes the draft's continuation layers; the pool
-    # binds every planned field regardless of which model consumes it.
+    """The target's compute view onto the shared arena + target backend."""
+    # The merged spec includes the draft's continuation layers; the target
+    # view binds every planned field regardless of which model consumes it.
     pool = create_cache_pool(
         cache_spec,
         config,
+        arena,
         num_layers=len(cache_spec.layer_group_ids),
         rank=rank,
-        enable_memory_saver=enable_memory_saver,
     )
     if is_hybrid_linear:
-        # Identity map, NOT a no-op: the wrapper is the per-view carrier of
-        # the MLA-write sanitize contract (LayerMappedKVPool.set_mla_kv_buffer
-        # forces sanitize=True for the hybrid chunked-prefill path). Target
-        # and draft share the ONE pool, so a pool-level flag could not
-        # express per-view sanitize semantics.
-        mapped = LayerMappedKVPool(pool, list(range(len(cache_spec.layer_group_ids))))
         backend = _create_hybrid_linear_attn_backend(
             server_args,
             model_config,
             config,
-            pool=mapped,
+            pool=pool,
             full_attn_backend_name=full_attn_backend_name,
             is_kda=is_kda,
         )
-        return backend, mapped
+        return backend, pool
 
     backend = _create_attn_backend(model_config.attention_arch, config)
     if not is_inkling:
@@ -679,54 +652,39 @@ def _create_draft_components(
     model_config,
     config,
     pool,
-    cache_spec: CachePoolSpec | None,
+    cache_spec: CachePoolSpec,
     num_target_layers: int,
     full_attn_backend_name: str | None,
+    is_heterogeneous: bool,
     is_hybrid_linear: bool,
     is_kda: bool,
     is_inkling: bool,
 ):
-    """Draft backend + the ONE pool viewed through the draft's layer window.
+    """Draft backend + the ONE arena viewed through the draft's layer window.
 
-    One big model, one pool: draft layers are continuation layers
-    (global ids ``num_target_layers..``) of the merged plan the target
-    pool already binds. The draft side needs no pool of its own — only a
-    LayerMappedKVPool translating its local layer ids onto the global
-    continuation range, exactly the mapping hybrid models already use.
+    One big model, one arena: draft layers are continuation layers of the
+    merged plan, so the draft pool is a second compute view whose
+    ``field_layer_offset`` places its LOCAL layer ids (a NextN draft's one
+    layer is layer 0) onto the continuation range. Nothing remaps ids on the
+    way through -- the view *is* the mapping, and an id outside the window is
+    rejected rather than silently offset onto another model's planes.
     """
     if config is None:
         return None, None
-    num_layers = model_config.num_attention_layers
-    if cache_spec is not None:
-        if is_hybrid_linear or is_inkling:
-            raise RuntimeError(
-                "heterogeneous cache views currently support ordinary drafts only"
-            )
-        # The draft pool is a compute view, not an allocation: it binds local
-        # layer 0..N to the merged plan's continuation fields while sharing
-        # the target's buffer and global field registry. Its transfer counter
-        # stays local/None; heterogeneous PD is rejected before construction.
-        draft_pool = create_cache_pool(
-            cache_spec,
-            config,
-            num_layers=num_layers,
-            rank=pool.rank,
-            enable_memory_saver=False,
-            field_layer_offset=num_target_layers,
-            backing_pool=pool,
+    if is_heterogeneous and (is_hybrid_linear or is_inkling):
+        raise RuntimeError(
+            "heterogeneous cache views currently support ordinary drafts only"
         )
-        backend = _create_attn_backend(model_config.attention_arch, config)
-        return backend, draft_pool
-    # Draft layers carry LOCAL ids (a NextN draft's one layer is layer 0);
-    # their planes are the merged plan's continuation range. The map must be
-    # {local: global} — the wrapper's default ({global: pool_idx}, the hybrid
-    # convention) is this map's INVERSE and would route every draft write to
-    # the target's first layers. Global ids (V4 MTP layers carry them) pass
-    # through _map's identity default unharmed.
-    draft_pool = LayerMappedKVPool(
-        pool,
-        [num_target_layers + local for local in range(num_layers)],
-        layer_map={local: num_target_layers + local for local in range(num_layers)},
+    num_layers = model_config.num_attention_layers
+    # The draft view's transfer counter stays local/None; heterogeneous PD is
+    # rejected before construction.
+    draft_pool = create_cache_pool(
+        cache_spec,
+        config,
+        pool.arena,
+        num_layers=num_layers,
+        rank=pool.rank,
+        field_layer_offset=num_target_layers,
     )
     if is_hybrid_linear:
         backend = _create_hybrid_linear_attn_backend(
@@ -811,7 +769,6 @@ def create_attn_components(
     CachePool,
     AttentionBackend | None,
     CachePool | None,
-    int,
     dict | None,
 ]:
     architectures = getattr(model_config.hf_config, "architectures", None) or []
@@ -977,34 +934,34 @@ def create_attn_components(
         overlap_schedule_depth=overlap_schedule_depth,
     )
     spec = cache_setup.spec
+    # The target view binds every planned field, draft continuation layers
+    # included, so the merged plan has one owner. The draft is a second view
+    # over the same arena, offset onto its own layer window.
     target_spec = spec
     draft_view_spec = None
-    if heterogeneous_draft_family is not None:
-        target_spec = spec.layer_view(
-            first_layer=0,
-            num_layers=cache_setup.num_target_layers,
-        )
+    if cache_setup.num_draft_layers:
         draft_view_spec = spec.layer_view(
             first_layer=cache_setup.num_target_layers,
             num_layers=cache_setup.num_draft_layers,
             family=heterogeneous_draft_family,
-            publish_runtime_contract=False,
+        )
+    if heterogeneous_draft_family is not None:
+        target_spec = spec.layer_view(
+            first_layer=0,
+            num_layers=cache_setup.num_target_layers,
         )
     prefix_granularity = spec.memory_plan.prefix_granularity
     _validate_lcm_page_size(
         config,
         prefix_granularity=prefix_granularity,
     )
-    _set_cache_group_block_granularities(config, spec)
     if draft_attn_config is not None:
         _validate_lcm_page_size(
             draft_attn_config,
             prefix_granularity=prefix_granularity,
         )
-        _set_cache_group_block_granularities(draft_attn_config, spec)
     cache_budget_bytes = cache_setup.cache_budget_bytes
     fixed_workspace_bytes = cache_setup.fixed_workspace_bytes
-    max_num_tokens = spec.pool_size
     logger.info(
         "Cache profile: parent_bytes=%d, P=%d, parents=%d, token_capacity=%d, "
         "layers=%d (draft %d), groups=%s",
@@ -1020,18 +977,20 @@ def create_attn_components(
         },
     )
 
-    if max_num_tokens <= 0:
-        raise ValueError(
-            f"KV cache token pool size must be positive, got {max_num_tokens}"
-        )
-
+    # One model, one arena: the merged plan's single allocation, which every
+    # compute view below (target, draft) is a layer window onto.
+    arena = create_cache_arena(
+        spec,
+        device=config.device,
+        enable_memory_saver=enable_memory_saver,
+    )
     backend, pool = _create_target_components(
         server_args=server_args,
         model_config=model_config,
         config=config,
         cache_spec=target_spec,
+        arena=arena,
         rank=rank,
-        enable_memory_saver=enable_memory_saver,
         full_attn_backend_name=target_full_attn_backend_name,
         is_hybrid_linear=is_hybrid_linear,
         is_kda=is_hybrid_mla_kda,
@@ -1045,6 +1004,7 @@ def create_attn_components(
         cache_spec=draft_view_spec,
         num_target_layers=cache_setup.num_target_layers,
         full_attn_backend_name=draft_full_attn_backend_name,
+        is_heterogeneous=heterogeneous_draft_family is not None,
         is_hybrid_linear=draft_is_hybrid_gdn or draft_is_hybrid_mla_kda,
         is_kda=draft_is_hybrid_mla_kda,
         is_inkling=any(a in _INKLING_ARCHITECTURES for a in draft_architectures),
@@ -1057,7 +1017,8 @@ def create_attn_components(
         if side_backend is None or side_pool is None:
             continue
         side_backend.set_cache_pool(side_pool)
-        if getattr(side_pool, "runtime_contract", None) is None:
+        side_arena = getattr(side_pool, "arena", None)
+        if getattr(side_arena, "runtime_contract", None) is None:
             continue
         mark_cache_contract = getattr(side_backend, "mark_cache_contract", None)
         if mark_cache_contract is None:
@@ -1085,6 +1046,5 @@ def create_attn_components(
         pool,
         draft_attn_backend,
         draft_pool,
-        max_num_tokens,
         cache_storage,
     )

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -121,8 +121,7 @@ def _cache_storage_report(
     packing = {
         group.group_id: int(group.cache_blocks_per_lcm_block) for group in plan.groups
     }
-    # The arena is the one definition of child-token capacity; re-deriving it
-    # here only to compare against itself is what this report used to do.
+    # The arena is the one definition of child-token capacity.
     physical_token_capacity = int(arena.size)
     geometry = {
         "prefix_granularity": int(plan.prefix_granularity),
@@ -137,8 +136,8 @@ def _cache_storage_report(
         },
     }
 
-    # One pool: the draft "pool" is a layer-mapped view of the same buffer,
-    # so the one allocation already covers both models' layers.
+    # One arena: the draft view shares this allocation, so it already covers
+    # both models' layers.
     arena_bytes = _arena_allocated_bytes(arena)
     allocated_cache_bytes = arena_bytes + fixed_workspace_bytes
     if allocated_cache_bytes > configured_cache_bytes:

--- a/python/tokenspeed/runtime/layers/paged_attention.py
+++ b/python/tokenspeed/runtime/layers/paged_attention.py
@@ -56,7 +56,7 @@ class PagedAttention(nn.Module):
         self.layer_id = layer_id
         self.logit_cap = logit_cap
         self.sliding_window_size = sliding_window_size or -1
-        # paged cache group ("" -> single-table fallback in the backend).
+        # cache group ("" -> single-table fallback in the backend).
         # make group_id mandatory once flat is the only path.
         self.group_id = group_id
         self.k_scale = None
@@ -97,15 +97,15 @@ class PagedAttention(nn.Module):
         )
 
 
-def validate_paged_cache_group_ids(
+def validate_cache_group_ids(
     model: nn.Module,
-    paged_cache_group_specs: Sequence,
+    cache_group_specs: Sequence,
 ) -> None:
     """Fail fast (ValueError) when a pool publishing more than one paged-cache
     group meets a PagedAttention layer whose group_id is empty or unknown --
     instead of a KeyError deep in the backend, possibly during graph capture.
     """
-    group_ids = {str(spec.group_id) for spec in paged_cache_group_specs}
+    group_ids = {str(spec.group_id) for spec in cache_group_specs}
     if len(group_ids) <= 1:
         return
     model_name = type(model).__name__
@@ -116,7 +116,7 @@ def validate_paged_cache_group_ids(
             raise ValueError(
                 f"{model_name}: attention layer {name!r} (layer_id="
                 f"{module.layer_id}) has empty group_id but the KV pool "
-                f"publishes {len(group_ids)} paged-cache groups "
+                f"publishes {len(group_ids)} cache groups "
                 f"{sorted(group_ids)}; pass group_id=<layer_type> to "
                 "PagedAttention (see gpt_oss.py)."
             )
@@ -124,6 +124,6 @@ def validate_paged_cache_group_ids(
             raise ValueError(
                 f"{model_name}: attention layer {name!r} (layer_id="
                 f"{module.layer_id}) has group_id={module.group_id!r} which "
-                "is not among the KV pool's paged-cache groups "
+                "is not among the KV pool's cache groups "
                 f"{sorted(group_ids)}."
             )

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -88,6 +88,15 @@ from tokenspeed.runtime.layers.attention.deepseek_v4.metadata import (
     DeepseekV4IndexerPrefillMetadata,
     DeepseekV4SparseIndexerMetadata,
 )
+from tokenspeed.runtime.layers.attention.deepseek_v4_geometry import (
+    DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+    V4_KERNEL_BLOCK_ROWS,
+    deepseek_v4_indexer_mxfp4_layout_from_row_bytes,
+    deepseek_v4_indexer_mxfp4_scale_dim,
+    deepseek_v4_indexer_mxfp4_value_bytes,
+    deepseek_v4_nope_dim,
+    v4_compressed_kv_group_id,
+)
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_csa_compress_kv_cache_insert,
     deepseek_v4_csa_indexer_cache_insert,
@@ -102,15 +111,6 @@ from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
 from tokenspeed.runtime.layers.attention.kv_cache.hybrid_deepseek_v4 import (
     _group_slot_mapping_from_raw,
     _mask_invalid_graph_tokens,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec import (
-    DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
-    V4_KERNEL_BLOCK_ROWS,
-    deepseek_v4_indexer_mxfp4_layout_from_row_bytes,
-    deepseek_v4_indexer_mxfp4_scale_dim,
-    deepseek_v4_indexer_mxfp4_value_bytes,
-    deepseek_v4_nope_dim,
-    v4_compressed_kv_group_id,
 )
 from tokenspeed.runtime.layers.deepseek_v4_mhc import mhc_fused_hc as fast_mhc_fused_hc
 from tokenspeed.runtime.layers.deepseek_v4_mhc import mhc_post as fast_mhc_post

--- a/python/tokenspeed/runtime/models/dflash.py
+++ b/python/tokenspeed/runtime/models/dflash.py
@@ -176,7 +176,7 @@ class DFlashAttention(nn.Module):
                 cache_loc=out_cache_loc,
                 k_scale=self.attn.k_scale,
                 v_scale=self.attn.v_scale,
-                page_size=ctx.token_to_kv_pool.kv_page_size,
+                page_size=ctx.token_to_kv_pool.arena.kv_page_size,
             )
         else:
             ctx.token_to_kv_pool.set_kv_buffer(

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -582,7 +582,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             weights,
             seq_lens,
             page_table,
-            page_size=ctx.token_to_kv_pool.kv_page_size,
+            page_size=ctx.token_to_kv_pool.arena.kv_page_size,
             topk=topk,
             softmax_scale=self.indexer.weights_softmax_scale,
             q_len_per_req=q_len_per_req,
@@ -621,7 +621,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             )
 
         topk = self.index_topk
-        page_size = ctx.token_to_kv_pool.kv_page_size
+        page_size = ctx.token_to_kv_pool.arena.kv_page_size
         max_seq_len = int(seq_lens.max().item())
         max_pages = (max_seq_len + page_size - 1) // page_size
         page_table = chunk_meta.page_table[:, :max_pages].to(
@@ -708,7 +708,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
             topk=topk,
             softmax_scale=self.indexer.weights_softmax_scale,
             index_k_cache=index_k_cache,
-            page_size=ctx.token_to_kv_pool.kv_page_size,
+            page_size=ctx.token_to_kv_pool.arena.kv_page_size,
             max_logits_bytes=max(1, max_logits_mb) * 1024 * 1024,
         )
         return GlmDsaPrefillTopK(

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -563,8 +563,8 @@ class InklingAttention(nn.Module):
             num_kv_heads=self.num_tp_kv_heads,
             layer_id=layer_id,
             sliding_window_size=(config.sliding_window_size - 1) if is_local else -1,
-            # Group ids == config.paged_cache_layer_types labels (sliding sub-groups included).
-            group_id=config.paged_cache_layer_types[layer_id],
+            # Group ids == config.cache_layer_types labels (sliding sub-groups included).
+            group_id=config.cache_layer_types[layer_id],
         )
 
         self.q_size = self.head_dim * self.num_tp_heads

--- a/python/tokenspeed/runtime/models/kimi_k3_dspark.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_dspark.py
@@ -203,7 +203,7 @@ class K3DSparkDecoderLayer(nn.Module):
         # The draft's MLA layers join the target's full_attention paged-cache
         # group (K3 publishes 4 groups: full_attention + 3 KDA linear). The
         # inherited attn_mqa/attn_mha are built without a group_id; tag them so
-        # validate_paged_cache_group_ids binds them to the full_attention table
+        # validate_cache_group_ids binds them to the full_attention table
         # instead of failing on an empty group_id. Mirrors the target
         # (kimi_k3.py MLA layer construction).
         self.self_attn.attn_mqa.group_id = FULL_ATTENTION

--- a/python/tokenspeed/runtime/pd/cache_protocol.py
+++ b/python/tokenspeed/runtime/pd/cache_protocol.py
@@ -42,7 +42,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     MXFP8_KV_SCALE_TILE_TOKENS,
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
     Retention,
     TransferPolicy,
 )
@@ -303,9 +303,7 @@ class CacheTransferContract:
     """Thin PD wire envelope around the cache-owned plan and group specs."""
 
     plan: CacheMemoryPlan
-    group_specs: tuple[PagedCacheGroupSpec, ...]
-    # Dtypes align positionally with plan.fields; field IDs stay plan-owned.
-    field_dtypes: tuple[str, ...]
+    group_specs: tuple[CacheGroupSpec, ...]
     transfer_schema: CacheTransferSchema = CacheTransferSchema()
 
     def __post_init__(self) -> None:
@@ -320,10 +318,7 @@ class CacheTransferContract:
         )
 
     def field_dtype(self, field_id: str) -> str:
-        for field, dtype in zip(self.plan.fields, self.field_dtypes, strict=True):
-            if field.field_id == field_id:
-                return dtype
-        raise KeyError(field_id)
+        return self.plan.field(field_id).dtype
 
     def to_wire_bytes(self) -> bytes:
         return _dump_wire_json(
@@ -365,9 +360,8 @@ class CacheTransferContract:
             return cls(
                 plan=plan,
                 group_specs=tuple(
-                    PagedCacheGroupSpec(**spec) for spec in payload["group_specs"]
+                    CacheGroupSpec(**spec) for spec in payload["group_specs"]
                 ),
-                field_dtypes=tuple(payload["field_dtypes"]),
                 transfer_schema=CacheTransferSchema(
                     tuple(
                         CacheFieldTransferSpec(
@@ -390,11 +384,10 @@ def build_cache_transfer_contract(
     *,
     plan: CacheMemoryPlan,
     buffer: object,
-    group_specs: Sequence[PagedCacheGroupSpec],
-    field_dtypes: Mapping[str, str],
+    group_specs: Sequence[CacheGroupSpec],
     transfer_schema: CacheTransferSchema = CacheTransferSchema(),
 ) -> tuple[CacheTransferContract, int]:
-    """Bind one cache memory plan to its semantics, dtypes, and raw slab."""
+    """Bind one cache memory plan to its semantics and raw slab."""
     specs = tuple(group_specs)
     plan_group_ids = tuple(group.group_id for group in plan.groups)
     spec_group_ids = tuple(spec.group_id for spec in specs)
@@ -404,15 +397,9 @@ def build_cache_transfer_contract(
             f"missing={sorted(set(plan_group_ids) - set(spec_group_ids))}, "
             f"extra={sorted(set(spec_group_ids) - set(plan_group_ids))}"
         )
-    expected_field_ids = {field.field_id for field in plan.fields}
-    if set(field_dtypes) != expected_field_ids:
-        raise CacheContractError(
-            "cache field dtype map must contain exactly the planned fields"
-        )
     contract = CacheTransferContract(
         plan=plan,
         group_specs=specs,
-        field_dtypes=tuple(field_dtypes[field.field_id] for field in plan.fields),
         transfer_schema=transfer_schema,
     )
     if (
@@ -428,18 +415,16 @@ def build_cache_transfer_contract(
     return contract, buffer.data_ptr()
 
 
-def build_pool_cache_transfer_contract(
-    pool: object,
+def build_arena_cache_transfer_contract(
+    arena: object,
     *,
     transfer_schema: CacheTransferSchema = CacheTransferSchema(),
 ) -> tuple[CacheTransferContract, int]:
-    """Build the PD wire envelope from the cache-owned arena binding."""
-    buffer, field_dtypes = pool.cache_contract_binding()
+    """Build the PD wire envelope from the cache arena it transfers."""
     return build_cache_transfer_contract(
-        plan=pool.plan,
-        buffer=buffer,
-        group_specs=pool.paged_cache_group_specs,
-        field_dtypes=field_dtypes,
+        plan=arena.plan,
+        buffer=arena.contract_binding(),
+        group_specs=arena.cache_group_specs,
         transfer_schema=transfer_schema,
     )
 
@@ -641,9 +626,8 @@ def validate_cache_peer_layout(
             if peer_partition is not None:
                 peer_global_shape[peer_partition.axis] = peer_partition.global_extent
             if (
-                layout.field_dtype(local_field.field_id)
-                != peer_layout.field_dtype(peer_field.field_id)
-                or local_field.element_size != peer_field.element_size
+                # element_size derives from dtype, so one comparison covers both.
+                local_field.dtype != peer_field.dtype
                 or local_partition != peer_partition
                 or tuple(local_global_shape) != tuple(peer_global_shape)
             ):
@@ -863,7 +847,7 @@ __all__ = [
     "build_cache_page_manifest",
     "build_cache_transfer_schema",
     "build_cache_transfer_contract",
-    "build_pool_cache_transfer_contract",
+    "build_arena_cache_transfer_contract",
     "validate_cache_manifest",
     "validate_cache_peer_layout",
 ]

--- a/python/tokenspeed/runtime/pd/cache_protocol.py
+++ b/python/tokenspeed/runtime/pd/cache_protocol.py
@@ -30,7 +30,7 @@ validation.
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
@@ -41,7 +41,6 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     cache_field_layer_id,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    MXFP8_KV_SCALE_TILE_TOKENS,
     CacheGroupSpec,
     Retention,
     TransferPolicy,

--- a/python/tokenspeed/runtime/pd/factory.py
+++ b/python/tokenspeed/runtime/pd/factory.py
@@ -21,9 +21,9 @@
 """Factories for PD KV transfer helpers."""
 
 from tokenspeed.runtime.pd.cache_protocol import (
+    build_arena_cache_transfer_contract,
     build_cache_fields_by_producer_step,
     build_cache_transfer_schema,
-    build_pool_cache_transfer_contract,
 )
 from tokenspeed.runtime.pd.decode_executor import DisaggDecodeExecutor
 from tokenspeed.runtime.pd.mooncake.entities import KVArgs, KVManagerArgs
@@ -44,16 +44,16 @@ def get_kv_args(
     # the target pool's merged plan, so exactly one typed slab registration is
     # published for both target and draft caches.
     transfer_schema = build_cache_transfer_schema(
-        token_to_kv_pool.plan,
+        token_to_kv_pool.arena.plan,
         model_config=model_config,
         draft_model_config=draft_model_config,
     )
     producer_schedule = build_cache_fields_by_producer_step(
-        token_to_kv_pool.plan,
+        token_to_kv_pool.arena.plan,
         num_target_layers=model_config.num_attention_layers,
     )
-    layout, base_addr = build_pool_cache_transfer_contract(
-        token_to_kv_pool,
+    layout, base_addr = build_arena_cache_transfer_contract(
+        token_to_kv_pool.arena,
         transfer_schema=transfer_schema,
     )
     return KVArgs(

--- a/python/tokenspeed/runtime/pd/mooncake/entities.py
+++ b/python/tokenspeed/runtime/pd/mooncake/entities.py
@@ -28,7 +28,7 @@ from tokenspeed.runtime.pd.cache_protocol import (
     CacheTransferContract,
 )
 from tokenspeed.runtime.pd.transfer_plan import (
-    MAX_PAGED_CACHE_TP_SIZE,
+    MAX_CACHE_TP_SIZE,
     CacheTransferFragment,
 )
 
@@ -169,7 +169,7 @@ class KVArgsRegisterInfo:
             msg[6],
             name="CachePD decode_tp_size",
             minimum=1,
-            maximum=MAX_PAGED_CACHE_TP_SIZE,
+            maximum=MAX_CACHE_TP_SIZE,
         )
         decode_tp_rank = _bounded_ascii_uint(
             msg[7],

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -49,7 +49,7 @@ from tokenspeed.runtime.pd.mooncake.entities import (
 )
 from tokenspeed.runtime.pd.transfer_plan import (
     CacheTransferFragment,
-    PagedCacheTransferPlanner,
+    CacheTransferPlanner,
 )
 from tokenspeed.runtime.pd.utils import (
     DisaggregationMode,
@@ -290,7 +290,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         peer_layout = registration.peer_cache_layout
         prefill_tp_size = self.world_size // self.dp_size
         local_tp_rank = self.attn_tp_rank % prefill_tp_size
-        planner = PagedCacheTransferPlanner(
+        planner = CacheTransferPlanner(
             prefill_tp_size=prefill_tp_size,
             decode_tp_size=registration.decode_tp_size,
             prefill_layout=layout,

--- a/python/tokenspeed/runtime/pd/mooncake/receiver.py
+++ b/python/tokenspeed/runtime/pd/mooncake/receiver.py
@@ -36,7 +36,7 @@ from tokenspeed.runtime.pd.cache_protocol import (
 )
 from tokenspeed.runtime.pd.mooncake.entities import KVTransferError
 from tokenspeed.runtime.pd.transfer_plan import (
-    PagedCacheTransferPlanner,
+    CacheTransferPlanner,
     RankTransferPlan,
 )
 from tokenspeed.runtime.utils import (
@@ -128,7 +128,7 @@ def _calc(kv_mgr, prefill_parallel_info: PrefillParallelInfo) -> ReceiverRoutePl
     if prefill_cache_layout is None:
         raise RuntimeError("Paged cache decode connected to a non-Paged cache prefill")
     decode_tp_rank = kv_mgr.kv_args.engine_rank % local_tp_size_per_dp_rank
-    planner = PagedCacheTransferPlanner(
+    planner = CacheTransferPlanner(
         prefill_tp_size=prefill_tp_size_per_dp_rank,
         decode_tp_size=local_tp_size_per_dp_rank,
         prefill_layout=prefill_cache_layout,

--- a/python/tokenspeed/runtime/pd/transfer_plan.py
+++ b/python/tokenspeed/runtime/pd/transfer_plan.py
@@ -54,7 +54,7 @@ class CacheTransferFragment:
     rows_per_page: int
 
 
-MAX_PAGED_CACHE_TP_SIZE = 1024
+MAX_CACHE_TP_SIZE = 1024
 
 
 @dataclass(frozen=True)
@@ -89,7 +89,7 @@ class _RankPartition:
     local_offset: int
 
 
-class PagedCacheTransferPlanner:
+class CacheTransferPlanner:
     """Plan model-neutral dense Paged-cache fields across unequal TP sizes."""
 
     def __init__(
@@ -102,12 +102,9 @@ class PagedCacheTransferPlanner:
     ):
         if prefill_tp_size <= 0 or decode_tp_size <= 0:
             raise UnsupportedPDLayoutError("Paged cache TP sizes must be positive")
-        if (
-            prefill_tp_size > MAX_PAGED_CACHE_TP_SIZE
-            or decode_tp_size > MAX_PAGED_CACHE_TP_SIZE
-        ):
+        if prefill_tp_size > MAX_CACHE_TP_SIZE or decode_tp_size > MAX_CACHE_TP_SIZE:
             raise UnsupportedPDLayoutError(
-                f"Paged cache TP sizes cannot exceed {MAX_PAGED_CACHE_TP_SIZE}"
+                f"Paged cache TP sizes cannot exceed {MAX_CACHE_TP_SIZE}"
             )
         self.prefill_tp_size = prefill_tp_size
         self.decode_tp_size = decode_tp_size

--- a/test/runtime/cache_pd_test_utils.py
+++ b/test/runtime/cache_pd_test_utils.py
@@ -29,9 +29,10 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheGroupLayout,
     CacheMemoryPlan,
     CachePlaneLayout,
+    cache_dtype_bytes,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 from tokenspeed.runtime.pd.cache_protocol import (
     CacheFieldPartition,
@@ -53,7 +54,6 @@ class _TestCacheField:
     page_zero_offset: int
     page_stride_bytes: int
     shape: tuple[int, ...]
-    element_size: int
     partition: CacheFieldPartition | None
     producer_step: int | None
 
@@ -84,7 +84,6 @@ def segment(
     *,
     shape: tuple[int, ...] = (1,),
     dtype: str = "uint8",
-    element_size: int = 1,
     offset: int = 0,
     stride: int | None = None,
     axis: int | None = None,
@@ -92,7 +91,7 @@ def segment(
     parts: tuple[int, ...] = (),
     producer_step: int | None = None,
 ) -> _TestCacheField:
-    payload = prod(shape) * element_size
+    payload = prod(shape) * cache_dtype_bytes(dtype)
     partition = (
         None
         if extent is None
@@ -108,7 +107,6 @@ def segment(
         offset,
         payload if stride is None else stride,
         shape,
-        element_size,
         partition,
         producer_step,
     )
@@ -142,24 +140,22 @@ def layout(
     )
     specs = tuple(
         (
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id=entry.group_id,
                 retention=entry.retention,
                 sliding_window_tokens=entry.sliding_window_tokens,
                 family=entry.family,
-                cache_blocks_per_lcm_block=entry.cache_blocks_per_lcm_block,
                 transfer_policy=entry.transfer_policy,
                 checkpoint_granularity=entry.prefix_granularity,
             )
             if entry.family == "state" and entry.retention == "full_history"
-            else PagedCacheGroupSpec(
+            else CacheGroupSpec(
                 group_id=entry.group_id,
                 retention=entry.retention,
                 rows_per_page=entry.prefix_granularity,
                 entry_stride_tokens=1,
                 sliding_window_tokens=entry.sliding_window_tokens,
                 family=entry.family,
-                cache_blocks_per_lcm_block=entry.cache_blocks_per_lcm_block,
                 transfer_policy=entry.transfer_policy,
             )
         )
@@ -168,7 +164,6 @@ def layout(
 
     fields: list[CacheFieldLayout] = []
     planes: list[CachePlaneLayout] = []
-    dtypes: list[str] = []
     for group_position, entry in enumerate(groups):
         for field_position, field in enumerate(entry.fields):
             plane_id = f"test.{group_position}.{field_position}.{field.field_id}"
@@ -185,12 +180,11 @@ def layout(
                     field_id=field.field_id,
                     plane_id=plane_id,
                     shape=field.shape,
-                    element_size=field.element_size,
+                    dtype=field.dtype,
                     field_offset_bytes=0,
                     page_stride_bytes=field.page_stride_bytes,
                 )
             )
-            dtypes.append(field.dtype)
 
     return CacheTransferContract(
         plan=CacheMemoryPlan(
@@ -202,7 +196,6 @@ def layout(
             fields=tuple(fields),
         ),
         group_specs=specs,
-        field_dtypes=tuple(dtypes),
         transfer_schema=CacheTransferSchema(
             tuple(
                 CacheFieldTransferSpec(field.field_id, field.partition)

--- a/test/runtime/cache_pool_test_utils.py
+++ b/test/runtime/cache_pool_test_utils.py
@@ -2,12 +2,134 @@ from __future__ import annotations
 
 import torch
 
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
+from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 from tokenspeed.runtime.layers.attention.kv_cache.recipes import spec
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-    mha_cache_fields,
-    mla_cache_fields,
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+    CacheFieldSpec,
+    cache_dtype_name,
+    pack,
+    scatter_stored_dtype_name,
 )
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import solve_cache_layout
+
+
+def specs_for_layers(
+    *,
+    layer_types,
+    group_ids,
+    prefix_granularity,
+    sliding_window_tokens=None,
+    page_sizes=None,
+    pd_disaggregation_enabled=False,
+):
+    """The group specs a layer vocabulary produces.
+
+    A group must declare fields, so this supplies a one-byte placeholder per
+    layer: the subject here is the scheduler semantics (retention, family,
+    block span), not the bytes.
+    """
+    return tuple(
+        group_spec
+        for group_spec, _ in spec.group(
+            layer_types=layer_types,
+            group_ids=group_ids,
+            sliding_window_tokens=sliding_window_tokens,
+            prefix_granularity=prefix_granularity,
+            page_sizes=page_sizes,
+            pd_disaggregation_enabled=pd_disaggregation_enabled,
+            fields_for_layer=lambda layer_id, group_id, occurrence: (
+                CacheFieldSpec(
+                    f"layer.{layer_id}.probe", f"unit.{occurrence}", (1,), "uint8"
+                ),
+            ),
+        )
+    )
+
+
+def one_group(group_id: str, *fields, **spec_kwargs):
+    """One ``(spec, fields)`` pair for a plan under test.
+
+    A whole-group declaration, the way a recipe declares a group that is not
+    per-layer: the id is spelled once, in its spec, and its fields hang off
+    it. Row geometry defaults so a byte-layout test need not restate
+    scheduler semantics. ``group`` (the pipeline stage) is the other way in.
+    """
+    spec_kwargs.setdefault("retention", "full_history")
+    if "checkpoint_granularity" not in spec_kwargs:
+        spec_kwargs.setdefault("rows_per_page", spec_kwargs.pop("page_size", 1))
+        spec_kwargs.setdefault("entry_stride_tokens", 1)
+    return spec.CacheGroupSpec(group_id=group_id, **spec_kwargs), tuple(fields)
+
+
+def plan_group_specs(plan) -> tuple[spec.CacheGroupSpec, ...]:
+    """Row-geometry specs for every group the plan names.
+
+    The arena publishes a contract unconditionally, so a test that only
+    exercises field geometry still needs specs. Derive them from the plan
+    rather than restating numbers: a group's CacheBlock spans
+    ``prefix_granularity / cache_blocks_per_lcm_block`` tokens, declared here
+    as one row per token. Tests whose subject *is* the geometry or the
+    retention/transfer policy pass their own specs instead.
+    """
+    return tuple(
+        spec.CacheGroupSpec(
+            group_id=group.group_id,
+            retention="full_history",
+            rows_per_page=plan.prefix_granularity // group.cache_blocks_per_lcm_block,
+            entry_stride_tokens=1,
+        )
+        for group in plan.groups
+    )
+
+
+class MinimalCacheView(CachePool):
+    """The smallest constructible cache view.
+
+    ``CachePool`` is abstract in exactly the four accessors a view owes its
+    kernels, so this stub doubles as the list of what a real pool must add.
+    Use it to exercise view-layer behaviour the base class owns (arena
+    ownership, dtype, layer window, the scheduler bridge) without dragging in
+    a family's kernel buffers.
+    """
+
+    layer_num = 0
+
+    def get_key_buffer(self, layer_id: int) -> torch.Tensor:
+        raise AssertionError("not exercised")
+
+    def get_value_buffer(self, layer_id: int) -> torch.Tensor:
+        raise AssertionError("not exercised")
+
+    def get_kv_buffer(self, layer_id: int):
+        raise AssertionError("not exercised")
+
+    def set_kv_buffer(self, layer, loc, cache_k, cache_v) -> None:
+        raise AssertionError("not exercised")
+
+
+def make_arena(plan, device: str = "cuda", **kwargs) -> CacheArena:
+    """Allocate the arena the pool(s) under test are compute views onto."""
+    kwargs.setdefault("cache_group_specs", plan_group_specs(plan))
+    return CacheArena(plan, device, **kwargs)
+
+
+def make_pool(pool_cls, plan, *, device="cpu", arena=None, **kwargs):
+    """Build one pool as a compute view over ``plan``'s arena.
+
+    Tests name a plan and the view's compute parameters; the arena is
+    created here (or shared, when several views of one arena are under
+    test) so no test has to restate the allocation contract.
+    """
+    arena_kwargs = {
+        key: kwargs.pop(key)
+        for key in ("cache_group_specs", "token_capacity")
+        if key in kwargs
+    }
+    if arena is None:
+        arena = make_arena(plan, device, **arena_kwargs)
+    elif arena_kwargs:
+        raise TypeError("arena parameters cannot be passed alongside a shared arena")
+    return arena, pool_cls(arena=arena, **kwargs)
 
 
 def plan_fields(
@@ -18,16 +140,23 @@ def plan_fields(
     num_lcm_blocks=None,
     **kwargs,
 ):
-    """Solve a layout and bind capacity the way the recipes do."""
-    layout = solve_cache_layout(
-        fields,
+    """Solve a layout and bind capacity the way the recipes do.
+
+    ``fields`` is the ``{group_id: fields}`` map a recipe field builder
+    returns; declarations are formed here, the same join the recipes do.
+    """
+    layout = pack(
+        tuple(
+            one_group(group_id, *declared, rows_per_page=prefix_granularity)
+            for group_id, declared in fields.items()
+        ),
         prefix_granularity=prefix_granularity,
         **kwargs,
     )
     if budget_bytes is not None:
         # Parent 0 backs logical null page 0 and is never schedulable.
         num_lcm_blocks = budget_bytes // layout.lcm_block_bytes - 1
-    return layout.with_num_lcm_blocks(num_lcm_blocks)
+    return layout.bind(num_lcm_blocks)
 
 
 def make_layer_group_ids(
@@ -59,6 +188,7 @@ def make_mha_memory_plan(
     sliding_window_tokens: int | tuple[int | None, ...] | None = None,
     mxfp8: bool = False,
 ):
+    """An MHA plan the way the recipe builds one: group, pack, bind."""
     if size % prefix_granularity:
         raise ValueError("test pool size must be divisible by prefix_granularity")
     group_ids = make_layer_group_ids(
@@ -66,23 +196,65 @@ def make_mha_memory_plan(
         layer_types=layer_types,
         sliding_window_tokens=sliding_window_tokens,
     )
-    fields = mha_cache_fields(
-        layer_group_ids=group_ids,
-        prefix_granularity=prefix_granularity,
-        kv_heads=kv_heads,
-        head_dim=head_dim,
-        kv_element_size=(1 if mxfp8 else torch.empty((), dtype=dtype).element_size()),
-        kv_scale_block_size=(32 if mxfp8 else 0),
-        kv_scale_element_size=(1 if mxfp8 else 0),
+    kv_dtype = (
+        cache_dtype_name(torch.float8_e4m3fn)
+        if mxfp8
+        else scatter_stored_dtype_name(dtype)
     )
-    layout = solve_cache_layout(
-        fields,
+    shape = (prefix_granularity, kv_heads, head_dim)
+
+    def fields_for_layer(layer_id, group_id, occurrence):
+        fields = (
+            CacheFieldSpec(
+                f"layer.{layer_id}.k", f"unit.{occurrence}.k", shape, kv_dtype
+            ),
+            CacheFieldSpec(
+                f"layer.{layer_id}.v", f"unit.{occurrence}.v", shape, kv_dtype
+            ),
+        )
+        if not mxfp8:
+            return fields
+        scale_dim = head_dim // 32
+        # The same shape OrdinaryRecipe declares: the interleaved paged scale
+        # layout, one tile group per MXFP8_KV_SCALE_TILE_TOKENS of the page.
+        scale_shape = (
+            kv_heads,
+            prefix_granularity // spec.MXFP8_KV_SCALE_TILE_TOKENS,
+            32,
+            scale_dim,
+            scale_dim,
+        )
+        scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
+        return fields + (
+            CacheFieldSpec(
+                f"layer.{layer_id}.k_scale",
+                f"unit.{occurrence}.k_scale",
+                scale_shape,
+                scale_dtype,
+            ),
+            CacheFieldSpec(
+                f"layer.{layer_id}.v_scale",
+                f"unit.{occurrence}.v_scale",
+                scale_shape,
+                scale_dtype,
+            ),
+        )
+
+    groups = spec.group(
+        layer_types=layer_types,
+        group_ids=group_ids,
+        sliding_window_tokens=sliding_window_tokens,
         prefix_granularity=prefix_granularity,
-        cache_blocks_per_lcm_block={group_id: 1 for group_id in group_ids},
+        fields_for_layer=fields_for_layer,
+    )
+    layout = pack(
+        groups,
+        prefix_granularity=prefix_granularity,
+        cache_blocks_per_lcm_block={gid: 1 for gid in set(group_ids)},
         alignment=1,
         max_padding_fraction=1.0,
     )
-    return layout.with_num_lcm_blocks(size // prefix_granularity)
+    return layout.bind(size // prefix_granularity)
 
 
 def make_mla_memory_plan(
@@ -93,19 +265,29 @@ def make_mla_memory_plan(
     latent_width: int,
     dtype: torch.dtype,
 ):
+    """An MLA plan: one full-attention group, one latent field per layer."""
     if size % prefix_granularity:
         raise ValueError("test pool size must be divisible by prefix_granularity")
-    fields = mla_cache_fields(
-        layer_group_ids=("full_attention",) * layer_num,
+    latent_dtype = scatter_stored_dtype_name(dtype)
+    groups = spec.group(
+        layer_types=("full_attention",) * layer_num,
+        group_ids=("full_attention",) * layer_num,
+        sliding_window_tokens=None,
         prefix_granularity=prefix_granularity,
-        latent_width=latent_width,
-        element_size=torch.empty((), dtype=dtype).element_size(),
+        fields_for_layer=lambda layer_id, group_id, occurrence: (
+            CacheFieldSpec(
+                f"layer.{layer_id}.latent_kv",
+                f"slot.{occurrence}",
+                (prefix_granularity, 1, latent_width),
+                latent_dtype,
+            ),
+        ),
     )
-    layout = solve_cache_layout(
-        fields,
+    layout = pack(
+        groups,
         prefix_granularity=prefix_granularity,
         cache_blocks_per_lcm_block={"full_attention": 1},
         alignment=1,
         max_padding_fraction=1.0,
     )
-    return layout.with_num_lcm_blocks(size // prefix_granularity)
+    return layout.bind(size // prefix_granularity)

--- a/test/runtime/cache_pool_test_utils.py
+++ b/test/runtime/cache_pool_test_utils.py
@@ -8,6 +8,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes import spec
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
     cache_dtype_name,
+    mxfp8_kv_scale_fields,
     pack,
     scatter_stored_dtype_name,
 )
@@ -214,30 +215,14 @@ def make_mha_memory_plan(
         )
         if not mxfp8:
             return fields
-        scale_dim = head_dim // 32
-        # The same shape OrdinaryRecipe declares: the interleaved paged scale
-        # layout, one tile group per MXFP8_KV_SCALE_TILE_TOKENS of the page.
-        scale_shape = (
-            kv_heads,
-            prefix_granularity // spec.MXFP8_KV_SCALE_TILE_TOKENS,
-            32,
-            scale_dim,
-            scale_dim,
-        )
-        scale_dtype = cache_dtype_name(torch.float8_e8m0fnu)
-        return fields + (
-            CacheFieldSpec(
-                f"layer.{layer_id}.k_scale",
-                f"unit.{occurrence}.k_scale",
-                scale_shape,
-                scale_dtype,
-            ),
-            CacheFieldSpec(
-                f"layer.{layer_id}.v_scale",
-                f"unit.{occurrence}.v_scale",
-                scale_shape,
-                scale_dtype,
-            ),
+        # The production builder, so a test plan cannot declare a scale shape
+        # the recipes would never emit.
+        return fields + mxfp8_kv_scale_fields(
+            layer_id=layer_id,
+            occurrence=occurrence,
+            kv_heads=kv_heads,
+            head_dim=head_dim,
+            prefix_granularity=prefix_granularity,
         )
 
     groups = spec.group(

--- a/test/runtime/conftest.py
+++ b/test/runtime/conftest.py
@@ -31,32 +31,89 @@ def _poison(shape, device="cuda", dtype=torch.int32):
     return torch.full(shape, 987_654, device=device, dtype=dtype)
 
 
-def kimi_tp8_plan(*, num_lcm_blocks: int = 7):
+def kimi_recipe(
+    *,
+    text_config=None,
+    tp_size: int = 8,
+    draft_layers: int = 0,
+    pd_enabled: bool = False,
+    max_bs: int = 1,
+    max_scheduled_tokens: int = 128,
+    context_len: int = 4096,
+    decode_input_tokens: int = 1,
+    overlap_schedule_depth: int = 0,
+):
+    """A Kimi-K3 recipe over the reference config, with tiny scheduler limits."""
+    from types import SimpleNamespace
+
     from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
     from tokenspeed.runtime.layers.attention.kv_cache.recipes.kimi_k3 import (
-        solve_kimi_k3_cache_layout,
+        KimiK3Recipe,
     )
 
-    layout = solve_kimi_k3_cache_layout(
-        KimiLinearConfig(),
-        tp_size=8,
-        mla_cache_dtype=torch.float8_e4m3fn,
-        mla_quant_method=None,
+    text_config = text_config if text_config is not None else KimiLinearConfig()
+    attn_config = SimpleNamespace(
+        attn_tp_size=tp_size,
+        kv_cache_dtype=torch.float8_e4m3fn,
+        kv_cache_quant_method=None,
+        kv_lora_rank=text_config.kv_lora_rank,
+        qk_rope_head_dim=text_config.qk_rope_head_dim,
+        prefix_granularity=128,
+        max_bs=max_bs,
+        # K3's per-group demand reads the scheduler's concurrency through
+        # CacheRecipe.scheduler_limits, context length included.
+        context_len=context_len,
+        pd_disaggregation_enabled=pd_enabled,
     )
-    return layout.with_num_lcm_blocks(num_lcm_blocks)
+    # The real K3 draft is BF16 MLA over the FP8 target arena.
+    draft_attn_config = (
+        SimpleNamespace(**{**vars(attn_config), "kv_cache_dtype": torch.bfloat16})
+        if draft_layers
+        else None
+    )
+    return KimiK3Recipe(
+        server_args=SimpleNamespace(
+            max_total_tokens=None, chunked_prefill_size=max_scheduled_tokens
+        ),
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(text_config=text_config)
+        ),
+        attn_config=attn_config,
+        draft_model_config=(
+            SimpleNamespace(num_attention_layers=draft_layers) if draft_layers else None
+        ),
+        draft_attn_config=draft_attn_config,
+        cache_budget_bytes=1 << 34,
+        decode_input_tokens=decode_input_tokens,
+        overlap_schedule_depth=overlap_schedule_depth,
+    )
+
+
+def kimi_tp8_layout(**recipe_kwargs):
+    """The capacity-independent K3 layout: group, then pack."""
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import pack
+
+    recipe = kimi_recipe(**recipe_kwargs)
+    groups = recipe.groups()
+    layout = pack(
+        groups,
+        prefix_granularity=recipe.prefix_granularity,
+        cache_blocks_per_lcm_block=recipe.packing(groups),
+        alignment=recipe.alignment,
+        max_padding_fraction=recipe.max_padding_fraction,
+    )
+    # Same order as CacheRecipe.setup: group, pack, check, then bind.
+    recipe.check_layout(layout)
+    return recipe, groups, layout
+
+
+def kimi_tp8_plan(*, num_lcm_blocks: int = 7):
+    return kimi_tp8_layout()[2].bind(num_lcm_blocks)
 
 
 def _kimi_group_specs(group_ids, layer_types, plan):
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        build_paged_cache_group_specs,
-    )
-
-    return build_paged_cache_group_specs(
-        layer_types=layer_types,
-        group_ids=group_ids,
-        sliding_window_tokens=None,
-        prefix_granularity=plan.prefix_granularity,
-    )
+    del group_ids, layer_types, plan
+    return tuple(spec for spec, _ in kimi_recipe().groups())
 
 
 def make_kimi_pool(device, usable_pages: int = 6, *, with_mla_dims: bool = True):
@@ -64,48 +121,31 @@ def make_kimi_pool(device, usable_pages: int = 6, *, with_mla_dims: bool = True)
     from tokenspeed.runtime.layers.attention.kv_cache.hybrid_kda import (
         HybridKDATokenToKVPool,
     )
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.kimi_k3 import (
-        kimi_k3_layer_group_ids,
-    )
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        FULL_ATTENTION,
-        LINEAR_ATTENTION,
-    )
 
     del with_mla_dims
     text_config = KimiLinearConfig()
     plan = kimi_tp8_plan(num_lcm_blocks=usable_pages)
-    group_ids = kimi_k3_layer_group_ids(text_config)
-    layer_types = tuple(
-        FULL_ATTENTION if group_id == FULL_ATTENTION else LINEAR_ATTENTION
-        for group_id in group_ids
-    )
-    return HybridKDATokenToKVPool(
-        size=usable_pages * 12 * plan.prefix_granularity,
+    recipe = kimi_recipe()
+    group_ids = recipe.target_group_ids
+    layer_types = recipe.layer_types
+    from cache_pool_test_utils import make_pool
+
+    _, pool = make_pool(
+        HybridKDATokenToKVPool,
+        plan,
+        device=device,
         model_dtype=torch.bfloat16,
         dtype=torch.float8_e4m3fn,
         quant_method=None,
         kv_lora_rank=MLA_KV_LORA_RANK,
         qk_rope_head_dim=MLA_QK_ROPE_DIM,
         layer_num=text_config.num_hidden_layers,
-        device=device,
-        enable_memory_saver=False,
-        prefix_granularity=plan.prefix_granularity,
         rank=0,
         layer_types=layer_types,
         layer_group_ids=group_ids,
-        paged_cache_group_specs=_kimi_group_specs(group_ids, layer_types, plan),
-        state_field_dtypes={
-            field_id: dtype
-            for layer_id, layer_type in enumerate(layer_types)
-            if layer_type == LINEAR_ATTENTION
-            for field_id, dtype in (
-                (f"layer.{layer_id}.conv_state", torch.bfloat16),
-                (f"layer.{layer_id}.recurrent_state", torch.float32),
-            )
-        },
-        memory_plan=plan,
+        cache_group_specs=_kimi_group_specs(group_ids, layer_types, plan),
     )
+    return pool
 
 
 @pytest.fixture(scope="module")
@@ -154,7 +194,7 @@ def cache_metadata_for(contract, tables, device, *, filler_page: int = 1):
 
 def full_attention_metadata_for(pool, full_table_np, device):
     return cache_metadata_for(
-        pool.runtime_contract,
+        pool.arena.runtime_contract,
         {"full_attention": np.asarray(full_table_np, dtype=np.int32)},
         device,
     )

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -50,7 +50,6 @@ def _layout(
                 "layer.0.kv",
                 dtype="bfloat16",
                 shape=(8,),
-                element_size=2,
                 offset=history_offset,
                 stride=page_stride_bytes,
             ),
@@ -61,7 +60,6 @@ def _layout(
                 "layer.1.state",
                 dtype="bfloat16",
                 shape=(8,),
-                element_size=2,
                 offset=state_offset,
                 stride=page_stride_bytes,
             ),
@@ -85,7 +83,6 @@ def _typed_layout(
                 "layer.0.k",
                 dtype="bfloat16",
                 shape=(2, local_heads, 2),
-                element_size=2,
                 axis=1,
                 extent=global_heads,
             ),
@@ -488,17 +485,11 @@ def test_cache_factory_exposes_only_typed_arena() -> None:
     layout = _layout()
     buffer = torch.zeros(layout.plan.arena_bytes, dtype=torch.uint8)
     pool = SimpleNamespace(
-        supports_disaggregation=True,
-        plan=layout.plan,
-        paged_cache_group_specs=layout.group_specs,
-        cache_contract_binding=lambda: (
-            buffer,
-            {
-                field.field_id: dtype
-                for field, dtype in zip(
-                    layout.plan.fields, layout.field_dtypes, strict=True
-                )
-            },
+        arena=SimpleNamespace(
+            supports_disaggregation=True,
+            plan=layout.plan,
+            cache_group_specs=layout.group_specs,
+            contract_binding=lambda: buffer,
         ),
     )
 
@@ -729,12 +720,11 @@ def test_layerwise_final_preserves_speculative_candidates() -> None:
     assert executor._layerwise_token_published == set()
 
 
-def test_shared_manager_executes_strided_paged_cache_tp_fragment() -> None:
+def test_shared_manager_executes_strided_cache_tp_fragment() -> None:
     source_segment = make_segment(
         "layer.0.k",
         dtype="bfloat16",
         shape=(2, 2, 2),
-        element_size=2,
         stride=32,
         axis=1,
         extent=4,
@@ -743,7 +733,6 @@ def test_shared_manager_executes_strided_paged_cache_tp_fragment() -> None:
         "layer.0.k",
         dtype="bfloat16",
         shape=(2, 4, 2),
-        element_size=2,
         stride=64,
         axis=1,
         extent=4,

--- a/test/runtime/distributed/test_cache_pd_layerwise.py
+++ b/test/runtime/distributed/test_cache_pd_layerwise.py
@@ -56,7 +56,7 @@ from tokenspeed.runtime.pd.mooncake.entities import (  # noqa: E402
     TransferKVChunk,
 )
 from tokenspeed.runtime.pd.transfer_plan import (  # noqa: E402
-    PagedCacheTransferPlanner,
+    CacheTransferPlanner,
 )
 from tokenspeed.runtime.pd.utils import StepCounter  # noqa: E402
 
@@ -83,7 +83,6 @@ def _segment(
         field_id,
         dtype="bfloat16",
         shape=shape,
-        element_size=2,
         offset=page_zero_offset,
         stride=page_stride_bytes,
         axis=partition_axis,
@@ -452,7 +451,7 @@ def test_heterogeneous_zero_edge_interval_does_not_fall_back_to_identity() -> No
 
     source_layout = _heterogeneous_layout(destination=False)
     destination_layout = _heterogeneous_layout(destination=True)
-    planner = PagedCacheTransferPlanner(
+    planner = CacheTransferPlanner(
         prefill_tp_size=2,
         decode_tp_size=1,
         prefill_layout=source_layout,

--- a/test/runtime/distributed/test_cache_pd_manifest.py
+++ b/test/runtime/distributed/test_cache_pd_manifest.py
@@ -25,7 +25,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CachePlaneLayout,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 from tokenspeed.runtime.pd.cache_protocol import (  # noqa: E402
     CacheContractError,
@@ -50,16 +50,14 @@ def _group_spec(
     prefix_granularity: int = 4,
     retention: str = "full_history",
     sliding_window_tokens: int | None = None,
-    packing: int = 1,
-) -> PagedCacheGroupSpec:
-    return PagedCacheGroupSpec(
+) -> CacheGroupSpec:
+    return CacheGroupSpec(
         group_id=group_id,
         retention=retention,
         rows_per_page=prefix_granularity,
         entry_stride_tokens=1,
         sliding_window_tokens=sliding_window_tokens,
         family=family,
-        cache_blocks_per_lcm_block=packing,
         transfer_policy=policy,
     )
 
@@ -70,7 +68,7 @@ def _field(
     *,
     plane_id: str = "cache",
     shape: tuple[int, ...] = (1,),
-    element_size: int = 1,
+    dtype: str = "uint8",
     offset: int = 0,
     stride: int = 128,
 ) -> CacheFieldLayout:
@@ -79,22 +77,22 @@ def _field(
         field_id=field_id,
         plane_id=plane_id,
         shape=shape,
-        element_size=element_size,
+        dtype=dtype,
         field_offset_bytes=offset,
         page_stride_bytes=stride,
     )
 
 
 def _contract(
-    specs: tuple[PagedCacheGroupSpec, ...],
+    specs: tuple[CacheGroupSpec, ...],
     fields: tuple[CacheFieldLayout, ...],
     *,
     block_size: int = 4,
     capacity: int = 64,
     page_bytes: int = 128,
     planes: tuple[CachePlaneLayout, ...] | None = None,
-    dtypes: tuple[str, ...] | None = None,
     transfer_schema: CacheTransferSchema = CacheTransferSchema(),
+    packing: int = 1,
 ) -> CacheTransferContract:
     plan = CacheMemoryPlan(
         prefix_granularity=block_size,
@@ -103,8 +101,8 @@ def _contract(
         groups=tuple(
             CacheGroupLayout(
                 group_id=spec.group_id,
-                cache_blocks_per_lcm_block=spec.cache_blocks_per_lcm_block,
-                page_count=(1 + (capacity - 1) * spec.cache_blocks_per_lcm_block),
+                cache_blocks_per_lcm_block=packing,
+                page_count=(1 + (capacity - 1) * packing),
             )
             for spec in specs
         ),
@@ -121,7 +119,6 @@ def _contract(
     return CacheTransferContract(
         plan=plan,
         group_specs=specs,
-        field_dtypes=dtypes or tuple("uint8" for _ in fields),
         transfer_schema=transfer_schema,
     )
 
@@ -285,7 +282,7 @@ def test_contract_and_manifest_wire_round_trip_has_no_version_field() -> None:
 
 
 def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
-    spec = _group_spec("history", "history", "full_suffix", packing=2)
+    spec = _group_spec("history", "history", "full_suffix")
     # Null parent plus three usable parents, each packing two child pages.
     layout = _contract(
         (spec,),
@@ -294,13 +291,13 @@ def test_lcm_group_capacity_uses_its_cache_blocks_per_parent() -> None:
                 "history",
                 "layer.0.k",
                 shape=(64,),
-                element_size=2,
+                dtype="bfloat16",
                 stride=128,
             ),
         ),
         capacity=4,
         page_bytes=1024,
-        dtypes=("bfloat16",),
+        packing=2,
     )
     tables = {"history": np.array([[5, 6]], dtype=np.int32)}
     operation = SimpleNamespace(block_tables_arrays=lambda: tables)
@@ -330,7 +327,6 @@ def test_destination_manifest_uses_peer_local_group_packing() -> None:
             "history",
             "full_suffix",
             prefix_granularity=2,
-            packing=packing,
         )
         return _contract(
             (spec,),
@@ -339,14 +335,14 @@ def test_destination_manifest_uses_peer_local_group_packing() -> None:
                     "history",
                     "layer.0.k",
                     shape=(4,),
-                    element_size=2,
+                    dtype="bfloat16",
                     stride=8,
                 ),
             ),
             block_size=2,
             capacity=4,
             page_bytes=physical_page_bytes,
-            dtypes=("bfloat16",),
+            packing=packing,
         )
 
     source_layout = layout(packing=1, physical_page_bytes=8)
@@ -437,7 +433,7 @@ def _two_plane_lcm_plan(num_lcm_blocks: int) -> CacheMemoryPlan:
                 field_id="layer.0.k",
                 plane_id="k",
                 shape=(4, 8),
-                element_size=2,
+                dtype="bfloat16",
                 field_offset_bytes=0,
                 page_stride_bytes=256,
             ),
@@ -446,7 +442,7 @@ def _two_plane_lcm_plan(num_lcm_blocks: int) -> CacheMemoryPlan:
                 field_id="layer.0.v",
                 plane_id="v",
                 shape=(4, 8),
-                element_size=2,
+                dtype="bfloat16",
                 field_offset_bytes=0,
                 page_stride_bytes=256,
             ),
@@ -455,53 +451,39 @@ def _two_plane_lcm_plan(num_lcm_blocks: int) -> CacheMemoryPlan:
 
 
 _LCM_SPECS = (
-    PagedCacheGroupSpec(
+    CacheGroupSpec(
         group_id="history",
         retention="full_history",
         rows_per_page=4,
         entry_stride_tokens=1,
         sliding_window_tokens=None,
         family="history",
-        cache_blocks_per_lcm_block=2,
         transfer_policy="full_suffix",
     ),
 )
 
 
 def _recipe_contract(
-    fields,
-    specs,
-    dtypes,
+    groups,
     *,
     ptr=0x10000,
     q=128,
     transfer_schema=CacheTransferSchema(),
     **solve,
 ):
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
-        solve_cache_layout,
-    )
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import pack
 
-    plan = solve_cache_layout(
-        fields,
+    specs = tuple(spec for spec, _ in groups)
+    plan = pack(
+        groups,
         prefix_granularity=q,
         max_padding_fraction=1.0,
         **solve,
-    ).with_num_lcm_blocks(3)
-    aligned_specs = tuple(
-        replace(
-            spec,
-            cache_blocks_per_lcm_block=(
-                plan.group(spec.group_id).cache_blocks_per_lcm_block
-            ),
-        )
-        for spec in specs
-    )
+    ).bind(3)
     return build_cache_transfer_contract(
         plan=plan,
         buffer=_cache_buffer(plan.arena_bytes, data_ptr=ptr),
-        group_specs=aligned_specs,
-        field_dtypes=dtypes,
+        group_specs=specs,
         transfer_schema=transfer_schema,
     )[0]
 
@@ -512,7 +494,6 @@ def test_lcm_contract_registers_one_arena_and_preserves_group_geometry() -> None
         plan=plan,
         buffer=_cache_buffer(plan.arena_bytes),
         group_specs=_LCM_SPECS,
-        field_dtypes={"layer.0.k": "bfloat16", "layer.0.v": "bfloat16"},
     )
 
     assert layout.plan.num_lcm_blocks + 1 == 4
@@ -531,13 +512,11 @@ def test_peer_layout_allows_capacity_and_offsets_to_differ() -> None:
         plan=_two_plane_lcm_plan(3),
         buffer=_cache_buffer(4096),
         group_specs=_LCM_SPECS,
-        field_dtypes={"layer.0.k": "bfloat16", "layer.0.v": "bfloat16"},
     )
     large, _ = build_cache_transfer_contract(
         plan=_two_plane_lcm_plan(5),
         buffer=_cache_buffer(6144, data_ptr=0x20000),
         group_specs=_LCM_SPECS,
-        field_dtypes={"layer.0.k": "bfloat16", "layer.0.v": "bfloat16"},
     )
 
     assert small.plan.num_lcm_blocks != large.plan.num_lcm_blocks
@@ -557,10 +536,7 @@ def test_pd_derives_ordinary_transfer_metadata_from_physical_plan(
     from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
     from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-        _ordinary_fields,
-    )
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-        build_paged_cache_group_specs,
+        OrdinaryRecipe,
     )
 
     common = {
@@ -598,30 +574,22 @@ def test_pd_derives_ordinary_transfer_metadata_from_physical_plan(
         pd_disaggregation_enabled=True,
     )
 
-    fields, group_ids = _ordinary_fields(config, 2)
-    packing = {group_id: 1 for group_id in group_ids}
-    specs = build_paged_cache_group_specs(
-        layer_types=(),
-        group_ids=group_ids,
-        sliding_window_tokens=None,
-        prefix_granularity=config.prefix_granularity,
-        cache_blocks_per_lcm_block=packing,
-        pd_disaggregation_enabled=True,
+    recipe = OrdinaryRecipe(
+        family=family,
+        server_args=SimpleNamespace(max_total_tokens=None),
+        model_config=SimpleNamespace(num_attention_layers=2),
+        attn_config=config,
+        draft_model_config=None,
+        draft_attn_config=None,
+        cache_budget_bytes=1 << 24,
+        decode_input_tokens=1,
+        overlap_schedule_depth=0,
     )
-    field_dtypes = {
-        field.field_id: (
-            "uint8"
-            if family == "dsa" and field.field_id.endswith(".index_k")
-            else "bfloat16"
-        )
-        for field in fields
-    }
+    groups = recipe.groups()
     layout = _recipe_contract(
-        fields,
-        specs,
-        field_dtypes,
+        groups,
         q=config.prefix_granularity,
-        cache_blocks_per_lcm_block=packing,
+        cache_blocks_per_lcm_block=recipe.packing(groups),
         alignment=1,
     )
     model_config = SimpleNamespace(
@@ -640,15 +608,9 @@ def test_pd_derives_ordinary_transfer_metadata_from_physical_plan(
     assert layout.plan.prefix_granularity == 16
     assert len(layout.group_specs) == 1
     group = layout.group_specs[0]
-    assert (
-        group.group_id,
-        group.family,
-        group.cache_blocks_per_lcm_block,
-    ) == (
-        "full_attention",
-        "history",
-        1,
-    )
+    assert (group.group_id, group.family) == ("full_attention", "history")
+    # Packing lives on the plan, not on the group spec.
+    assert layout.plan.group("full_attention").cache_blocks_per_lcm_block == 1
 
     fields_by_id = {
         field.field_id: field for field in layout.fields_for_group(group.group_id)
@@ -669,10 +631,11 @@ def test_pd_derives_ordinary_transfer_metadata_from_physical_plan(
             if family == "dsa" and is_index
             else (16, 1, 8) if field_id.endswith(".latent_kv") else (16, 2, 8)
         )
-        expected_element_size = 1 if family == "dsa" and is_index else 2
-        assert layout.field_dtype(field_id) == field_dtypes[field_id]
+        # The recipe put the dtype in the plan; the contract reads it back.
+        expected_dtype = "uint8" if family == "dsa" and is_index else "bfloat16"
+        assert layout.field_dtype(field_id) == expected_dtype
         assert field.shape == expected_shape
-        assert field.element_size == expected_element_size
+        assert field.element_size == (1 if expected_dtype == "uint8" else 2)
         partition = layout.transfer_schema.partition_for(field_id)
         if field_id.endswith((".k", ".v")):
             assert partition is not None

--- a/test/runtime/distributed/test_mla_dsa_pd_contract.py
+++ b/test/runtime/distributed/test_mla_dsa_pd_contract.py
@@ -43,14 +43,10 @@ from ci_system.ci_register import register_cuda_ci  # noqa: E402
 register_cuda_ci(est_time=20, suite="runtime-1gpu")
 
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-    _dsa_fields,
-    _mla_fields,
+    OrdinaryRecipe,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
-    solve_cache_layout,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    build_paged_cache_group_specs,
+    pack,
 )
 
 _P = 64
@@ -58,95 +54,129 @@ _NUM_LAYERS = 3
 _NUM_LCM_BLOCKS = 6
 
 
-class _MLACfg:
-    kv_lora_rank = 512
-    qk_rope_head_dim = 64
-    kv_cache_dtype = torch.bfloat16
-    kv_cache_quant_method = ""
-    index_head_dim = 128
-    page_size = _P
-    dtype = torch.bfloat16
+def _attn_config(family: str, pd_enabled: bool):
+    """A real MLA/DSA config: the recipe dispatches fields on the type."""
+    from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
+    from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 
-
-def _plan(fields):
-    layout = solve_cache_layout(
-        fields,
+    common = dict(
+        device="cpu",
+        backend_name="mla",
+        num_attention_heads=64,
+        num_kv_heads=64,
+        attn_tp_size=1,
+        head_dim=192,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        context_len=1024,
+        max_graph_bs=1,
+        max_bs=1,
         prefix_granularity=_P,
-        cache_blocks_per_lcm_block={f.group_id: 1 for f in fields},
-        alignment=1,
-        max_padding_fraction=1.0,
-    )
-    return layout.with_num_lcm_blocks(_NUM_LCM_BLOCKS)
-
-
-def _specs(plan, pd_enabled: bool):
-    return build_paged_cache_group_specs(
-        layer_types=("full_attention",) * _NUM_LAYERS,
-        group_ids=("full_attention",) * _NUM_LAYERS,
-        sliding_window_tokens=None,
-        prefix_granularity=_P,
+        kernel_page_size=_P,
+        kv_cache_quant_method="",
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        v_head_dim=128,
+        scaling=1.0,
+        kv_cache_dim=576,
+        max_scheduled_tokens=_P,
         pd_disaggregation_enabled=pd_enabled,
     )
+    if family == "dsa":
+        return DSAConfig(index_topk=1, index_head_dim=128, index_n_heads=1, **common)
+    return MLAConfig(**common)
+
+
+def _recipe(family: str, pd_enabled: bool = False):
+    """An ordinary recipe over ``_NUM_LAYERS`` MLA/DSA layers."""
+    from types import SimpleNamespace
+
+    config = _attn_config(family, pd_enabled)
+    return OrdinaryRecipe(
+        family=family,
+        server_args=SimpleNamespace(max_total_tokens=_NUM_LCM_BLOCKS * _P),
+        model_config=SimpleNamespace(num_attention_layers=_NUM_LAYERS),
+        attn_config=config,
+        draft_model_config=None,
+        draft_attn_config=None,
+        cache_budget_bytes=1 << 30,
+        decode_input_tokens=1,
+        overlap_schedule_depth=0,
+    )
+
+
+def _plan_and_specs(family: str, pd_enabled: bool = False):
+    recipe = _recipe(family, pd_enabled)
+    groups = recipe.groups()
+    layout = pack(
+        groups,
+        prefix_granularity=recipe.prefix_granularity,
+        cache_blocks_per_lcm_block=recipe.packing(groups),
+        alignment=recipe.alignment,
+        max_padding_fraction=recipe.max_padding_fraction,
+    )
+    return layout.bind(_NUM_LCM_BLOCKS), tuple(spec for spec, _ in groups)
 
 
 def _make_mla_pool(pd_enabled: bool):
     from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 
-    fields = _mla_fields(_MLACfg(), _NUM_LAYERS)
-    plan = _plan(fields)
-    return MLATokenToKVPool(
-        size=_NUM_LCM_BLOCKS * _P,
+    plan, specs = _plan_and_specs("mla", pd_enabled)
+    from cache_pool_test_utils import make_pool
+
+    _, pool = make_pool(
+        MLATokenToKVPool,
+        plan,
+        device="cpu",
         model_dtype=torch.bfloat16,
         dtype=torch.bfloat16,
         quant_method="",
-        kv_lora_rank=_MLACfg.kv_lora_rank,
-        qk_rope_head_dim=_MLACfg.qk_rope_head_dim,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
         layer_num=_NUM_LAYERS,
-        device="cpu",
-        enable_memory_saver=False,
-        prefix_granularity=_P,
         rank=0,
-        memory_plan=plan,
-        paged_cache_group_specs=_specs(plan, pd_enabled),
+        cache_group_specs=specs,
         token_capacity=_NUM_LCM_BLOCKS * _P,
         layer_group_ids=("full_attention",) * _NUM_LAYERS,
     )
+    return pool
 
 
 def _make_dsa_pool(pd_enabled: bool):
     from tokenspeed.runtime.layers.attention.kv_cache.dsa import DSATokenToKVPool
 
-    fields = _dsa_fields(_MLACfg(), _NUM_LAYERS)
-    plan = _plan(fields)
-    return DSATokenToKVPool(
-        size=_NUM_LCM_BLOCKS * _P,
+    plan, specs = _plan_and_specs("dsa", pd_enabled)
+    from cache_pool_test_utils import make_pool
+
+    _, pool = make_pool(
+        DSATokenToKVPool,
+        plan,
+        device="cpu",
         model_dtype=torch.bfloat16,
         dtype=torch.bfloat16,
         quant_method="",
-        kv_lora_rank=_MLACfg.kv_lora_rank,
-        qk_rope_head_dim=_MLACfg.qk_rope_head_dim,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
         layer_num=_NUM_LAYERS,
-        device="cpu",
-        enable_memory_saver=False,
-        prefix_granularity=_P,
         rank=0,
-        index_head_dim=_MLACfg.index_head_dim,
-        memory_plan=plan,
-        paged_cache_group_specs=_specs(plan, pd_enabled),
+        index_head_dim=128,
+        cache_group_specs=specs,
         token_capacity=_NUM_LCM_BLOCKS * _P,
         layer_group_ids=("full_attention",) * _NUM_LAYERS,
     )
+    return pool
 
 
 def test_mla_pool_advertises_pd_contract_when_enabled() -> None:
     from tokenspeed.runtime.pd.cache_protocol import (
-        build_pool_cache_transfer_contract,
+        build_arena_cache_transfer_contract,
     )
 
     pool = _make_mla_pool(pd_enabled=True)
-    assert pool.supports_disaggregation is True
-    contract, base_addr = build_pool_cache_transfer_contract(pool)
-    assert base_addr == pool.buffer.data_ptr()
+    assert pool.arena.supports_disaggregation is True
+    contract, base_addr = build_arena_cache_transfer_contract(pool.arena)
+    assert base_addr == pool.arena.buffer.data_ptr()
     field_ids = {
         field.field_id for field in contract.fields_for_group("full_attention")
     }
@@ -155,13 +185,13 @@ def test_mla_pool_advertises_pd_contract_when_enabled() -> None:
 
 def test_dsa_pool_contract_covers_latent_and_index_k() -> None:
     from tokenspeed.runtime.pd.cache_protocol import (
-        build_pool_cache_transfer_contract,
+        build_arena_cache_transfer_contract,
     )
 
     pool = _make_dsa_pool(pd_enabled=True)
-    assert pool.supports_disaggregation is True
-    contract, base_addr = build_pool_cache_transfer_contract(pool)
-    assert base_addr == pool.buffer.data_ptr()
+    assert pool.arena.supports_disaggregation is True
+    contract, base_addr = build_arena_cache_transfer_contract(pool.arena)
+    assert base_addr == pool.arena.buffer.data_ptr()
     fields = contract.fields_for_group("full_attention")
     field_ids = {field.field_id for field in fields}
     # DSA packs BOTH latent_kv and index_k for every layer into the one
@@ -178,10 +208,10 @@ def test_pd_contract_refused_when_disabled() -> None:
     import pytest
 
     from tokenspeed.runtime.pd.cache_protocol import (
-        build_pool_cache_transfer_contract,
+        build_arena_cache_transfer_contract,
     )
 
     pool = _make_mla_pool(pd_enabled=False)
-    assert pool.supports_disaggregation is False
+    assert pool.arena.supports_disaggregation is False
     with pytest.raises(RuntimeError, match="no transfer policy"):
-        build_pool_cache_transfer_contract(pool)
+        build_arena_cache_transfer_contract(pool.arena)

--- a/test/runtime/distributed/test_pd_transfer_plan.py
+++ b/test/runtime/distributed/test_pd_transfer_plan.py
@@ -17,7 +17,7 @@ from runtime.cache_pd_test_utils import segment  # noqa: E402
 from runtime.cache_pd_test_utils import layout as make_layout  # noqa: E402
 
 from tokenspeed.runtime.pd.transfer_plan import (
-    PagedCacheTransferPlanner,
+    CacheTransferPlanner,
 )
 
 
@@ -33,7 +33,6 @@ def _paged_layout(
             "layer.0.k",
             dtype="bfloat16",
             shape=(2, local_heads, 2),
-            element_size=2,
             offset=page_zero_offset,
             stride=page_stride,
             axis=1,
@@ -45,7 +44,6 @@ def _paged_layout(
             "layer.1.latent",
             dtype="bfloat16",
             shape=(2, 1),
-            element_size=2,
             offset=page_zero_offset + 1024,
             stride=16,
         )
@@ -67,7 +65,6 @@ def _composite_paged_layout(
                 "layer.0.conv",
                 dtype="bfloat16",
                 shape=shape,
-                element_size=2,
                 stride=page_stride,
                 axis=partition_axis,
                 extent=sum(global_parts),
@@ -80,7 +77,7 @@ def _composite_paged_layout(
 
 
 def _planner(prefill_tp, decode_tp, prefill_layout, decode_layout):
-    return PagedCacheTransferPlanner(
+    return CacheTransferPlanner(
         prefill_tp_size=prefill_tp,
         decode_tp_size=decode_tp,
         prefill_layout=prefill_layout,
@@ -144,7 +141,7 @@ def _composite_planner(
     )
 
 
-def test_paged_cache_planner_splits_token_major_rows_from_tp1_to_tp2():
+def test_cache_planner_splits_token_major_rows_from_tp1_to_tp2():
     planner = _paged_planner(1, 2, 4, 2, 64, 32)
 
     first = planner.plan_for_decode_rank(0)
@@ -165,7 +162,7 @@ def test_paged_cache_planner_splits_token_major_rows_from_tp1_to_tp2():
     assert second_k.bytes_per_row == 8
 
 
-def test_paged_cache_planner_merges_tp2_to_tp1():
+def test_cache_planner_merges_tp2_to_tp1():
     planner = _paged_planner(2, 1, 2, 4, 32, 64)
 
     plan = planner.plan_for_decode_rank(0)
@@ -185,7 +182,7 @@ def test_paged_cache_planner_merges_tp2_to_tp1():
     )
 
 
-def test_paged_cache_planner_handles_gqa_replicas_and_idle_prefill_ranks() -> None:
+def test_cache_planner_handles_gqa_replicas_and_idle_prefill_ranks() -> None:
     planner = _paged_planner(4, 1, 1, 2, 32, 64, global_heads=2)
 
     plan = planner.plan_for_decode_rank(0)
@@ -193,7 +190,7 @@ def test_paged_cache_planner_handles_gqa_replicas_and_idle_prefill_ranks() -> No
     assert plan.target_prefill_ranks == (0, 2)
 
 
-def test_paged_cache_planner_maps_non_multiple_tp_sizes() -> None:
+def test_cache_planner_maps_non_multiple_tp_sizes() -> None:
     planner = _paged_planner(2, 3, 3, 2, 96, 64, global_heads=6)
 
     plans = tuple(planner.plan_for_decode_rank(rank) for rank in range(3))
@@ -201,7 +198,7 @@ def test_paged_cache_planner_maps_non_multiple_tp_sizes() -> None:
     assert [plan.target_prefill_ranks for plan in plans] == [(0,), (0, 1), (1,)]
 
 
-def test_paged_cache_planner_splits_each_qkv_part_from_tp1_to_tp2():
+def test_cache_planner_splits_each_qkv_part_from_tp1_to_tp2():
     planner = _composite_planner(1, 2, (16, 2), (8, 2), 0, (4, 4, 8), 64, 32)
 
     plan = planner.plan_for_decode_rank(1)

--- a/test/runtime/models/test_inkling_models.py
+++ b/test/runtime/models/test_inkling_models.py
@@ -114,23 +114,23 @@ class TestInklingConfigRegistry(unittest.TestCase):
         self.assertEqual(layout[InklingConvStream.MLP], (2 * kv_dim + h, h))
         self.assertEqual(inkling_conv_total_dim(text, 1), 2 * kv_dim + 2 * h)
 
-    def test_paged_cache_layer_types_sliding_subgroups(self):
+    def test_cache_layer_types_sliding_subgroups(self):
         """Cache-group labels: sliding layers split round-robin into
         equal-count sub-groups sized by the full-layer count, so every
         hybrid slab is bound by one layer of each group (5+1 truncated,
         5x11+11 at full depth; see kv_cache.recipes.publish.hybrid_slab_group_size).
-        Exposed as paged_cache_layer_types, NOT layer_types: transformers
+        Exposed as cache_layer_types, NOT layer_types: transformers
         validates layer_types against ALLOWED_LAYER_TYPES, which rejects
         sub-group labels."""
         text = load_inkling_config().get_text_config()
         self.assertEqual(
-            text.paged_cache_layer_types,
+            text.cache_layer_types,
             [f"sliding_attention_{k}" for k in range(5)] + ["full_attention"],
         )
         # Full depth: 66 layers -> 5 sub-groups of 11 sliding + 11 full.
         full = load_inkling_config(num_layers=None).get_text_config()
         full_ids = list(range(5, 66, 6))
-        lt = full.paged_cache_layer_types
+        lt = full.cache_layer_types
         self.assertEqual(
             [i for i, t in enumerate(lt) if t == "full_attention"], full_ids
         )
@@ -140,7 +140,7 @@ class TestInklingConfigRegistry(unittest.TestCase):
         # Draft (nextn) shape: local_layer_ids=[] -> all full, indexable
         # by draft layer_id.
         draft = InklingModelConfig(num_hidden_layers=4, local_layer_ids=[])
-        self.assertEqual(draft.paged_cache_layer_types, ["full_attention"] * 4)
+        self.assertEqual(draft.cache_layer_types, ["full_attention"] * 4)
 
     def test_local_layer_ids_validation(self):
         with self.assertRaises(ValueError):

--- a/test/runtime/models/test_llama_eagle3.py
+++ b/test/runtime/models/test_llama_eagle3.py
@@ -17,7 +17,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import FULL_ATTEN
 from tokenspeed.runtime.layers.layernorm import RMSNorm
 from tokenspeed.runtime.layers.paged_attention import (
     PagedAttention,
-    validate_paged_cache_group_ids,
+    validate_cache_group_ids,
 )
 from tokenspeed.runtime.models.llama_eagle3 import LlamaForCausalLMEagle3
 from tokenspeed.runtime.utils.env import global_server_args_dict
@@ -126,7 +126,7 @@ def test_eagle3_attention_routes_to_full_attention_cache_group(
 
     assert paged_layers
     assert {layer.group_id for layer in paged_layers} == {FULL_ATTENTION}
-    validate_paged_cache_group_ids(
+    validate_cache_group_ids(
         model,
         (
             SimpleNamespace(group_id=FULL_ATTENTION),

--- a/test/runtime/test_aligned_max_scheduled_tokens.py
+++ b/test/runtime/test_aligned_max_scheduled_tokens.py
@@ -1,7 +1,7 @@
 """aligned_max_scheduled_tokens (engine/scheduler_utils, applied in
 engine/event_loop before make_config).
 
-Recurrent-state paged-cache groups (family=State, retention=FullHistory; the
+Recurrent-state cache groups (family=State, retention=FullHistory; the
 C++ ``final_state_manager`` criterion) register their snapshot only when a
 prefill chunk ends page-aligned (RegistersAlignedFinalPageOnly). The helper
 floors the scheduler's max_scheduled_tokens to the LCM of those groups' page
@@ -24,9 +24,9 @@ from ci_system.ci_register import register_cuda_ci
 register_cuda_ci(est_time=5, suite="runtime-1gpu")
 
 from tokenspeed_scheduler import (
-    PagedCacheGroupConfig,
-    PagedCacheGroupFamily,
-    PagedCacheRetention,
+    CacheGroupConfig,
+    CacheGroupFamily,
+    CacheRetention,
 )
 
 from tokenspeed.runtime.engine.scheduler_utils import aligned_max_scheduled_tokens
@@ -34,11 +34,11 @@ from tokenspeed.runtime.engine.scheduler_utils import aligned_max_scheduled_toke
 
 def _group(
     group_id: str,
-    family: PagedCacheGroupFamily,
-    retention: PagedCacheRetention,
+    family: CacheGroupFamily,
+    retention: CacheRetention,
     page_size: int = 64,
     sliding_window_tokens: int | None = None,
-) -> PagedCacheGroupConfig:
+) -> CacheGroupConfig:
     kwargs = dict(
         group_id=group_id,
         rows_per_page=page_size,
@@ -49,23 +49,23 @@ def _group(
     )
     if sliding_window_tokens is not None:
         kwargs["sliding_window_tokens"] = sliding_window_tokens
-    return PagedCacheGroupConfig(**kwargs)
+    return CacheGroupConfig(**kwargs)
 
 
-def _kimi_k3_groups(page_size: int = 1536) -> list[PagedCacheGroupConfig]:
+def _kimi_k3_groups(page_size: int = 1536) -> list[CacheGroupConfig]:
     groups = [
         _group(
             "full_attention",
-            PagedCacheGroupFamily.History,
-            PagedCacheRetention.FullHistory,
+            CacheGroupFamily.History,
+            CacheRetention.FullHistory,
             page_size=page_size,
         )
     ]
     groups.extend(
         _group(
             f"linear_attention_{i}",
-            PagedCacheGroupFamily.State,
-            PagedCacheRetention.FullHistory,
+            CacheGroupFamily.State,
+            CacheRetention.FullHistory,
             page_size=page_size,
         )
         for i in range(3)
@@ -85,8 +85,8 @@ class AlignedMaxScheduledTokensTest(unittest.TestCase):
         groups = [
             _group(
                 "full_attention",
-                PagedCacheGroupFamily.History,
-                PagedCacheRetention.FullHistory,
+                CacheGroupFamily.History,
+                CacheRetention.FullHistory,
                 page_size=1536,
             )
         ]
@@ -102,8 +102,8 @@ class AlignedMaxScheduledTokensTest(unittest.TestCase):
         groups = [
             _group(
                 "v4.swa_kv",
-                PagedCacheGroupFamily.State,
-                PagedCacheRetention.SlidingWindow,
+                CacheGroupFamily.State,
+                CacheRetention.SlidingWindow,
                 page_size=1536,
                 sliding_window_tokens=1536,
             )
@@ -120,8 +120,8 @@ class AlignedMaxScheduledTokensTest(unittest.TestCase):
         groups = [
             _group(
                 "state",
-                PagedCacheGroupFamily.State,
-                PagedCacheRetention.FullHistory,
+                CacheGroupFamily.State,
+                CacheRetention.FullHistory,
                 page_size=96,
             )
         ]
@@ -131,14 +131,14 @@ class AlignedMaxScheduledTokensTest(unittest.TestCase):
         groups = [
             _group(
                 "state_a",
-                PagedCacheGroupFamily.State,
-                PagedCacheRetention.FullHistory,
+                CacheGroupFamily.State,
+                CacheRetention.FullHistory,
                 page_size=64,
             ),
             _group(
                 "state_b",
-                PagedCacheGroupFamily.State,
-                PagedCacheRetention.FullHistory,
+                CacheGroupFamily.State,
+                CacheRetention.FullHistory,
                 page_size=96,
             ),
         ]

--- a/test/runtime/test_cache_memory_plan.py
+++ b/test/runtime/test_cache_memory_plan.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 import types
 import unittest
+from collections.abc import Mapping
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -83,6 +84,32 @@ def _load_cache_modules():
     return plan, layouts
 
 
+def _tagged_field(group_id, field_id, plane_id, shape, dtype, **kwargs):
+    """``(group_id, CacheFieldSpec)`` -- the tag says which group declares it.
+
+    Byte-layout tests care about the tag only to route the field into a
+    group, so they keep one readable line per field; _plan_fields turns the
+    tags into declarations.
+    """
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+        CacheFieldSpec,
+    )
+
+    return group_id, CacheFieldSpec(field_id, plane_id, shape, dtype, **kwargs)
+
+
+def _group(group_id: str, *fields, **spec_kwargs):
+    """Declare one cache group the way a recipe does: id once, fields under it.
+
+    Row geometry defaults so a byte-layout test need not restate scheduler
+    semantics; ``rows_per_page`` is the group's CacheBlock token span.
+    """
+    # A duck-typed spec: the planner reads only ``spec.group_id``, and this
+    # module loads its subject by file path -- importing the real spec module
+    # here would shadow it in sys.modules for every later test.
+    return types.SimpleNamespace(group_id=group_id, **spec_kwargs), tuple(fields)
+
+
 class CacheMemoryPlanTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -97,214 +124,28 @@ class CacheMemoryPlanTest(unittest.TestCase):
         num_lcm_blocks=None,
         **kwargs,
     ):
-        """Solve a layout and bind capacity the way the recipes do."""
-        layout = self.plan_module.solve_cache_layout(
-            fields,
+        """Solve a layout and bind capacity the way the recipes do.
+
+        ``fields`` is either the ``{group_id: fields}`` map a recipe field
+        builder returns, or a sequence of ``(group_id, CacheFieldSpec)``
+        pairs from :func:`_tagged_field`. Both are grouped into declarations
+        here, the same join the recipes do.
+        """
+        if isinstance(fields, Mapping):
+            by_group = {group_id: tuple(group) for group_id, group in fields.items()}
+        else:
+            by_group = {}
+            for group_id, field in fields:
+                by_group[group_id] = by_group.get(group_id, ()) + (field,)
+        layout = self.plan_module.pack(
+            tuple(_group(group_id, *group) for group_id, group in by_group.items()),
             prefix_granularity=prefix_granularity,
             **kwargs,
         )
         if budget_bytes is not None:
             # Parent 0 backs logical null page 0 and is never schedulable.
             num_lcm_blocks = budget_bytes // layout.lcm_block_bytes - 1
-        return layout.with_num_lcm_blocks(num_lcm_blocks)
-
-    def test_qwen_recipe_keeps_one_logical_block_size(self):
-        fields = self.layouts_module.qwen_gdn_cache_fields(
-            layer_types=("linear_attention", "full_attention"),
-            layer_group_ids=("linear_attention_0", "full_attention"),
-            prefix_granularity=128,
-            kv_shape=(128, 1, 128),
-            kv_element_size=2,
-            conv_shape=(256, 3),
-            conv_element_size=2,
-            ssm_shape=(8, 128, 128),
-            ssm_element_size=4,
-        )
-
-        self.assertEqual(
-            {field.group_id for field in fields},
-            {"linear_attention_0", "full_attention"},
-        )
-        by_id = {field.field_id: field for field in fields}
-        self.assertEqual(by_id["layer.1.k"].shape[0], 128)
-        self.assertEqual(by_id["layer.0.ssm"].shape, (8, 128, 128))
-
-    def test_qwen_mtp_padding_allowance_tracks_draft_planes(self):
-        qwen = sys.modules[
-            "tokenspeed.runtime.layers.attention.kv_cache.recipes.qwen35"
-        ]
-        for full_attention_layers, linear_value_heads in ((6, 16), (12, 64)):
-            with self.subTest(full_attention_layers=full_attention_layers):
-                layer_types = (
-                    "linear_attention",
-                    "linear_attention",
-                    "linear_attention",
-                    "full_attention",
-                ) * full_attention_layers
-                group_ids = (
-                    "linear_attention_0",
-                    "linear_attention_1",
-                    "linear_attention_2",
-                    "full_attention",
-                ) * full_attention_layers
-                conv_dim = 128 * 16 * 2 + 128 * linear_value_heads
-                target_fields = self.layouts_module.qwen_gdn_cache_fields(
-                    layer_types=layer_types,
-                    layer_group_ids=group_ids,
-                    prefix_granularity=128,
-                    kv_shape=(128, 2, 256),
-                    kv_element_size=1,
-                    conv_shape=(conv_dim, 3),
-                    conv_element_size=2,
-                    ssm_shape=(linear_value_heads, 128, 128),
-                    ssm_element_size=4,
-                )
-                draft_fields = self.layouts_module.draft_cache_fields(
-                    layer_group_ids=("full_attention",),
-                    enabled_layer_ids=(0,),
-                    prefix_granularity=128,
-                    layer_kv_heads=(2,),
-                    head_dim=256,
-                    kv_element_size=1,
-                )
-                merged_fields = target_fields + self.plan_module.continue_layer_fields(
-                    draft_fields,
-                    first_layer_id=len(layer_types),
-                )
-
-                target_layout = self.plan_module.solve_cache_layout(
-                    target_fields,
-                    prefix_granularity=128,
-                    alignment=256,
-                    max_padding_fraction=1.0,
-                )
-                with self.assertRaisesRegex(
-                    ValueError,
-                    "linear_attention_0.*padding fraction",
-                ):
-                    self.plan_module.solve_cache_layout(
-                        merged_fields,
-                        prefix_granularity=128,
-                        alignment=256,
-                        max_padding_fraction=1.0,
-                    )
-
-                padding_limit = qwen.qwen_gdn_max_padding_fraction(
-                    layer_types=layer_types,
-                    num_draft_layers=1,
-                )
-                merged_layout = self.plan_module.solve_cache_layout(
-                    merged_fields,
-                    prefix_granularity=128,
-                    alignment=256,
-                    max_padding_fraction=padding_limit,
-                )
-
-                def padding_fraction(layout, fields, group_id):
-                    raw_bytes = sum(
-                        field.payload_bytes
-                        for field in fields
-                        if field.group_id == group_id
-                    )
-                    packing = dict(layout.group_packing)[group_id]
-                    return layout.lcm_block_bytes / packing / raw_bytes - 1.0
-
-                target_padding = padding_fraction(
-                    target_layout,
-                    target_fields,
-                    "linear_attention_0",
-                )
-                merged_padding = padding_fraction(
-                    merged_layout,
-                    merged_fields,
-                    "linear_attention_0",
-                )
-                self.assertAlmostEqual(
-                    merged_padding,
-                    target_padding + (1.0 + target_padding) / full_attention_layers,
-                )
-                self.assertEqual(
-                    padding_fraction(
-                        merged_layout,
-                        merged_fields,
-                        "full_attention",
-                    ),
-                    0.0,
-                )
-                self.assertEqual(
-                    qwen.qwen_gdn_max_padding_fraction(
-                        layer_types=layer_types,
-                        num_draft_layers=0,
-                    ),
-                    1.0,
-                )
-
-        with self.assertRaisesRegex(ValueError, "full-attention layer"):
-            qwen.qwen_gdn_max_padding_fraction(
-                layer_types=("linear_attention",),
-                num_draft_layers=1,
-            )
-
-    def test_ordinary_profile_reserves_null_page_inside_budget(self):
-        ordinary = sys.modules[
-            "tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary"
-        ]
-        env_module = types.ModuleType("tokenspeed.runtime.utils.env")
-        env_module.envs = types.SimpleNamespace(
-            TOKENSPEED_CI_SMALL_KV_SIZE=types.SimpleNamespace(
-                get_set_value_or=lambda default: default
-            )
-        )
-
-        with unittest.mock.patch.dict(
-            sys.modules,
-            {"tokenspeed.runtime.utils.env": env_module},
-        ):
-            usable_pages = ordinary._profiled_pages(
-                cache_budget_bytes=16_384,
-                bytes_per_token=16,
-                prefix_granularity=64,
-                max_total_tokens=None,
-            )
-
-        self.assertEqual(usable_pages, 15)
-
-    def test_mha_layers_keep_distinct_fields_with_shared_placement(self):
-        fields = self.layouts_module.mha_cache_fields(
-            layer_group_ids=(
-                "sliding_attention",
-                "full_attention",
-                "sliding_attention",
-                "full_attention",
-            ),
-            prefix_granularity=128,
-            kv_heads=2,
-            head_dim=8,
-            kv_element_size=2,
-        )
-        by_id = {field.field_id: field for field in fields}
-
-        self.assertEqual(by_id["layer.0.k"].plane_id, by_id["layer.1.k"].plane_id)
-        self.assertEqual(by_id["layer.0.v"].plane_id, by_id["layer.1.v"].plane_id)
-        self.assertEqual(by_id["layer.2.k"].plane_id, by_id["layer.3.k"].plane_id)
-        self.assertNotEqual(
-            by_id["layer.0.k"].plane_id,
-            by_id["layer.2.k"].plane_id,
-        )
-
-        plan = self._plan_fields(
-            fields,
-            prefix_granularity=128,
-            num_lcm_blocks=2,
-            cache_blocks_per_lcm_block={
-                "sliding_attention": 1,
-                "full_attention": 1,
-            },
-            alignment=1,
-            max_padding_fraction=1.0,
-        )
-        self.assertEqual(len(plan.planes), 4)
-        self.assertEqual(len(plan.fields), 8)
+        return layout.bind(num_lcm_blocks)
 
     def test_inkling_pool_exclusively_owns_conv_views(self):
         def class_methods(path, class_name):
@@ -334,30 +175,6 @@ class CacheMemoryPlanTest(unittest.TestCase):
         }
         self.assertTrue(conv_methods.isdisjoint(generic_methods))
         self.assertTrue(conv_methods.issubset(inkling_methods))
-
-    def test_model_fields_live_in_dedicated_recipe_modules(self):
-        expected = {
-            "ordinary.py": {
-                "mha_cache_fields",
-                "mla_cache_fields",
-                "draft_cache_fields",
-            },
-            "qwen35.py": {"qwen_gdn_cache_fields"},
-            "inkling.py": {"inkling_cache_fields"},
-            "kimi_k3.py": {"kimi_k3_cache_fields"},
-            "deepseek_v4.py": {"deepseek_v4_cache_fields"},
-        }
-
-        for file_name, function_names in expected.items():
-            module = ast.parse((_RECIPE_DIR / file_name).read_text())
-            definitions = {
-                node.name for node in module.body if isinstance(node, ast.FunctionDef)
-            }
-            self.assertTrue(function_names.issubset(definitions), file_name)
-
-        planner_source = (_RECIPE_DIR / "plan.py").read_text().lower()
-        for model_name in ("qwen", "inkling", "kimi", "deepseek"):
-            self.assertNotIn(model_name, planner_source)
 
     def test_recipes_and_memory_plan_do_not_own_pd_metadata(self):
         pd_fields = {
@@ -425,73 +242,21 @@ class CacheMemoryPlanTest(unittest.TestCase):
             if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
         }
         self.assertNotIn("create_cache_pool", called_names)
-        self.assertNotIn("solve_cache_layout", called_names)
+        self.assertNotIn("pack", called_names)
         self.assertNotIn("profile_max_num_pages", called_names)
 
-    def test_deepseek_v4_recipe_uses_one_p256_scheduler_domain(self):
-        fields = self.layouts_module.deepseek_v4_cache_fields(
-            layer_ratios=(1, 4, 128),
-            prefix_granularity=256,
-            swa_shape=(128,),
-            compressed_shapes={4: (64,), 128: (2,)},
-            compressor_state_shapes={4: (8, 16), 128: (128, 8)},
-            indexer_kv_shape=(64, 4),
-            indexer_state_shape=(8, 32),
-            kv_page_stride_alignment_bytes=576,
-        )
-
-        by_id = {field.field_id: field for field in fields}
-        self.assertEqual(by_id["layer.0.swa"].shape, (128,))
-        self.assertEqual(by_id["layer.1.compressed_kv"].shape, (64,))
-        self.assertEqual(by_id["layer.2.compressor_state"].shape, (128, 8))
-        self.assertEqual(
-            by_id["layer.0.swa"].plane_id,
-            by_id["layer.1.compressed_kv"].plane_id,
-        )
-        self.assertEqual(by_id["layer.1.indexer_kv"].plane_id, "unit.1")
-        self.assertFalse(by_id["layer.0.swa"].exact_page_stride)
-        self.assertFalse(by_id["layer.1.compressor_state"].exact_page_stride)
-        self.assertEqual(
-            by_id["layer.0.swa"].page_stride_alignment_bytes,
-            576,
-        )
-        self.assertEqual(
-            by_id["layer.1.compressed_kv"].page_stride_alignment_bytes,
-            576,
-        )
-
-        plan = self._plan_fields(
-            fields,
-            prefix_granularity=256,
-            num_lcm_blocks=4,
-            max_padding_fraction=float("inf"),
-        )
-
-        self.assertEqual(plan.prefix_granularity, 256)
-        self.assertEqual(
-            {group.group_id for group in plan.groups},
-            {
-                "v4.swa_kv",
-                "v4.c4a.compressed_kv",
-                "v4.c4a.compressor_state",
-                "v4.c128a.compressed_kv",
-                "v4.c128a.compressor_state",
-                "v4.c4a.indexer_compressor_state",
-            },
-        )
-
     def test_planner_expresses_byte_ratio_as_per_group_packing(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         fields = (
-            field("history", "history.k", "unit.0.a", (128, 1, 8), 2),
-            field("history", "history.v", "unit.0.b", (128, 1, 8), 2),
-            field("state", "state.ssm", "unit.0.a", (1, 1, 128), 2),
+            field("history", "history.k", "unit.0.a", (128, 1, 8), "bfloat16"),
+            field("history", "history.v", "unit.0.b", (128, 1, 8), "bfloat16"),
+            field("state", "state.ssm", "unit.0.a", (1, 1, 128), "bfloat16"),
             field(
                 "state",
                 "state.conv",
                 "unit.0.b",
                 (1, 128),
-                2,
+                "bfloat16",
                 exact_page_stride=False,
             ),
         )
@@ -514,19 +279,23 @@ class CacheMemoryPlanTest(unittest.TestCase):
         )
 
     def test_layout_is_capacity_independent(self):
-        field = self.plan_module.CacheFieldSpec
-        fields = (
-            field("full", "full.k", "unit.0.k", (128, 8), 2),
-            field("full", "full.v", "unit.0.v", (128, 8), 2),
+        from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+            CacheFieldSpec,
         )
 
-        layout = self.plan_module.solve_cache_layout(
-            fields,
+        layout = self.plan_module.pack(
+            (
+                _group(
+                    "full",
+                    CacheFieldSpec("full.k", "unit.0.k", (128, 8), "bfloat16"),
+                    CacheFieldSpec("full.v", "unit.0.v", (128, 8), "bfloat16"),
+                ),
+            ),
             prefix_granularity=128,
             alignment=16,
         )
-        small = layout.with_num_lcm_blocks(2)
-        large = layout.with_num_lcm_blocks(5)
+        small = layout.bind(2)
+        large = layout.bind(5)
 
         self.assertEqual(small.lcm_block_bytes, large.lcm_block_bytes)
         self.assertEqual(
@@ -541,7 +310,7 @@ class CacheMemoryPlanTest(unittest.TestCase):
         )
 
     def test_flexible_field_preserves_required_page_stride_alignment(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         plan = self._plan_fields(
             (
                 field(
@@ -549,7 +318,7 @@ class CacheMemoryPlanTest(unittest.TestCase):
                     "compressed.kv",
                     "unit.0",
                     (64, 9),
-                    1,
+                    "uint8",
                     exact_page_stride=False,
                     page_stride_alignment_bytes=576,
                 ),
@@ -558,7 +327,7 @@ class CacheMemoryPlanTest(unittest.TestCase):
                     "wide.state",
                     "unit.0",
                     (6000,),
-                    1,
+                    "uint8",
                     exact_page_stride=False,
                 ),
             ),
@@ -584,7 +353,7 @@ class CacheMemoryPlanTest(unittest.TestCase):
             field_id="history.k",
             plane_id="plane.a",
             shape=(8, 16),
-            element_size=2,
+            dtype="bfloat16",
             field_offset_bytes=0,
             page_stride_bytes=256,
         )
@@ -600,10 +369,10 @@ class CacheMemoryPlanTest(unittest.TestCase):
         self.assertEqual(plan.arena_bytes, 5120)
 
     def test_duplicate_field_ids_are_rejected(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         fields = (
-            field("a", "duplicate", "plane.a", (16,), 2),
-            field("b", "duplicate", "plane.b", (16,), 2),
+            field("a", "duplicate", "plane.a", (16,), "bfloat16"),
+            field("b", "duplicate", "plane.b", (16,), "bfloat16"),
         )
 
         with self.assertRaisesRegex(ValueError, "field ids must be unique"):
@@ -614,10 +383,10 @@ class CacheMemoryPlanTest(unittest.TestCase):
             )
 
     def test_fixed_parent_count_and_explicit_packing(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         fields = (
-            field("history", "history.k", "plane.k", (128, 8), 2),
-            field("state", "state.ssm", "plane.k", (128, 2), 2),
+            field("history", "history.k", "plane.k", (128, 8), "bfloat16"),
+            field("state", "state.ssm", "plane.k", (128, 2), "bfloat16"),
         )
 
         plan = self._plan_fields(
@@ -635,9 +404,9 @@ class CacheMemoryPlanTest(unittest.TestCase):
         self.assertEqual(plan.group("state").page_count, 29)
 
     def test_explicit_packing_is_bounded_by_page_ids_not_a_magic_count(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         plan = self._plan_fields(
-            (field("history", "history.k", "plane.k", (1,), 1),),
+            (field("history", "history.k", "plane.k", (1,), "uint8"),),
             prefix_granularity=16,
             num_lcm_blocks=2,
             cache_blocks_per_lcm_block={"history": 256},
@@ -650,11 +419,11 @@ class CacheMemoryPlanTest(unittest.TestCase):
         self.assertEqual(plan.group("history").page_count, 513)
 
     def test_automatic_packing_keeps_large_exact_byte_ratio(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         plan = self._plan_fields(
             (
-                field("history", "history.k", "plane.shared", (1,), 1),
-                field("state", "state.ssm", "plane.shared", (256,), 1),
+                field("history", "history.k", "plane.shared", (1,), "uint8"),
+                field("state", "state.ssm", "plane.shared", (256,), "uint8"),
             ),
             prefix_granularity=16,
             num_lcm_blocks=2,
@@ -667,8 +436,8 @@ class CacheMemoryPlanTest(unittest.TestCase):
         self.assertEqual(plan.group("state").cache_blocks_per_lcm_block, 1)
 
     def test_fixed_parent_count_must_be_a_positive_integer(self):
-        field = self.plan_module.CacheFieldSpec
-        fields = (field("history", "history.k", "plane.k", (128, 8), 2),)
+        field = _tagged_field
+        fields = (field("history", "history.k", "plane.k", (128, 8), "bfloat16"),)
 
         for count in (0, -1, True, 1.5, "2"):
             with (
@@ -682,10 +451,10 @@ class CacheMemoryPlanTest(unittest.TestCase):
                 )
 
     def test_explicit_packing_rejects_groups_outside_plan(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         fields = (
-            field("history", "history.k", "plane.k", (128, 8), 2),
-            field("state", "state.ssm", "plane.s", (128, 2), 2),
+            field("history", "history.k", "plane.k", (128, 8), "bfloat16"),
+            field("state", "state.ssm", "plane.s", (128, 2), "bfloat16"),
         )
 
         with self.assertRaisesRegex(ValueError, "outside the plan"):
@@ -699,10 +468,10 @@ class CacheMemoryPlanTest(unittest.TestCase):
     def test_partial_packing_pins_named_groups_and_solves_the_rest(self):
         # A draft plan pins the groups it shares with the target (page ids
         # must align) while its draft-only groups pack by byte ratio.
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         fields = (
-            field("history", "history.k", "plane.k", (128, 8), 2),
-            field("state", "state.ssm", "plane.s", (128, 2), 2),
+            field("history", "history.k", "plane.k", (128, 8), "bfloat16"),
+            field("state", "state.ssm", "plane.s", (128, 2), "bfloat16"),
         )
 
         unpinned = self._plan_fields(
@@ -729,8 +498,8 @@ class CacheMemoryPlanTest(unittest.TestCase):
         )
 
     def test_explicit_packing_rejects_invalid_count(self):
-        field = self.plan_module.CacheFieldSpec
-        fields = (field("history", "history.k", "plane.k", (128, 8), 2),)
+        field = _tagged_field
+        fields = (field("history", "history.k", "plane.k", (128, 8), "bfloat16"),)
 
         for count in (0, -1, True, 1.5, "2"):
             with (
@@ -745,10 +514,10 @@ class CacheMemoryPlanTest(unittest.TestCase):
                 )
 
     def test_explicit_packing_preserves_exact_stride_validation(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         fields = (
-            field("history", "history.k", "plane.shared", (128, 8), 2),
-            field("state", "state.ssm", "plane.shared", (128, 3), 2),
+            field("history", "history.k", "plane.shared", (128, 8), "bfloat16"),
+            field("state", "state.ssm", "plane.shared", (128, 3), "bfloat16"),
         )
 
         with self.assertRaisesRegex(ValueError, "needs page stride"):
@@ -759,131 +528,6 @@ class CacheMemoryPlanTest(unittest.TestCase):
                 cache_blocks_per_lcm_block={"history": 1, "state": 2},
             )
 
-    def test_draft_history_recipe_emits_only_enabled_kv_fields(self):
-        fields = self.layouts_module.draft_cache_fields(
-            layer_group_ids=("full", "swa", "unused"),
-            enabled_layer_ids=(0, 1),
-            prefix_granularity=128,
-            layer_kv_heads=(2, 4, 8),
-            head_dim=64,
-            kv_element_size=2,
-        )
-
-        self.assertEqual(
-            {field.field_id for field in fields},
-            {"layer.0.k", "layer.0.v", "layer.1.k", "layer.1.v"},
-        )
-        self.assertEqual({field.group_id for field in fields}, {"full", "swa"})
-
-    def test_inkling_bf16_and_fp8_checkpoint_planes(self):
-        bf16 = self.layouts_module.inkling_cache_fields(
-            layer_group_ids=("swa",),
-            prefix_granularity=128,
-            layer_kv_heads=(2,),
-            head_dim=128,
-            kv_element_size=2,
-            hidden_size=256,
-            checkpoint_rows=3,
-            kvconv_element_size=2,
-            hiddenconv_element_size=2,
-        )
-        fp8 = self.layouts_module.inkling_cache_fields(
-            layer_group_ids=("swa",),
-            prefix_granularity=128,
-            layer_kv_heads=(2,),
-            head_dim=128,
-            kv_element_size=1,
-            hidden_size=256,
-            checkpoint_rows=3,
-            kvconv_element_size=2,
-            hiddenconv_element_size=1,
-            kv_scale_block_size=32,
-            kv_scale_element_size=1,
-        )
-
-        bf16_by_id = {field.field_id: field for field in bf16}
-        fp8_by_id = {field.field_id: field for field in fp8}
-        self.assertEqual(
-            bf16_by_id["layer.0.attnconv"].plane_id,
-            "unit.0.hidden_k",
-        )
-        self.assertEqual(
-            fp8_by_id["layer.0.attnconv"].plane_id,
-            "unit.0.k",
-        )
-        self.assertIn("layer.0.k_scale", fp8_by_id)
-        self.assertIn("layer.0.v_scale", fp8_by_id)
-
-    def test_inkling_draft_conv_fields_join_target_checkpoint_groups(self):
-        """Draft depth layers carry kvconv/hiddenconv checkpoint fields as
-        continuation tenants of the TARGET's conv groups: same group ids
-        (no draft-specific namespace), planes shifted to the continuation
-        range, kvconv tails squatting in the draft kv planes."""
-        recipe_kwargs = dict(
-            prefix_granularity=128,
-            head_dim=128,
-            kv_element_size=2,
-            hidden_size=256,
-            checkpoint_rows=3,
-            kvconv_element_size=2,
-            hiddenconv_element_size=2,
-        )
-        target = self.layouts_module.inkling_cache_fields(
-            layer_group_ids=("full", "swa"), layer_kv_heads=(2, 4), **recipe_kwargs
-        )
-        draft = self.layouts_module.inkling_cache_fields(
-            layer_group_ids=("swa", "full"), layer_kv_heads=(4, 2), **recipe_kwargs
-        )
-        (
-            merged,
-            _,
-            _,
-            _,
-            num_draft_layers,
-        ) = self.plan_module.merge_continuation_layers(
-            fields=target,
-            layer_types=("full", "swa"),
-            group_ids=("full", "swa"),
-            draft_fields=draft,
-            draft_layer_types=("swa", "full"),
-            draft_group_ids=("swa", "full"),
-        )
-        self.assertEqual(num_draft_layers, 2)
-        by_id = {field.field_id: field for field in merged}
-        # Continuation renumbering: draft layer 0 -> global layer 2, its
-        # occurrence-0 planes -> unit.2.*; conv groups are the target's own.
-        self.assertEqual(by_id["layer.2.kvconv_k"].group_id, "kvconv")
-        self.assertEqual(by_id["layer.2.kvconv_k"].plane_id, "unit.2.k")
-        self.assertEqual(by_id["layer.2.attnconv"].group_id, "hiddenconv")
-        self.assertEqual(by_id["layer.2.attnconv"].plane_id, "unit.2.hidden_k")
-        self.assertEqual(
-            {field.group_id for field in merged},
-            {"full", "swa", "kvconv", "hiddenconv"},
-        )
-        plan = self._plan_fields(
-            merged,
-            prefix_granularity=128,
-            num_lcm_blocks=2,
-            max_padding_fraction=float("inf"),
-        )
-        # The draft kvconv tail lives in the same plane as the draft KV
-        # (squatter), while the 2-byte hidden tail spills to its own plane.
-        self.assertEqual(
-            plan.field("layer.2.kvconv_k").plane_id,
-            plan.field("layer.2.k").plane_id,
-        )
-        self.assertNotEqual(
-            plan.field("layer.2.attnconv").plane_id,
-            plan.field("layer.2.k").plane_id,
-        )
-        # One page-id space per conv group covers target AND draft tenants.
-        self.assertGreaterEqual(plan.group("kvconv").cache_blocks_per_lcm_block, 1)
-        self.assertGreaterEqual(plan.group("hiddenconv").cache_blocks_per_lcm_block, 1)
-
-
-if __name__ == "__main__":
-    unittest.main()
-
 
 class CapacityReportTest(unittest.TestCase):
     """Per-group capacity in its own unit; binding admission = min."""
@@ -891,17 +535,24 @@ class CapacityReportTest(unittest.TestCase):
     def _mixed_plan(self):
         from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
             CacheFieldSpec,
-            solve_cache_layout,
+            pack,
         )
 
-        fields = (
-            CacheFieldSpec("history", "history.k", "plane.shared", (128, 8), 2),
-            CacheFieldSpec("state", "state.ssm", "plane.shared", (128, 8), 2),
-            CacheFieldSpec("swa", "swa.kv", "plane.shared", (128, 8), 2),
+        groups = (
+            _group(
+                "history",
+                CacheFieldSpec("history.k", "plane.shared", (128, 8), "bfloat16"),
+            ),
+            _group(
+                "state",
+                CacheFieldSpec("state.ssm", "plane.shared", (128, 8), "bfloat16"),
+            ),
+            _group(
+                "swa",
+                CacheFieldSpec("swa.kv", "plane.shared", (128, 8), "bfloat16"),
+            ),
         )
-        return solve_cache_layout(fields, prefix_granularity=128).with_num_lcm_blocks(
-            100
-        )
+        return pack(groups, prefix_granularity=128).bind(100)
 
     def test_units_and_supported_requests(self):
         plan = self._mixed_plan()
@@ -945,40 +596,23 @@ class ContinuationLayerFieldsTest(CacheMemoryPlanTest):
     """One-big-model merged solve: draft fields join as continuation layers
     (renumbered after the target's), sharing group ids and packing."""
 
-    def test_renumbering_shifts_layer_unit_and_slot_ids(self):
-        from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
-            CacheFieldSpec,
-            continue_layer_fields,
-        )
-
-        draft = (
-            CacheFieldSpec("history", "layer.0.kv", "slot.0", (128, 8), 2),
-            CacheFieldSpec("history", "layer.1.k", "unit.1.k", (128, 8), 2),
-        )
-        shifted = continue_layer_fields(draft, first_layer_id=24)
-        self.assertEqual(shifted[0].field_id, "layer.24.kv")
-        self.assertEqual(shifted[0].plane_id, "slot.24")
-        self.assertEqual(shifted[1].field_id, "layer.25.k")
-        self.assertEqual(shifted[1].plane_id, "unit.25.k")
-        # Group ids are untouched: shared page-id space by construction.
-        self.assertTrue(all(f.group_id == "history" for f in shifted))
-
     def test_merged_solve_shares_group_packing(self):
         from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
             CacheFieldSpec,
-            continue_layer_fields,
         )
 
         target = (
-            CacheFieldSpec("history", "layer.0.kv", "slot.0", (128, 8), 2),
-            CacheFieldSpec("history", "layer.1.kv", "slot.1", (128, 8), 2),
+            CacheFieldSpec("layer.0.kv", "slot.0", (128, 8), "bfloat16"),
+            CacheFieldSpec("layer.1.kv", "slot.1", (128, 8), "bfloat16"),
         )
-        draft = (CacheFieldSpec("history", "layer.0.kv", "slot.0", (128, 8), 2),)
-        merged = self.plan_module.solve_cache_layout(
-            target + continue_layer_fields(draft, first_layer_id=2),
+        # The draft layer is layer 2 of the one big model: global ids from the
+        # first walk, so nothing needs renumbering.
+        draft = (CacheFieldSpec("layer.2.kv", "slot.2", (128, 8), "bfloat16"),)
+        merged = self.plan_module.pack(
+            (_group("history", *target, *draft),),
             prefix_granularity=128,
         )
-        plan = merged.with_num_lcm_blocks(2)
+        plan = merged.bind(2)
         # One group, one packing, one page-id space; the draft layer is
         # just layer 2 of the one big model.
         self.assertEqual(dict(merged.group_packing), {"history": 1})
@@ -998,18 +632,18 @@ class BindingUtilizationTest(CacheMemoryPlanTest):
     """
 
     def test_wide_group_full_narrow_group_partial(self):
-        field = self.plan_module.CacheFieldSpec
+        field = _tagged_field
         # Two groups share one plane (aliased): wide 256B/page x1, narrow
         # 100B/page x1 -> parent is sized by the wide tenant.
         plan = self._plan_fields(
             (
-                field("wide", "w.kv", "plane.shared", (256,), 1),
+                field("wide", "w.kv", "plane.shared", (256,), "uint8"),
                 field(
                     "narrow",
                     "n.state",
                     "plane.shared",
                     (100,),
-                    1,
+                    "uint8",
                     exact_page_stride=False,
                 ),
             ),

--- a/test/runtime/test_cache_metadata_kernel_table.py
+++ b/test/runtime/test_cache_metadata_kernel_table.py
@@ -57,7 +57,7 @@ def _metadata(pool, rows):
 @requires_cuda
 def test_kernel_table_expansion_preserves_token_locations() -> None:
     pool = _make_pool("cuda", usable_pages=6)
-    P = pool.prefix_granularity
+    P = pool.arena.prefix_granularity
     metadata, op = _metadata(pool, [[3, 5], [1, 4]])
 
     logical = metadata.require_full_attention_table(active_forward_op=op)
@@ -102,7 +102,9 @@ def test_kernel_table_identity_when_sizes_match() -> None:
     metadata, op = _metadata(pool, [[3, 5]])
 
     table = metadata.kernel_table(
-        kernel_page_size=pool.prefix_granularity, max_pages=None, active_forward_op=op
+        kernel_page_size=pool.arena.prefix_granularity,
+        max_pages=None,
+        active_forward_op=op,
     )
     logical = metadata.require_full_attention_table(active_forward_op=op)
     assert table.data_ptr() == logical.data_ptr()
@@ -111,7 +113,7 @@ def test_kernel_table_identity_when_sizes_match() -> None:
 @requires_cuda
 def test_kernel_table_max_pages_pads_with_null_page() -> None:
     pool = _make_pool("cuda", usable_pages=6)
-    P = pool.prefix_granularity
+    P = pool.arena.prefix_granularity
     ratio = P // _KERNEL_PAGE
     metadata, op = _metadata(pool, [[3, 5]])
 
@@ -144,7 +146,7 @@ def test_kernel_table_rejects_stale_forward_op() -> None:
 @requires_cuda
 def test_validate_live_pages_flags_null_page_in_live_range() -> None:
     pool = _make_pool("cuda", usable_pages=6)
-    P = pool.prefix_granularity
+    P = pool.arena.prefix_granularity
     # Row 0 is fine; row 1 has the null page 0 inside its live range.
     metadata, op = _metadata(pool, [[3, 5], [0, 4]])
     seq_lens = torch.tensor([2 * P, P], device="cuda", dtype=torch.int32)
@@ -155,7 +157,7 @@ def test_validate_live_pages_flags_null_page_in_live_range() -> None:
 @requires_cuda
 def test_validate_live_pages_ignores_pages_past_seq_len() -> None:
     pool = _make_pool("cuda", usable_pages=6)
-    P = pool.prefix_granularity
+    P = pool.arena.prefix_granularity
     # -1 hole in the tail column is legal padding while seq stays on page 0.
     metadata, op = _metadata(pool, [[3, -1]])
     seq_lens = torch.tensor([P], device="cuda", dtype=torch.int32)

--- a/test/runtime/test_cache_pool.py
+++ b/test/runtime/test_cache_pool.py
@@ -7,126 +7,209 @@ import unittest
 import torch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from cache_pool_test_utils import MinimalCacheView, make_arena, one_group
 from ci_system.ci_register import register_cuda_ci
 
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
 from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
-    solve_cache_layout,
+    pack,
 )
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 
 def _plan():
-    return solve_cache_layout(
+    return pack(
         (
-            CacheFieldSpec("history", "history.k", "plane.a", (4,), 1),
-            CacheFieldSpec("state", "state.ssm", "plane.b", (8,), 1),
+            one_group(
+                "history",
+                CacheFieldSpec("history.k", "plane.a", (4,), "uint8"),
+                rows_per_page=2,
+            ),
+            one_group(
+                "state",
+                CacheFieldSpec("state.ssm", "plane.b", (8,), "uint8"),
+                rows_per_page=4,
+            ),
         ),
         prefix_granularity=4,
         cache_blocks_per_lcm_block={"history": 2, "state": 1},
         max_padding_fraction=1.0,
-    ).with_num_lcm_blocks(2)
+    ).bind(2)
 
 
-class CachePoolContractTest(unittest.TestCase):
-    def test_requires_a_prepared_memory_plan(self):
-        with self.assertRaisesRegex(TypeError, "memory_plan"):
-            CachePool(
-                size=16,
-                dtype=torch.uint8,
-                device="cpu",
-                prefix_granularity=4,
-                rank=0,
-            )
+def _arena(device: str = "cpu") -> CacheArena:
+    return make_arena(_plan(), device)
 
-    def test_owns_buffer_and_creates_typed_field_views(self):
-        pool = CachePool(
-            size=16,
-            dtype=torch.uint8,
-            device="cpu",
-            prefix_granularity=4,
-            rank=0,
-            memory_plan=_plan(),
+
+class CacheArenaContractTest(unittest.TestCase):
+    def test_allocates_the_planned_arena_on_construction(self):
+        arena = _arena()
+
+        # Allocation is eager and owned here, so no compute view can observe
+        # an unbound arena or race to allocate it.
+        self.assertEqual(arena.buffer.dtype, torch.uint8)
+        self.assertEqual(arena.buffer.numel(), arena.plan.arena_bytes)
+
+    def test_materializes_every_planned_field_on_construction(self):
+        arena = _arena()
+
+        # The plan names every field and its dtype, so nothing is bound
+        # later and no consumer can observe a half-built arena.
+        self.assertEqual(
+            arena.field_ids(), {field.field_id for field in arena.plan.fields}
         )
 
-        history = pool.field("history.k", torch.uint8)
+    def test_field_views_share_the_one_buffer_and_are_stable(self):
+        arena = _arena()
 
-        self.assertIs(history, pool.field("history.k", torch.uint8))
+        history = arena.field("history.k")
+
+        self.assertIs(history, arena.field("history.k"))
+        self.assertEqual(history.dtype, torch.uint8)
         self.assertEqual(
             history.untyped_storage().data_ptr(),
-            pool.buffer.untyped_storage().data_ptr(),
+            arena.buffer.untyped_storage().data_ptr(),
         )
+
+    def test_field_takes_its_dtype_from_the_plan(self):
+        plan = pack(
+            (
+                one_group(
+                    "history",
+                    CacheFieldSpec("history.k", "plane.a", (4,), "bfloat16"),
+                    rows_per_page=4,
+                ),
+            ),
+            prefix_granularity=4,
+            cache_blocks_per_lcm_block={"history": 1},
+            max_padding_fraction=1.0,
+        ).bind(2)
+
+        self.assertEqual(
+            make_arena(plan, "cpu").field("history.k").dtype, torch.bfloat16
+        )
+
+    def test_field_rejects_an_unplanned_field(self):
+        arena = _arena()
+
+        with self.assertRaisesRegex(ValueError, "not planned"):
+            arena.field("history.absent")
+
+    def test_size_matches_the_tightest_packed_group(self):
+        arena = _arena()
+
+        # 2 parents * 2 history blocks per parent * P=4.
+        self.assertEqual(arena.size, 16)
+
+
+class CachePoolViewTest(unittest.TestCase):
+    def test_a_pool_reports_the_arena_it_views(self):
+        arena = _arena()
+        pool = MinimalCacheView(arena, torch.uint8, rank=0)
+
+        # A view owns no memory and no geometry: it names the arena, and
+        # callers ask the arena. Nothing is mirrored onto the view.
+        self.assertIs(pool.arena, arena)
+        for owned_by_arena in (
+            "plan",
+            "buffer",
+            "size",
+            "prefix_granularity",
+            "kv_page_size",
+            "runtime_contract",
+            "cache_group_specs",
+        ):
+            self.assertFalse(
+                hasattr(pool, owned_by_arena),
+                f"{owned_by_arena} must be read off the arena, not the view",
+            )
+
+    def test_two_views_of_one_arena_share_field_views(self):
+        arena = _arena()
+        target = MinimalCacheView(arena, torch.uint8, rank=0)
+        draft = MinimalCacheView(arena, torch.uint8, rank=0)
+
+        self.assertIs(target.arena, draft.arena)
+        self.assertIs(target.arena.field("history.k"), draft.arena.field("history.k"))
+
+    def test_views_of_one_arena_may_read_it_as_different_dtypes(self):
+        arena = _arena()
+
+        # A heterogeneous draft (bf16 head over an fp8 target) is two views
+        # over one allocation, so dtype is per-view, never arena-wide.
+        self.assertEqual(
+            MinimalCacheView(arena, torch.uint8, rank=0).dtype, torch.uint8
+        )
+        self.assertEqual(
+            MinimalCacheView(arena, torch.bfloat16, rank=0).dtype, torch.bfloat16
+        )
+
+    def test_a_view_must_implement_every_kernel_accessor(self):
+        """The four accessors are abstract, so a pool that forgets one cannot
+        be constructed -- the failure lands at wiring time, not at the first
+        write into a half-implemented view."""
+        self.assertEqual(
+            sorted(CachePool.__abstractmethods__),
+            ["get_key_buffer", "get_kv_buffer", "get_value_buffer", "set_kv_buffer"],
+        )
+
+        class _Forgetful(CachePool):
+            def get_key_buffer(self, layer_id: int):
+                raise AssertionError("not exercised")
+
+        with self.assertRaisesRegex(TypeError, "abstract"):
+            _Forgetful(_arena(), torch.uint8, rank=0)
+
+    def test_rejects_a_negative_field_layer_offset(self):
+        arena = _arena()
+
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            MinimalCacheView(arena, torch.uint8, rank=0, field_layer_offset=-1)
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
-class CachePoolCudaTest(unittest.TestCase):
-    def test_fields_share_one_buffer_and_reuse_the_same_view(self):
-        pool = CachePool(
-            size=16,
-            dtype=torch.uint8,
-            device="cuda",
-            prefix_granularity=4,
-            rank=0,
-            memory_plan=_plan(),
-        )
-
-        history = pool.field("history.k", torch.uint8)
-
-        self.assertIs(history, pool.field("history.k", torch.uint8))
-        self.assertEqual(
-            history.untyped_storage().data_ptr(),
-            pool.buffer.untyped_storage().data_ptr(),
-        )
-
-    def test_field_rejects_wrong_dtype_width(self):
-        pool = CachePool(
-            size=16,
-            dtype=torch.uint8,
-            device="cuda",
-            prefix_granularity=4,
-            rank=0,
-            memory_plan=_plan(),
-        )
-
-        with self.assertRaisesRegex(ValueError, "dtype itemsize"):
-            pool.field("history.k", torch.float32)
-
+class CacheArenaCudaTest(unittest.TestCase):
     def test_zero_blocks_clears_only_the_selected_group_blocks(self):
-        pool = CachePool(
-            size=16,
-            dtype=torch.uint8,
-            device="cuda",
-            prefix_granularity=4,
-            rank=0,
-            memory_plan=_plan(),
-        )
-        history = pool.field("history.k", torch.uint8)
-        state = pool.field("state.ssm", torch.uint8)
+        arena = _arena("cuda")
+        history = arena.field("history.k")
+        state = arena.field("state.ssm")
         history.fill_(7)
         state.fill_(9)
 
-        pool.zero_blocks({"history": [1]})
+        arena.zero_blocks({"history": [1]})
         torch.cuda.synchronize()
 
-        self.assertTrue(bool((history[0] == 7).all()))
-        self.assertTrue(bool((history[1] == 0).all()))
-        self.assertTrue(bool((history[2:] == 7).all()))
+        # history.k is a per-token field (planned shape leads with P=4), so
+        # its view is token-indexed: block 1 covers tokens [4, 8).
+        self.assertTrue(bool((history[:4] == 7).all()))
+        self.assertTrue(bool((history[4:8] == 0).all()))
+        self.assertTrue(bool((history[8:] == 7).all()))
         self.assertTrue(bool((state == 9).all()))
 
     def test_zero_blocks_rejects_out_of_range_block(self):
-        pool = CachePool(
-            size=16,
-            dtype=torch.uint8,
-            device="cuda",
-            prefix_granularity=4,
-            rank=0,
-            memory_plan=_plan(),
-        )
+        arena = _arena("cuda")
 
         with self.assertRaises(IndexError):
-            pool.zero_blocks({"state": [pool.plan.group("state").page_count]})
+            arena.zero_blocks({"state": [arena.plan.group("state").page_count]})
+
+    def test_clear_zeros_the_whole_arena_once(self):
+        arena = _arena("cuda")
+        history = arena.field("history.k")
+        state = arena.field("state.ssm")
+        history.fill_(7)
+        state.fill_(9)
+
+        # Both views name the same owner, so a fan-out over target+draft is
+        # idempotent rather than double work on half the arena.
+        MinimalCacheView(arena, torch.uint8, rank=0).clear_kv_buffers()
+        MinimalCacheView(arena, torch.uint8, rank=0).clear_kv_buffers()
+        torch.cuda.synchronize()
+
+        self.assertTrue(bool((history == 0).all()))
+        self.assertTrue(bool((state == 0).all()))
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -9,19 +9,19 @@ from tokenspeed.runtime.cache.transfer.layout import combine_cache_transfer_layo
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
-from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
-from tokenspeed.runtime.layers.attention.kv_cache.factory import create_cache_pool
+from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
+from tokenspeed.runtime.layers.attention.kv_cache.factory import (
+    create_cache_arena,
+    create_cache_pool,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.hybrid_mha import (
     HybridMHATokenToKVPool,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.mha import MHATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-    build_hybrid_cache_setup,
-)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecipe
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
-    merge_continuation_layers,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
     prepare_cache_setup,
@@ -29,9 +29,20 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     FULL_ATTENTION,
     LINEAR_ATTENTION,
-    PagedCacheGroupSpec,
-    build_paged_cache_group_specs,
+    CacheGroupSpec,
 )
+
+
+def _pool_over_new_arena(spec, config, *, num_layers: int, rank: int = 0):
+    """Allocate an arena for ``spec`` and bind one compute view onto it."""
+    arena = create_cache_arena(spec, device=config.device, enable_memory_saver=False)
+    return create_cache_pool(
+        spec,
+        config,
+        arena,
+        num_layers=num_layers,
+        rank=rank,
+    )
 
 
 def _mha_config() -> MHAConfig:
@@ -110,59 +121,96 @@ def _msa_config() -> MSAConfig:
     )
 
 
-def _hybrid_setup_with_narrow_draft():
-    # The recipe merges target and draft layers BEFORE the builder
-    # (merge_continuation_layers); "state" here is a layer-external group,
-    # plain tuple concatenation like Inkling's checkpoint columns.
-    (
-        fields,
+class _SyntheticHybridRecipe(CacheRecipe):
+    """A minimal hybrid family, expressed the way a real one is.
+
+    Its layer vocabulary and byte shapes are fixtures; everything else comes
+    from the base pipeline. That a made-up family needs only these seams is
+    the point -- the shared stages carry the rest.
+    """
+
+    family = "inkling"
+
+    def __init__(
+        self,
+        *,
         layer_types,
         group_ids,
-        _,
-        num_draft_layers,
-    ) = merge_continuation_layers(
-        fields=(
-            CacheFieldSpec("full_attention", "layer.0.kv", "slot.0", (256,), 1),
-            CacheFieldSpec("state", "layer.0.state", "slot.0", (128,), 1),
-        ),
-        layer_types=("full_attention",),
-        group_ids=("full_attention",),
-        draft_fields=(
-            CacheFieldSpec("full_attention", "layer.0.kv", "slot.0", (256,), 1),
-        ),
-        draft_layer_types=("full_attention",),
-        draft_group_ids=("full_attention",),
-    )
-    group_specs = (
-        *build_paged_cache_group_specs(
-            layer_types=layer_types,
-            group_ids=group_ids,
-            sliding_window_tokens=None,
-            prefix_granularity=4,
-        ),
-        PagedCacheGroupSpec(
-            group_id="state",
-            retention="full_history",
-            sliding_window_tokens=None,
-            family="state",
-            checkpoint_granularity=4,
-        ),
-    )
-    return build_hybrid_cache_setup(
-        family="inkling",
-        server_args=SimpleNamespace(max_total_tokens=None),
-        fields=fields,
-        layer_types=layer_types,
-        group_ids=group_ids,
-        group_specs=group_specs,
-        state_dtypes={},
-        layer_kv_head_counts=None,
-        num_draft_layers=num_draft_layers,
+        num_draft_layers=0,
+        windows=None,
+        extra_state_group=None,
         cache_budget_bytes=2_048,
-        fixed_workspace_bytes=0,
-        prefix_granularity=4,
-        max_padding_fraction=1.0,
-    )
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            server_args=SimpleNamespace(max_total_tokens=None),
+            model_config=None,
+            attn_config=SimpleNamespace(
+                prefix_granularity=4, sliding_window_tokens=windows
+            ),
+            draft_model_config=None,
+            draft_attn_config=None,
+            cache_budget_bytes=cache_budget_bytes,
+            decode_input_tokens=1,
+            overlap_schedule_depth=0,
+            **kwargs,
+        )
+        self._layer_types = tuple(layer_types)
+        self._group_ids = tuple(group_ids)
+        self._num_draft_layers = num_draft_layers
+        self._extra_state_group = extra_state_group
+
+    @property
+    def layer_types(self):
+        return self._layer_types
+
+    @property
+    def group_ids(self):
+        return self._group_ids
+
+    @property
+    def num_draft_layers(self):
+        return self._num_draft_layers
+
+    @property
+    def max_padding_fraction(self) -> float:
+        return 1.0
+
+    def fields_for_layer(self, layer_id, group_id, occurrence):
+        return (
+            CacheFieldSpec(
+                f"layer.{layer_id}.kv", f"slot.{occurrence}", (256,), "uint8"
+            ),
+        )
+
+    def groups(self):
+        groups = super().groups()
+        if self._extra_state_group is None:
+            return groups
+        # A layer-external state group, like Inkling's checkpoint columns:
+        # declared whole, its id written once.
+        return groups + (
+            (
+                CacheGroupSpec(
+                    group_id=self._extra_state_group,
+                    retention="full_history",
+                    sliding_window_tokens=None,
+                    family="state",
+                    checkpoint_granularity=self.prefix_granularity,
+                ),
+                (CacheFieldSpec("layer.0.state", "slot.0", (128,), "uint8"),),
+            ),
+        )
+
+
+def _hybrid_setup_with_narrow_draft():
+    """One KV group shared by target and draft, plus a state column."""
+    return _SyntheticHybridRecipe(
+        layer_types=("full_attention", "full_attention"),
+        group_ids=("full_attention", "full_attention"),
+        num_draft_layers=1,
+        extra_state_group="state",
+    ).setup()
 
 
 def test_attention_configs_do_not_own_cache_setup() -> None:
@@ -247,20 +295,16 @@ def test_qwen_recipe_preserves_backend_kernel_page_size() -> None:
         f"{LINEAR_ATTENTION}_0",
         FULL_ATTENTION,
     )
-    assert setup.spec.state_field_dtypes == {
-        "layer.0.conv": torch.bfloat16,
-        "layer.0.ssm": torch.float32,
+    # The plan is the single source of field dtypes; no side channel.
+    plan_dtypes = {
+        field.field_id: field.dtype for field in setup.spec.memory_plan.fields
     }
+    assert plan_dtypes["layer.0.conv"] == "bfloat16"
+    assert plan_dtypes["layer.0.ssm"] == "float32"
     assert not hasattr(attn_config, "lcm_memory_plan")
-    pool = create_cache_pool(
-        setup.spec,
-        attn_config,
-        num_layers=2,
-        rank=0,
-        enable_memory_saver=False,
-    )
+    pool = _pool_over_new_arena(setup.spec, attn_config, num_layers=2)
     assert type(pool) is HybridMHATokenToKVPool
-    assert pool.buffer is not None
+    assert pool.arena.buffer is not None
 
 
 def test_ordinary_mha_reserves_null_parent_within_cache_budget() -> None:
@@ -289,22 +333,14 @@ def test_ordinary_mha_reserves_null_parent_within_cache_budget() -> None:
     assert setup.spec.memory_plan.arena_bytes <= 16_384
     assert setup.spec.token_capacity == 960
     assert setup.num_draft_layers == 0
-    pool = create_cache_pool(
-        setup.spec,
-        attn_config,
-        num_layers=2,
-        rank=0,
-        enable_memory_saver=False,
-    )
+    pool = _pool_over_new_arena(setup.spec, attn_config, num_layers=2)
     assert type(pool) is MHATokenToKVPool
-    assert pool.runtime_contract.token_capacity == setup.spec.token_capacity
+    assert pool.arena.runtime_contract.token_capacity == setup.spec.token_capacity
     with pytest.raises(TypeError, match="incompatible with MHAConfig"):
-        create_cache_pool(
+        _pool_over_new_arena(
             replace(setup.spec, family="kimi_k3"),
             attn_config,
             num_layers=2,
-            rank=0,
-            enable_memory_saver=False,
         )
 
 
@@ -334,15 +370,9 @@ def test_ordinary_mla_reserves_null_parent_within_cache_budget() -> None:
     assert setup.spec.memory_plan.arena_bytes <= 24_576
     assert setup.spec.token_capacity == 960
     assert setup.num_draft_layers == 0
-    pool = create_cache_pool(
-        setup.spec,
-        attn_config,
-        num_layers=2,
-        rank=0,
-        enable_memory_saver=False,
-    )
+    pool = _pool_over_new_arena(setup.spec, attn_config, num_layers=2)
     assert type(pool) is MLATokenToKVPool
-    assert pool.runtime_contract.token_capacity == setup.spec.token_capacity
+    assert pool.arena.runtime_contract.token_capacity == setup.spec.token_capacity
 
 
 @pytest.mark.parametrize(
@@ -354,7 +384,7 @@ def test_ordinary_recipe_uses_the_draft_attention_family(
     target_config,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from tokenspeed.runtime.pd.cache_protocol import build_pool_cache_transfer_contract
+    from tokenspeed.runtime.pd.cache_protocol import build_arena_cache_transfer_contract
 
     model_config = SimpleNamespace(num_attention_layers=2, hf_config=SimpleNamespace())
     draft_model_config = SimpleNamespace(
@@ -396,69 +426,34 @@ def test_ordinary_recipe_uses_the_draft_attention_family(
         first_layer=2,
         num_layers=1,
         family="mha",
-        publish_runtime_contract=False,
+    )
+    # One arena, two compute views: the target's window and the draft's
+    # continuation window, with no owner/view asymmetry to encode.
+    arena = create_cache_arena(
+        setup.spec, device=target_attn_config.device, enable_memory_saver=False
     )
     target_pool = create_cache_pool(
         target_spec,
         target_attn_config,
+        arena,
         num_layers=2,
         rank=0,
-        enable_memory_saver=False,
     )
-    unbound_pool = CachePool(
-        setup.spec.pool_size,
-        target_pool.dtype,
-        "cpu",
-        setup.spec.memory_plan.prefix_granularity,
-        0,
-        setup.spec.memory_plan,
-    )
-    with pytest.raises(ValueError, match="must bind its fields before a view"):
-        CachePool(
-            setup.spec.pool_size,
-            target_pool.dtype,
-            "cpu",
-            setup.spec.memory_plan.prefix_granularity,
-            0,
-            setup.spec.memory_plan,
-            backing_pool=unbound_pool,
-        )
-    with pytest.raises(ValueError, match="must inherit, not republish"):
-        CachePool(
-            setup.spec.pool_size,
-            target_pool.dtype,
-            "cpu",
-            setup.spec.memory_plan.prefix_granularity,
-            0,
-            setup.spec.memory_plan,
-            paged_cache_group_specs=target_spec.paged_cache_group_specs,
-            backing_pool=target_pool,
-        )
-    with pytest.raises(ValueError, match="only supported by ordinary MHA or MLA pools"):
-        create_cache_pool(
-            target_spec,
-            _msa_config(),
-            num_layers=2,
-            rank=0,
-            enable_memory_saver=False,
-            backing_pool=target_pool,
-        )
     draft_pool = create_cache_pool(
         draft_spec,
         draft_attn_config,
+        arena,
         num_layers=1,
         rank=0,
-        enable_memory_saver=False,
         field_layer_offset=2,
-        backing_pool=target_pool,
     )
 
     assert type(draft_pool) is MHATokenToKVPool
-    assert draft_pool.buffer is target_pool.buffer
-    assert draft_pool._fields is target_pool._fields
-    assert draft_pool.runtime_contract is target_pool.runtime_contract
+    assert draft_pool.arena is target_pool.arena
+    assert draft_pool.arena.buffer is target_pool.arena.buffer
+    assert draft_pool.arena.runtime_contract is target_pool.arena.runtime_contract
     assert draft_pool.layerwise_load_tracker is None
-    assert set(target_pool._fields) == {
+    assert arena.field_ids() == {
         field.field_id for field in setup.spec.memory_plan.fields
     }
     target_layout = target_pool.cache_transfer_layout()
@@ -469,22 +464,22 @@ def test_ordinary_recipe_uses_the_draft_attention_family(
     draft_transfer_fields = {
         field_id for consumer in draft_layout.consumers for field_id in consumer
     }
-    assert target_transfer_fields == set(target_pool._fields) - draft_field_ids
+    assert target_transfer_fields == arena.field_ids() - draft_field_ids
     assert draft_transfer_fields == draft_field_ids
     combined_layout = combine_cache_transfer_layouts(
         target_layout,
         draft_layout,
-        group_ids=tuple(spec.group_id for spec in target_pool.paged_cache_group_specs),
+        group_ids=tuple(spec.group_id for spec in target_pool.arena.cache_group_specs),
     )
     assert len(combined_layout.consumers) == 3
-    assert combined_layout.buffers == (target_pool.buffer,)
+    assert combined_layout.buffers == (target_pool.arena.buffer,)
     assert {
         field.field_id for group in combined_layout.groups for field in group.fields
-    } == set(target_pool._fields)
-    contract, base_addr = build_pool_cache_transfer_contract(target_pool)
-    assert contract.plan is target_pool.plan
-    assert base_addr == target_pool.buffer.data_ptr()
-    assert len(contract.field_dtypes) == len(target_pool._fields)
+    } == arena.field_ids()
+    contract, base_addr = build_arena_cache_transfer_contract(target_pool.arena)
+    assert contract.plan is target_pool.arena.plan
+    assert base_addr == target_pool.arena.buffer.data_ptr()
+    assert {field.field_id for field in contract.plan.fields} == arena.field_ids()
 
     target_last_layer = target_pool.get_key_buffer(1).clone()
 
@@ -506,11 +501,11 @@ def test_ordinary_recipe_uses_the_draft_attention_family(
     assert torch.equal(draft_pool.get_value_buffer(0)[0], cache_v[0])
     assert torch.equal(target_pool.get_key_buffer(1), target_last_layer)
 
-    # Sleep/wake repair visits both objects; only the allocation owner clears.
+    # Sleep/wake repair visits both views; both name the one arena, so a
+    # clear through either zeros the shared allocation exactly as well.
     draft_pool.clear_kv_buffers()
-    assert torch.equal(draft_pool.get_key_buffer(0)[0], cache_k[0])
-    target_pool.clear_kv_buffers()
     assert not torch.count_nonzero(draft_pool.get_key_buffer(0))
+    assert not torch.count_nonzero(target_pool.get_key_buffer(1))
 
 
 def test_heterogeneous_draft_guards_fail_fast() -> None:
@@ -532,6 +527,7 @@ def test_heterogeneous_draft_guards_fail_fast() -> None:
             cache_spec=object(),
             num_target_layers=1,
             full_attn_backend_name=None,
+            is_heterogeneous=True,
             is_hybrid_linear=True,
             is_kda=False,
             is_inkling=False,
@@ -598,66 +594,13 @@ def test_hybrid_draft_only_sliding_group_packs_by_ratio() -> None:
     plan) participates in the draft solve with its own byte-ratio packing;
     shared groups keep the target's pinned packing.
     """
-    (
-        fields,
-        layer_types,
-        group_ids,
-        _,
-        num_draft_layers,
-    ) = merge_continuation_layers(
-        fields=(
-            CacheFieldSpec(
-                "full_attention",
-                "layer.0.kv",
-                "slot.0",
-                (256,),
-                1,
-            ),
-        ),
-        layer_types=("full_attention",),
-        group_ids=("full_attention",),
-        draft_fields=(
-            CacheFieldSpec(
-                "full_attention",
-                "layer.0.kv",
-                "slot.0",
-                (256,),
-                1,
-            ),
-            # Draft-only sliding-window layers: not present in the target plan.
-            CacheFieldSpec(
-                "draft_swa",
-                "layer.1.kv",
-                "slot.1",
-                (256,),
-                1,
-            ),
-        ),
-        draft_layer_types=("full_attention", "sliding_attention"),
-        draft_group_ids=("full_attention", "draft_swa"),
-    )
-    # ONE spec derivation over the merged layers, per-layer windows.
-    group_specs = build_paged_cache_group_specs(
-        layer_types=layer_types,
-        group_ids=group_ids,
-        sliding_window_tokens=(None, None, 8),
-        prefix_granularity=4,
-    )
-    setup = build_hybrid_cache_setup(
-        family="inkling",
-        server_args=SimpleNamespace(max_total_tokens=None),
-        fields=fields,
-        layer_types=layer_types,
-        group_ids=group_ids,
-        group_specs=group_specs,
-        state_dtypes={},
-        layer_kv_head_counts=None,
-        num_draft_layers=num_draft_layers,
+    setup = _SyntheticHybridRecipe(
+        layer_types=("full_attention", "full_attention", "sliding_attention"),
+        group_ids=("full_attention", "full_attention", "draft_swa"),
+        num_draft_layers=2,
+        windows=(None, None, 8),
         cache_budget_bytes=4_096,
-        fixed_workspace_bytes=0,
-        prefix_granularity=4,
-        max_padding_fraction=1.0,
-    )
+    ).setup()
 
     # One big model: both draft layers are continuation layers (global
     # layers 1 and 2) of the one merged plan. The full_attention group is
@@ -673,7 +616,7 @@ def test_hybrid_draft_only_sliding_group_packs_by_ratio() -> None:
         "full_attention",
         "draft_swa",
     )
-    published = {spec.group_id for spec in setup.spec.paged_cache_group_specs}
+    published = {spec.group_id for spec in setup.spec.cache_group_specs}
     assert published == {"full_attention", "draft_swa"}
 
 
@@ -684,122 +627,133 @@ def test_union_contract_flows_draft_groups_to_scheduler_config() -> None:
     instantiates its existing SwaManager for them, no draft concept
     anywhere."""
     import torch
+    from cache_pool_test_utils import MinimalCacheView
 
-    from tokenspeed.runtime.engine.scheduler_utils import pool_to_paged_cache_groups
-    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
+    from tokenspeed.runtime.engine.scheduler_utils import pool_to_cache_groups
 
-    (
-        fields,
-        layer_types,
-        group_ids,
-        _,
-        num_draft_layers,
-    ) = merge_continuation_layers(
-        fields=(CacheFieldSpec("full_attention", "layer.0.kv", "slot.0", (256,), 1),),
-        layer_types=("full_attention",),
-        group_ids=("full_attention",),
-        draft_fields=(
-            CacheFieldSpec("full_attention", "layer.0.kv", "slot.0", (256,), 1),
-            CacheFieldSpec("draft_swa", "layer.1.kv", "slot.1", (256,), 1),
-        ),
-        draft_layer_types=("full_attention", "sliding_attention"),
-        draft_group_ids=("full_attention", "draft_swa"),
-    )
-    group_specs = build_paged_cache_group_specs(
-        layer_types=layer_types,
-        group_ids=group_ids,
-        sliding_window_tokens=(None, None, 8),
-        prefix_granularity=4,
-    )
-    setup = build_hybrid_cache_setup(
-        family="inkling",
-        server_args=SimpleNamespace(max_total_tokens=None),
-        fields=fields,
-        layer_types=layer_types,
-        group_ids=group_ids,
-        group_specs=group_specs,
-        state_dtypes={},
-        layer_kv_head_counts=None,
-        num_draft_layers=num_draft_layers,
+    setup = _SyntheticHybridRecipe(
+        layer_types=("full_attention", "full_attention", "sliding_attention"),
+        group_ids=("full_attention", "full_attention", "draft_swa"),
+        num_draft_layers=2,
+        windows=(None, None, 8),
         cache_budget_bytes=4_096,
-        fixed_workspace_bytes=0,
-        prefix_granularity=4,
-        max_padding_fraction=1.0,
-    )
-    pool = CachePool(
-        size=setup.spec.pool_size,
-        dtype=torch.uint8,
-        device="cpu",
-        prefix_granularity=4,
+    ).setup()
+    pool = MinimalCacheView(
+        CacheArena(
+            setup.spec.memory_plan,
+            "cpu",
+            cache_group_specs=setup.spec.cache_group_specs,
+            token_capacity=setup.spec.token_capacity,
+        ),
+        torch.uint8,
         rank=0,
-        memory_plan=setup.spec.memory_plan,
-        paged_cache_group_specs=setup.spec.paged_cache_group_specs,
-        token_capacity=setup.spec.token_capacity,
     )
-    groups = {g.group_id: g for g in pool_to_paged_cache_groups(pool)}
+    groups = {g.group_id: g for g in pool_to_cache_groups(pool)}
     assert set(groups) == {"full_attention", "draft_swa"}
     swa = groups["draft_swa"]
     assert swa.sliding_window_tokens == 8
-    # Packing and page counts come from the ONE merged plan.
+    # Packing and page counts come from the ONE merged plan, carried across
+    # the bridge by the contract rather than stamped onto the group specs.
     plan_group = setup.spec.memory_plan.group("draft_swa")
+    contract = pool.arena.runtime_contract
+    assert contract.group_packing["draft_swa"] == plan_group.cache_blocks_per_lcm_block
     assert swa.cache_blocks_per_lcm_block == plan_group.cache_blocks_per_lcm_block
     assert swa.total_pages == plan_group.page_count
 
 
 def test_draft_view_maps_local_layer_ids_to_continuation_planes() -> None:
-    """Tripwire for the draft layer-map DIRECTION: a draft model's local
-    layer 0 must resolve to the merged pool's continuation plane
-    (num_target_layers), never to the target's layer 0. The inverse map
-    (the hybrid {global: pool_idx} convention) silently corrupts the
-    target's first layers with every draft KV write."""
-    from tokenspeed.runtime.layers.attention.kv_cache.base import LayerMappedKVPool
+    """Tripwire for the draft window's DIRECTION and its bounds.
 
-    class _FakePool:
-        page_size = 4
+    A draft model numbers its layers locally, so local layer 0 must resolve to
+    the merged plan's continuation plane (num_target_layers), never to the
+    target's layer 0. And an id already carrying a global number must be
+    REJECTED rather than offset a second time -- silently addressing another
+    model's planes is how the KV of two models gets crossed.
+    """
+    from cache_pool_test_utils import MinimalCacheView
 
-        def get_key_buffer(self, layer_id: int) -> int:
-            return layer_id
+    class _Window(MinimalCacheView):
+        """Just a layer window: the subject is _field_layer_id's arithmetic."""
+
+        def __init__(self, *, first_layer: int, num_layers: int) -> None:
+            self._field_layer_offset = first_layer
+            self.layer_num = num_layers
 
     num_target_layers = 61
-    draft_pool = LayerMappedKVPool(
-        _FakePool(),
-        [num_target_layers + local for local in range(1)],
-        layer_map={local: num_target_layers + local for local in range(1)},
+    draft = _Window(first_layer=num_target_layers, num_layers=3)
+
+    assert draft._field_layer_id(0) == num_target_layers
+    assert draft._field_layer_id(2) == num_target_layers + 2
+    for outside in (num_target_layers, 3, -1):
+        with pytest.raises(ValueError, match="outside this cache view"):
+            draft._field_layer_id(outside)
+
+    # The target view starts at 0, so its own ids pass through unchanged.
+    target = _Window(first_layer=0, num_layers=num_target_layers)
+    assert target._field_layer_id(7) == 7
+
+
+# --- recipe seams that used to be standalone functions ---
+
+
+def test_qwen_mtp_padding_allowance_tracks_draft_planes() -> None:
+    """The Qwen bound grows with the draft's mirrored K/V planes.
+
+    p = 1 + 2 * draft_layers / full_attention_layers: no draft keeps the
+    original 1.0, and each MTP layer buys headroom for the planes it adds.
+    """
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.qwen35 import (
+        QwenGDNRecipe,
     )
-    # Local draft layer 0 -> global continuation plane 61.
-    assert draft_pool.get_key_buffer(0) == num_target_layers
-    # A layer already carrying its global id (V4 MTP convention) passes through.
-    assert draft_pool.get_key_buffer(num_target_layers) == num_target_layers
 
-    # The hybrid default stays the inverse: global sparse ids -> compact slots.
-    hybrid_pool = LayerMappedKVPool(_FakePool(), [3, 7, 11])
-    assert hybrid_pool.get_key_buffer(7) == 1
+    def bound(*, full_attention_layers, draft_layers):
+        recipe = QwenGDNRecipe.__new__(QwenGDNRecipe)
+        recipe.__dict__["target_layer_types"] = (
+            "linear_attention",
+            "linear_attention",
+            "linear_attention",
+            "full_attention",
+        ) * full_attention_layers
+        recipe.draft_attn_config = object() if draft_layers else None
+        recipe.draft_model_config = SimpleNamespace(num_attention_layers=draft_layers)
+        return QwenGDNRecipe.max_padding_fraction.fget(recipe)
+
+    for full_attention_layers in (6, 12):
+        assert bound(full_attention_layers=full_attention_layers, draft_layers=0) == 1.0
+        assert (
+            abs(
+                bound(full_attention_layers=full_attention_layers, draft_layers=1)
+                - (1.0 + 2.0 / full_attention_layers)
+            )
+            < 1e-9
+        )
 
 
-def test_draft_view_maps_inkling_conv_checkpoint_accessors() -> None:
-    """Same tripwire for the Inkling conv-checkpoint accessors: the
-    __getattr__ pass-through would resolve them against the target's
-    layers 0..n, silently restoring/publishing the wrong planes."""
-    from tokenspeed.runtime.layers.attention.kv_cache.base import LayerMappedKVPool
+def test_ordinary_profile_reserves_null_page_inside_budget() -> None:
+    """Profiled capacity keeps the null page inside the budget.
 
-    class _FakePool:
-        page_size = 4
-
-        def kvconv_checkpoint_buffers(self, layer_id: int):
-            return ("kv", layer_id)
-
-        def hiddenconv_checkpoint_buffer(self, layer_id: int, component: str):
-            return ("hidden", layer_id, component)
-
-    num_target_layers = 66
-    draft_pool = LayerMappedKVPool(
-        _FakePool(),
-        [num_target_layers + local for local in range(3)],
-        layer_map={local: num_target_layers + local for local in range(3)},
+    16_384 bytes at 16 bytes/token and P=64 buys 16 pages; one is the reserved
+    null page, so 15 are schedulable.
+    """
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
+        OrdinaryRecipe,
     )
-    assert draft_pool.kvconv_checkpoint_buffers(0) == ("kv", 66)
-    assert draft_pool.hiddenconv_checkpoint_buffer(2, "mlpconv") == (
-        "hidden",
-        68,
-        "mlpconv",
+
+    recipe = OrdinaryRecipe.__new__(OrdinaryRecipe)
+    recipe.cache_budget_bytes = 16_384
+    recipe.server_args = SimpleNamespace(max_total_tokens=None)
+    recipe.attn_config = SimpleNamespace(
+        prefix_granularity=64,
+        cache_cell_size=lambda: 16,
+        layer_types=(),
+        sliding_window_tokens=None,
     )
+    recipe.draft_attn_config = None
+    recipe.model_config = SimpleNamespace(num_attention_layers=1)
+
+    usable_pages = recipe.num_lcm_blocks(
+        SimpleNamespace(lcm_block_bytes=1, prefix_granularity=64, group_packing=())
+    )
+
+    assert usable_pages == 15
+    assert (usable_pages + 1) * 64 * 16 <= 16_384

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -765,7 +765,7 @@ def test_draft_view_maps_local_layer_ids_to_continuation_planes() -> None:
     assert target._field_layer_id(7) == 7
 
 
-# --- recipe seams that used to be standalone functions ---
+# --- individual recipe seams ---
 
 
 def test_qwen_mtp_padding_allowance_tracks_draft_planes() -> None:

--- a/test/runtime/test_cudagraph_per_group.py
+++ b/test/runtime/test_cudagraph_per_group.py
@@ -109,9 +109,12 @@ class CacheGroupIdsTest(_TorchCase):
         )
 
     def _pool(self, group_ids):
+        # A cache view names its arena; the arena publishes the specs.
         return SimpleNamespace(
-            paged_cache_group_specs=tuple(
-                SimpleNamespace(group_id=gid) for gid in group_ids
+            arena=SimpleNamespace(
+                cache_group_specs=tuple(
+                    SimpleNamespace(group_id=gid) for gid in group_ids
+                )
             )
         )
 
@@ -159,9 +162,11 @@ class DraftCacheGroupIdsTest(_TorchCase):
                 cache_consumer_families=frozenset(families),
             ),
             draft_token_to_kv_pool=SimpleNamespace(
-                paged_cache_group_specs=(
-                    SimpleNamespace(group_id="full_attention", family="history"),
-                    SimpleNamespace(group_id="state", family="state"),
+                arena=SimpleNamespace(
+                    cache_group_specs=(
+                        SimpleNamespace(group_id="full_attention", family="history"),
+                        SimpleNamespace(group_id="state", family="state"),
+                    )
                 )
             ),
         )
@@ -222,7 +227,7 @@ class WrapperReplayGroupedTest(_TorchCase):
         mock = SimpleNamespace(
             attn_backend=SimpleNamespace(
                 uses_cache_groups=True,
-                uses_paged_cache_groups=False,
+                needs_group_block_tables=False,
                 uses_padded_decode_token_mask=False,
                 init_forward_metadata_replay_cuda_graph=record,
             ),
@@ -284,13 +289,13 @@ class WrapperReplayGroupedTest(_TorchCase):
         mock = SimpleNamespace(
             attn_backend=SimpleNamespace(
                 uses_cache_groups=False,
-                uses_paged_cache_groups=False,
+                needs_group_block_tables=False,
                 uses_padded_decode_token_mask=False,
                 init_forward_metadata_replay_cuda_graph=lambda *args, **kwargs: None,
             ),
             draft_attn_backend=SimpleNamespace(
                 uses_cache_groups=True,
-                uses_paged_cache_groups=False,
+                needs_group_block_tables=False,
                 uses_padded_decode_token_mask=False,
                 init_forward_metadata_replay_cuda_graph=record_draft,
             ),
@@ -343,7 +348,7 @@ class WrapperReplayGroupedTest(_TorchCase):
 
         backend_contract = {
             "uses_cache_groups": True,
-            "uses_paged_cache_groups": False,
+            "needs_group_block_tables": False,
             "uses_padded_decode_token_mask": True,
         }
         mock = SimpleNamespace(
@@ -421,13 +426,15 @@ class WrapperCaptureGroupIdsTest(_TorchCase):
                 seq_lens_buf=torch.ones(MAX_BS, dtype=torch.int32),
             ),
             attn_backend=SimpleNamespace(
-                uses_paged_cache_groups=False,
+                needs_group_block_tables=False,
                 uses_cache_groups=uses_cache_groups,
                 init_forward_metadata_capture_cuda_graph=record,
             ),
             token_to_kv_pool=SimpleNamespace(
-                paged_cache_group_specs=tuple(
-                    SimpleNamespace(group_id=gid) for gid in group_ids
+                arena=SimpleNamespace(
+                    cache_group_specs=tuple(
+                        SimpleNamespace(group_id=gid) for gid in group_ids
+                    )
                 )
             ),
             drafter=None,
@@ -481,11 +488,13 @@ class WrapperEagerGroupGuardTest(_TorchCase):
             config=SimpleNamespace(),
             attn_backend=SimpleNamespace(
                 uses_cache_groups=True,
-                uses_paged_cache_groups=False,
+                needs_group_block_tables=False,
             ),
             token_to_kv_pool=SimpleNamespace(
-                paged_cache_group_specs=tuple(
-                    SimpleNamespace(group_id=gid) for gid in group_ids
+                arena=SimpleNamespace(
+                    cache_group_specs=tuple(
+                        SimpleNamespace(group_id=gid) for gid in group_ids
+                    )
                 )
             ),
             drafter=None,
@@ -548,8 +557,10 @@ class IdleBlockTablesTest(_TorchCase):
     def _wrapper(self, group_ids):
         return SimpleNamespace(
             token_to_kv_pool=SimpleNamespace(
-                paged_cache_group_specs=tuple(
-                    SimpleNamespace(group_id=gid) for gid in group_ids
+                arena=SimpleNamespace(
+                    cache_group_specs=tuple(
+                        SimpleNamespace(group_id=gid) for gid in group_ids
+                    )
                 )
             ),
             device="cpu",

--- a/test/runtime/test_deepseek_v4_attention_ops.py
+++ b/test/runtime/test_deepseek_v4_attention_ops.py
@@ -39,6 +39,10 @@ from tokenspeed_kernel.ops.attention.triton.deepseek_v4 import (
 )
 from tokenspeed_kernel.ops.transform import hadamard_transform
 
+from tokenspeed.runtime.layers.attention.deepseek_v4_geometry import (
+    deepseek_v4_swa_scale_dim,
+    deepseek_v4_swa_token_stride,
+)
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_combine_dense_swa_indices,
     deepseek_v4_combine_topk_swa_indices,
@@ -60,10 +64,6 @@ from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
 )
 from tokenspeed.runtime.layers.attention.kv_cache.hybrid_deepseek_v4 import (
     _mask_invalid_graph_tokens,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec import (
-    deepseek_v4_swa_scale_dim,
-    deepseek_v4_swa_token_stride,
 )
 from tokenspeed.runtime.models.deepseek_v4 import (
     _deepseek_v4_sanitize_swa_slot_mapping,

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -2473,7 +2473,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_plan_rejects_nonpositive_capacity(self):
-        # Capacity is a plan quantity now (the pool derives its size from the
+        # Capacity is a plan quantity (the pool derives its size from the
         # arena), so the planner owns this guard.
         config = SimpleNamespace(
             compress_ratios=[1],

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -63,6 +63,18 @@ from tokenspeed.runtime.layers.attention.deepseek_v4.metadata import (
     DeepseekV4IndexerDecodePlan,
     DeepseekV4IndexerPrefillMetadata,
 )
+from tokenspeed.runtime.layers.attention.deepseek_v4_geometry import (
+    V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
+    V4_SWA_KV_GROUP_ID,
+    deepseek_v4_cache_layout_from_config,
+    deepseek_v4_indexer_fp8_row_bytes,
+    deepseek_v4_indexer_mxfp4_row_bytes,
+    deepseek_v4_nope_dim,
+    deepseek_v4_swa_row_bytes,
+    deepseek_v4_swa_token_stride,
+    v4_compressed_kv_group_id,
+    v4_compressor_state_group_id,
+)
 from tokenspeed.runtime.layers.attention.deepseek_v4_ops import (
     deepseek_v4_compute_global_topk_indices_and_lens,
     fused_qnorm_rope_kv_insert,
@@ -75,25 +87,15 @@ from tokenspeed.runtime.layers.attention.kv_cache.hybrid_deepseek_v4 import (
     _split_block_tables_into_v4_metadata,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4 import (
-    build_deepseek_v4_cache_fields,
-    prepare_deepseek_v4_cache,
-    solve_deepseek_v4_memory_layout,
-)
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4_cache_spec import (
-    V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
-    V4_SWA_KV_GROUP_ID,
-    build_v4_cache_specs,
-    deepseek_v4_cache_layout_from_config,
-    deepseek_v4_indexer_fp8_row_bytes,
-    deepseek_v4_indexer_mxfp4_row_bytes,
-    deepseek_v4_nope_dim,
-    deepseek_v4_swa_row_bytes,
-    deepseek_v4_swa_token_stride,
-    v4_compressed_kv_group_id,
-    v4_compressor_state_group_id,
+    DeepseekV4Recipe,
+    v4_c4_state_window,
+    v4_compressed_kv_spec,
+    v4_compressor_state_spec,
+    v4_indexer_state_spec,
+    v4_swa_kv_spec,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 from tokenspeed.runtime.layers.layernorm import FusedRMSNorm, RMSNorm
 from tokenspeed.runtime.layers.quantization import (
@@ -162,36 +164,98 @@ from tokenspeed.runtime.utils.hf_transformers_utils import (
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
 
+def _v4_spec_set(hf_config, *, layer_ratio, decode_input_tokens: int = 1):
+    """The spec set a ratio vector declares, in the recipe's own order."""
+    ratios = {int(ratio) for ratio in layer_ratio}
+    window = v4_c4_state_window(decode_input_tokens)
+    specs = [v4_swa_kv_spec(hf_config)]
+    for ratio in sorted(r for r in ratios if r > 1):
+        specs.append(v4_compressor_state_spec(ratio, c4_state_window=window))
+        specs.append(v4_compressed_kv_spec(ratio))
+    if 4 in ratios:
+        specs.append(v4_indexer_state_spec(c4_state_window=window))
+    return tuple(specs)
+
+
+def _v4_recipe(
+    hf_config, *, prefix_granularity: int = 256, decode_input_tokens: int = 1
+):
+    """A V4 recipe over one hf_config, with tiny scheduler limits."""
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4 import (
+        DeepseekV4Recipe,
+    )
+
+    num_layers = len(hf_config.compress_ratios)
+    return DeepseekV4Recipe(
+        server_args=SimpleNamespace(
+            max_total_tokens=None,
+            chunked_prefill_size=prefix_granularity,
+            attention_use_fp4_indexer_cache=True,
+            speculative_algorithm=None,
+        ),
+        model_config=SimpleNamespace(
+            hf_config=hf_config, num_attention_layers=num_layers
+        ),
+        attn_config=SimpleNamespace(
+            prefix_granularity=prefix_granularity,
+            max_bs=1,
+            context_len=4096,
+            pd_disaggregation_enabled=False,
+        ),
+        draft_model_config=None,
+        draft_attn_config=None,
+        cache_budget_bytes=1 << 34,
+        decode_input_tokens=decode_input_tokens,
+        overlap_schedule_depth=0,
+    )
+
+
+def _v4_layout(hf_config, **kwargs):
+    """``(recipe, groups, packed layout)`` -- group then pack, as setup does."""
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import pack
+
+    recipe = _v4_recipe(hf_config, **kwargs)
+    groups = recipe.groups()
+    layout = pack(
+        groups,
+        prefix_granularity=recipe.prefix_granularity,
+        cache_blocks_per_lcm_block=recipe.packing(groups),
+        alignment=recipe.alignment,
+        max_padding_fraction=recipe.max_padding_fraction,
+    )
+    recipe.check_layout(layout)
+    return recipe, groups, layout
+
+
+def _fake_pool(*group_specs, **arena_attrs) -> SimpleNamespace:
+    """A cache-view double: the arena publishes, the view just names it."""
+    return SimpleNamespace(
+        arena=SimpleNamespace(cache_group_specs=tuple(group_specs), **arena_attrs)
+    )
+
+
 def _make_planned_deepseek_v4_pool(
     layout,
     hf_config,
     *,
     num_lcm_blocks: int = 2,
 ):
-    fields = build_deepseek_v4_cache_fields(
-        layout,
-        sliding_window=int(hf_config.sliding_window),
-        prefix_granularity=256,
-    )
-    plan = solve_deepseek_v4_memory_layout(fields).with_num_lcm_blocks(num_lcm_blocks)
+    _, groups, packed = _v4_layout(hf_config)
+    plan = packed.bind(num_lcm_blocks)
     max_packing = max(group.cache_blocks_per_lcm_block for group in plan.groups)
     pool_size = num_lcm_blocks * max_packing * plan.prefix_granularity
-    specs = tuple(
-        build_v4_cache_specs(
-            hf_config,
-            layer_ratio=layout.layer_ratio,
-        )
-    )
-    pool = HybridDeepseekV4TokenToKVPool(
-        size=pool_size,
+    specs = tuple(spec for spec, _ in groups)
+    from cache_pool_test_utils import make_pool
+
+    _, pool = make_pool(
+        HybridDeepseekV4TokenToKVPool,
+        plan,
+        device="cpu",
         model_dtype=torch.bfloat16,
         layout=layout,
         layer_num=len(layout.layer_ratio),
-        device="cpu",
-        enable_memory_saver=False,
         rank=0,
-        memory_plan=plan,
-        paged_cache_group_specs=specs,
+        cache_group_specs=specs,
         token_capacity=pool_size,
     )
     return pool, plan
@@ -803,7 +867,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         captured = {}
 
         class FakeBackend:
-            uses_paged_cache_groups = True
+            needs_group_block_tables = True
             uses_padded_decode_token_mask = True
 
             def init_forward_metadata_replay_cuda_graph(self, *args, **kwargs):
@@ -839,7 +903,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         captured = {"target": {}, "draft": {}}
 
         class FakeBackend:
-            uses_paged_cache_groups = True
+            needs_group_block_tables = True
             uses_padded_decode_token_mask = False
 
             def __init__(self, key):
@@ -922,7 +986,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         captured = {"target": [], "draft": []}
 
         class FakeBackend:
-            uses_paged_cache_groups = False
+            needs_group_block_tables = False
 
             def __init__(self, key):
                 self.key = key
@@ -964,7 +1028,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         captured = {"target": [], "draft": []}
 
         class FakeBackend:
-            uses_paged_cache_groups = True
+            needs_group_block_tables = True
             uses_cache_groups = True
 
             def __init__(self, key):
@@ -987,16 +1051,12 @@ class TestDeepseekV4Config(unittest.TestCase):
             draft_seq_lens_buf=torch.zeros(1, dtype=torch.int32),
         )
         wrapper.use_v4_mtp_paged_metadata = True
-        wrapper.token_to_kv_pool = SimpleNamespace(
-            paged_cache_group_specs=(
-                SimpleNamespace(group_id="v4.swa_kv", family="history"),
-                SimpleNamespace(group_id="v4.state", family="state"),
-            )
+        wrapper.token_to_kv_pool = _fake_pool(
+            SimpleNamespace(group_id="v4.swa_kv", family="history"),
+            SimpleNamespace(group_id="v4.state", family="state"),
         )
-        wrapper.draft_token_to_kv_pool = SimpleNamespace(
-            paged_cache_group_specs=(
-                SimpleNamespace(group_id="v4.swa_kv", family="history"),
-            )
+        wrapper.draft_token_to_kv_pool = _fake_pool(
+            SimpleNamespace(group_id="v4.swa_kv", family="history"),
         )
 
         wrapper._init_forward_metadata(
@@ -1024,7 +1084,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         captured = {"target": [], "draft": []}
 
         class FakeBackend:
-            uses_paged_cache_groups = False
+            needs_group_block_tables = False
 
             def __init__(self, key):
                 self.key = key
@@ -2412,7 +2472,9 @@ class TestDeepseekV4Config(unittest.TestCase):
             (plan.group("v4.c4a.compressed_kv").page_count, 64 * 68),
         )
 
-    def test_deepseek_v4_kv_pool_rejects_nonpositive_size(self):
+    def test_deepseek_v4_plan_rejects_nonpositive_capacity(self):
+        # Capacity is a plan quantity now (the pool derives its size from the
+        # arena), so the planner owns this guard.
         config = SimpleNamespace(
             compress_ratios=[1],
             head_dim=512,
@@ -2425,26 +2487,11 @@ class TestDeepseekV4Config(unittest.TestCase):
             page_size=64,
             use_fp4_indexer_cache=True,
         )
+        cache_layout = _v4_layout(config)[2]
 
-        with self.assertRaisesRegex(ValueError, "must be positive"):
-            HybridDeepseekV4TokenToKVPool(
-                size=0,
-                model_dtype=torch.bfloat16,
-                layout=layout,
-                layer_num=1,
-                device="cpu",
-                enable_memory_saver=False,
-                rank=0,
-                memory_plan=solve_deepseek_v4_memory_layout(
-                    build_deepseek_v4_cache_fields(
-                        layout,
-                        sliding_window=128,
-                        prefix_granularity=256,
-                    ),
-                ).with_num_lcm_blocks(1),
-                paged_cache_group_specs=(),
-                token_capacity=256,
-            )
+        for capacity in (0, -1):
+            with self.assertRaisesRegex(ValueError, "must be a positive integer"):
+                cache_layout.bind(capacity)
 
     def test_deepseek_v4_group_slot_mapping_consumes_compact_base_offsets(self):
         slots = _group_slot_mapping_from_raw(
@@ -2470,7 +2517,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             torch.equal(slots, torch.tensor([640, 641, 642, 1280, 1281, 1282]))
         )
 
-    def test_deepseek_v4_backend_preserves_compact_paged_cache_contract(self):
+    def test_deepseek_v4_backend_preserves_compact_cache_contract(self):
         backend = DeepseekV4AttentionBackend(
             SimpleNamespace(
                 prefix_granularity=64,
@@ -2523,18 +2570,9 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         backend.prefix_granularity = 256
-        group_ids = {
-            V4_SWA_KV_GROUP_ID,
-            v4_compressor_state_group_id(4),
-            v4_compressed_kv_group_id(4),
-            v4_compressor_state_group_id(128),
-            v4_compressed_kv_group_id(128),
-            V4_INDEXER_COMPRESSOR_STATE_GROUP_ID,
-        }
-        specs = build_v4_cache_specs(
+        specs = _v4_spec_set(
             SimpleNamespace(sliding_window=128),
             layer_ratio=(4, 128),
-            cache_blocks_per_lcm_block={group_id: 1 for group_id in group_ids},
         )
         widths = {
             spec.group_id: backend._cuda_graph_group_table_width(
@@ -2612,14 +2650,14 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         specs = (
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="fine",
                 retention="full_history",
                 rows_per_page=4,
                 entry_stride_tokens=1,
                 sliding_window_tokens=None,
             ),
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="coarse",
                 retention="full_history",
                 rows_per_page=256,
@@ -2630,8 +2668,8 @@ class TestDeepseekV4Config(unittest.TestCase):
         counts = {"fine": 20001, "coarse": 1025}
 
         backend.configure_runtime(
-            paged_cache_group_specs=specs,
-            paged_cache_group_page_counts=counts,
+            cache_group_specs=specs,
+            cache_group_page_counts=counts,
         )
         tables = {
             "fine": torch.ones((1, 1), dtype=torch.int32),
@@ -2650,8 +2688,8 @@ class TestDeepseekV4Config(unittest.TestCase):
         # Graph setup may repeat the same contract but must not replace it.
         backend.init_cuda_graph_state(
             max_bs=1,
-            paged_cache_group_specs=specs,
-            paged_cache_group_page_counts=counts,
+            cache_group_specs=specs,
+            cache_group_page_counts=counts,
         )
         changed = {"fine": 20002, "coarse": 1025}
         with self.assertRaisesRegex(RuntimeError, "changed after initialization"):
@@ -2810,13 +2848,13 @@ class TestDeepseekV4Config(unittest.TestCase):
     def test_deepseek_v4_target_mtp_graph_replay_refreshes_flat_tables(self):
         device = torch.device("cuda")
         target_specs = tuple(
-            build_v4_cache_specs(
+            _v4_spec_set(
                 SimpleNamespace(sliding_window=128),
                 layer_ratio=(1, 4, 128),
             )
         )
         draft_specs = tuple(
-            build_v4_cache_specs(
+            _v4_spec_set(
                 SimpleNamespace(sliding_window=128),
                 layer_ratio=(1,),
             )
@@ -2847,14 +2885,14 @@ class TestDeepseekV4Config(unittest.TestCase):
         draft = make_backend(is_draft=True)
         target.init_cuda_graph_state(
             max_bs=2,
-            paged_cache_group_specs=target_specs,
-            paged_cache_group_page_counts=target_counts,
+            cache_group_specs=target_specs,
+            cache_group_page_counts=target_counts,
             max_tokens_per_req=4,
         )
         draft.init_cuda_graph_state(
             max_bs=2,
-            paged_cache_group_specs=draft_specs,
-            paged_cache_group_page_counts=draft_counts,
+            cache_group_specs=draft_specs,
+            cache_group_page_counts=draft_counts,
             max_tokens_per_req=4,
         )
 
@@ -3175,8 +3213,8 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         backend.init_cuda_graph_state(
             2,
-            paged_cache_group_specs=(
-                PagedCacheGroupSpec(
+            cache_group_specs=(
+                CacheGroupSpec(
                     group_id="v4.swa_kv",
                     retention="sliding_window",
                     rows_per_page=64,
@@ -3184,7 +3222,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                     sliding_window_tokens=128,
                 ),
             ),
-            paged_cache_group_page_counts={"v4.swa_kv": 1024},
+            cache_group_page_counts={"v4.swa_kv": 1024},
             max_tokens_per_req=1,
         )
         compact = torch.tensor([[10, 11], [20, -1]], dtype=torch.int32)
@@ -3391,6 +3429,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             head_dim=512,
             qk_rope_head_dim=64,
             index_head_dim=128,
+            sliding_window=128,
         )
         layout = deepseek_v4_cache_layout_from_config(
             config,
@@ -3398,24 +3437,17 @@ class TestDeepseekV4Config(unittest.TestCase):
             use_fp4_indexer_cache=True,
         )
 
+        from cache_pool_test_utils import make_pool
+
         with self.assertRaisesRegex(ValueError, "layer_num"):
-            HybridDeepseekV4TokenToKVPool(
-                size=128,
+            make_pool(
+                HybridDeepseekV4TokenToKVPool,
+                _v4_layout(config)[2].bind(1),
+                device="cpu",
                 model_dtype=torch.bfloat16,
                 layout=layout,
                 layer_num=2,
-                device="cpu",
-                enable_memory_saver=False,
                 rank=0,
-                memory_plan=solve_deepseek_v4_memory_layout(
-                    build_deepseek_v4_cache_fields(
-                        layout,
-                        sliding_window=128,
-                        prefix_granularity=256,
-                    ),
-                ).with_num_lcm_blocks(1),
-                paged_cache_group_specs=(),
-                token_capacity=256,
             )
 
     def test_deepseek_v4_metadata_maps_compressed_slots(self):
@@ -3571,7 +3603,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         )
         backend.configure_runtime(
-            paged_cache_group_specs=(
+            cache_group_specs=(
                 SimpleNamespace(
                     group_id=V4_SWA_KV_GROUP_ID,
                     retention="sliding_window",
@@ -3579,7 +3611,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                     entry_stride_tokens=1,
                 ),
             ),
-            paged_cache_group_page_counts={V4_SWA_KV_GROUP_ID: 128},
+            cache_group_page_counts={V4_SWA_KV_GROUP_ID: 128},
         )
         backend.init_forward_metadata(
             bs=3,
@@ -3927,11 +3959,11 @@ class TestDeepseekV4Config(unittest.TestCase):
                     build(granularity)
 
     def test_deepseek_v4_spec_geometry_is_prefix_granularity_free(self):
-        """build_v4_cache_specs takes no P; block spans come from the kernel
+        """The spec constructors take no P; block spans come from the kernel
         page registry (256 // ratio rows x ratio-token stride)."""
         specs = {
             spec.group_id: spec
-            for spec in build_v4_cache_specs(
+            for spec in _v4_spec_set(
                 SimpleNamespace(sliding_window=128),
                 layer_ratio=(1, 4, 128),
                 decode_input_tokens=1,
@@ -4525,8 +4557,8 @@ class TestDeepseekV4Config(unittest.TestCase):
         group_id = v4_compressed_kv_group_id(4)
         backend.init_cuda_graph_state(
             max_bs=4,
-            paged_cache_group_specs=(
-                PagedCacheGroupSpec(
+            cache_group_specs=(
+                CacheGroupSpec(
                     group_id=group_id,
                     retention="full_history",
                     rows_per_page=64,
@@ -4534,7 +4566,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                     sliding_window_tokens=None,
                 ),
             ),
-            paged_cache_group_page_counts={group_id: 128},
+            cache_group_page_counts={group_id: 128},
         )
         backend.init_forward_metadata_capture_cuda_graph(
             bs=4,
@@ -5946,13 +5978,8 @@ def test_v4_merged_solve_draft_is_a_continuation_layer():
     layout = deepseek_v4_cache_layout_from_config(
         hf_config, page_size=64, use_fp4_indexer_cache=False
     )
-    fields = build_deepseek_v4_cache_fields(
-        layout,
-        sliding_window=int(hf_config.sliding_window),
-        prefix_granularity=256,
-    )
-    merged = solve_deepseek_v4_memory_layout(fields)
-    plan = merged.with_num_lcm_blocks(2)
+    merged = _v4_layout(hf_config)[2]
+    plan = merged.bind(2)
     # Every layer's swa field (all 6 layers incl. the MTP continuation
     # layer) shares the one v4.swa_kv group — one packing, one page-id
     # space for target and draft alike.
@@ -5964,11 +5991,11 @@ def test_v4_merged_solve_draft_is_a_continuation_layer():
 
 
 def test_v4_pd_recipe_and_readiness_follow_cache_producers():
-    setup = prepare_deepseek_v4_cache(
+    setup = DeepseekV4Recipe(
         server_args=SimpleNamespace(
             speculative_algorithm=None,
             attention_use_fp4_indexer_cache=False,
-            max_total_tokens=512,
+            max_total_tokens=64 * 1024,
             chunked_prefill_size=256,
         ),
         model_config=SimpleNamespace(
@@ -5993,7 +6020,7 @@ def test_v4_pd_recipe_and_readiness_follow_cache_producers():
         cache_budget_bytes=1 << 30,
         decode_input_tokens=1,
         overlap_schedule_depth=0,
-    )
+    ).setup()
     schedule = build_cache_fields_by_producer_step(
         setup.spec.memory_plan, num_target_layers=3
     )

--- a/test/runtime/test_draft_advance_seqlens.py
+++ b/test/runtime/test_draft_advance_seqlens.py
@@ -134,7 +134,7 @@ def test_msa_init_cuda_graph_state_matches_helper_signature():
     raised TypeError: missing 1 required positional argument: 'seq_lens_buf'.
     """
     be = _msa_backend()
-    init_backend_cuda_graph_state(be, 8, paged_cache_group_specs=())
+    init_backend_cuda_graph_state(be, 8, cache_group_specs=())
     # And it must own the buffer rather than alias a controller tensor.
     assert be.cuda_graph_seq_lens.shape[0] == 8
     assert be.cuda_graph_seq_lens.dtype == torch.int32
@@ -143,7 +143,7 @@ def test_msa_init_cuda_graph_state_matches_helper_signature():
 def test_msa_inherits_default_advance():
     """msa's buffer uses the default name, so the base implementation applies."""
     be = _msa_backend()
-    init_backend_cuda_graph_state(be, 8, paged_cache_group_specs=())
+    init_backend_cuda_graph_state(be, 8, cache_group_specs=())
     seq_lens = torch.tensor([11, 12, 13, 14], dtype=torch.int32)
     be.advance_draft_forward_metadata(seq_lens)
     assert torch.equal(be.cuda_graph_seq_lens[:4], seq_lens)

--- a/test/runtime/test_drafter_accept_indexing.py
+++ b/test/runtime/test_drafter_accept_indexing.py
@@ -51,7 +51,7 @@ class TestDrafterAcceptIndexing(unittest.TestCase):
             spec_num_steps=3,
             draft_model_runner=model_runner,
             cache_view=CacheView(
-                torch.zeros((max_bs, 4), dtype=torch.int32), page_size=128
+                torch.zeros((max_bs, 4), dtype=torch.int32), kernel_page_size=128
             ),
             attn_backend=backend,
             runtime_states=runtime_states,

--- a/test/runtime/test_flashmla_cache_groups.py
+++ b/test/runtime/test_flashmla_cache_groups.py
@@ -20,7 +20,7 @@
 
 """FlashMLABackend cache-group (LCM) decode metadata.
 
-Validates that FlashMLA, when bound to a paged-cache contract, resolves its
+Validates that FlashMLA, when bound to a cache contract, resolves its
 decode block table and latent write locations from the LCM full-history table
 rather than the classic ``page_table`` path. Exercises the metadata math only
 (no FlashMLA CUDA kernel), so it runs on any CUDA device.
@@ -69,7 +69,7 @@ def _make_flashmla_backend(pool, speculative_num_draft_tokens: int = 1):
         kv_cache_dtype=torch.bfloat16,
         prefix_granularity=_KERNEL_PAGE,
         kernel_page_size=_KERNEL_PAGE,
-        context_len=8 * pool.prefix_granularity,
+        context_len=8 * pool.arena.prefix_granularity,
         max_bs=8,
         max_graph_bs=8,
         kv_cache_quant_method="",
@@ -113,7 +113,7 @@ def test_flashmla_grouped_decode_block_table_and_write_locs() -> None:
     from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 
     pool = _make_pool("cuda", usable_pages=6)
-    page_size = pool.prefix_granularity  # logical (scheduler) page size
+    page_size = pool.arena.prefix_granularity  # logical (scheduler) page size
     ratio = page_size // _KERNEL_PAGE
     layer_id = _mla_layer_id(pool)
     layer = type("L", (), {"layer_id": layer_id})()
@@ -157,7 +157,7 @@ def test_flashmla_grouped_prefill_index_math() -> None:
     from tokenspeed.runtime.layers.attention.page_table import expand_page_table
 
     pool = _make_pool("cuda", usable_pages=6)
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     backend = _make_flashmla_backend(pool)
 
     # The mixin consumes the KERNEL-page table (upstream expansion); build it
@@ -200,7 +200,7 @@ def test_flashmla_grouped_target_verify_writes_whole_window() -> None:
     from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 
     pool = _make_pool("cuda", usable_pages=6)
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     spec = 4
     backend = _make_flashmla_backend(pool, speculative_num_draft_tokens=spec)
 
@@ -265,7 +265,7 @@ def _make_draft_flashmla_backend(pool):
         kv_cache_dtype=torch.bfloat16,
         prefix_granularity=_KERNEL_PAGE,
         kernel_page_size=_KERNEL_PAGE,
-        context_len=8 * pool.prefix_granularity,
+        context_len=8 * pool.arena.prefix_granularity,
         max_bs=8,
         max_graph_bs=8,
         kv_cache_quant_method="",
@@ -300,7 +300,7 @@ def test_flashmla_draft_consumes_staged_page_table() -> None:
     from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 
     pool = _make_pool("cuda", usable_pages=6)
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     ratio = page_size // _KERNEL_PAGE
     backend = _make_draft_flashmla_backend(pool)
 

--- a/test/runtime/test_gdn_state_paging.py
+++ b/test/runtime/test_gdn_state_paging.py
@@ -31,7 +31,8 @@ class _CacheMetadata:
 
 class _ContractPool:
     def __init__(self, page_size, components):
-        self.runtime_contract = SimpleNamespace(
+        # The arena publishes the contract; a view only names its arena.
+        contract = SimpleNamespace(
             prefix_granularity=page_size,
             group_specs=tuple(
                 SimpleNamespace(
@@ -44,6 +45,7 @@ class _ContractPool:
                 )
             ),
         )
+        self.arena = SimpleNamespace(runtime_contract=contract)
         self._components = components
         self._group_ids_by_layer = {
             layer_id: group_id for layer_id, (group_id, _, _) in components.items()

--- a/test/runtime/test_generation_output_processor.py
+++ b/test/runtime/test_generation_output_processor.py
@@ -65,6 +65,9 @@ class _ForwardOp:
     request_ids = ["prefill", "decode"]
     request_pool_indices = [0, 1]
     input_lengths = [4, 1]
+    # Total prefill size per extend slot, as C++ Request::PrefillSize() reports
+    # it: for a fresh request this equals prefix + input.
+    prefill_lengths = [4]
     extend_prefix_lens = [0]
 
     def num_extends(self):
@@ -196,6 +199,7 @@ def test_nan_flag_keeps_single_sanitized_token():
         request_ids = ["decode"]
         request_pool_indices = [0]
         input_lengths = [1]
+        prefill_lengths = []
         extend_prefix_lens = []
 
         def num_extends(self):
@@ -271,6 +275,7 @@ def test_log_request_stats_disabled_by_default():
             request_ids = ["d"]
             request_pool_indices = [0]
             input_lengths = [1]
+            prefill_lengths = []
             extend_prefix_lens = []
 
             def num_extends(self):
@@ -438,6 +443,7 @@ def test_log_request_stats_records_timestamps_through_forward():
             request_ids = ["d"]
             request_pool_indices = [0]
             input_lengths = [1]
+            prefill_lengths = []
             extend_prefix_lens = []
 
             def num_extends(self):

--- a/test/runtime/test_group_aware_mha.py
+++ b/test/runtime/test_group_aware_mha.py
@@ -91,7 +91,7 @@ class SelectPageTableTest(unittest.TestCase):
             self.backend._select_page_table(self._layer(""), self._multi_group_meta())
 
 
-class ValidatePagedCacheGroupIdsTest(unittest.TestCase):
+class ValidateCacheGroupIdsTest(unittest.TestCase):
     """Init-time fail-fast: multi-group pool requires labeled layers."""
 
     def setUp(self):
@@ -101,13 +101,13 @@ class ValidatePagedCacheGroupIdsTest(unittest.TestCase):
 
             from tokenspeed.runtime.layers.paged_attention import (
                 PagedAttention,
-                validate_paged_cache_group_ids,
+                validate_cache_group_ids,
             )
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(f"needs torch: {exc}")
         self.nn = nn
         self.PagedAttention = PagedAttention
-        self.validate = validate_paged_cache_group_ids
+        self.validate = validate_cache_group_ids
 
     def _model(self, group_ids):
         nn, PagedAttention = self.nn, self.PagedAttention

--- a/test/runtime/test_group_specs_from_layer_types.py
+++ b/test/runtime/test_group_specs_from_layer_types.py
@@ -5,6 +5,7 @@ import os
 import pathlib
 import sys
 import unittest
+from types import SimpleNamespace
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -33,14 +34,35 @@ def _load(mod_name: str, file_path: pathlib.Path):
 # spec.py is self-contained: load it from the repo file under a private
 # name (no real package import, no sys.modules shadowing needed).
 _spec = _load("kv_cache_spec_under_test", _RECIPES_DIR / "spec.py")
-group_specs_from_layer_types = _spec.group_specs_from_layer_types
 layer_group_ids = _spec.layer_group_ids
-PagedCacheGroupSpec = _spec.PagedCacheGroupSpec
+CacheGroupSpec = _spec.CacheGroupSpec
+_spec.CacheFieldSpec = _load(
+    "kv_cache_plan_under_test", _RECIPES_DIR / "plan.py"
+).CacheFieldSpec
+
+
+def _group_specs(module, **kwargs):
+    """The specs a layer vocabulary produces, via the one-walk ``group``.
+
+    A group must declare fields, so a one-byte placeholder stands in: these
+    tests are about scheduler semantics, not bytes.
+    """
+    return tuple(
+        group_spec
+        for group_spec, _ in module.group(
+            fields_for_layer=lambda layer_id, group_id, occurrence: (
+                module.CacheFieldSpec(
+                    f"layer.{layer_id}.probe", f"unit.{occurrence}", (1,), "uint8"
+                ),
+            ),
+            **kwargs,
+        )
+    )
 
 
 def _specs(**kwargs):
-    """Call group_specs_from_layer_types the way the recipes do: group_ids
-    derived from the layer types unless the test supplies a finer split."""
+    """Call ``group`` the way the recipes do: group_ids derived from the
+    layer types unless the test supplies a finer split."""
     kwargs.setdefault(
         "group_ids",
         layer_group_ids(
@@ -48,14 +70,14 @@ def _specs(**kwargs):
             sliding_window_tokens=kwargs["sliding_window_tokens"],
         ),
     )
-    return group_specs_from_layer_types(**kwargs)
+    return _group_specs(_spec, **kwargs)
 
 
 class GroupSpecsFromLayerTypesTest(unittest.TestCase):
     def test_group_spec_has_no_producer_boundary_capability(self):
         self.assertNotIn(
             "materializes_all_boundaries",
-            PagedCacheGroupSpec.__dataclass_fields__,
+            CacheGroupSpec.__dataclass_fields__,
         )
 
     def test_gpt_oss_mixed_shape_yields_two_groups(self):
@@ -381,12 +403,12 @@ class MultiWindowGroupSpecsTest(unittest.TestCase):
         self.assertEqual(len(specs), 2)
 
 
-class PagedCacheGroupSpecShapeTest(unittest.TestCase):
+class CacheGroupSpecShapeTest(unittest.TestCase):
     """A spec declares exactly one geometry shape: row geometry (paged KV)
     or checkpoint_granularity (snapshot state)."""
 
     def test_row_geometry_shape(self):
-        spec = PagedCacheGroupSpec(
+        spec = CacheGroupSpec(
             group_id="kv",
             retention="full_history",
             rows_per_page=16,
@@ -398,7 +420,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
         self.assertIsNone(spec.checkpoint_granularity)
 
     def test_checkpoint_shape(self):
-        spec = PagedCacheGroupSpec(
+        spec = CacheGroupSpec(
             group_id="state",
             retention="full_history",
             sliding_window_tokens=None,
@@ -411,7 +433,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
 
     def test_shapes_are_mutually_exclusive(self):
         with self.assertRaises(ValueError):
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="state",
                 retention="full_history",
                 rows_per_page=16,
@@ -423,7 +445,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
 
     def test_missing_shape_raises(self):
         with self.assertRaises(ValueError):
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="kv",
                 retention="full_history",
                 sliding_window_tokens=None,
@@ -431,7 +453,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
 
     def test_partial_row_geometry_raises(self):
         with self.assertRaises(ValueError):
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="kv",
                 retention="full_history",
                 rows_per_page=16,
@@ -440,7 +462,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
 
     def test_checkpoint_requires_state_family(self):
         with self.assertRaises(ValueError):
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="kv",
                 retention="full_history",
                 sliding_window_tokens=None,
@@ -450,7 +472,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
 
     def test_nonpositive_geometry_raises(self):
         with self.assertRaises(ValueError):
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="kv",
                 retention="full_history",
                 rows_per_page=0,
@@ -458,7 +480,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
                 sliding_window_tokens=None,
             )
         with self.assertRaises(ValueError):
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="state",
                 retention="full_history",
                 sliding_window_tokens=None,
@@ -468,7 +490,7 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
 
     def test_state_family_may_keep_row_geometry(self):
         # V4-style row-buffer groups are state-family with real rows.
-        spec = PagedCacheGroupSpec(
+        spec = CacheGroupSpec(
             group_id="v4.compressor",
             retention="sliding_window",
             rows_per_page=16,
@@ -480,40 +502,55 @@ class PagedCacheGroupSpecShapeTest(unittest.TestCase):
         self.assertEqual(spec.block_granularity, 64)
 
 
-class PoolToPagedCacheGroupsIntegrationTest(unittest.TestCase):
-    """pool_to_paged_cache_groups converts published specs to a multi-group
+def _fake_pool(specs, *, packing=1) -> SimpleNamespace:
+    """A cache view whose arena publishes ``specs`` as its contract.
+
+    Page counts and packing are the plan's facts, carried by the contract
+    beside the specs -- the bridge reads them from there, never off a spec.
+    """
+    return SimpleNamespace(
+        arena=SimpleNamespace(
+            runtime_contract=SimpleNamespace(
+                group_specs=tuple(specs),
+                group_page_counts={spec.group_id: 1024 for spec in specs},
+                group_packing={spec.group_id: packing for spec in specs},
+            )
+        )
+    )
+
+
+class PoolToCacheGroupsIntegrationTest(unittest.TestCase):
+    """pool_to_cache_groups converts published specs to a multi-group
     scheduler config. Needs torch + the tokenspeed_scheduler ext; skips
     where those are absent."""
 
     def _import_converter(self):
         try:
             from tokenspeed.runtime.engine.scheduler_utils import (
-                pool_to_paged_cache_groups,
+                pool_to_cache_groups,
             )
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(
-                f"pool_to_paged_cache_groups unavailable (needs torch + "
+                f"pool_to_cache_groups unavailable (needs torch + "
                 f"tokenspeed_scheduler ext): {exc}"
             )
-        return pool_to_paged_cache_groups
+        return pool_to_cache_groups
 
     def test_two_group_specs_convert_to_two_scheduler_groups(self):
         from types import SimpleNamespace
 
-        pool_to_paged_cache_groups = self._import_converter()
+        pool_to_cache_groups = self._import_converter()
 
         specs = _specs(
             layer_types=["full_attention", "sliding_attention"],
             sliding_window_tokens=128,
             prefix_granularity=16,
         )
-        # Duck-typed stand-in: only the two attributes the converter reads.
-        fake_pool = SimpleNamespace(
-            paged_cache_group_specs=specs,
-            paged_cache_group_page_counts={s.group_id: 1024 for s in specs},
-        )
+        # Duck-typed stand-in: a view naming an arena whose contract is
+        # what the converter reads.
+        fake_pool = _fake_pool(specs)
 
-        groups = pool_to_paged_cache_groups(fake_pool)
+        groups = pool_to_cache_groups(fake_pool)
 
         self.assertEqual(len(groups), 2)
         group_ids = {g.group_id for g in groups}
@@ -522,34 +559,20 @@ class PoolToPagedCacheGroupsIntegrationTest(unittest.TestCase):
     def test_checkpoint_spec_folds_to_row_geometry_at_the_bridge(self):
         from types import SimpleNamespace
 
-        pool_to_paged_cache_groups = self._import_converter()
+        pool_to_cache_groups = self._import_converter()
 
         specs = _specs(
             layer_types=["linear_attention", "full_attention"],
             sliding_window_tokens=None,
             prefix_granularity=16,
         )
-        fake_pool = SimpleNamespace(
-            paged_cache_group_specs=specs,
-            paged_cache_group_page_counts={s.group_id: 1024 for s in specs},
-        )
+        fake_pool = _fake_pool(specs)
 
-        groups = {g.group_id: g for g in pool_to_paged_cache_groups(fake_pool)}
+        groups = {g.group_id: g for g in pool_to_cache_groups(fake_pool)}
 
         state = groups["linear_attention"]
         self.assertEqual(state.rows_per_page, 16)
         self.assertEqual(state.entry_stride_tokens, 1)
-
-    def test_empty_specs_convert_to_no_groups(self):
-        pool_to_paged_cache_groups = self._import_converter()
-
-        from types import SimpleNamespace
-
-        fake_pool = SimpleNamespace(
-            paged_cache_group_specs=(),
-            paged_cache_group_page_counts={},
-        )
-        self.assertEqual(pool_to_paged_cache_groups(fake_pool), [])
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -83,24 +83,23 @@ class GroupAwareWireTest(unittest.TestCase):
 
     def test_pool_transfer_layout_matches_scheduler_group_order(self):
         try:
-            from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
+            from cache_pool_test_utils import MinimalCacheView
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(f"needs runtime dependencies: {exc}")
 
-        pool = CachePool.__new__(CachePool)
+        pool = MinimalCacheView.__new__(MinimalCacheView)
         pool.layer_num = 2
-        pool.buffer = object()
-        pool._backing_pool = None
         pool._field_layer_offset = 0
-        pool._fields = {
-            "layer.0.state": object(),
-            "layer.1.k": object(),
-        }
-        pool.paged_cache_group_specs = (
-            SimpleNamespace(group_id="state"),
-            SimpleNamespace(group_id="full"),
+        # The arena owns the buffer, the field views and the published specs;
+        # the pool only answers for them.
+        pool.arena = SimpleNamespace(
+            buffer=object(),
+            cache_group_specs=(
+                SimpleNamespace(group_id="state"),
+                SimpleNamespace(group_id="full"),
+            ),
         )
-        pool.plan = SimpleNamespace(
+        pool.arena.plan = SimpleNamespace(
             num_lcm_blocks=4,
             planes=(
                 SimpleNamespace(
@@ -310,8 +309,10 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
                 self.load_tracker = tracker
 
         pool = SyntheticPool()
-        pool.paged_cache_group_specs = tuple(
-            SimpleNamespace(group_id=group.group_id) for group in layout.groups
+        pool.arena = SimpleNamespace(
+            cache_group_specs=tuple(
+                SimpleNamespace(group_id=group.group_id) for group in layout.groups
+            ),
         )
         with patch.object(self.executor_module, "_HOST_MEM_HEADROOM_BYTES", 0):
             executor = self.executor_module.L2CacheExecutor(

--- a/test/runtime/test_hybrid_cudagraph_kwargs.py
+++ b/test/runtime/test_hybrid_cudagraph_kwargs.py
@@ -52,8 +52,8 @@ class _NamedExtraBackend:
     def __init__(self):
         self.calls = []
 
-    def init_cuda_graph_state(self, max_bs, paged_cache_group_specs=None):
-        self.calls.append((max_bs, paged_cache_group_specs))
+    def init_cuda_graph_state(self, max_bs, cache_group_specs=None):
+        self.calls.append((max_bs, cache_group_specs))
 
 
 class _RaisingBackend:
@@ -67,7 +67,7 @@ class _RaisingBackend:
 
 
 _EXTRAS = {
-    "paged_cache_group_specs": ("full_attention", "linear_attention"),
+    "cache_group_specs": ("full_attention", "linear_attention"),
     "max_tokens_per_req": 2,
     "overlap_schedule_depth": 1,
 }
@@ -100,7 +100,7 @@ class InitBackendCudaGraphStateHelperTest(unittest.TestCase):
         self.helper(backend, 4, **_EXTRAS)
         self.assertEqual(
             backend.calls,
-            [(4, _EXTRAS["paged_cache_group_specs"])],
+            [(4, _EXTRAS["cache_group_specs"])],
         )
 
     def test_type_error_from_backend_body_propagates(self):

--- a/test/runtime/test_hybrid_mla_kv_nan_sanitize.py
+++ b/test/runtime/test_hybrid_mla_kv_nan_sanitize.py
@@ -18,83 +18,58 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""``LayerMappedKVPool.set_mla_kv_buffer`` layer remap + write pass-through.
+"""The KDA cache sanitizes its latent writes; the plain MLA cache does not.
 
 Context (the Kimi-K3 CUDA-graph "!!!" bug): under the prefill breakable graph,
 the dummy-batch capture (out_cache_loc == the reserved ``dummy_kv_slot``)
 writes NaN K/V. The paged MLA decode kernel then reads that shared dummy slot
-through the zero-padded block-table entries and computes ``q·k`` *before* the
+through the zero-padded block-table entries and computes ``q.k`` *before* the
 causal mask, so ``NaN + -inf = NaN`` survives the mask and poisons a live row's
-softmax -> all-NaN logits -> ``argmax`` picks token 0 ("!"). Eager prefill leaves
-the dummy slot finite (``q·0`` masks cleanly), so the bug only appears with the
-prefill graph on. The wrapper requests sanitization from the cache writer so
-the cache never stores NaN without allocating temporary tensors.
+softmax -> all-NaN logits -> ``argmax`` picks token 0 ("!"). Eager prefill
+leaves the dummy slot finite (``q.0`` masks cleanly), so the bug only appears
+with the prefill graph on.
+
+Sanitization is a fact of *this cache*, not of a wrapper around it: no call
+site passes ``sanitize=`` at all, so the default the pool class declares IS
+the contract -- and it holds for every view of the arena, target or draft.
 """
 
 from __future__ import annotations
 
-import torch
+import inspect
+import pathlib
 
-from tokenspeed.runtime.layers.attention.kv_cache.base import LayerMappedKVPool
-
-
-class _RecordingInnerPool:
-    """Minimal stand-in that records exactly what the wrapper forwards."""
-
-    page_size = 64
-
-    def __init__(self):
-        self.received = None
-
-    def set_mla_kv_buffer(self, layer, loc, cache_k_nope, cache_k_rope, sanitize=False):
-        self.received = (
-            layer.layer_id,
-            cache_k_nope,
-            cache_k_rope,
-            sanitize,
-        )
+from tokenspeed.runtime.layers.attention.kv_cache.hybrid_kda import (
+    HybridKDATokenToKVPool,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 
 
-class _Layer:
-    def __init__(self, layer_id: int):
-        self.layer_id = layer_id
+def _sanitize_default(cls) -> bool:
+    return inspect.signature(cls.set_mla_kv_buffer).parameters["sanitize"].default
 
 
-def test_set_mla_kv_buffer_remaps_layer_and_forwards_untouched():
-    inner = _RecordingInnerPool()
-    # Hybrid model: only layers 3/7/11 are full-attention -> pool slots 0/1/2.
-    pool = LayerMappedKVPool(inner, [3, 7, 11])
-    layer = _Layer(7)
-
-    # NaN/Inf pass through by design: the write kernel squashes them in-kernel.
-    k_nope = torch.tensor([[1.0, float("nan")], [float("inf"), 2.0]])
-    k_rope = torch.tensor([[float("nan"), 3.0]])
-    loc = torch.zeros(2, dtype=torch.int64)
-
-    pool.set_mla_kv_buffer(layer, loc, k_nope, k_rope)
-
-    got_lid, got_nope, got_rope, sanitize = inner.received
-    # Global layer id is remapped to its pool slot for the inner write (7 -> 1)
-    # and restored on the layer object afterwards.
-    assert got_lid == 1
-    assert layer.layer_id == 7
-    # Sanitization is owned by the cache writer so the wrapper forwards the
-    # original views without allocating two temporary tensors.
-    assert sanitize is True
-    assert got_nope is k_nope
-    assert got_rope is k_rope
+def test_kda_cache_sanitizes_latent_writes_by_default() -> None:
+    assert _sanitize_default(HybridKDATokenToKVPool) is True
 
 
-def test_set_mla_kv_buffer_noop_for_finite_input():
-    inner = _RecordingInnerPool()
-    pool = LayerMappedKVPool(inner, [3, 7, 11])
-    k_nope = torch.randn(4, 8)
-    k_rope = torch.randn(4, 2)
-    loc = torch.arange(4, dtype=torch.int64)
+def test_plain_mla_cache_does_not_sanitize_by_default() -> None:
+    """The bug needs the KDA arena's aliased state pages; a pure MLA pool
+    keeps the cheaper write, so the two defaults must stay distinct."""
+    assert _sanitize_default(MLATokenToKVPool) is False
 
-    pool.set_mla_kv_buffer(_Layer(3), loc, k_nope, k_rope)
 
-    _, got_nope, got_rope, sanitize = inner.received
-    assert sanitize is True
-    assert got_nope is k_nope
-    assert got_rope is k_rope
+def test_the_default_is_the_whole_contract() -> None:
+    """No caller may pass ``sanitize=``: the pools' own defaults decide.
+
+    A call site that opts in per write would put the graph-padding contract
+    back in the callers' hands, which is how it came to live in a wrapper.
+    """
+    root = pathlib.Path(__file__).resolve().parents[2] / "python"
+    allowed = {"hybrid_kda.py", "mla.py"}  # the two definitions themselves
+    offenders = sorted(
+        str(path.relative_to(root))
+        for path in root.rglob("*.py")
+        if path.name not in allowed and "sanitize=" in path.read_text()
+    )
+    assert offenders == []

--- a/test/runtime/test_inkling_activation_parity.py
+++ b/test/runtime/test_inkling_activation_parity.py
@@ -200,20 +200,12 @@ class _Harness:
             kv_cache_quant_method="none",
         )
         inner = MHAAttnBackend(config)
-        from cache_pool_test_utils import make_mha_memory_plan
+        from cache_pool_test_utils import make_mha_memory_plan, make_pool
 
-        self.kv_pool = MHATokenToKVPool(
-            size=1024,
-            dtype=torch.bfloat16,
-            head_num=text.num_key_value_heads,
-            head_dim=text.head_dim,
-            layer_num=text.num_hidden_layers,
-            device=device,
-            enable_memory_saver=False,
-            prefix_granularity=PAGE_SIZE,
-            rank=0,
-            layer_group_ids=("full_attention",) * text.num_hidden_layers,
-            memory_plan=make_mha_memory_plan(
+        # One arena, one view over it: the pool owns no memory or geometry.
+        _arena, self.kv_pool = make_pool(
+            MHATokenToKVPool,
+            make_mha_memory_plan(
                 size=1024,
                 prefix_granularity=PAGE_SIZE,
                 layer_num=text.num_hidden_layers,
@@ -221,6 +213,13 @@ class _Harness:
                 head_dim=text.head_dim,
                 dtype=torch.bfloat16,
             ),
+            device=device,
+            dtype=torch.bfloat16,
+            head_num=text.num_key_value_heads,
+            head_dim=text.head_dim,
+            layer_num=text.num_hidden_layers,
+            rank=0,
+            layer_group_ids=("full_attention",) * text.num_hidden_layers,
         )
         conv_pool = InklingConvStatePool(
             num_layers=text.num_hidden_layers,

--- a/test/runtime/test_inkling_mtp_text_config.py
+++ b/test/runtime/test_inkling_mtp_text_config.py
@@ -3,7 +3,7 @@
 Checkpoints since 4d71c3ea mix SWA and full-attention MTP depths
 (``mtp_config.local_layer_ids``); ``inkling_mtp_text_config`` turns the base
 text config into the draft worker's depth config: depth-local ids become the
-``local_layer_ids`` that drive attention geometry and paged-cache labels,
+``local_layer_ids`` that drive attention geometry and cache-group labels,
 and depths beyond ``--speculative-num-steps`` are pruned (an MTP chain only
 runs depths 0..steps-1).
 """
@@ -69,10 +69,10 @@ class TestInklingMTPTextConfig(unittest.TestCase):
                 cfg.swa_num_key_value_heads,
             ],
         )
-        # Every depth gets its own paged-cache group so the shared slab has
+        # Every depth gets its own cache group so the shared slab has
         # no dead rows (1 full + 2 sliding sub-groups of one layer each).
         self.assertEqual(
-            cfg.paged_cache_layer_types,
+            cfg.cache_layer_types,
             ["sliding_attention_0", "full_attention", "sliding_attention_1"],
         )
         # The base config is untouched (deepcopy).
@@ -96,7 +96,7 @@ class TestInklingMTPTextConfig(unittest.TestCase):
         cfg = inkling_mtp_text_config(text)
         self.assertEqual(cfg.num_hidden_layers, 4)
         self.assertEqual(cfg.local_layer_ids, [])
-        self.assertEqual(cfg.paged_cache_layer_types, ["full_attention"] * 4)
+        self.assertEqual(cfg.cache_layer_types, ["full_attention"] * 4)
 
     def test_steps_beyond_depths_keeps_all_depths(self):
         # The registry raises for steps > depths; the config transform must

--- a/test/runtime/test_kimi_k3_cache_pool.py
+++ b/test/runtime/test_kimi_k3_cache_pool.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
+from test.runtime.conftest import kimi_recipe, kimi_tp8_layout
+
 import pytest
 import torch
+from cache_pool_test_utils import make_arena
 
 from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
 from tokenspeed.runtime.layers.attention.kv_cache.hybrid_kda import (
     HybridKDATokenToKVPool,
 )
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.kimi_k3 import (
-    kimi_k3_layer_group_ids,
-    solve_kimi_k3_cache_layout,
-)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     FULL_ATTENTION,
     LINEAR_ATTENTION,
-    build_paged_cache_group_specs,
 )
 
 
@@ -22,18 +20,10 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
 def test_kimi_k3_pool_binds_mla_and_kda_to_one_lcm_backing() -> None:
     text_config = KimiLinearConfig()
     num_lcm_blocks = 2
-    layout = solve_kimi_k3_cache_layout(
-        text_config,
-        tp_size=8,
-        mla_cache_dtype=torch.float8_e4m3fn,
-        mla_quant_method=None,
-    )
-    plan = layout.with_num_lcm_blocks(num_lcm_blocks)
-    group_ids = kimi_k3_layer_group_ids(text_config)
-    layer_types = tuple(
-        FULL_ATTENTION if group_id == FULL_ATTENTION else LINEAR_ATTENTION
-        for group_id in group_ids
-    )
+    recipe, groups, layout = kimi_tp8_layout(pd_enabled=True)
+    plan = layout.bind(num_lcm_blocks)
+    group_ids = recipe.target_group_ids
+    layer_types = recipe.layer_types
     linear = text_config.linear_attn_config
     tp_size = 8
     conv_shape = (
@@ -45,52 +35,36 @@ def test_kimi_k3_pool_binds_mla_and_kda_to_one_lcm_backing() -> None:
         linear["head_dim"],
         linear["head_dim"],
     )
+    arena = make_arena(
+        plan,
+        cache_group_specs=tuple(spec for spec, _ in groups),
+        token_capacity=1024,
+    )
     pool = HybridKDATokenToKVPool(
-        size=num_lcm_blocks * 12 * plan.prefix_granularity,
+        arena=arena,
         model_dtype=torch.bfloat16,
         dtype=torch.float8_e4m3fn,
         quant_method=None,
         kv_lora_rank=text_config.kv_lora_rank,
         qk_rope_head_dim=text_config.qk_rope_head_dim,
         layer_num=text_config.num_hidden_layers,
-        device="cuda",
-        enable_memory_saver=False,
-        prefix_granularity=plan.prefix_granularity,
         rank=0,
         layer_types=layer_types,
         layer_group_ids=group_ids,
-        paged_cache_group_specs=build_paged_cache_group_specs(
-            layer_types=layer_types,
-            group_ids=group_ids,
-            sliding_window_tokens=None,
-            prefix_granularity=plan.prefix_granularity,
-            pd_disaggregation_enabled=True,
-        ),
-        state_field_dtypes={
-            field_id: dtype
-            for layer_id, layer_type in enumerate(layer_types)
-            if layer_type == LINEAR_ATTENTION
-            for field_id, dtype in (
-                (f"layer.{layer_id}.conv_state", torch.bfloat16),
-                (f"layer.{layer_id}.recurrent_state", torch.float32),
-            )
-        },
-        memory_plan=plan,
-        token_capacity=1024,
     )
 
     assert pool.num_lcm_blocks == num_lcm_blocks
-    assert pool.runtime_contract is not None
-    assert pool.runtime_contract.token_capacity == 1024
+    assert pool.arena.runtime_contract is not None
+    assert pool.arena.runtime_contract.token_capacity == 1024
     assert {
-        spec.group_id: spec.transfer_policy for spec in pool.paged_cache_group_specs
+        spec.group_id: spec.transfer_policy for spec in pool.arena.cache_group_specs
     } == {
         FULL_ATTENTION: "full_suffix",
         f"{LINEAR_ATTENTION}_0": "latest_snapshot",
         f"{LINEAR_ATTENTION}_1": "latest_snapshot",
         f"{LINEAR_ATTENTION}_2": "latest_snapshot",
     }
-    assert pool.runtime_contract.group_page_counts == {
+    assert pool.arena.runtime_contract.group_page_counts == {
         FULL_ATTENTION: num_lcm_blocks * 12 + 1,
         f"{LINEAR_ATTENTION}_0": num_lcm_blocks + 1,
         f"{LINEAR_ATTENTION}_1": num_lcm_blocks + 1,
@@ -104,7 +78,7 @@ def test_kimi_k3_pool_binds_mla_and_kda_to_one_lcm_backing() -> None:
     )
     assert (
         pool.kv_buffer[full_layer].untyped_storage().data_ptr()
-        == pool.buffer.untyped_storage().data_ptr()
+        == pool.arena.buffer.untyped_storage().data_ptr()
     )
     conv, recurrent = pool.get_state_buffers(state_layer)
     assert tuple(conv.shape[1:]) == conv_shape
@@ -112,65 +86,29 @@ def test_kimi_k3_pool_binds_mla_and_kda_to_one_lcm_backing() -> None:
     assert (
         conv.untyped_storage().data_ptr()
         == recurrent.untyped_storage().data_ptr()
-        == pool.buffer.untyped_storage().data_ptr()
+        == pool.arena.buffer.untyped_storage().data_ptr()
     )
 
 
 def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
-    from tokenspeed.runtime.layers.attention.kv_cache.factory import create_cache_pool
-    from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-        mla_cache_fields,
+    from tokenspeed.runtime.layers.attention.kv_cache.factory import (
+        create_cache_arena,
+        create_cache_pool,
     )
+    from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
     from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import CachePoolSpec
 
     text_config = KimiLinearConfig()
-    target_group_ids = kimi_k3_layer_group_ids(text_config)
-    target_layer_types = tuple(
-        FULL_ATTENTION if group_id == FULL_ATTENTION else LINEAR_ATTENTION
-        for group_id in target_group_ids
-    )
     num_draft_layers = 5
-    draft_layer_types = (FULL_ATTENTION,) * num_draft_layers
-    draft_fields = mla_cache_fields(
-        layer_group_ids=draft_layer_types,
-        prefix_granularity=128,
-        latent_width=576,
-        element_size=torch.bfloat16.itemsize,
-    )
-    plan = solve_kimi_k3_cache_layout(
-        text_config,
-        tp_size=8,
-        mla_cache_dtype=torch.float8_e4m3fn,
-        mla_quant_method=None,
-        draft_fields=draft_fields,
-        draft_layer_count=num_draft_layers,
-    ).with_num_lcm_blocks(1)
-    merged_layer_types = target_layer_types + draft_layer_types
-    merged_group_ids = target_group_ids + draft_layer_types
-    state_dtypes = {
-        f"layer.{layer_id}.conv_state": torch.bfloat16
-        for layer_id, layer_type in enumerate(target_layer_types)
-        if layer_type == LINEAR_ATTENTION
-    } | {
-        f"layer.{layer_id}.recurrent_state": torch.float32
-        for layer_id, layer_type in enumerate(target_layer_types)
-        if layer_type == LINEAR_ATTENTION
-    }
+    recipe, groups, layout = kimi_tp8_layout(draft_layers=num_draft_layers)
+    plan = layout.bind(1)
     merged_spec = CachePoolSpec(
         family="kimi_k3",
         memory_plan=plan,
-        layer_types=merged_layer_types,
-        layer_group_ids=merged_group_ids,
-        paged_cache_group_specs=build_paged_cache_group_specs(
-            layer_types=merged_layer_types,
-            group_ids=merged_group_ids,
-            sliding_window_tokens=None,
-            prefix_granularity=plan.prefix_granularity,
-            pd_disaggregation_enabled=False,
-        ),
-        state_field_dtypes=state_dtypes,
+        layer_types=recipe.layer_types,
+        layer_group_ids=recipe.group_ids,
+        cache_group_specs=tuple(spec for spec, _ in groups),
         token_capacity=128,
     )
     target_spec = merged_spec.layer_view(
@@ -181,7 +119,6 @@ def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
         first_layer=text_config.num_hidden_layers,
         num_layers=num_draft_layers,
         family="mla",
-        publish_runtime_contract=False,
     )
 
     common_config = dict(
@@ -214,44 +151,46 @@ def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
         is_draft=True,
         **common_config,
     )
+    arena = create_cache_arena(
+        merged_spec, device=target_config.device, enable_memory_saver=False
+    )
     target_pool = create_cache_pool(
         target_spec,
         target_config,
+        arena,
         num_layers=text_config.num_hidden_layers,
         rank=0,
-        enable_memory_saver=False,
     )
     draft_pool = create_cache_pool(
         draft_spec,
         draft_config,
+        arena,
         num_layers=num_draft_layers,
         rank=0,
-        enable_memory_saver=False,
         field_layer_offset=text_config.num_hidden_layers,
-        backing_pool=target_pool,
     )
 
     assert isinstance(target_pool, HybridKDATokenToKVPool)
     assert type(draft_pool) is MLATokenToKVPool
-    assert draft_pool.buffer is target_pool.buffer
-    assert draft_pool._fields is target_pool._fields
-    assert draft_pool.runtime_contract is target_pool.runtime_contract
+    assert draft_pool.arena is target_pool.arena
+    assert draft_pool.arena.buffer is target_pool.arena.buffer
+    assert draft_pool.arena.runtime_contract is target_pool.arena.runtime_contract
     target_cache = target_pool.get_key_buffer(text_config.full_attention_layer_ids[0])
     assert target_cache.dtype == torch.float8_e4m3fn
     assert draft_pool.get_key_buffer(0).dtype == torch.bfloat16
     assert (
         draft_pool.kv_buffer[0].data_ptr()
-        == target_pool.field("layer.93.latent_kv", torch.bfloat16).data_ptr()
+        == target_pool.arena.field("layer.93.latent_kv").data_ptr()
     )
-    assert set(target_pool._fields) == {
+    assert arena.field_ids() == {
         field.field_id for field in merged_spec.memory_plan.fields
     }
-    full_attention_segments = set(target_pool._block_byte_segments(FULL_ATTENTION, [1]))
+    full_attention_segments = set(arena.block_byte_segments(FULL_ATTENTION, [1]))
     for global_layer_id in range(93, 98):
         field_id = f"layer.{global_layer_id}.latent_kv"
         field = plan.field(field_id)
         assert (
-            target_pool._field_block_byte_offset(field_id, 1),
+            arena.field_block_byte_offset(field_id, 1),
             field.payload_bytes,
         ) in full_attention_segments
 
@@ -259,7 +198,6 @@ def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
     target_before = target_pool.kv_buffer[target_layer].clone()
     draft_pool.kv_buffer[0][1].fill_(1)
     assert torch.equal(target_pool.kv_buffer[target_layer], target_before)
+    # Both views name the one arena, so a clear through either zeros it.
     draft_pool.clear_kv_buffers()
-    assert torch.count_nonzero(draft_pool.kv_buffer[0])
-    target_pool.clear_kv_buffers()
     assert not torch.count_nonzero(draft_pool.kv_buffer[0])

--- a/test/runtime/test_kimi_k3_cache_spec.py
+++ b/test/runtime/test_kimi_k3_cache_spec.py
@@ -6,26 +6,13 @@ import sys
 _TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.dirname(_TEST_DIR))
 
-from test.runtime.conftest import TP8_PAGE_SET_BYTES
+from test.runtime.conftest import TP8_PAGE_SET_BYTES, kimi_tp8_layout
 
 import torch
 
-from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.kimi_k3 import (
-    kimi_k3_lcm_blocks_needed,
-    kimi_k3_token_capacity_for_cache_pool,
-    solve_kimi_k3_cache_layout,
-)
-
 
 def _plan(num_lcm_blocks: int, *, tp_size: int = 8):
-    layout = solve_kimi_k3_cache_layout(
-        KimiLinearConfig(),
-        tp_size=tp_size,
-        mla_cache_dtype=torch.float8_e4m3fn,
-        mla_quant_method=None,
-    )
-    return layout.with_num_lcm_blocks(num_lcm_blocks)
+    return kimi_tp8_layout(tp_size=tp_size)[2].bind(num_lcm_blocks)
 
 
 def test_lcm_reference_geometry_is_exact() -> None:
@@ -93,71 +80,36 @@ def test_lcm_geometry_packs_two_kda_pages_at_tp16() -> None:
 
 
 def test_lcm_parent_demand_uses_per_group_packing() -> None:
-    plan = _plan(300)
-    sizing = dict(
-        max_scheduled_tokens=8_192,
-        max_live_requests=1,
-        decode_input_tokens=1,
-        overlap_schedule_depth=0,
-    )
+    recipe, _, layout = kimi_tp8_layout(max_bs=1, max_scheduled_tokens=8_192)
 
-    assert kimi_k3_lcm_blocks_needed(plan, token_capacity=131_072, **sizing) == 284
-    assert (
-        kimi_k3_token_capacity_for_cache_pool(
-            plan,
-            num_lcm_blocks=284,
-            upper_bound_tokens=131_072,
-            **sizing,
-        )
-        == 131_072
-    )
-    assert (
-        kimi_k3_token_capacity_for_cache_pool(
-            plan,
-            num_lcm_blocks=283,
-            upper_bound_tokens=131_072,
-            **sizing,
-        )
-        < 131_072
-    )
+    # 131_072 tokens at this concurrency needs exactly 284 parents; the search
+    # inverts that demand -- what 284 parents admit needs no more than 284,
+    # and one parent fewer admits strictly less.
+    assert recipe.parents_needed(layout, 131_072) == 284
+    admitted = recipe.token_capacity(layout, 284)
+    assert admitted >= 131_072
+    assert recipe.parents_needed(layout, admitted) <= 284
+    assert recipe.token_capacity(layout, 283) < admitted
 
 
 def test_k3_merged_solve_with_draft_shares_page_ids():
     """One big model: five BF16 draft MLA layers join the K3 solve as
     continuation layers 93-97 in the full_attention group — same packing/page-id
     space, one plan, one arena."""
-    import torch
-
-    from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-        mla_cache_fields,
-    )
-
-    draft_fields = mla_cache_fields(
-        layer_group_ids=("full_attention",) * 5,
-        prefix_granularity=128,
-        latent_width=576,
-        element_size=torch.bfloat16.itemsize,
-    )
-    merged = solve_kimi_k3_cache_layout(
-        KimiLinearConfig(),
-        tp_size=8,
-        mla_cache_dtype=torch.float8_e4m3fn,
-        mla_quant_method=None,
-        draft_fields=draft_fields,
-        draft_layer_count=5,
-    )
+    _, _, merged = kimi_tp8_layout(draft_layers=5)
     # 24 target MLA planes + 5 draft continuation planes.
     assert len(merged.plane_bytes) == 29
     assert dict(merged.group_packing)["full_attention"] == 12
-    plan = merged.with_num_lcm_blocks(7)
+    plan = merged.bind(7)
     target_field = plan.field("layer.3.latent_kv")
     assert target_field.element_size == 1
     target_plane_ids = {f"slot.{slot}" for slot in range(24)}
-    for global_layer_id in range(93, 98):
+    for draft_index, global_layer_id in enumerate(range(93, 98)):
         draft_field = plan.field(f"layer.{global_layer_id}.latent_kv")
         assert draft_field.group_id == target_field.group_id == "full_attention"
-        assert draft_field.plane_id == f"slot.{global_layer_id}"
+        # Planes number by tenancy, not by layer id: the draft layers are the
+        # group's 25th..29th tenants, continuing the target's slot.0..23.
+        assert draft_field.plane_id == f"slot.{24 + draft_index}"
         assert draft_field.plane_id not in target_plane_ids
         assert draft_field.element_size == 2
         assert draft_field.page_stride_bytes == 2 * target_field.page_stride_bytes
@@ -171,19 +123,7 @@ def test_k3_binding_utilization_with_real_bf16_draft_geometry():
     """Binding-hole metric on real K3 geometry: full bindings use
     the whole parent; state bindings use 88.2%, dropping to ~62.2% when the
     five BF16 draft planes widen the parent."""
-    import torch
-
-    from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
-    from tokenspeed.runtime.layers.attention.kv_cache.recipes.ordinary import (
-        mla_cache_fields,
-    )
-
-    base = solve_kimi_k3_cache_layout(
-        KimiLinearConfig(),
-        tp_size=8,
-        mla_cache_dtype=torch.float8_e4m3fn,
-        mla_quant_method=None,
-    ).with_num_lcm_blocks(10)
+    base = kimi_tp8_layout()[2].bind(10)
     report = base.capacity_report()
     assert abs(report["full_attention"]["binding_utilization"] - 1.0) < 1e-3
     for k in range(3):
@@ -191,20 +131,8 @@ def test_k3_binding_utilization_with_real_bf16_draft_geometry():
             abs(report[f"linear_attention_{k}"]["binding_utilization"] - 0.882) < 1e-3
         )
 
-    draft_fields = mla_cache_fields(
-        layer_group_ids=("full_attention",) * 5,
-        prefix_granularity=128,
-        latent_width=576,
-        element_size=torch.bfloat16.itemsize,
-    )
-    merged = solve_kimi_k3_cache_layout(
-        KimiLinearConfig(),
-        tp_size=8,
-        mla_cache_dtype=torch.float8_e4m3fn,
-        mla_quant_method=None,
-        draft_fields=draft_fields,
-        draft_layer_count=5,
-    ).with_num_lcm_blocks(10)
+    merged = kimi_tp8_layout(draft_layers=5)[2]
+    merged = merged.bind(10)
     widened = merged.capacity_report()
     assert abs(widened["full_attention"]["binding_utilization"] - 1.0) < 1e-3
     assert abs(widened["linear_attention_0"]["binding_utilization"] - 0.6224) < 1e-3

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -621,17 +621,9 @@ class KimiK3LcmPlanTests(unittest.TestCase):
 
     @staticmethod
     def _plan(cfg, tp):
-        from tokenspeed.runtime.layers.attention.kv_cache.recipes.kimi_k3 import (
-            solve_kimi_k3_cache_layout,
-        )
+        from test.runtime.conftest import kimi_tp8_layout
 
-        layout = solve_kimi_k3_cache_layout(
-            cfg,
-            tp_size=tp,
-            mla_cache_dtype=torch.float8_e4m3fn,
-            mla_quant_method=None,
-        )
-        return layout.with_num_lcm_blocks(64)
+        return kimi_tp8_layout(text_config=cfg, tp_size=tp)[2].bind(64)
 
     def test_linear_packing_scales_with_attn_tp(self):
         """KDA pages pack into an MLA-sized plane, so tp=16 -- where the KDA
@@ -681,9 +673,9 @@ class KimiK3LcmPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "69 KDA and 24 MLA"):
             self._plan(cfg, 8)
 
-    def test_kda_group_split_must_divide(self):
-        """A KDA layer count that does not split into the fixed state groups
-        is rejected loudly."""
+    def test_reduced_layer_split_must_ride_inside_the_mla_planes(self):
+        """A reduced-layer variant whose KDA groups need a plane of their own
+        is rejected loudly: 5 MLA layers cannot host 6 KDA slots."""
         base = KimiLinearConfig()
         linear = dict(base.linear_attn_config)
         num_layers = 23  # 17 KDA layers: not divisible by 3

--- a/test/runtime/test_kimi_k3_cudagraph.py
+++ b/test/runtime/test_kimi_k3_cudagraph.py
@@ -156,17 +156,17 @@ class _StubFullAttnMeta:
         return self._table
 
     def kernel_table(
-        self, group_id=None, *, page_size, max_pages=None, active_forward_op
+        self, group_id=None, *, kernel_page_size, max_pages=None, active_forward_op
     ):
         if active_forward_op is not self._forward_op:
             raise RuntimeError("stale forward op")
-        key = (group_id, page_size, max_pages)
+        key = (group_id, kernel_page_size, max_pages)
         cached = self._kernel_tables.get(key)
         if cached is None:
             cached = expand_page_table(
                 self._table,
                 block_granularity=self.prefix_granularity,
-                kernel_page_size=page_size,
+                kernel_page_size=kernel_page_size,
                 max_kernel_pages=max_pages,
             )
             self._kernel_tables[key] = cached

--- a/test/runtime/test_kimi_k3_integration.py
+++ b/test/runtime/test_kimi_k3_integration.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 from tokenspeed.runtime.engine.scheduler_utils import (
-    pool_to_paged_cache_groups,
+    pool_to_cache_groups,
     scheduler_cache_geometry_from_pool,
 )
 
@@ -18,15 +18,11 @@ from tokenspeed.runtime.engine.scheduler_utils import (
 def test_scheduler_uses_lcm_parents_and_per_group_child_counts() -> None:
     pool = make_kimi_pool("cpu", usable_pages=2)
 
-    geometry = scheduler_cache_geometry_from_pool(
-        pool,
-        fallback_token_capacity=pool.size,
-        fallback_prefix_granularity=pool.prefix_granularity,
-    )
+    geometry = scheduler_cache_geometry_from_pool(pool)
     assert geometry.num_usable_pages == 2
     assert geometry.num_device_pages == 3
     assert geometry.prefix_granularity == 128
-    groups = pool_to_paged_cache_groups(pool)
+    groups = pool_to_cache_groups(pool)
     assert {group.group_id for group in groups} == set(KIMI_GROUP_IDS)
     assert {group.group_id: group.total_pages for group in groups} == {
         "full_attention": 25,
@@ -42,7 +38,7 @@ def test_metadata_validates_each_groups_own_page_range() -> None:
         "full_attention": np.array([[24]], dtype=np.int32),
         "linear_attention_0": np.array([[2]], dtype=np.int32),
     }
-    metadata, forward_op = cache_metadata_for(pool.runtime_contract, valid, "cpu")
+    metadata, forward_op = cache_metadata_for(pool.arena.runtime_contract, valid, "cpu")
     assert metadata.max_page_ids == {
         "full_attention": 24,
         "linear_attention_0": 2,
@@ -55,7 +51,7 @@ def test_metadata_validates_each_groups_own_page_range() -> None:
 
     with pytest.raises(ValueError, match="outside -1..2"):
         cache_metadata_for(
-            pool.runtime_contract,
+            pool.arena.runtime_contract,
             {"linear_attention_0": np.array([[3]], dtype=np.int32)},
             "cpu",
         )

--- a/test/runtime/test_kimi_k3_kda.py
+++ b/test/runtime/test_kimi_k3_kda.py
@@ -1,4 +1,4 @@
-"""Kimi-K3 KDA recurrent state on the paged-cache contract path.
+"""Kimi-K3 KDA recurrent state on the cache contract path.
 
 Coverage:
 
@@ -59,10 +59,10 @@ from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
     compute_state_block_indices,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.cache_runtime import (
-    PagedCacheRuntimeContract,
+    CacheRuntimeContract,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-    PagedCacheGroupSpec,
+    CacheGroupSpec,
 )
 
 register_cuda_ci(est_time=240, suite="runtime-1gpu")
@@ -98,7 +98,7 @@ def _stub_contract(*, prefix_granularity: int, usable_pages: int):
     group_ids = ("full_attention", *_STATE_GROUPS)
     specs = tuple(
         (
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id=group_id,
                 retention="full_history",
                 rows_per_page=prefix_granularity,
@@ -106,7 +106,7 @@ def _stub_contract(*, prefix_granularity: int, usable_pages: int):
                 sliding_window_tokens=None,
             )
             if group_id == "full_attention"
-            else PagedCacheGroupSpec(
+            else CacheGroupSpec(
                 group_id=group_id,
                 retention="full_history",
                 sliding_window_tokens=None,
@@ -116,12 +116,13 @@ def _stub_contract(*, prefix_granularity: int, usable_pages: int):
         )
         for group_id in group_ids
     )
-    return PagedCacheRuntimeContract(
+    return CacheRuntimeContract(
         prefix_granularity=prefix_granularity,
         num_lcm_blocks=usable_pages,
         token_capacity=usable_pages * prefix_granularity,
         group_specs=specs,
         group_page_counts={spec.group_id: usable_pages + 1 for spec in specs},
+        group_packing={spec.group_id: 1 for spec in specs},
     )
 
 
@@ -130,7 +131,8 @@ class _StubContractPool:
     conv/recurrent component slabs indexed by page id (page 0 = null)."""
 
     def __init__(self, contract, device, conv_dim, width, num_heads, head_dim):
-        self.runtime_contract = contract
+        # The arena publishes the contract; a view only names its arena.
+        self.arena = SimpleNamespace(runtime_contract=contract)
         num_pages = contract.group_page_counts[_STATE_GROUPS[0]]
         self._groups = {i: _STATE_GROUPS[i] for i in range(3)}
         self._components = {
@@ -197,7 +199,7 @@ def test_set_kv_pool_binds_contract_state_groups() -> None:
     backend = _backend("cpu", contract_pool=pool)
     assert backend.state_paging_active
     assert backend._state_group_ids == _STATE_GROUPS
-    assert backend._checkpoint_granularity == pool.prefix_granularity
+    assert backend._checkpoint_granularity == pool.arena.prefix_granularity
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +226,7 @@ def test_dual_index_reuses_one_slot_plan_and_groups_are_independent(
 ) -> None:
     pool = _make_kimi_pool("cpu", usable_pages=24)
     backend = _backend("cpu", contract_pool=pool)
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
 
     plan_calls = 0
     real = hybrid_linear_attn._compute_state_block_index_plan
@@ -238,7 +240,7 @@ def test_dual_index_reuses_one_slot_plan_and_groups_are_independent(
 
     bs = 2
     tables = _kimi_tables(bs, width=2)
-    metadata, forward_op = _metadata_for(pool.runtime_contract, tables, "cpu")
+    metadata, forward_op = _metadata_for(pool.arena.runtime_contract, tables, "cpu")
     # Decode: request 0 crosses into its second page, request 1 stays inside
     # its first page.
     seq_lens = torch.tensor([page_size + 1, 5], dtype=torch.int32)
@@ -295,7 +297,7 @@ def test_cuda_graph_replay_refreshes_buffers_in_place() -> None:
     }
     # Distinct per-group tables so the refresh is provably group-specific.
     tables = _kimi_tables(bs=2, width=4, base=1)
-    metadata, forward_op = _metadata_for(pool.runtime_contract, tables, "cpu")
+    metadata, forward_op = _metadata_for(pool.arena.runtime_contract, tables, "cpu")
     # bs 2 requests, one padding row (real_bs 1). Decode: before = seq-1.
     backend.init_forward_metadata_replay_cuda_graph(
         bs=2,
@@ -315,7 +317,7 @@ def test_cuda_graph_replay_refreshes_buffers_in_place() -> None:
         # Real row 0 refreshed from this group's table; padded row 1 -> pad.
         expected_in, _ = compute_state_block_indices(
             torch.as_tensor(tables[gid][:1]),
-            pool.runtime_contract.prefix_granularity,
+            pool.arena.runtime_contract.prefix_granularity,
             torch.tensor([4]),  # before = seq_len 5 - 1
             torch.tensor([5]),
             validate=False,
@@ -788,7 +790,7 @@ def test_kda_cache_pool_component_views_end_to_end(
     through the conv + KDA kernels: prefill + decodes on one KDA layer of
     each of the three groups, vs naive + FLA."""
     pool = _make_kimi_pool("cuda", usable_pages=4)
-    contract = pool.runtime_contract
+    contract = pool.arena.runtime_contract
     layer_ids = [_kda_layer_for_group(pool, gid) for gid in _STATE_GROUPS]
 
     # Kimi TP8 geometry: 12 heads, D=128, conv_dim 4608.

--- a/test/runtime/test_kimi_k3_mla.py
+++ b/test/runtime/test_kimi_k3_mla.py
@@ -94,7 +94,7 @@ def test_bridge_exposes_full_attention_group_and_block_size() -> None:
     metadata, forward_op = _metadata_for(pool, table, "cpu")
 
     assert metadata.full_attention_group_id == "full_attention"
-    assert metadata.block_granularity == pool.prefix_granularity
+    assert metadata.block_granularity == pool.arena.prefix_granularity
     resolved = metadata.require_full_attention_table(active_forward_op=forward_op)
     assert torch.equal(resolved, torch.tensor(table, dtype=torch.int32))
 
@@ -110,15 +110,16 @@ def test_bridge_exposes_full_attention_group_and_block_size() -> None:
 def test_pool_mla_views_are_no_copy_and_layer_gated() -> None:
     pool = _make_pool("cpu", usable_pages=2)
     layer_id = _mla_layer_id(pool)
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
 
     key = pool.get_key_buffer(layer_id)
-    component = pool.get_component(layer_id, "latent_kv")
 
     assert key.shape == ((2 * 12 + 1) * page_size, 1, _LATENT_DIM)
     assert key.dtype == torch.float8_e4m3fn
-    assert key.data_ptr() == component.data_ptr()
-    assert key.untyped_storage().data_ptr() == pool.buffer.untyped_storage().data_ptr()
+    assert (
+        key.untyped_storage().data_ptr()
+        == pool.arena.buffer.untyped_storage().data_ptr()
+    )
 
     value = pool.get_value_buffer(layer_id)
     assert value.shape[-1] == _KV_LORA_RANK
@@ -127,8 +128,12 @@ def test_pool_mla_views_are_no_copy_and_layer_gated() -> None:
     assert key2.data_ptr() == key.data_ptr()
     assert value2.shape == value.shape
 
+    # The two surfaces are layer-gated in both directions: latent KV is read
+    # through the kv buffers, KDA state only through get_component.
     with pytest.raises(ValueError, match="state layer"):
         pool.get_key_buffer(_kda_layer_id(pool))
+    with pytest.raises(ValueError, match="no KDA state"):
+        pool.get_component(layer_id, "latent_kv")
 
 
 @requires_cuda
@@ -138,8 +143,14 @@ def test_pool_write_location_oracle_page_id_times_p_plus_offset() -> None:
     pool = _make_pool("cuda", usable_pages=3)
     layer_id = _mla_layer_id(pool)
     layer = _fake_layer(layer_id)
-    page_size = pool.prefix_granularity
-    component = pool.get_component(layer_id, "latent_kv")
+    page_size = pool.arena.prefix_granularity
+    # Page contiguity is a plan invariant (exact_page_stride), so the flat slot
+    # view folds into pages -- which is the oracle under test.
+    paged_latent = (
+        pool.get_key_buffer(layer_id)
+        .view(torch.uint8)
+        .view(-1, page_size, 1, _LATENT_DIM)
+    )
 
     # Page-boundary coverage: last slot of page 1, first slot of page 2,
     # interior of page 3.
@@ -156,11 +167,11 @@ def test_pool_write_location_oracle_page_id_times_p_plus_offset() -> None:
 
     expected = latent.to(torch.float8_e4m3fn).view(torch.uint8)
     for row, (page, off) in enumerate([(1, page_size - 1), (2, 0), (3, 7)]):
-        got_bytes = component[page, off, 0]
+        got_bytes = paged_latent[page, off, 0]
         assert torch.equal(got_bytes, expected[row, 0]), (page, off)
 
     # Null page 0 must stay untouched.
-    assert torch.count_nonzero(component[0]).item() == 0
+    assert torch.count_nonzero(paged_latent[0]).item() == 0
 
     # Round-trip through the read adapter.
     nope, rope = pool.get_mla_kv_buffer(layer, locs, torch.bfloat16)
@@ -224,7 +235,7 @@ def backend_factory(cuda_env, gpu_pool):
             kv_cache_dtype=torch.float8_e4m3fn,
             prefix_granularity=_KERNEL_PAGE,
             kernel_page_size=_KERNEL_PAGE,
-            context_len=4 * gpu_pool.prefix_granularity,
+            context_len=4 * gpu_pool.arena.prefix_granularity,
             max_bs=8,
             max_graph_bs=8,
             kv_cache_quant_method="",
@@ -244,7 +255,7 @@ def backend_factory(cuda_env, gpu_pool):
 
 def _write_history(pool, layer, logical_rows, lengths, seed=0):
     torch.manual_seed(seed)
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     for pages, length in zip(logical_rows, lengths):
         positions = torch.arange(length, device="cuda", dtype=torch.int64)
         locs = _token_locs(pages, positions, page_size)
@@ -283,7 +294,7 @@ def test_decode_grouped_matches_single_table_and_reference(
     backend_factory, gpu_pool
 ) -> None:
     pool = gpu_pool
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     layer = _fake_layer(_mla_layer_id(pool), scaling=_LATENT_DIM**-0.5)
     # req0 crosses a logical page boundary; req1 ends exactly at one.
     logical_rows = [[2, 4], [1, -1]]
@@ -354,7 +365,7 @@ def test_decode_grouped_writes_land_at_group_locations(
     """forward_decode(save_kv_cache=True) writes via grouped locationations, not the
     caller's page_table-derived out_cache_loc."""
     pool = gpu_pool
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     layer = _fake_layer(_mla_layer_id(pool))
     logical_rows = [[3, 5]]
     seq_lens_cpu = [page_size + 41]
@@ -410,7 +421,7 @@ def _init_prefill(backend, pool, logical_rows, prefix, extend, *, grouped: bool)
         backend.init_forward_metadata(
             req_pool_indices=torch.arange(bs, device="cuda", dtype=torch.int64),
             page_table=_kernel_page_table(
-                logical_rows, pool.prefix_granularity, "cuda"
+                logical_rows, pool.arena.prefix_granularity, "cuda"
             ),
             **kwargs,
         )
@@ -426,7 +437,7 @@ def test_chunked_prefill_grouped_matches_single_table_and_reference(
     from tokenspeed.runtime.utils.pdl import pdl_enabled
 
     pool = gpu_pool
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     layer = _fake_layer(_mla_layer_id(pool), scaling=192**-0.5)
     # req0's prefix crosses a page boundary mid-page; req1's prefix ends
     # exactly on one, and its extend tokens cross into a fresh page.
@@ -561,7 +572,7 @@ def test_path_never_reads_page_table(backend_factory, gpu_pool) -> None:
     from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 
     pool = gpu_pool
-    page_size = pool.prefix_granularity
+    page_size = pool.arena.prefix_granularity
     logical_rows = [[2, 5], [4, -1]]
     seq_lens_cpu = [page_size + 3, 9]
     backend = backend_factory()

--- a/test/runtime/test_lcm_scheduler_geometry.py
+++ b/test/runtime/test_lcm_scheduler_geometry.py
@@ -3,46 +3,39 @@ from types import SimpleNamespace
 from tokenspeed.runtime.engine.scheduler_utils import scheduler_cache_geometry_from_pool
 
 
-def test_lcm_scheduler_geometry_counts_parents_not_child_pages():
-    pool = SimpleNamespace(runtime_contract=None, num_lcm_blocks=37)
+def _pool(*, num_lcm_blocks: int, prefix_granularity: int, token_capacity: int):
+    """A pool whose arena published the contract, the only geometry source."""
+    return SimpleNamespace(
+        arena=SimpleNamespace(
+            runtime_contract=SimpleNamespace(
+                num_lcm_blocks=num_lcm_blocks,
+                prefix_granularity=prefix_granularity,
+                token_capacity=token_capacity,
+            )
+        )
+    )
 
+
+def test_lcm_scheduler_geometry_counts_parents_not_child_pages():
+    # The scheduler pages are LCM parents; a group's child pages are its own
+    # per-group count, not this number.
     geometry = scheduler_cache_geometry_from_pool(
-        pool,
-        fallback_token_capacity=37 * 8 * 128,
-        fallback_prefix_granularity=128,
+        _pool(num_lcm_blocks=37, prefix_granularity=128, token_capacity=37 * 8 * 128)
     )
 
     assert geometry.prefix_granularity == 128
+    # Parent 0 is the reserved null LCM block.
     assert geometry.num_device_pages == 38
     assert geometry.num_usable_pages == 37
     assert geometry.token_capacity == 37 * 8 * 128
 
 
 def test_lcm_scheduler_geometry_uses_contract_token_capacity():
-    contract = SimpleNamespace(
-        num_lcm_blocks=37,
-        prefix_granularity=128,
-        token_capacity=10_000,
-    )
-    pool = SimpleNamespace(runtime_contract=contract, num_lcm_blocks=37)
-
+    # Capacity comes from the contract, never re-derived from parents times a
+    # packing guess.
     geometry = scheduler_cache_geometry_from_pool(
-        pool,
-        fallback_token_capacity=37 * 12 * 128,
-        fallback_prefix_granularity=128,
+        _pool(num_lcm_blocks=37, prefix_granularity=128, token_capacity=10_000)
     )
 
     assert geometry.num_usable_pages == 37
     assert geometry.token_capacity == 10_000
-
-
-def test_ordinary_scheduler_geometry_adds_the_null_page():
-    geometry = scheduler_cache_geometry_from_pool(
-        SimpleNamespace(runtime_contract=None),
-        fallback_token_capacity=4 * 64,
-        fallback_prefix_granularity=64,
-    )
-
-    assert geometry.num_device_pages == 5
-    assert geometry.num_usable_pages == 4
-    assert geometry.token_capacity == 4 * 64

--- a/test/runtime/test_mha_pool_spec_decode_groups.py
+++ b/test/runtime/test_mha_pool_spec_decode_groups.py
@@ -52,7 +52,7 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
         kwargs.update(overrides)
         from cache_pool_test_utils import make_layer_group_ids
 
-        kwargs["memory_plan"] = make_mha_memory_plan(
+        plan = make_mha_memory_plan(
             size=kwargs["size"],
             prefix_granularity=kwargs["prefix_granularity"],
             layer_num=kwargs["layer_num"],
@@ -70,13 +70,11 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
                 sliding_window_tokens=kwargs.get("sliding_window_tokens"),
             ),
         )
-        from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-            build_paged_cache_group_specs,
-        )
+        from cache_pool_test_utils import specs_for_layers
 
         kwargs.setdefault(
-            "paged_cache_group_specs",
-            build_paged_cache_group_specs(
+            "cache_group_specs",
+            specs_for_layers(
                 layer_types=kwargs.get("layer_types", ()),
                 group_ids=kwargs["layer_group_ids"],
                 sliding_window_tokens=kwargs.get("sliding_window_tokens"),
@@ -84,21 +82,27 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
             ),
         )
         kwargs.pop("sliding_window_tokens", None)
-        return self.MHATokenToKVPool(**kwargs)
+        device = kwargs.pop("device")
+        for owned_by_arena in ("size", "prefix_granularity", "enable_memory_saver"):
+            kwargs.pop(owned_by_arena, None)
+        from cache_pool_test_utils import make_pool
+
+        _, pool = make_pool(self.MHATokenToKVPool, plan, device=device, **kwargs)
+        return pool
 
     def test_plain_no_spec_publishes_single_full_group(self):
         # The scheduler allocates pages only through configured groups, so
         # plain models keep one full-history group published.
         pool = self._pool()
-        self.assertEqual(len(pool.paged_cache_group_specs), 1)
-        spec = pool.paged_cache_group_specs[0]
+        self.assertEqual(len(pool.arena.cache_group_specs), 1)
+        spec = pool.arena.cache_group_specs[0]
         self.assertEqual(spec.group_id, "full_attention")
         self.assertEqual(spec.retention, "full_history")
-        self.assertIn("full_attention", pool.paged_cache_group_page_counts)
-        self.assertIsNotNone(pool.buffer)
+        self.assertIn("full_attention", pool.arena.cache_group_page_counts)
+        self.assertIsNotNone(pool.arena.buffer)
         self.assertEqual(
             pool.k_buffer[0].untyped_storage().data_ptr(),
-            pool.buffer.untyped_storage().data_ptr(),
+            pool.arena.buffer.untyped_storage().data_ptr(),
         )
 
     def test_hybrid_no_spec_publishes_two_groups(self):
@@ -110,11 +114,11 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
             layer_num=len(GPT_OSS_LAYER_TYPES),
         )
         self.assertEqual(
-            {s.group_id for s in pool.paged_cache_group_specs},
+            {s.group_id for s in pool.arena.cache_group_specs},
             {"full_attention", "sliding_attention"},
         )
         self.assertEqual(
-            set(pool.paged_cache_group_page_counts),
+            set(pool.arena.cache_group_page_counts),
             {"full_attention", "sliding_attention"},
         )
 

--- a/test/runtime/test_mla_cache_group_id.py
+++ b/test/runtime/test_mla_cache_group_id.py
@@ -12,7 +12,7 @@ register_cuda_ci(est_time=5, suite="runtime-1gpu")
 
 from tokenspeed.runtime.layers.paged_attention import (  # noqa: E402
     PagedAttention,
-    validate_paged_cache_group_ids,
+    validate_cache_group_ids,
 )
 
 
@@ -51,9 +51,9 @@ class TestMlaCacheGroupId(unittest.TestCase):
         specs = (_Spec(FULL_ATTENTION), _Spec("linear_attention"))
         model = _Model()
         with self.assertRaises(ValueError):
-            validate_paged_cache_group_ids(model, specs)
+            validate_cache_group_ids(model, specs)
         model.attn.group_id = FULL_ATTENTION
-        validate_paged_cache_group_ids(model, specs)  # must not raise
+        validate_cache_group_ids(model, specs)  # must not raise
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_multi_window_page_counts.py
+++ b/test/runtime/test_multi_window_page_counts.py
@@ -44,7 +44,7 @@ _RUNTIME_DIR = (
 _KV_CACHE_DIR = _RUNTIME_DIR / "layers" / "attention" / "kv_cache"
 _RECIPES_DIR = _KV_CACHE_DIR / "recipes"
 
-# compute_paged_cache_group_page_counts lazily imports ceil_div from
+# compute_cache_group_page_counts lazily imports ceil_div from
 # tokenspeed.runtime.utils.common, whose package pulls torch/psutil. Prefer the
 # real module (container runs); register a minimal equivalent only where the
 # runtime deps are absent, so the pure math stays testable everywhere.
@@ -69,14 +69,41 @@ def _load(mod_name: str, file_path: pathlib.Path):
 # spec.py is self-contained: load it from the repo file under a private
 # name (no real package import, no sys.modules shadowing needed).
 _pcs = _load("kv_cache_spec_for_page_counts", _RECIPES_DIR / "spec.py")
-compute_paged_cache_group_page_counts = _pcs.compute_paged_cache_group_page_counts
-group_specs_from_layer_types = _pcs.group_specs_from_layer_types
-PagedCacheGroupSpec = _pcs.PagedCacheGroupSpec
-DUMMY = _pcs._PAGED_CACHE_GROUP_DUMMY_PAGES
+compute_cache_group_page_counts = _pcs.compute_cache_group_page_counts
+CacheGroupSpec = _pcs.CacheGroupSpec
+_pcs.CacheFieldSpec = _load(
+    "kv_cache_plan_for_page_counts", _RECIPES_DIR / "plan.py"
+).CacheFieldSpec
+
+
+def _group_specs(module, **kwargs):
+    """The specs a layer vocabulary produces, via the one-walk ``group``.
+
+    A group must declare fields, so a one-byte placeholder stands in: these
+    tests are about scheduler semantics, not bytes.
+    """
+    return tuple(
+        group_spec
+        for group_spec, _ in module.group(
+            fields_for_layer=lambda layer_id, group_id, occurrence: (
+                module.CacheFieldSpec(
+                    f"layer.{layer_id}.probe", f"unit.{occurrence}", (1,), "uint8"
+                ),
+            ),
+            **kwargs,
+        )
+    )
+
+
+def group_specs_from_layer_types(**kwargs):
+    return _group_specs(_pcs, **kwargs)
+
+
+DUMMY = _pcs._CACHE_GROUP_DUMMY_PAGES
 
 
 def _spec(group_id, retention, window=None, rows_per_page=64):
-    return PagedCacheGroupSpec(
+    return CacheGroupSpec(
         group_id=group_id,
         retention=retention,
         rows_per_page=rows_per_page,
@@ -96,7 +123,7 @@ class MultiWindowPageCountsTest(unittest.TestCase):
             max_context_len=4096,
         )
         defaults.update(kw)
-        return compute_paged_cache_group_page_counts(specs, **defaults)
+        return compute_cache_group_page_counts(specs, **defaults)
 
     def test_each_window_budgets_independently(self):
         counts = self.counts(
@@ -170,7 +197,7 @@ class SuffixedGroupIdFlowTest(unittest.TestCase):
             [s.group_id for s in specs],
             ["full_attention", "sliding_attention_128", "sliding_attention_4"],
         )
-        counts = compute_paged_cache_group_page_counts(
+        counts = compute_cache_group_page_counts(
             specs,
             max_live_requests=4,
             max_scheduled_tokens=512,

--- a/test/runtime/test_multimodal_mrope.py
+++ b/test/runtime/test_multimodal_mrope.py
@@ -23,19 +23,22 @@ class _Qwen35Config:
 
 @pytest.mark.parametrize("num_extends", [0, 1])
 def test_text_only_mrope_positions_copy_linear_positions_directly(num_extends):
-    model_executor = pytest.importorskip(
-        "tokenspeed.runtime.execution.model_executor", exc_type=ImportError
+    """With no multimodal inputs, all three M-RoPE axes are the linear
+    positions -- and the override is a view of the graph-stable buffer, so a
+    captured forward reads the values this write produced."""
+    runtime = pytest.importorskip(
+        "tokenspeed.runtime.execution.multimodal_runtime", exc_type=ImportError
     )
-    executor = object.__new__(model_executor.ModelExecutor)
-    executor.config = SimpleNamespace(model_is_mrope=True)
-    executor.input_buffers = SimpleNamespace(
+    mm_runtime = object.__new__(runtime.MultimodalRuntime)
+    mm_runtime.model_is_mrope = True
+    mm_runtime.input_buffers = SimpleNamespace(
         positions_buf=torch.arange(4, dtype=torch.int64),
         mrope_positions_buf=torch.empty((3, 4), dtype=torch.int64),
     )
     forward_op = SimpleNamespace(num_extends=lambda: num_extends)
 
-    positions = executor._build_mrope_positions_override(
-        forward_op,
+    positions = mm_runtime.build_positions_override(
+        forward_op=forward_op,
         multimodal_context=None,
         total_tokens=4,
     )
@@ -43,6 +46,9 @@ def test_text_only_mrope_positions_copy_linear_positions_directly(num_extends):
     assert torch.equal(
         positions,
         torch.arange(4, dtype=torch.int64).unsqueeze(0).expand(3, -1),
+    )
+    assert (
+        positions.data_ptr() == mm_runtime.input_buffers.mrope_positions_buf.data_ptr()
     )
 
 

--- a/test/runtime/test_mxfp8_kv_pool.py
+++ b/test/runtime/test_mxfp8_kv_pool.py
@@ -40,24 +40,14 @@ LAYERS = 2
 
 
 def _make_pool(page_size: int, size: int = 512):
-    from cache_pool_test_utils import make_mha_memory_plan
+    from cache_pool_test_utils import make_arena, make_mha_memory_plan
 
     from tokenspeed.runtime.layers.attention.kv_cache.mha import (
         MHATokenToKVPoolMXFP8,
     )
 
-    return MHATokenToKVPoolMXFP8(
-        size=size,
-        dtype=torch.bfloat16,
-        head_num=HEADS,
-        head_dim=HEAD_DIM,
-        layer_num=LAYERS,
-        device="cuda",
-        enable_memory_saver=False,
-        prefix_granularity=page_size,
-        rank=0,
-        layer_group_ids=("full_attention",) * LAYERS,
-        memory_plan=make_mha_memory_plan(
+    arena = make_arena(
+        make_mha_memory_plan(
             size=size,
             prefix_granularity=page_size,
             layer_num=LAYERS,
@@ -65,7 +55,16 @@ def _make_pool(page_size: int, size: int = 512):
             head_dim=HEAD_DIM,
             dtype=torch.bfloat16,
             mxfp8=True,
-        ),
+        )
+    )
+    return MHATokenToKVPoolMXFP8(
+        arena,
+        dtype=torch.bfloat16,
+        head_num=HEADS,
+        head_dim=HEAD_DIM,
+        layer_num=LAYERS,
+        rank=0,
+        layer_group_ids=("full_attention",) * LAYERS,
     )
 
 
@@ -85,17 +84,18 @@ def _dequant(q: torch.Tensor, sf: torch.Tensor) -> torch.Tensor:
     return q.to(torch.float32) * scale
 
 
-@pytest.mark.parametrize("page_size", [128, 64])
-def test_store_and_roundtrip(page_size: int):
+def test_store_and_roundtrip():
+    """The mxfp8 pool is a P=128 pool; no recipe can plan its scales at any
+    other grain (test_config_rejects_non_128_page asserts the rejection)."""
     torch.manual_seed(0)
-    pool = _make_pool(page_size)
+    pool = _make_pool(128)
     layer = SimpleNamespace(layer_id=1)
 
     T = 96
     kv = torch.randn(T, HEADS, HEAD_DIM, device="cuda", dtype=torch.bfloat16)
     k_q, k_sf = _quantize(kv)
     v_q, v_sf = _quantize(kv * 0.5)
-    loc = torch.randperm(pool.size, device="cuda")[:T].to(torch.int64)
+    loc = torch.randperm(pool.arena.size, device="cuda")[:T].to(torch.int64)
 
     pool.set_kv_buffer(layer, loc, k_q, v_q, k_scale=k_sf, v_scale=v_sf)
 
@@ -104,24 +104,20 @@ def test_store_and_roundtrip(page_size: int):
     assert torch.equal(pool.v_buffer[1][loc].view(torch.uint8), v_q.view(torch.uint8))
 
     # Scales land in the layout's documented position.
-    k_sfbuf, v_sfbuf = pool.get_kv_scale_buffer(1)
-    if page_size == 128:
-        u32 = k_sfbuf.view(torch.uint8).reshape(-1, HEADS, 128, 4).view(torch.int32)
-        src = (
-            k_sf.view(torch.uint8)
-            .reshape(T, HEADS, 4)
-            .contiguous()
-            .view(torch.int32)
-            .reshape(T, HEADS)
-        )
-        for t in range(0, T, 17):  # sample positions
-            slot = int(loc[t])
-            page, off = divmod(slot, 128)
-            pos = (off % 32) * 4 + (off // 32)
-            assert torch.equal(u32[page, :, pos, 0], src[t])
-    else:
-        assert torch.equal(k_sfbuf[loc].view(torch.uint8), k_sf.view(torch.uint8))
-        assert torch.equal(v_sfbuf[loc].view(torch.uint8), v_sf.view(torch.uint8))
+    k_sfbuf, _v_sfbuf = pool.get_kv_scale_buffer(1)
+    u32 = k_sfbuf.view(torch.uint8).reshape(-1, HEADS, 128, 4).view(torch.int32)
+    src = (
+        k_sf.view(torch.uint8)
+        .reshape(T, HEADS, 4)
+        .contiguous()
+        .view(torch.int32)
+        .reshape(T, HEADS)
+    )
+    for t in range(0, T, 17):  # sample positions
+        slot = int(loc[t])
+        page, off = divmod(slot, 128)
+        pos = (off % 32) * 4 + (off // 32)
+        assert torch.equal(u32[page, :, pos, 0], src[t])
 
     # Roundtrip: dequantized K matches original within fp8 blockscale error.
     k_rt = _dequant(pool.k_buffer[1][loc], k_sf)
@@ -144,7 +140,7 @@ def test_requires_prequantized_and_scales():
 def test_size_accounting_includes_scales():
     pool = _make_pool(128)
     k_size, v_size = pool.get_kv_size_bytes()
-    slots = pool.size + pool.prefix_granularity
+    slots = pool.arena.size + pool.arena.prefix_granularity
     expect_data = slots * HEADS * HEAD_DIM * LAYERS  # 1 byte/elem
     expect_sf = slots * HEADS * SF_DIM * LAYERS
     assert k_size == expect_data + expect_sf
@@ -167,26 +163,14 @@ SHARED_KV_HEADS = (2, 4, 2, 4)
 
 
 def _make_shared_pool(size: int = 512):
-    from cache_pool_test_utils import make_mha_memory_plan
+    from cache_pool_test_utils import make_arena, make_mha_memory_plan
 
     from tokenspeed.runtime.layers.attention.kv_cache.mha import (
         MHATokenToKVPoolMXFP8,
     )
 
-    return MHATokenToKVPoolMXFP8(
-        size=size,
-        dtype=torch.float8_e4m3fn,
-        head_num=HEADS,
-        head_dim=HEAD_DIM,
-        layer_num=len(SHARED_LAYER_TYPES),
-        device="cuda",
-        enable_memory_saver=False,
-        prefix_granularity=128,
-        rank=0,
-        layer_types=SHARED_LAYER_TYPES,
-        layer_group_ids=SHARED_LAYER_TYPES,
-        layer_kv_head_counts=SHARED_KV_HEADS,
-        memory_plan=make_mha_memory_plan(
+    arena = make_arena(
+        make_mha_memory_plan(
             size=size,
             prefix_granularity=128,
             layer_num=len(SHARED_LAYER_TYPES),
@@ -196,7 +180,18 @@ def _make_shared_pool(size: int = 512):
             layer_types=SHARED_LAYER_TYPES,
             sliding_window_tokens=512,
             mxfp8=True,
-        ),
+        )
+    )
+    return MHATokenToKVPoolMXFP8(
+        arena,
+        dtype=torch.float8_e4m3fn,
+        head_num=HEADS,
+        head_dim=HEAD_DIM,
+        layer_num=len(SHARED_LAYER_TYPES),
+        rank=0,
+        layer_types=SHARED_LAYER_TYPES,
+        layer_group_ids=SHARED_LAYER_TYPES,
+        layer_kv_head_counts=SHARED_KV_HEADS,
     )
 
 
@@ -213,9 +208,11 @@ def test_shared_field_geometry_and_aliasing():
     assert pool.k_scale_buffer[0].data_ptr() != pool.k_scale_buffer[2].data_ptr()
     assert pool.k_buffer[0].dtype == torch.float8_e4m3fn
 
-    # One byte-uniform scale field per block: data bytes / 32 e8m0 each.
+    # One byte-uniform scale field per block: data bytes / 32 e8m0 each. The
+    # plan's own rank is the interleaved layout's; only the bytes are pinned.
     slot_sf = 128 * HEADS * HEAD_DIM // 32
-    assert pool.k_scale_buffer[0].shape == (num_blocks, slot_sf)
+    assert pool.k_scale_buffer[0].shape[0] == num_blocks
+    assert pool.k_scale_buffer[0][0].numel() == slot_sf
 
     # Layer views factorize the same bytes: full (h/2, k=2), swa (h, k=1).
     k_full, _ = pool.get_kv_scale_buffer(0)
@@ -288,6 +285,7 @@ def _make_config(prefix_granularity: int):
 
 def _create_config_pool(config):
     from tokenspeed.runtime.layers.attention.kv_cache.factory import (
+        create_cache_arena,
         create_cache_pool,
     )
     from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
@@ -305,12 +303,15 @@ def _create_config_pool(config):
         decode_input_tokens=1,
         overlap_schedule_depth=0,
     )
+    arena = create_cache_arena(
+        setup.spec, device=config.device, enable_memory_saver=False
+    )
     return create_cache_pool(
         setup.spec,
         config,
+        arena,
         num_layers=LAYERS,
         rank=0,
-        enable_memory_saver=False,
     )
 
 
@@ -330,7 +331,7 @@ def test_config_selects_mxfp8_pool_and_sizes():
 
 def test_config_rejects_non_128_page():
     config = _make_config(prefix_granularity=64)
-    with pytest.raises(AssertionError, match="block-size 128"):
+    with pytest.raises(AssertionError, match="prefix-granularity 128"):
         _create_config_pool(config)
 
 

--- a/test/runtime/test_page_zeroing_contract.py
+++ b/test/runtime/test_page_zeroing_contract.py
@@ -37,7 +37,7 @@ class ZeroCachePagesContractTest(unittest.TestCase):
 
     def test_pure_attention_pool_ignores_page_reuse_list(self):
         # No zero_pages and not flagged as state-aliasing -> skip, no raise.
-        pool = types.SimpleNamespace(paged_cache_requires_page_zeroing=False)
+        pool = types.SimpleNamespace(requires_page_zeroing=False)
         self.assertIsNone(self._call(pool, [1, 2, 3]))
 
     def test_missing_flag_defaults_to_skip(self):
@@ -46,14 +46,14 @@ class ZeroCachePagesContractTest(unittest.TestCase):
 
     def test_state_aliasing_pool_without_impl_fails_loudly(self):
         # Declares it needs zeroing but forgot to implement it -> tripwire.
-        pool = types.SimpleNamespace(paged_cache_requires_page_zeroing=True)
+        pool = types.SimpleNamespace(requires_page_zeroing=True)
         with self.assertRaises(RuntimeError):
             self._call(pool, [1, 2, 3])
 
     def test_pool_with_impl_is_invoked(self):
         seen = []
         pool = types.SimpleNamespace(
-            paged_cache_requires_page_zeroing=True,
+            requires_page_zeroing=True,
             zero_pages=lambda page_ids: seen.append(list(page_ids)),
         )
         # device="cpu" -> returns None after invoking zero_pages.
@@ -63,7 +63,7 @@ class ZeroCachePagesContractTest(unittest.TestCase):
     def test_group_aware_pool_is_invoked(self):
         seen = []
         pool = types.SimpleNamespace(
-            paged_cache_requires_page_zeroing=True,
+            requires_page_zeroing=True,
             zero_new_blocks=lambda pages: seen.append(dict(pages)),
         )
         pages = {"full": [4, 5], "state": [9]}
@@ -74,14 +74,16 @@ class ZeroCachePagesContractTest(unittest.TestCase):
         target_seen = []
         draft_seen = []
         target = types.SimpleNamespace(
-            paged_cache_requires_page_zeroing=True,
+            requires_page_zeroing=True,
             zero_new_blocks=lambda pages: target_seen.append(dict(pages)),
         )
         draft = types.SimpleNamespace(
-            paged_cache_requires_page_zeroing=True,
-            paged_cache_group_specs=(
-                types.SimpleNamespace(group_id="history"),
-                types.SimpleNamespace(group_id="state"),
+            requires_page_zeroing=True,
+            arena=types.SimpleNamespace(
+                cache_group_specs=(
+                    types.SimpleNamespace(group_id="history"),
+                    types.SimpleNamespace(group_id="state"),
+                ),
             ),
             zero_new_blocks=lambda pages: draft_seen.append(dict(pages)),
         )

--- a/test/runtime/test_prefill_graph.py
+++ b/test/runtime/test_prefill_graph.py
@@ -22,6 +22,19 @@ from ci_system.ci_register import register_cuda_ci
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 
+def _spec(group_id: str, *, family: str = "history", **fields) -> SimpleNamespace:
+    """A published group-spec double. ``family`` decides state vs history, so
+    it is never inferred from the group id."""
+    return SimpleNamespace(group_id=group_id, family=family, **fields)
+
+
+def _fake_pool(*, specs=(), **arena_attrs) -> SimpleNamespace:
+    """A cache-view double: the arena publishes, the view just names it."""
+    return SimpleNamespace(
+        arena=SimpleNamespace(cache_group_specs=tuple(specs), **arena_attrs)
+    )
+
+
 class SliceMhaExtendInputsTest(unittest.TestCase):
     """MHA kernels see exactly the rows covered by live cu-seqlens."""
 
@@ -115,11 +128,11 @@ class DummyGroupTablesTest(unittest.TestCase):
             max_num_pages=0,  # fall back to bucket-derived width
             state_group_ids=frozenset({"linear_attention"}),
         )
-        pool = SimpleNamespace(
-            paged_cache_group_specs=(
-                SimpleNamespace(group_id="full_attention"),
-                SimpleNamespace(group_id="sliding_attention"),
-                SimpleNamespace(group_id="linear_attention"),  # state: included
+        pool = _fake_pool(
+            specs=(
+                _spec("full_attention"),
+                _spec("sliding_attention"),
+                _spec("linear_attention", family="state"),  # state: included
             )
         )
         tables = self._bare(backend, pool)._dummy_group_tables(100, 1)
@@ -145,9 +158,7 @@ class DummyGroupTablesTest(unittest.TestCase):
             max_num_pages=2500,
             state_group_ids=frozenset(),
         )
-        pool = SimpleNamespace(
-            paged_cache_group_specs=(SimpleNamespace(group_id="full_attention"),)
-        )
+        pool = _fake_pool(specs=(_spec("full_attention"),))
         tables = self._bare(backend, pool)._dummy_group_tables(100, 1)
         self.assertEqual(tables["full_attention"].shape, (1, 2500))
 
@@ -159,16 +170,10 @@ class DummyGroupTablesTest(unittest.TestCase):
             max_num_pages=257,
             state_group_ids=frozenset(),
         )
-        pool = SimpleNamespace(
-            paged_cache_group_specs=(
-                SimpleNamespace(
-                    group_id="fine",
-                    block_granularity=4,
-                ),
-                SimpleNamespace(
-                    group_id="coarse",
-                    block_granularity=256,
-                ),
+        pool = _fake_pool(
+            specs=(
+                _spec("fine", block_granularity=4),
+                _spec("coarse", block_granularity=256),
             )
         )
 
@@ -187,10 +192,10 @@ class DummyGroupTablesTest(unittest.TestCase):
             kernel_page_size=32, max_num_pages=0, state_group_ids=frozenset()
         )
         wrapper = SimpleNamespace(uses_cache_groups=True, full_attn_backend=child)
-        pool = SimpleNamespace(
-            paged_cache_group_specs=(
-                SimpleNamespace(group_id="full_attention"),
-                SimpleNamespace(group_id="linear_attention"),
+        pool = _fake_pool(
+            specs=(
+                _spec("full_attention"),
+                _spec("linear_attention", family="state"),
             )
         )
         tables = self._bare(wrapper, pool)._dummy_group_tables(64, 1)
@@ -199,7 +204,7 @@ class DummyGroupTablesTest(unittest.TestCase):
 
     def test_backend_without_cache_groups_is_empty(self):
         backend = SimpleNamespace(uses_cache_groups=False)
-        pool = SimpleNamespace(paged_cache_group_specs=())
+        pool = _fake_pool(specs=())
         self.assertEqual(self._bare(backend, pool)._dummy_group_tables(64, 1), {})
 
     def test_runtime_contract_pool_is_eligible_for_capture(self):
@@ -216,7 +221,7 @@ class DummyGroupTablesTest(unittest.TestCase):
             disable_prefill_graph=False,
             data_parallel_size=1,
         )
-        pool = SimpleNamespace(runtime_contract=object())
+        pool = _fake_pool(runtime_contract=object())
         with (
             mock.patch(
                 "tokenspeed.runtime.execution.prefill_graph.get_prefill_token_buckets",

--- a/test/runtime/test_scheduler_config_guard.py
+++ b/test/runtime/test_scheduler_config_guard.py
@@ -6,6 +6,7 @@ import importlib.util
 import os
 import sys
 import unittest
+from types import SimpleNamespace
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -14,7 +15,7 @@ from ci_system.ci_register import register_cuda_ci
 register_cuda_ci(est_time=5, suite="runtime-1gpu")
 
 
-def _load_paged_cache_spec():
+def _load_cache_spec():
     try:
         from tokenspeed.runtime.layers.attention.kv_cache.recipes import spec
 
@@ -36,14 +37,14 @@ def _load_paged_cache_spec():
             "recipes",
             "spec.py",
         )
-        spec = importlib.util.spec_from_file_location("_paged_cache_spec_guard", path)
+        spec = importlib.util.spec_from_file_location("_cache_spec_guard", path)
         module = importlib.util.module_from_spec(spec)
         sys.modules[spec.name] = module
         spec.loader.exec_module(module)
         return module
 
 
-_pcs = _load_paged_cache_spec()
+_pcs = _load_cache_spec()
 
 
 class FakeGroupSpec:
@@ -58,7 +59,8 @@ class FakeContract:
 
 class FakePool:
     def __init__(self, contract: FakeContract | None):
-        self.runtime_contract = contract
+        # The arena publishes the contract; a view only names its arena.
+        self.arena = SimpleNamespace(runtime_contract=contract)
 
 
 class HistoryBackend:
@@ -74,7 +76,7 @@ class ValidateSchedulerConfigTest(unittest.TestCase):
         self.assertNotIn("scheduler_ext_flat_kvcache", _pcs.__dict__)
 
     def test_contractless_pool_rejected(self):
-        with self.assertRaisesRegex(RuntimeError, "PagedCacheRuntimeContract"):
+        with self.assertRaisesRegex(RuntimeError, "CacheRuntimeContract"):
             _pcs.validate_scheduler_config(
                 attn_backend=HistoryBackend(),
                 kv_pool=FakePool(None),

--- a/test/runtime/test_server_args_attention_backends.py
+++ b/test/runtime/test_server_args_attention_backends.py
@@ -134,26 +134,6 @@ class TestAttentionBackendChoices(unittest.TestCase):
                 prefix_granularity=128,
             )
 
-    def test_lcm_group_block_granularities_are_published_before_backend_construction(
-        self,
-    ):
-        config = SimpleNamespace(group_block_granularities={"stale": 64})
-        spec = SimpleNamespace(
-            memory_plan=SimpleNamespace(prefix_granularity=128),
-            layer_group_ids=("full_attention", "linear_attention_0"),
-            paged_cache_group_specs=(
-                SimpleNamespace(group_id="full_attention", block_granularity=128),
-                SimpleNamespace(group_id="linear_attention_0", block_granularity=64),
-            ),
-        )
-
-        registry._set_cache_group_block_granularities(config, spec)
-
-        self.assertEqual(
-            config.group_block_granularities,
-            {"full_attention": 128, "linear_attention_0": 64},
-        )
-
     def test_mha_config_propagates_speculative_settings(self):
         server_args = SimpleNamespace(
             device="cuda",

--- a/test/runtime/test_sliding_cache_loc.py
+++ b/test/runtime/test_sliding_cache_loc.py
@@ -120,11 +120,11 @@ def test_cache_view_dispatches_by_retention() -> None:
     cache_start = torch.tensor([64], device="cuda", dtype=torch.int32)
     out = torch.zeros(1, dtype=torch.int64, device="cuda")
 
-    sliding_view = CacheView(table, page_size=_P, retention="sliding_window")
+    sliding_view = CacheView(table, kernel_page_size=_P, retention="sliding_window")
     sliding_view.out_cache_loc_uniform(out, cache_start, num_tokens=1)
     assert int(out[0]) == 91 * _P  # ring-wrapped onto column 0
 
-    full_view = CacheView(table, page_size=_P, retention="full_history")
+    full_view = CacheView(table, kernel_page_size=_P, retention="full_history")
     full_view.out_cache_loc_uniform(out, cache_start, num_tokens=1)
     # Full-history clamps the out-of-table page index and routes overflow
     # to slot 0 — a different, non-ring behavior.
@@ -133,7 +133,11 @@ def test_cache_view_dispatches_by_retention() -> None:
 
 def test_cache_view_rejects_unknown_retention() -> None:
     with pytest.raises(ValueError, match="retention"):
-        CacheView(torch.zeros(1, 1, dtype=torch.int32), page_size=16, retention="state")
+        CacheView(
+            torch.zeros(1, 1, dtype=torch.int32),
+            kernel_page_size=16,
+            retention="state",
+        )
 
 
 @requires_cuda

--- a/test/runtime/test_trtllm_cache_groups.py
+++ b/test/runtime/test_trtllm_cache_groups.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 
 # CI Registration (parsed via AST, runtime no-op)
@@ -45,9 +46,10 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
         device="cpu",
         groups=None,
     ):
-        from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
+        from cache_pool_test_utils import MinimalCacheView
+
         from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
-            PagedCacheGroupSpec,
+            CacheGroupSpec,
         )
 
         # Bypass __init__: the paths under test read only these attributes.
@@ -58,9 +60,11 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
         b.group_block_granularities = dict(groups or {})
         b.cache_pool = None
         if groups:
-            b.cache_pool = CachePool.__new__(CachePool)
-            b.cache_pool.paged_cache_group_specs = tuple(
-                PagedCacheGroupSpec(
+            b.cache_pool = MinimalCacheView.__new__(MinimalCacheView)
+            # The arena publishes the specs; the pool answers for them.
+            b.cache_pool.arena = SimpleNamespace()
+            b.cache_pool.arena.cache_group_specs = tuple(
+                CacheGroupSpec(
                     group_id=group_id,
                     retention="full_history",
                     rows_per_page=group_page_size,
@@ -115,9 +119,11 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
             [[6, 7, 10, 11, 0, 1]],
         )
 
-    def test_constructor_keeps_group_geometry_for_eager_metadata(self):
+    def test_binding_the_pool_learns_group_geometry_for_eager_metadata(self):
+        # One learner, one source: set_cache_pool runs on every path, so eager
+        # metadata sees the same geometry a captured graph would, and state
+        # groups land in state_group_ids rather than the span map.
         from tokenspeed.runtime.execution import workspace
-        from tokenspeed.runtime.layers.attention.backends import trtllm
         from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
         from tokenspeed.runtime.utils.env import envs
 
@@ -136,7 +142,6 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
             max_bs=1,
             max_graph_bs=1,
             kv_cache_quant_method="none",
-            group_block_granularities={"full_attention": 128},
         )
         with (
             envs.TOKENSPEED_WORKSPACE_TRTLLM_MHA_MB.override(1),
@@ -144,37 +149,31 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
         ):
             backend = self.Backend(config)
 
-        self.assertEqual(backend.group_block_granularities, {"full_attention": 128})
-
-    def test_constructor_accepts_config_without_group_geometry(self):
-        from tokenspeed.runtime.execution import workspace
-        from tokenspeed.runtime.layers.attention.backends import trtllm
-        from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
-        from tokenspeed.runtime.utils.env import envs
-
-        config = MSAConfig(
-            device="cpu",
-            backend_name="msa",
-            num_attention_heads=4,
-            num_kv_heads=1,
-            head_dim=64,
-            attn_tp_size=1,
-            dtype=self.torch.bfloat16,
-            kv_cache_dtype=self.torch.bfloat16,
-            prefix_granularity=64,
-            kernel_page_size=64,
-            context_len=256,
-            max_bs=1,
-            max_graph_bs=1,
-            kv_cache_quant_method="none",
-        )
-        with (
-            envs.TOKENSPEED_WORKSPACE_TRTLLM_MHA_MB.override(1),
-            mock.patch.object(workspace, "_pools", {}),
-        ):
-            backend = self.Backend(config)
-
+        # Nothing is known before the pool arrives.
         self.assertEqual(backend.group_block_granularities, {})
+        self.assertEqual(backend.state_group_ids, frozenset())
+
+        pool = SimpleNamespace(
+            arena=SimpleNamespace(
+                cache_group_specs=(
+                    SimpleNamespace(
+                        group_id="full_attention",
+                        family="history",
+                        block_granularity=128,
+                    ),
+                    SimpleNamespace(
+                        group_id="linear_attention_0",
+                        family="state",
+                        block_granularity=64,
+                    ),
+                )
+            )
+        )
+        backend.set_cache_pool(pool)
+
+        self.assertIs(backend.cache_pool, pool)
+        self.assertEqual(backend.group_block_granularities, {"full_attention": 128})
+        self.assertEqual(backend.state_group_ids, frozenset({"linear_attention_0"}))
 
     def test_build_page_table_keeps_single_table_direct_copy_path(self):
         b = self._bare_backend(page_size=64, max_num_pages=4)

--- a/test/runtime/test_unified_kv_slab_pool.py
+++ b/test/runtime/test_unified_kv_slab_pool.py
@@ -39,6 +39,12 @@ _pcs = _load("kv_cache_spec_slab_under_test", _RECIPES_DIR / "spec.py")
 hybrid_slab_group_size = _pcs.hybrid_slab_group_size
 
 
+def _specs_for_layers(**kwargs):
+    from cache_pool_test_utils import specs_for_layers
+
+    return specs_for_layers(**kwargs)
+
+
 def _real_spec():
     # The REAL package module (not the file-loaded shadow above): pool
     # constructions need specs whose class passes the contract's
@@ -95,7 +101,7 @@ class HybridSlabGroupSizeTest(unittest.TestCase):
 
     def test_none_when_unknown_label(self):
         # Unknown input degrades to None (safe legacy layout), never raises;
-        # loud rejection is group_specs_from_layer_types' job.
+        # loud rejection is spec.group's job.
         lt = GPT_OSS_LAYER_TYPES + ("banana_attention",)
         self.assertIsNone(hybrid_slab_group_size(lt))
 
@@ -174,7 +180,11 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
         self.MHATokenToKVPool = MHATokenToKVPool
 
     def _pool(self, **overrides):
-        from cache_pool_test_utils import make_layer_group_ids, make_mha_memory_plan
+        from cache_pool_test_utils import (
+            make_layer_group_ids,
+            make_mha_memory_plan,
+            make_pool,
+        )
 
         kwargs = {
             "size": 32,
@@ -190,7 +200,7 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
             "sliding_window_tokens": 128,
         }
         kwargs.update(overrides)
-        kwargs["memory_plan"] = make_mha_memory_plan(
+        plan = make_mha_memory_plan(
             size=kwargs["size"],
             prefix_granularity=kwargs["prefix_granularity"],
             layer_num=kwargs["layer_num"],
@@ -209,7 +219,15 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
             ),
         )
         kwargs.pop("sliding_window_tokens", None)
-        return self.MHATokenToKVPool(**kwargs)
+        # The arena owns the allocation; ``size`` and the plan geometry are
+        # its properties, not the view's.
+        device = kwargs.pop("device")
+        kwargs.pop("size")
+        kwargs.pop("prefix_granularity")
+        kwargs.pop("enable_memory_saver")
+        arena, pool = make_pool(self.MHATokenToKVPool, plan, device=device, **kwargs)
+        self.arena = arena
+        return pool
 
     def test_plan_aliases_distinct_layer_views(self):
         pool = self._pool()
@@ -299,7 +317,7 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
         from cache_pool_test_utils import make_layer_group_ids
 
         from tokenspeed.runtime.pd.cache_protocol import (
-            build_pool_cache_transfer_contract,
+            build_arena_cache_transfer_contract,
         )
 
         group_ids = make_layer_group_ids(
@@ -307,7 +325,7 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
             layer_types=GPT_OSS_LAYER_TYPES,
             sliding_window_tokens=128,
         )
-        specs = _real_spec().build_paged_cache_group_specs(
+        specs = _specs_for_layers(
             layer_types=GPT_OSS_LAYER_TYPES,
             group_ids=group_ids,
             sliding_window_tokens=128,
@@ -316,97 +334,76 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
         )
         pool = self._pool(
             layer_group_ids=group_ids,
-            paged_cache_group_specs=specs,
+            cache_group_specs=specs,
         )
 
-        layout, base_addr = build_pool_cache_transfer_contract(pool)
+        layout, base_addr = build_arena_cache_transfer_contract(pool.arena)
 
-        self.assertTrue(pool.supports_disaggregation)
-        self.assertEqual(base_addr, pool.buffer.data_ptr())
-        self.assertEqual(layout.plan, pool.plan)
+        self.assertTrue(pool.arena.supports_disaggregation)
+        self.assertEqual(base_addr, pool.arena.buffer.data_ptr())
+        self.assertEqual(layout.plan, pool.arena.plan)
         groups = {spec.retention: spec for spec in layout.group_specs}
         self.assertEqual(set(groups), {"full_history", "sliding_window"})
         self.assertIsNone(groups["full_history"].sliding_window_tokens)
         self.assertEqual(groups["sliding_window"].sliding_window_tokens, 128)
 
-    def test_constructor_without_specs_publishes_no_contract(self):
-        # The recipe is the single source of group specs; a pool constructed
-        # without them (tests, partial harnesses) publishes no contract.
-        kwargs = {
-            "size": 32,
-            "dtype": self.torch.bfloat16,
-            "head_num": 1,
-            "head_dim": 8,
-            "layer_num": 1,
-            "device": "cpu",
-            "enable_memory_saver": False,
-            "prefix_granularity": 16,
-            "rank": 0,
-            "layer_types": ("full_attention",),
-            "layer_group_ids": ("full_attention",),
-        }
+    def test_arena_rejects_an_empty_group_spec_set(self):
+        # Publication is unconditional: an arena with no groups is one no
+        # scheduler can address, so it is rejected at construction rather
+        # than left in a contract-less mode for callers to discover.
         from cache_pool_test_utils import make_mha_memory_plan
 
-        kwargs["memory_plan"] = make_mha_memory_plan(
-            size=kwargs["size"],
-            prefix_granularity=kwargs["prefix_granularity"],
-            layer_num=kwargs["layer_num"],
-            kv_heads=kwargs["head_num"],
-            head_dim=kwargs["head_dim"],
-            dtype=kwargs["dtype"],
-            layer_types=kwargs["layer_types"],
+        from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
+
+        plan = make_mha_memory_plan(
+            size=32,
+            prefix_granularity=16,
+            layer_num=1,
+            kv_heads=1,
+            head_dim=8,
+            dtype=self.torch.bfloat16,
+            layer_types=("full_attention",),
         )
-        pool = self.MHATokenToKVPool(**kwargs)
 
-        self.assertEqual(pool.paged_cache_group_specs, ())
-        self.assertIsNone(pool.runtime_contract)
+        with self.assertRaisesRegex(ValueError, "at least one cache group spec"):
+            CacheArena(plan, "cpu", cache_group_specs=())
 
-    def test_constructor_aligns_recipe_specs_with_plan(self):
-        # Recipe specs carry default packing; the pool overwrites it (and the
+    def test_arena_aligns_recipe_specs_with_plan(self):
+        # Recipe specs carry default packing; the arena overwrites it (and the
         # page counts) from the memory plan before publishing the contract.
-        kwargs = {
-            "size": 32,
-            "dtype": self.torch.bfloat16,
-            "head_num": 1,
-            "head_dim": 8,
-            "layer_num": 1,
-            "device": "cpu",
-            "enable_memory_saver": False,
-            "prefix_granularity": 16,
-            "rank": 0,
-            "layer_types": ("full_attention",),
-            "layer_group_ids": ("full_attention",),
-        }
-        from cache_pool_test_utils import make_mha_memory_plan
+        from cache_pool_test_utils import make_arena, make_mha_memory_plan
 
-        kwargs["memory_plan"] = make_mha_memory_plan(
-            size=kwargs["size"],
-            prefix_granularity=kwargs["prefix_granularity"],
-            layer_num=kwargs["layer_num"],
-            kv_heads=kwargs["head_num"],
-            head_dim=kwargs["head_dim"],
-            dtype=kwargs["dtype"],
-            layer_types=kwargs["layer_types"],
+        plan = make_mha_memory_plan(
+            size=32,
+            prefix_granularity=16,
+            layer_num=1,
+            kv_heads=1,
+            head_dim=8,
+            dtype=self.torch.bfloat16,
+            layer_types=("full_attention",),
         )
-        kwargs["paged_cache_group_specs"] = _real_spec().build_paged_cache_group_specs(
-            layer_types=kwargs["layer_types"],
-            group_ids=kwargs["layer_group_ids"],
-            sliding_window_tokens=None,
-            prefix_granularity=kwargs["prefix_granularity"],
+        arena = make_arena(
+            plan,
+            device="cpu",
+            cache_group_specs=_specs_for_layers(
+                layer_types=("full_attention",),
+                group_ids=("full_attention",),
+                sliding_window_tokens=None,
+                prefix_granularity=16,
+            ),
         )
-        pool = self.MHATokenToKVPool(**kwargs)
 
-        self.assertIsNotNone(pool.runtime_contract)
+        self.assertIsNotNone(arena.runtime_contract)
         self.assertEqual(
-            [spec.group_id for spec in pool.paged_cache_group_specs],
+            [spec.group_id for spec in arena.cache_group_specs],
             ["full_attention"],
         )
-        plan_group = kwargs["memory_plan"].group("full_attention")
         self.assertEqual(
-            pool.paged_cache_group_page_counts["full_attention"],
-            plan_group.page_count,
+            arena.cache_group_page_counts["full_attention"],
+            plan.group("full_attention").page_count,
         )
-        self.assertEqual(pool.runtime_contract.token_capacity, kwargs["size"])
+        # No explicit token capacity: the arena falls back to child capacity.
+        self.assertEqual(arena.runtime_contract.token_capacity, 32)
 
 
 class MLAPoolAllocationHookTest(unittest.TestCase):
@@ -422,43 +419,28 @@ class MLAPoolAllocationHookTest(unittest.TestCase):
         self.torch = torch
         self.MLATokenToKVPool = MLATokenToKVPool
 
-    def test_constructor_uses_overridable_buffer_allocation(self):
+    def test_pool_arranges_arena_views_without_allocating(self):
         torch = self.torch
-        from cache_pool_test_utils import make_mla_memory_plan
+        from cache_pool_test_utils import make_mla_memory_plan, make_pool
 
-        class PoolWithCustomAllocation(self.MLATokenToKVPool):
-            def _create_buffers(self):
-                self.allocation_hook_called = True
-                self.kv_buffer = [
-                    torch.zeros(
-                        (self.size + self.prefix_granularity, 1, self.kv_cache_dim),
-                        dtype=self.store_dtype,
-                        device=self.device,
-                    )
-                    for _ in range(self.layer_num)
-                ]
-
-        pool = PoolWithCustomAllocation(
-            size=8,
-            model_dtype=torch.bfloat16,
-            dtype=torch.bfloat16,
-            quant_method=None,
-            kv_lora_rank=4,
-            qk_rope_head_dim=2,
-            layer_num=1,
-            device="cpu",
-            enable_memory_saver=False,
-            prefix_granularity=4,
-            rank=0,
-            memory_plan=make_mla_memory_plan(
+        arena, pool = make_pool(
+            self.MLATokenToKVPool,
+            make_mla_memory_plan(
                 size=8,
                 prefix_granularity=4,
                 layer_num=1,
                 latent_width=6,
                 dtype=torch.bfloat16,
             ),
+            model_dtype=torch.bfloat16,
+            dtype=torch.bfloat16,
+            quant_method=None,
+            kv_lora_rank=4,
+            qk_rope_head_dim=2,
+            layer_num=1,
+            rank=0,
             layer_group_ids=("full_attention",),
-            paged_cache_group_specs=_real_spec().build_paged_cache_group_specs(
+            cache_group_specs=_specs_for_layers(
                 layer_types=(),
                 group_ids=("full_attention",),
                 sliding_window_tokens=None,
@@ -466,20 +448,25 @@ class MLAPoolAllocationHookTest(unittest.TestCase):
             ),
         )
 
-        self.assertTrue(pool.allocation_hook_called)
-        self.assertEqual(tuple(pool.kv_buffer[0].shape), (12, 1, 6))
+        # The pool allocates nothing: each per-layer buffer is a reshape of
+        # the arena view the plan already materialized.
         self.assertEqual(
-            [spec.group_id for spec in pool.paged_cache_group_specs],
+            pool.kv_buffer[0].untyped_storage().data_ptr(),
+            arena.buffer.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(tuple(pool.kv_buffer[0].shape[1:]), (1, 6))
+        self.assertEqual(
+            [spec.group_id for spec in pool.arena.cache_group_specs],
             ["full_attention"],
         )
         self.assertGreater(
-            pool.paged_cache_group_page_counts["full_attention"],
+            pool.arena.cache_group_page_counts["full_attention"],
             1,
         )
 
 
-class StatePagedCacheGroupPageCountTest(unittest.TestCase):
-    """compute_paged_cache_group_page_counts: the family="state" branch is
+class StateCacheGroupPageCountTest(unittest.TestCase):
+    """compute_cache_group_page_counts: the family="state" branch is
     positive and bounded by the full-history formula for the same inputs
     (state rows keep <= 2 live pages per request -- the W=2 write window --
     and snapshots are bounded by the shared page-id space).
@@ -494,7 +481,7 @@ class StatePagedCacheGroupPageCountTest(unittest.TestCase):
             self.skipTest(f"page-count math needs the real package: {exc}")
 
     def _counts(self, **overrides):
-        specs = _pcs.group_specs_from_layer_types(
+        specs = _specs_for_layers(
             layer_types=("linear_attention", "full_attention"),
             group_ids=("linear_attention", "full_attention"),
             sliding_window_tokens=None,
@@ -507,7 +494,7 @@ class StatePagedCacheGroupPageCountTest(unittest.TestCase):
             "max_context_len": 4096,
         }
         params.update(overrides)
-        return _pcs.compute_paged_cache_group_page_counts(specs, **params)
+        return _pcs.compute_cache_group_page_counts(specs, **params)
 
     def test_state_count_positive_and_bounded_by_full_history(self):
         counts = self._counts()
@@ -534,25 +521,32 @@ class CachePoolFieldBindingTest(unittest.TestCase):
             from tokenspeed.runtime.layers.attention.kv_cache.mha import (
                 MHATokenToKVPool,
             )
-            from tokenspeed.runtime.layers.attention.kv_cache.recipes.qwen35 import (
-                qwen_gdn_cache_fields,
+            from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+                CacheFieldSpec,
             )
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(f"needs torch + tokenspeed_kernel: {exc}")
         self.torch = torch
         self.pool_cls = HybridMHATokenToKVPool
         self.mha_pool_cls = MHATokenToKVPool
-        fields = qwen_gdn_cache_fields(
-            layer_types=("linear_attention", "full_attention"),
-            layer_group_ids=("linear_attention_0", "full_attention"),
-            prefix_granularity=4,
-            kv_shape=(4, 1, 2),
-            kv_element_size=2,
-            conv_shape=(2, 2),
-            conv_element_size=2,
-            ssm_shape=(1, 2, 2),
-            ssm_element_size=2,
-        )
+        # Qwen-shaped: one GDN state layer (ssm + conv) and one KV layer, the
+        # state fields aliasing the KV planes.
+        fields = {
+            "linear_attention_0": (
+                CacheFieldSpec("layer.0.ssm", "unit.0.a", (1, 2, 2), "bfloat16"),
+                CacheFieldSpec(
+                    "layer.0.conv",
+                    "unit.0.b",
+                    (2, 2),
+                    "bfloat16",
+                    exact_page_stride=False,
+                ),
+            ),
+            "full_attention": (
+                CacheFieldSpec("layer.1.k", "unit.0.a", (4, 1, 2), "bfloat16"),
+                CacheFieldSpec("layer.1.v", "unit.0.b", (4, 1, 2), "bfloat16"),
+            ),
+        }
         self.plan = plan_fields(
             fields,
             prefix_granularity=4,
@@ -561,47 +555,33 @@ class CachePoolFieldBindingTest(unittest.TestCase):
         )
 
     def _pool(self):
-        return self.pool_cls(
-            size=8,
+        from cache_pool_test_utils import make_pool
+
+        _, pool = make_pool(
+            self.pool_cls,
+            self.plan,
             dtype=self.torch.bfloat16,
             head_num=1,
             head_dim=2,
             layer_num=2,
-            device="cpu",
-            enable_memory_saver=False,
-            prefix_granularity=4,
             rank=0,
             layer_types=("linear_attention", "full_attention"),
-            state_field_dtypes={
-                "layer.0.conv": self.torch.bfloat16,
-                "layer.0.ssm": self.torch.bfloat16,
-            },
-            memory_plan=self.plan,
             layer_group_ids=("linear_attention_0", "full_attention"),
-            paged_cache_group_specs=_real_spec().build_paged_cache_group_specs(
+            cache_group_specs=_specs_for_layers(
                 layer_types=("linear_attention", "full_attention"),
                 group_ids=("linear_attention_0", "full_attention"),
                 sliding_window_tokens=None,
                 prefix_granularity=4,
             ),
         )
+        return pool
 
     def _ordinary_pool(self):
-        from cache_pool_test_utils import make_mha_memory_plan
+        from cache_pool_test_utils import make_mha_memory_plan, make_pool
 
-        return self.mha_pool_cls(
-            size=8,
-            dtype=self.torch.bfloat16,
-            head_num=1,
-            head_dim=2,
-            layer_num=2,
-            device="cpu",
-            enable_memory_saver=False,
-            prefix_granularity=4,
-            rank=0,
-            layer_types=("linear_attention", "full_attention"),
-            layer_group_ids=("linear_attention", "full_attention"),
-            memory_plan=make_mha_memory_plan(
+        _, pool = make_pool(
+            self.mha_pool_cls,
+            make_mha_memory_plan(
                 size=8,
                 prefix_granularity=4,
                 layer_num=2,
@@ -610,7 +590,15 @@ class CachePoolFieldBindingTest(unittest.TestCase):
                 dtype=self.torch.bfloat16,
                 layer_types=("linear_attention", "full_attention"),
             ),
+            dtype=self.torch.bfloat16,
+            head_num=1,
+            head_dim=2,
+            layer_num=2,
+            rank=0,
+            layer_types=("linear_attention", "full_attention"),
+            layer_group_ids=("linear_attention", "full_attention"),
         )
+        return pool
 
     def test_pool_binds_history_and_state_views_from_one_arena(self):
         pool = self._pool()
@@ -622,22 +610,20 @@ class CachePoolFieldBindingTest(unittest.TestCase):
         self.assertIsNotNone(pool.v_buffer[1])
         self.assertEqual(
             conv.untyped_storage().data_ptr(),
-            pool.field("layer.0.conv", self.torch.bfloat16)
-            .untyped_storage()
-            .data_ptr(),
+            pool.arena.field("layer.0.conv").untyped_storage().data_ptr(),
         )
         self.assertEqual(
             ssm.untyped_storage().data_ptr(),
-            pool.field("layer.0.ssm", self.torch.bfloat16).untyped_storage().data_ptr(),
+            pool.arena.field("layer.0.ssm").untyped_storage().data_ptr(),
         )
 
     def test_pool_publishes_runtime_contract_and_component_mapping(self):
         pool = self._pool()
 
-        self.assertEqual(pool.runtime_contract.prefix_granularity, 4)
-        self.assertEqual(pool.runtime_contract.num_lcm_blocks, 1)
+        self.assertEqual(pool.arena.runtime_contract.prefix_granularity, 4)
+        self.assertEqual(pool.arena.runtime_contract.num_lcm_blocks, 1)
         self.assertEqual(
-            pool.runtime_contract.group_page_counts,
+            pool.arena.runtime_contract.group_page_counts,
             {"linear_attention_0": 3, "full_attention": 2},
         )
         self.assertEqual(pool.group_id_for_layer(0), "linear_attention_0")
@@ -651,7 +637,7 @@ class CachePoolFieldBindingTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not a state layer"):
             pool.get_state_buffers(1)
         with self.assertRaisesRegex(ValueError, "not planned"):
-            pool.field("missing", self.torch.bfloat16)
+            pool.arena.field("missing")
 
     def test_ordinary_pool_keeps_ordinary_per_layer_kv(self):
         pool = self._ordinary_pool()

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -13,63 +13,67 @@
 
 from __future__ import annotations
 
-import importlib.util
 import math
-import pathlib
-import sys
 import unittest
 from types import SimpleNamespace
 
-_CONFIGS_DIR = (
-    pathlib.Path(__file__).resolve().parents[2]
-    / "python"
-    / "tokenspeed"
-    / "runtime"
-    / "layers"
-    / "attention"
-    / "kv_cache"
-    / "recipes"
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecipe
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4 import (
+    v4_c4_state_window,
+    v4_compressed_kv_spec,
+    v4_compressor_state_spec,
+    v4_indexer_state_spec,
+    v4_swa_kv_spec,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    CacheGroupSpec,
+    compute_cache_group_page_counts,
+    compute_max_logical_pages_for_capture,
 )
 
 
-def _load(mod_name: str, file_name: str):
-    spec = importlib.util.spec_from_file_location(mod_name, _CONFIGS_DIR / file_name)
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[mod_name] = mod
-    spec.loader.exec_module(mod)
-    return mod
+def build_v4_cache_specs(hf_config, *, layer_ratio, decode_input_tokens=1):
+    """The spec set a ratio vector declares, in the recipe's own order.
+
+    The recipe reaches for these constructors one group at a time as it walks
+    layers; here the whole set is what is under test.
+    """
+    ratios = {int(ratio) for ratio in layer_ratio}
+    window = v4_c4_state_window(decode_input_tokens)
+    specs = [v4_swa_kv_spec(hf_config)]
+    for ratio in sorted(r for r in ratios if r > 1):
+        specs.append(v4_compressor_state_spec(ratio, c4_state_window=window))
+        specs.append(v4_compressed_kv_spec(ratio))
+    if 4 in ratios:
+        specs.append(v4_indexer_state_spec(c4_state_window=window))
+    return tuple(specs)
 
 
-# Shadow the real module only while the v4 spec module binds its imports,
-# then restore: leaving it would fork PagedCacheGroupSpec into two classes
-# and fail the contract's isinstance check in later test files.
-_orig_generic = sys.modules.get(
-    "tokenspeed.runtime.layers.attention.kv_cache.recipes.spec"
-)
-_generic = _load(
-    "tokenspeed.runtime.layers.attention.kv_cache.recipes.spec",
-    "spec.py",
-)
-_v4 = _load(
-    "tokenspeed_runtime_configs_deepseek_v4_cache_spec_smoke",
-    "deepseek_v4_cache_spec.py",
-)
-if _orig_generic is not None:
-    sys.modules["tokenspeed.runtime.layers.attention.kv_cache.recipes.spec"] = (
-        _orig_generic
-    )
-else:
-    del sys.modules["tokenspeed.runtime.layers.attention.kv_cache.recipes.spec"]
+class _CapacityProbe(CacheRecipe):
+    """A recipe that is nothing but its group specs and scheduler limits.
 
-build_v4_cache_specs = _v4.build_v4_cache_specs
-deepseek_v4_lcm_blocks_needed = _v4.deepseek_v4_lcm_blocks_needed
-deepseek_v4_token_capacity_for_cache_pool = (
-    _v4.deepseek_v4_token_capacity_for_cache_pool
-)
-compute_max_logical_pages_for_capture = _generic.compute_max_logical_pages_for_capture
-compute_paged_cache_group_page_counts = _generic.compute_paged_cache_group_page_counts
-PagedCacheGroupSpec = _generic.PagedCacheGroupSpec
+    ``parents_needed`` and ``_capacity_from_parents`` read only those two plus
+    the layout's per-group packing, so the inverse property can be probed
+    without a model config or a packed arena -- and this states which inputs
+    the capacity math is allowed to read.
+    """
+
+    family = "deepseek_v4"
+    layer_types = ()
+    group_ids = ()
+
+    def __init__(self, specs, limits) -> None:
+        self._specs = tuple(specs)
+        self._limits = dict(limits)
+
+    @property
+    def _group_specs(self):
+        return self._specs
+
+    @property
+    def scheduler_limits(self):
+        return self._limits
+
 
 _PAGE_SHAPES = ((4, 1), (4, 2), (16, 4), (2, 128))
 
@@ -80,14 +84,14 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
         for rows_per_page, entry_stride_tokens in _PAGE_SHAPES:
             raw_per_page = rows_per_page * entry_stride_tokens
             specs = [
-                PagedCacheGroupSpec(
+                CacheGroupSpec(
                     group_id="full",
                     retention="full_history",
                     rows_per_page=rows_per_page,
                     entry_stride_tokens=entry_stride_tokens,
                     sliding_window_tokens=None,
                 ),
-                PagedCacheGroupSpec(
+                CacheGroupSpec(
                     group_id="sliding",
                     retention="sliding_window",
                     rows_per_page=rows_per_page,
@@ -102,7 +106,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                 "max_context_len": 4096,
             }
             for verify_width in (1, 2, 4, 8):
-                baseline = compute_paged_cache_group_page_counts(
+                baseline = compute_cache_group_page_counts(
                     specs,
                     **common,
                     decode_input_tokens=verify_width,
@@ -114,7 +118,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                         verify_width=verify_width,
                         overlap_depth=overlap_depth,
                     ):
-                        actual = compute_paged_cache_group_page_counts(
+                        actual = compute_cache_group_page_counts(
                             specs,
                             **common,
                             decode_input_tokens=verify_width,
@@ -132,7 +136,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
     def test_capture_table_width_is_parameterized_by_verify_width_and_depth(self):
         for rows_per_page, entry_stride_tokens in _PAGE_SHAPES:
             raw_per_page = rows_per_page * entry_stride_tokens
-            full = PagedCacheGroupSpec(
+            full = CacheGroupSpec(
                 group_id="full",
                 retention="full_history",
                 rows_per_page=rows_per_page,
@@ -140,7 +144,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                 sliding_window_tokens=None,
             )
             window = 3 * raw_per_page + 1
-            sliding = PagedCacheGroupSpec(
+            sliding = CacheGroupSpec(
                 group_id="sliding",
                 retention="sliding_window",
                 rows_per_page=rows_per_page,
@@ -191,7 +195,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             # not, exercising both page-alignment relationships between the
             # window and the physical page stride.
             for window in (3 * raw_per_page, 3 * raw_per_page + 1):
-                spec = PagedCacheGroupSpec(
+                spec = CacheGroupSpec(
                     group_id="sliding",
                     retention="sliding_window",
                     rows_per_page=rows_per_page,
@@ -228,7 +232,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                                 )
 
     def test_overlap_sizing_rejects_invalid_runtime_parameters(self):
-        spec = PagedCacheGroupSpec(
+        spec = CacheGroupSpec(
             group_id="full",
             retention="full_history",
             rows_per_page=4,
@@ -253,7 +257,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
                 self.subTest(function="page_counts", overrides=overrides),
                 self.assertRaisesRegex(ValueError, message),
             ):
-                compute_paged_cache_group_page_counts([spec], **count_args, **overrides)
+                compute_cache_group_page_counts([spec], **count_args, **overrides)
 
         for overrides, message in (
             ({"max_context_len": -1}, "max_context_len"),
@@ -278,15 +282,15 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             self.subTest(group="bad-rows"),
             self.assertRaisesRegex(ValueError, "rows_per_page"),
         ):
-            PagedCacheGroupSpec("bad-rows", "full_history", 0, 1, None)
+            CacheGroupSpec("bad-rows", "full_history", 0, 1, None)
 
         invalid_specs = (
             (
-                PagedCacheGroupSpec("bad-window", "sliding_window", 4, 1, 0),
+                CacheGroupSpec("bad-window", "sliding_window", 4, 1, 0),
                 "sliding_window_tokens",
             ),
             (
-                PagedCacheGroupSpec("bad-retention", "unknown", 4, 1, None),
+                CacheGroupSpec("bad-retention", "unknown", 4, 1, None),
                 "unsupported retention",
             ),
         )
@@ -324,7 +328,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
 
     def test_sliding_window_scheduled_tokens_are_global_and_capped(self):
         specs = [
-            PagedCacheGroupSpec(
+            CacheGroupSpec(
                 group_id="sliding",
                 retention="sliding_window",
                 rows_per_page=4,
@@ -333,7 +337,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             )
         ]
 
-        counts = compute_paged_cache_group_page_counts(
+        counts = compute_cache_group_page_counts(
             specs,
             max_live_requests=10,
             max_scheduled_tokens=100,
@@ -361,7 +365,7 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             SimpleNamespace(sliding_window=128),
             layer_ratio=(1, 4, 128),
         )
-        counts = compute_paged_cache_group_page_counts(specs, **inputs)
+        counts = compute_cache_group_page_counts(specs, **inputs)
         bound = inputs["max_total_tokens"] * inputs["max_live_requests"]
         for spec in specs:
             n = counts[spec.group_id]
@@ -370,25 +374,15 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             self.assertTrue(math.isfinite(n), spec.group_id)
             self.assertLess(n, bound, spec.group_id)
 
-    def test_lcm_specs_preserve_group_block_granularities_and_publish_packing(self):
-        packing = {
-            "v4.swa_kv": 1,
-            "v4.c4a.compressor_state": 16,
-            "v4.c4a.compressed_kv": 2,
-            "v4.c128a.compressor_state": 32,
-            "v4.c128a.compressed_kv": 8,
-            "v4.c4a.indexer_compressor_state": 16,
-        }
-
+    def test_lcm_specs_own_row_geometry_and_declare_no_packing(self):
         specs = build_v4_cache_specs(
             SimpleNamespace(sliding_window=128),
             layer_ratio=(1, 4, 128),
-            cache_blocks_per_lcm_block=packing,
         )
 
-        self.assertEqual(
-            {spec.group_id: spec.cache_blocks_per_lcm_block for spec in specs},
-            packing,
+        # Packing is the memory plan's answer, so a spec cannot declare it.
+        self.assertFalse(
+            any(hasattr(spec, "cache_blocks_per_lcm_block") for spec in specs)
         )
         rows = {spec.group_id: spec.rows_per_page for spec in specs}
         self.assertEqual(rows["v4.swa_kv"], 64)
@@ -416,49 +410,37 @@ class TestV4SlidingWindowGroupsSmoke(unittest.TestCase):
             self.assertEqual(wide_windows[group_id], 10)
 
     def test_lcm_capacity_is_the_inverse_of_parent_demand(self):
-        packing = {
-            "v4.swa_kv": 1,
-            "v4.c4a.compressor_state": 4,
-            "v4.c4a.compressed_kv": 2,
-            "v4.c128a.compressor_state": 1,
-            "v4.c128a.compressed_kv": 8,
-            "v4.c4a.indexer_compressor_state": 4,
-        }
-        specs = build_v4_cache_specs(
-            SimpleNamespace(sliding_window=128),
-            layer_ratio=(1, 4, 128),
-            cache_blocks_per_lcm_block=packing,
+        layout = SimpleNamespace(
+            prefix_granularity=256,
+            group_packing=(
+                ("v4.swa_kv", 1),
+                ("v4.c4a.compressor_state", 4),
+                ("v4.c4a.compressed_kv", 2),
+                ("v4.c128a.compressor_state", 1),
+                ("v4.c128a.compressed_kv", 8),
+                ("v4.c4a.indexer_compressor_state", 4),
+            ),
         )
-        sizing = {
-            "prefix_granularity": 256,
-            "max_live_requests": 1,
-            "max_scheduled_tokens": 256,
-            "max_context_len": 4096,
-        }
+        probe = _CapacityProbe(
+            build_v4_cache_specs(
+                SimpleNamespace(sliding_window=128),
+                layer_ratio=(1, 4, 128),
+            ),
+            {
+                "max_live_requests": 1,
+                "max_scheduled_tokens": 256,
+                "max_context_len": 4096,
+                "decode_input_tokens": 1,
+                "overlap_schedule_depth": 0,
+            },
+        )
         num_lcm_blocks = 100
-        capacity = deepseek_v4_token_capacity_for_cache_pool(
-            specs,
-            num_lcm_blocks=num_lcm_blocks,
-            upper_bound_tokens=4096,
-            **sizing,
+        capacity = probe._capacity_from_parents(
+            layout, num_lcm_blocks, upper_bound=4096
         )
 
-        self.assertLessEqual(
-            deepseek_v4_lcm_blocks_needed(
-                specs,
-                token_capacity=capacity,
-                **sizing,
-            ),
-            num_lcm_blocks,
-        )
-        self.assertGreater(
-            deepseek_v4_lcm_blocks_needed(
-                specs,
-                token_capacity=capacity + 1,
-                **sizing,
-            ),
-            num_lcm_blocks,
-        )
+        self.assertLessEqual(probe.parents_needed(layout, capacity), num_lcm_blocks)
+        self.assertGreater(probe.parents_needed(layout, capacity + 1), num_lcm_blocks)
 
 
 if __name__ == "__main__":

--- a/tokenspeed-scheduler/CMakeLists.txt
+++ b/tokenspeed-scheduler/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(tokenspeed_scheduler_core STATIC
 
     csrc/scheduler/kv_cache_events.cpp
     csrc/scheduler/request.cpp
+    csrc/scheduler/types.cpp
     csrc/scheduler/outside_event_handler.cpp
     csrc/scheduler/scheduler.cpp
 

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -91,53 +91,53 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .value("D", tokenspeed::Role::kD)
         .value("Fused", tokenspeed::Role::kFused);
 
-    nb::enum_<tokenspeed::PagedCacheGroupConfig::Retention>(m, "PagedCacheRetention")
-        .value("FullHistory", tokenspeed::PagedCacheGroupConfig::Retention::FullHistory)
-        .value("SlidingWindow", tokenspeed::PagedCacheGroupConfig::Retention::SlidingWindow);
+    nb::enum_<tokenspeed::CacheGroupConfig::Retention>(m, "CacheRetention")
+        .value("FullHistory", tokenspeed::CacheGroupConfig::Retention::FullHistory)
+        .value("SlidingWindow", tokenspeed::CacheGroupConfig::Retention::SlidingWindow);
 
-    nb::enum_<tokenspeed::PagedCacheGroupFamily>(m, "PagedCacheGroupFamily")
-        .value("History", tokenspeed::PagedCacheGroupFamily::History)
-        .value("State", tokenspeed::PagedCacheGroupFamily::State);
+    nb::enum_<tokenspeed::CacheGroupFamily>(m, "CacheGroupFamily")
+        .value("History", tokenspeed::CacheGroupFamily::History)
+        .value("State", tokenspeed::CacheGroupFamily::State);
 
-    nb::enum_<tokenspeed::PagedCacheTransferPolicy>(m, "PagedCacheTransferPolicy")
-        .value("Unspecified", tokenspeed::PagedCacheTransferPolicy::Unspecified)
-        .value("FullSuffix", tokenspeed::PagedCacheTransferPolicy::FullSuffix)
-        .value("LatestSnapshot", tokenspeed::PagedCacheTransferPolicy::LatestSnapshot);
+    nb::enum_<tokenspeed::CacheTransferPolicy>(m, "CacheTransferPolicy")
+        .value("Unspecified", tokenspeed::CacheTransferPolicy::Unspecified)
+        .value("FullSuffix", tokenspeed::CacheTransferPolicy::FullSuffix)
+        .value("LatestSnapshot", tokenspeed::CacheTransferPolicy::LatestSnapshot);
 
-    nb::class_<tokenspeed::PagedCacheGroupConfig>(m, "PagedCacheGroupConfig")
+    nb::class_<tokenspeed::CacheGroupConfig>(m, "CacheGroupConfig")
         .def(nb::init<>())
         .def(
             "__init__",
-            [](tokenspeed::PagedCacheGroupConfig* self, std::string group_id, std::int32_t rows_per_page,
+            [](tokenspeed::CacheGroupConfig* self, std::string group_id, std::int32_t rows_per_page,
                std::int32_t entry_stride_tokens, std::int32_t total_pages,
-               tokenspeed::PagedCacheGroupConfig::Retention retention,
-               std::optional<std::int32_t> sliding_window_tokens, tokenspeed::PagedCacheGroupFamily family,
-               std::int32_t cache_blocks_per_lcm_block, tokenspeed::PagedCacheTransferPolicy transfer_policy) {
-                new (self) tokenspeed::PagedCacheGroupConfig{std::move(group_id),
-                                                             rows_per_page,
-                                                             entry_stride_tokens,
-                                                             total_pages,
-                                                             cache_blocks_per_lcm_block,
-                                                             retention,
-                                                             sliding_window_tokens,
-                                                             family,
-                                                             transfer_policy};
+               tokenspeed::CacheGroupConfig::Retention retention, std::optional<std::int32_t> sliding_window_tokens,
+               tokenspeed::CacheGroupFamily family, std::int32_t cache_blocks_per_lcm_block,
+               tokenspeed::CacheTransferPolicy transfer_policy) {
+                new (self) tokenspeed::CacheGroupConfig{std::move(group_id),
+                                                        rows_per_page,
+                                                        entry_stride_tokens,
+                                                        total_pages,
+                                                        cache_blocks_per_lcm_block,
+                                                        retention,
+                                                        sliding_window_tokens,
+                                                        family,
+                                                        transfer_policy};
             },
             nb::arg("group_id"), nb::arg("rows_per_page"), nb::arg("entry_stride_tokens"), nb::arg("total_pages"),
-            nb::arg("retention") = tokenspeed::PagedCacheGroupConfig::Retention::FullHistory,
-            nb::arg("sliding_window_tokens") = std::nullopt,
-            nb::arg("family") = tokenspeed::PagedCacheGroupFamily::History, nb::arg("cache_blocks_per_lcm_block") = 1,
-            nb::arg("transfer_policy") = tokenspeed::PagedCacheTransferPolicy::Unspecified)
-        .def_rw("group_id", &tokenspeed::PagedCacheGroupConfig::group_id)
-        .def_rw("rows_per_page", &tokenspeed::PagedCacheGroupConfig::rows_per_page)
-        .def_rw("entry_stride_tokens", &tokenspeed::PagedCacheGroupConfig::entry_stride_tokens)
-        .def_rw("total_pages", &tokenspeed::PagedCacheGroupConfig::total_pages)
-        .def_rw("cache_blocks_per_lcm_block", &tokenspeed::PagedCacheGroupConfig::cache_blocks_per_lcm_block)
-        .def_rw("retention", &tokenspeed::PagedCacheGroupConfig::retention)
-        .def_rw("sliding_window_tokens", &tokenspeed::PagedCacheGroupConfig::sliding_window_tokens)
-        .def_rw("family", &tokenspeed::PagedCacheGroupConfig::family)
-        .def_rw("transfer_policy", &tokenspeed::PagedCacheGroupConfig::transfer_policy)
-        .def("validate", &tokenspeed::PagedCacheGroupConfig::Validate);
+            nb::arg("retention") = tokenspeed::CacheGroupConfig::Retention::FullHistory,
+            nb::arg("sliding_window_tokens") = std::nullopt, nb::arg("family") = tokenspeed::CacheGroupFamily::History,
+            nb::arg("cache_blocks_per_lcm_block") = 1,
+            nb::arg("transfer_policy") = tokenspeed::CacheTransferPolicy::Unspecified)
+        .def_rw("group_id", &tokenspeed::CacheGroupConfig::group_id)
+        .def_rw("rows_per_page", &tokenspeed::CacheGroupConfig::rows_per_page)
+        .def_rw("entry_stride_tokens", &tokenspeed::CacheGroupConfig::entry_stride_tokens)
+        .def_rw("total_pages", &tokenspeed::CacheGroupConfig::total_pages)
+        .def_rw("cache_blocks_per_lcm_block", &tokenspeed::CacheGroupConfig::cache_blocks_per_lcm_block)
+        .def_rw("retention", &tokenspeed::CacheGroupConfig::retention)
+        .def_rw("sliding_window_tokens", &tokenspeed::CacheGroupConfig::sliding_window_tokens)
+        .def_rw("family", &tokenspeed::CacheGroupConfig::family)
+        .def_rw("transfer_policy", &tokenspeed::CacheGroupConfig::transfer_policy)
+        .def("validate", &tokenspeed::CacheGroupConfig::Validate);
 
     scheduler_config.def(nb::init<>())
         .def_rw("prefix_granularity", &tokenspeed::SchedulerConfig::prefix_granularity)
@@ -153,7 +153,7 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_prop_rw(
             "num_host_pages", [](const tokenspeed::SchedulerConfig& c) { return c.host_allocator.total_pages; },
             [](tokenspeed::SchedulerConfig& c, std::int32_t v) { c.host_allocator.total_pages = v; })
-        .def_rw("paged_cache_groups", &tokenspeed::SchedulerConfig::paged_cache_groups)
+        .def_rw("cache_groups", &tokenspeed::SchedulerConfig::cache_groups)
         .def_rw("disable_l2_cache", &tokenspeed::SchedulerConfig::disable_l2_cache)
         .def_rw("enable_l3_storage", &tokenspeed::SchedulerConfig::enable_l3_storage)
         .def_rw("enable_kv_cache_events", &tokenspeed::SchedulerConfig::enable_kv_cache_events)
@@ -326,7 +326,6 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def("max_single_request_tokens", &tokenspeed::Scheduler::MaxSingleRequestTokens)
         .def("clear_l1_cache", &tokenspeed::Scheduler::ClearL1Cache)
         .def("clear_cache", &tokenspeed::Scheduler::ClearCache)
-        .def("paged_cache_group_total_pages", &tokenspeed::Scheduler::PagedCacheGroupTotalPages, nb::arg("group_id"))
-        .def("paged_cache_group_available_pages", &tokenspeed::Scheduler::PagedCacheGroupAvailablePages,
-             nb::arg("group_id"));
+        .def("cache_group_total_pages", &tokenspeed::Scheduler::CacheGroupTotalPages, nb::arg("group_id"))
+        .def("cache_group_available_pages", &tokenspeed::Scheduler::CacheGroupAvailablePages, nb::arg("group_id"));
 }

--- a/tokenspeed-scheduler/csrc/cache/core/cache_config.cpp
+++ b/tokenspeed-scheduler/csrc/cache/core/cache_config.cpp
@@ -21,27 +21,31 @@
 #include "cache/core/cache_config.h"
 
 #include <stdexcept>
+#include <string>
 
 namespace tokenspeed {
 
-void PagedCacheGroupConfig::Validate() const {
+void CacheGroupConfig::Validate() const {
     if (group_id.empty()) {
-        throw std::invalid_argument("PagedCacheGroupConfig: group_id must be non-empty");
+        throw std::invalid_argument("CacheGroupConfig: group_id must be non-empty");
     }
+    // Every remaining message names the group: a model mixes several of them,
+    // and the offending one is the only actionable part of the diagnostic.
+    const std::string where = "Cache group '" + group_id + "': ";
     if (rows_per_page <= 0) {
-        throw std::invalid_argument("PagedCacheGroupConfig: rows_per_page must be > 0");
+        throw std::invalid_argument(where + "rows_per_page must be > 0");
     }
     if (entry_stride_tokens <= 0) {
-        throw std::invalid_argument("PagedCacheGroupConfig: entry_stride_tokens must be > 0");
+        throw std::invalid_argument(where + "entry_stride_tokens must be > 0");
     }
     if (total_pages < 1) {
-        throw std::invalid_argument("PagedCacheGroupConfig: total_pages must include the null page");
+        throw std::invalid_argument(where + "total_pages must include the null page");
     }
     if (cache_blocks_per_lcm_block <= 0) {
-        throw std::invalid_argument("PagedCacheGroupConfig: cache_blocks_per_lcm_block must be > 0");
+        throw std::invalid_argument(where + "cache_blocks_per_lcm_block must be > 0");
     }
     if (retention == Retention::SlidingWindow && (!sliding_window_tokens || *sliding_window_tokens <= 0)) {
-        throw std::invalid_argument("PagedCacheGroupConfig: sliding_window_tokens must be > 0 for sliding groups");
+        throw std::invalid_argument(where + "sliding_window_tokens must be > 0 for sliding groups");
     }
 }
 

--- a/tokenspeed-scheduler/csrc/cache/core/cache_config.h
+++ b/tokenspeed-scheduler/csrc/cache/core/cache_config.h
@@ -26,15 +26,15 @@
 
 namespace tokenspeed {
 
-enum class PagedCacheGroupFamily { History, State };
+enum class CacheGroupFamily { History, State };
 
-enum class PagedCacheTransferPolicy {
+enum class CacheTransferPolicy {
     Unspecified,
     FullSuffix,
     LatestSnapshot,
 };
 
-struct PagedCacheGroupConfig {
+struct CacheGroupConfig {
     enum class Retention {
         FullHistory,
         SlidingWindow,
@@ -48,10 +48,19 @@ struct PagedCacheGroupConfig {
     std::int32_t cache_blocks_per_lcm_block{1};
     Retention retention{Retention::FullHistory};
     std::optional<std::int32_t> sliding_window_tokens{};
-    PagedCacheGroupFamily family{PagedCacheGroupFamily::History};
-    PagedCacheTransferPolicy transfer_policy{PagedCacheTransferPolicy::Unspecified};
+    CacheGroupFamily family{CacheGroupFamily::History};
+    CacheTransferPolicy transfer_policy{CacheTransferPolicy::Unspecified};
 
     std::int32_t BlockGranularity() const { return rows_per_page * entry_stride_tokens; }
+
+    // A State group WITHOUT SlidingWindow retention keeps one recurrent-state
+    // checkpoint per block instead of a token history: the mamba-style group
+    // whose PD destination layout is a LatestSnapshot. family=State alone is
+    // not enough -- it also covers linear-attention sliding groups.
+    bool IsSnapshotStateGroup() const {
+        return family == CacheGroupFamily::State && retention != Retention::SlidingWindow;
+    }
+
     void Validate() const;
 };
 

--- a/tokenspeed-scheduler/csrc/scheduler/operations/cache.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/cache.cpp
@@ -20,8 +20,6 @@
 
 #include "scheduler/operations/cache.h"
 
-#include <stdexcept>
-
 #include "scheduler/types.h"
 
 namespace tokenspeed {
@@ -47,51 +45,26 @@ std::int32_t AlignPrefillChunk(std::int32_t first_pos, std::int32_t unscheduled,
 }
 
 std::vector<CacheGroupSpec> MakeSpecsFromConfig(const SchedulerConfig& config) {
-    _assert(config.prefix_granularity > 0, "scheduler prefix_granularity must be > 0");
     std::vector<CacheGroupSpec> specs;
-    specs.reserve(config.paged_cache_groups.size());
-    for (const PagedCacheGroupConfig& group : config.paged_cache_groups) {
-        _assert(group.cache_blocks_per_lcm_block > 0, "cache_blocks_per_lcm_block must be > 0");
-        const std::int32_t block_granularity = group.BlockGranularity();
-        _assert(block_granularity > 0, "cache group must have a positive block_granularity");
-        _assert(config.prefix_granularity % block_granularity == 0,
-                "group block_granularity must divide the scheduler prefix granularity");
-        // family=State marks trailing-window prefix reuse and covers both SWA and
-        // linear-attention groups; only a State group WITHOUT SlidingWindow
-        // retention is a mamba-style state group.
-        const bool final_state_manager = group.family == PagedCacheGroupFamily::State &&
-                                         group.retention != PagedCacheGroupConfig::Retention::SlidingWindow;
-        if (config.enable_pd_cache) {
-            const PagedCacheTransferPolicy expected =
-                final_state_manager ? PagedCacheTransferPolicy::LatestSnapshot : PagedCacheTransferPolicy::FullSuffix;
-            if (group.transfer_policy == PagedCacheTransferPolicy::Unspecified) {
-                throw std::invalid_argument("PD cache group '" + group.group_id +
-                                            "' requires an explicit transfer_policy");
-            }
-            if (group.transfer_policy != expected) {
-                throw std::invalid_argument("PD cache group '" + group.group_id +
-                                            "' transfer_policy does not match its scheduler "
-                                            "destination layout");
-            }
-        }
-        if (final_state_manager) {
+    specs.reserve(config.cache_groups.size());
+    for (const CacheGroupConfig& group : config.cache_groups) {
+        if (group.IsSnapshotStateGroup()) {
             specs.push_back(CacheGroupSpec{
                 .kind = AttnKind::kMambaState,
                 .sliding_window = 0,
                 .cache_blocks_per_lcm_block = group.cache_blocks_per_lcm_block,
-                .block_granularity = block_granularity,
+                .block_granularity = group.BlockGranularity(),
             });
             continue;
         }
-        const bool is_swa = group.retention == PagedCacheGroupConfig::Retention::SlidingWindow;
-        if (is_swa && (!group.sliding_window_tokens || *group.sliding_window_tokens <= 0)) {
-            throw std::invalid_argument("Cache group '" + group.group_id + "' requires positive sliding_window_tokens");
-        }
+        // family=State also covers linear-attention groups with a trailing
+        // window; those translate like any other sliding group.
+        const bool is_swa = group.retention == CacheGroupConfig::Retention::SlidingWindow;
         specs.push_back(CacheGroupSpec{
             .kind = is_swa ? AttnKind::kSlidingWindow : AttnKind::kFull,
             .sliding_window = is_swa ? *group.sliding_window_tokens : 0,
             .cache_blocks_per_lcm_block = group.cache_blocks_per_lcm_block,
-            .block_granularity = block_granularity,
+            .block_granularity = group.BlockGranularity(),
         });
     }
     return specs;

--- a/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/cache.h
@@ -32,7 +32,10 @@ namespace tokenspeed {
 
 struct SchedulerConfig;
 
-// One CacheGroupSpec per config paged_cache_group (group_id = index); all groups share config.prefix_granularity.
+// One CacheGroupSpec per config cache_group (group_id = index); all groups share config.prefix_granularity.
+// Pure translation: the caller must have accepted `config` through
+// SchedulerConfig::Validate() first, which is what makes every field read here
+// (packing, block granularity, a sliding group's window) well-formed.
 std::vector<CacheGroupSpec> MakeSpecsFromConfig(const SchedulerConfig& config);
 
 std::int32_t AlignPrefillChunk(std::int32_t first_pos, std::int32_t unscheduled, std::int32_t token_budget,

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -284,12 +284,12 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
                                           : fsm::PrefillSource::kLocal;
     if (config_.enable_pd_cache && source == fsm::PrefillSource::kRemote) {
         for (std::size_t i = 0; i < demands.size(); ++i) {
-            const PagedCacheGroupConfig& group = config_.paged_cache_groups[i];
+            const CacheGroupConfig& group = config_.cache_groups[i];
             const std::int32_t block_granularity = coordinator_.GroupBlockGranularity(i);
-            if (group.transfer_policy == PagedCacheTransferPolicy::LatestSnapshot) {
+            if (group.transfer_policy == CacheTransferPolicy::LatestSnapshot) {
                 demands[i].num_tokens = request->PrefillSize();
                 demands[i].materialized_suffix_start = (request->PrefillSize() - 1) / block_granularity;
-            } else if (group.retention == PagedCacheGroupConfig::Retention::SlidingWindow) {
+            } else if (group.retention == CacheGroupConfig::Retention::SlidingWindow) {
                 const std::int32_t retained_begin =
                     std::max(0, request->PrefillSize() - *group.sliding_window_tokens + 1);
                 demands[i].num_tokens = request->PrefillSize();

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -53,6 +53,13 @@ std::int32_t hostPoolBlocks(const SchedulerConfig& config) {
     return config.HasHostCache() ? config.host_allocator.NumUsableBlocks() : 0;
 }
 
+// config_ is the first member, so routing it through this helper validates the
+// configuration before any pool or the coordinator is built off it.
+SchedulerConfig validated(SchedulerConfig config) {
+    config.Validate();
+    return config;
+}
+
 CacheKey eventKey(const CacheKey& key) {
     // External events describe one scheduler-level boundary. Fold every
     // group/child offset behind that boundary into the same accounting key.
@@ -66,7 +73,7 @@ CacheKey eventKey(const CacheKey& key) {
 }  // namespace
 
 Scheduler::Scheduler(SchedulerConfig config)
-    : config_{std::move(config)},
+    : config_{validated(std::move(config))},
       req_pool_allocator_{config_.max_batch_size},
       block_pool_{config_.device_allocator.NumUsableBlocks()},
       host_pool_{hostPoolBlocks(config_)},
@@ -74,40 +81,9 @@ Scheduler::Scheduler(SchedulerConfig config)
                                    hostPoolBlocks(config_) > 0 ? &host_pool_ : nullptr,
                                    config_.StreamsDeviceCacheToHost())},
       tier_transfers_{coordinator_} {
-    if (config_.prefix_granularity <= 0) {
-        throw std::invalid_argument("Scheduler: prefix_granularity must be > 0");
-    }
-    if (config_.device_allocator.total_pages <= 1) {
-        throw std::invalid_argument("Scheduler: device cache must contain a null page and usable capacity");
-    }
-    if (config_.paged_cache_groups.empty()) {
-        throw std::invalid_argument("Scheduler: at least one cache group is required");
-    }
-    if (config_.decode_input_tokens < 0) {
-        throw std::invalid_argument("Scheduler: decode_input_tokens must be >= 0");
-    }
-    if (config_.max_scheduled_tokens <= 0) {
-        throw std::invalid_argument("Scheduler: max_scheduled_tokens must be > 0");
-    }
-    if (config_.overlap_schedule_depth < 0 || config_.overlap_schedule_depth > 1) {
-        throw std::invalid_argument("Scheduler: overlap_schedule_depth must be 0 or 1");
-    }
-    if (config_.overlap_schedule_depth > 0 && config_.decode_input_tokens == 0) {
-        throw std::invalid_argument("Scheduler: overlapped decode requires decode_input_tokens > 0");
-    }
-    if (config_.prefix_replay_tokens < 0) {
-        throw std::invalid_argument("Scheduler: prefix_replay_tokens must be >= 0");
-    }
-    if (config_.enable_l3_storage) {
-        throw std::invalid_argument("Scheduler: L3 storage is not supported by the cache coordinator");
-    }
-    if (coordinator_.HasMambaStateGroup() && config_.max_scheduled_tokens < coordinator_.PrefixGranularity()) {
-        throw std::invalid_argument("Scheduler: Mamba max_scheduled_tokens must cover one cache block");
-    }
-
-    cache_group_ids_.reserve(config_.paged_cache_groups.size());
-    for (const PagedCacheGroupConfig& group : config_.paged_cache_groups) {
-        group.Validate();
+    // config_.Validate() already ran; the body only derives state from it.
+    cache_group_ids_.reserve(config_.cache_groups.size());
+    for (const CacheGroupConfig& group : config_.cache_groups) {
         cache_group_ids_.push_back(group.group_id);
         const std::int32_t child_entries = config_.prefix_granularity / group.BlockGranularity();
         if (cache_entries_per_event_boundary_ > std::numeric_limits<std::int32_t>::max() - child_entries) {
@@ -161,9 +137,9 @@ std::int64_t Scheduler::singleRequestLcmBlocksRequired(std::int32_t token_limit)
         if (coordinator_.GroupIsPrefixClosed(i)) {
             child_pages = ceilDiv(static_cast<std::int64_t>(token_limit) + protected_tokens, block_granularity);
         } else if (config_.role == Role::kD) {
-            const PagedCacheGroupConfig& group = config_.paged_cache_groups[static_cast<std::size_t>(i)];
+            const CacheGroupConfig& group = config_.cache_groups[static_cast<std::size_t>(i)];
             const bool latest_snapshot =
-                config_.enable_pd_cache && group.transfer_policy == PagedCacheTransferPolicy::LatestSnapshot;
+                config_.enable_pd_cache && group.transfer_policy == CacheTransferPolicy::LatestSnapshot;
             if (latest_snapshot) {
                 // The final prompt page may be full, so a non-zero decode
                 // reservation can span one more page than its own page count.
@@ -174,7 +150,7 @@ std::int64_t Scheduler::singleRequestLcmBlocksRequired(std::int32_t token_limit)
                 // recomputing its suffix. Old State checkpoints are
                 // evictable, but one recovery chunk and its lookback must fit.
                 child_pages = std::max(snapshot_pages, local_prefill_peak());
-            } else if (config_.enable_pd_cache && group.retention == PagedCacheGroupConfig::Retention::SlidingWindow) {
+            } else if (config_.enable_pd_cache && group.retention == CacheGroupConfig::Retention::SlidingWindow) {
                 const std::int64_t dense_pages =
                     ceilDiv(static_cast<std::int64_t>(token_limit) + protected_tokens, block_granularity);
                 const std::int64_t window_pages = ceilDiv(static_cast<std::int64_t>(*group.sliding_window_tokens - 1) +
@@ -355,7 +331,7 @@ void Scheduler::SubmitRequests(const std::vector<RequestSpec>& request_specs) {
             throw std::invalid_argument("Scheduler: request token limit exceeds int32 range");
         }
         if (token_limit > max_single_request_tokens_) {
-            throw std::invalid_argument("Scheduler: request token limit exceeds paged-cache capacity");
+            throw std::invalid_argument("Scheduler: request token limit exceeds cache capacity");
         }
         pending_requests.push_back(std::make_unique<Request>(spec, config_.prefix_granularity, config_.role));
     }
@@ -399,11 +375,11 @@ std::size_t Scheduler::ActiveKvPages() const {
     return coordinator_.NumActiveLcmBlocks(request_tables);
 }
 
-std::int32_t Scheduler::PagedCacheGroupTotalPages(const std::string& group_id) const {
-    return config_.paged_cache_groups[groupIndex(group_id)].total_pages;
+std::int32_t Scheduler::CacheGroupTotalPages(const std::string& group_id) const {
+    return config_.cache_groups[groupIndex(group_id)].total_pages;
 }
 
-std::int32_t Scheduler::PagedCacheGroupAvailablePages(const std::string& group_id) const {
+std::int32_t Scheduler::CacheGroupAvailablePages(const std::string& group_id) const {
     return coordinator_.GroupAvailablePages(static_cast<std::int32_t>(groupIndex(group_id)));
 }
 

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -74,8 +74,8 @@ public:
     // before submitting requests.
     std::int32_t MaxSingleRequestTokens() const { return max_single_request_tokens_; }
 
-    std::int32_t PagedCacheGroupTotalPages(const std::string& group_id) const;
-    std::int32_t PagedCacheGroupAvailablePages(const std::string& group_id) const;
+    std::int32_t CacheGroupTotalPages(const std::string& group_id) const;
+    std::int32_t CacheGroupAvailablePages(const std::string& group_id) const;
 
     bool PdTransferPinned(const std::string& request_id) const { return pd_transfer_pins_.contains(request_id); }
     std::int32_t PoolFreeBlocks() const { return coordinator_.NumAvailableLcmBlocks(); }

--- a/tokenspeed-scheduler/csrc/scheduler/types.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/types.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "scheduler/types.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace tokenspeed {
+
+namespace {
+
+void validateGroup(const SchedulerConfig& config, const CacheGroupConfig& group) {
+    group.Validate();
+    const std::string where = "Cache group '" + group.group_id + "': ";
+    if (config.prefix_granularity % group.BlockGranularity() != 0) {
+        throw std::invalid_argument(where + "block_granularity must divide the scheduler prefix_granularity");
+    }
+    if (!config.enable_pd_cache) {
+        return;
+    }
+    // A group's transfer policy is dictated by the destination layout the
+    // scheduler builds for it, so it cannot be chosen independently.
+    const CacheTransferPolicy expected =
+        group.IsSnapshotStateGroup() ? CacheTransferPolicy::LatestSnapshot : CacheTransferPolicy::FullSuffix;
+    if (group.transfer_policy == CacheTransferPolicy::Unspecified) {
+        throw std::invalid_argument(where + "PD cache requires an explicit transfer_policy");
+    }
+    if (group.transfer_policy != expected) {
+        throw std::invalid_argument(where + "transfer_policy does not match its scheduler destination layout");
+    }
+}
+
+}  // namespace
+
+void SchedulerConfig::Validate() const {
+    if (prefix_granularity <= 0) {
+        throw std::invalid_argument("Scheduler: prefix_granularity must be > 0");
+    }
+    if (device_allocator.total_pages <= 1) {
+        throw std::invalid_argument("Scheduler: device cache must contain a null page and usable capacity");
+    }
+    if (cache_groups.empty()) {
+        throw std::invalid_argument("Scheduler: at least one cache group is required");
+    }
+    if (decode_input_tokens < 0) {
+        throw std::invalid_argument("Scheduler: decode_input_tokens must be >= 0");
+    }
+    if (max_scheduled_tokens <= 0) {
+        throw std::invalid_argument("Scheduler: max_scheduled_tokens must be > 0");
+    }
+    if (overlap_schedule_depth < 0 || overlap_schedule_depth > 1) {
+        throw std::invalid_argument("Scheduler: overlap_schedule_depth must be 0 or 1");
+    }
+    if (overlap_schedule_depth > 0 && decode_input_tokens == 0) {
+        throw std::invalid_argument("Scheduler: overlapped decode requires decode_input_tokens > 0");
+    }
+    if (prefix_replay_tokens < 0) {
+        throw std::invalid_argument("Scheduler: prefix_replay_tokens must be >= 0");
+    }
+    if (enable_l3_storage) {
+        throw std::invalid_argument("Scheduler: L3 storage is not supported by the cache coordinator");
+    }
+    for (const CacheGroupConfig& group : cache_groups) {
+        validateGroup(*this, group);
+        // A recurrent state advances one whole checkpoint at a time, so a chunk
+        // must be able to cover one cache block.
+        if (group.IsSnapshotStateGroup() && max_scheduled_tokens < prefix_granularity) {
+            throw std::invalid_argument("Scheduler: Mamba max_scheduled_tokens must cover one cache block");
+        }
+    }
+}
+
+}  // namespace tokenspeed

--- a/tokenspeed-scheduler/csrc/scheduler/types.h
+++ b/tokenspeed-scheduler/csrc/scheduler/types.h
@@ -38,7 +38,7 @@ struct SchedulerConfig {
     AllocatorConfig host_allocator;
     AllocatorConfig device_allocator;
 
-    std::vector<PagedCacheGroupConfig> paged_cache_groups{};
+    std::vector<CacheGroupConfig> cache_groups{};
 
     bool HasHostCache() const { return !disable_l2_cache && host_allocator.total_pages > 1; }
 
@@ -66,6 +66,15 @@ struct SchedulerConfig {
     // Zero preserves the default logits contract, which already recomputes at
     // least the final prompt token. The effective hit is page-aligned down.
     std::int32_t prefix_replay_tokens{0};
+
+    // The single validation entry point for a scheduler configuration: every
+    // scheduler scalar, every group's own invariants, and the cross-checks
+    // between them. Throws std::invalid_argument on the first violation.
+    //
+    // The Scheduler runs this before constructing any member, because the pools
+    // and the cache coordinator assert on the same fields and their assertions
+    // would otherwise preempt these diagnostics.
+    void Validate() const;
 };
 
 }  // namespace tokenspeed

--- a/tokenspeed-scheduler/python/tests/conftest.py
+++ b/tokenspeed-scheduler/python/tests/conftest.py
@@ -30,17 +30,17 @@ def _make_k3_config() -> "ts.SchedulerConfig":
     cfg.enable_l3_storage = False
     cfg.disable_l2_cache = True
     cfg.disable_prefix_cache = False
-    cfg.paged_cache_groups = [
-        ts.PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        ts.CacheGroupConfig(
             group_id=group_id,
             rows_per_page=cfg.prefix_granularity,
             entry_stride_tokens=1,
             total_pages=cfg.num_device_pages,
-            retention=ts.PagedCacheRetention.FullHistory,
+            retention=ts.CacheRetention.FullHistory,
             family=(
-                ts.PagedCacheGroupFamily.History
+                ts.CacheGroupFamily.History
                 if group_id == K3_HISTORY_GROUP
-                else ts.PagedCacheGroupFamily.State
+                else ts.CacheGroupFamily.State
             ),
         )
         for group_id in K3_GROUP_IDS

--- a/tokenspeed-scheduler/python/tests/test_cache_group_admission.py
+++ b/tokenspeed-scheduler/python/tests/test_cache_group_admission.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import pytest
 from tokenspeed_scheduler import (
+    CacheGroupConfig,
+    CacheGroupFamily,
+    CacheRetention,
     ExecutionEvent,
     ForwardEvent,
-    PagedCacheGroupConfig,
-    PagedCacheGroupFamily,
-    PagedCacheRetention,
     RequestSpec,
     Scheduler,
     SchedulerConfig,
@@ -66,15 +66,15 @@ def _overlap_admission_scheduler(verify_width: int) -> Scheduler:
     cfg.prefix_granularity = 1
     cfg.decode_input_tokens = verify_width
     cfg.overlap_schedule_depth = 1
-    # Paged-cache group page 0 is reserved by the allocator.
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    # Cache group page 0 is reserved by the allocator.
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id="overlap.history",
             rows_per_page=1,
             entry_stride_tokens=1,
             total_pages=total_pages,
-            retention=PagedCacheRetention.FullHistory,
-            family=PagedCacheGroupFamily.History,
+            retention=CacheRetention.FullHistory,
+            family=CacheGroupFamily.History,
         )
     ]
     scheduler = Scheduler(cfg)
@@ -88,16 +88,14 @@ def _overlap_admission_scheduler(verify_width: int) -> Scheduler:
 def test_overlap_decode_admission_uses_runtime_verify_width(verify_width: int):
     scheduler = _overlap_admission_scheduler(verify_width)
     assert _request_ids_in_plan(scheduler.next_execution_plan()) == {"r"}
-    assert (
-        scheduler.paged_cache_group_available_pages("overlap.history") == verify_width
-    )
+    assert scheduler.cache_group_available_pages("overlap.history") == verify_width
 
 
 def test_overlap_schedule_depth_defaults_to_zero_and_rejects_deeper_pipeline():
     assert SchedulerConfig().overlap_schedule_depth == 0
     cfg = _base_config()
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id="history",
             rows_per_page=cfg.prefix_granularity,
             entry_stride_tokens=1,
@@ -124,13 +122,13 @@ def test_sliding_release_before_admit_prevents_oom():
     cfg = _base_config(num_device_pages=8)
     cfg.prefix_granularity = 2
     cfg.max_scheduled_tokens = 1024
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id="swa.test",
             rows_per_page=2,
             entry_stride_tokens=1,
             total_pages=8,
-            retention=PagedCacheRetention.SlidingWindow,
+            retention=CacheRetention.SlidingWindow,
             sliding_window_tokens=4,
         )
     ]
@@ -152,13 +150,13 @@ def test_batch_admission_debits_simulated_free_pages():
     cfg.prefix_granularity = 2
     cfg.max_batch_size = 4
     cfg.max_scheduled_tokens = 512
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id=f"swa.g{i}",
             rows_per_page=2,
             entry_stride_tokens=1,
             total_pages=12,
-            retention=PagedCacheRetention.SlidingWindow,
+            retention=CacheRetention.SlidingWindow,
             sliding_window_tokens=4,
         )
         for i in range(2)
@@ -177,24 +175,24 @@ def test_batch_admission_debits_simulated_free_pages():
 def test_group_tables_use_each_groups_block_granularity():
     cfg = _base_config(num_device_pages=17)
     cfg.prefix_granularity = 8
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id="history",
             rows_per_page=8,
             entry_stride_tokens=1,
             total_pages=17,
-            retention=PagedCacheRetention.FullHistory,
-            family=PagedCacheGroupFamily.History,
+            retention=CacheRetention.FullHistory,
+            family=CacheGroupFamily.History,
         ),
-        PagedCacheGroupConfig(
+        CacheGroupConfig(
             group_id="state",
             rows_per_page=2,
             entry_stride_tokens=1,
             total_pages=65,
             cache_blocks_per_lcm_block=4,
-            retention=PagedCacheRetention.SlidingWindow,
+            retention=CacheRetention.SlidingWindow,
             sliding_window_tokens=4,
-            family=PagedCacheGroupFamily.State,
+            family=CacheGroupFamily.State,
         ),
     ]
     scheduler = Scheduler(cfg)

--- a/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
+++ b/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
@@ -32,12 +32,12 @@ Covers:
 
 import pytest
 from tokenspeed_scheduler import (
+    CacheGroupConfig,
+    CacheGroupFamily,
+    CacheRetention,
     ExecutionEvent,
     ExecutionPlan,
     ForwardEvent,
-    PagedCacheGroupConfig,
-    PagedCacheGroupFamily,
-    PagedCacheRetention,
     RequestSpec,
     Scheduler,
     SchedulerConfig,
@@ -59,14 +59,14 @@ def make_config(
     cfg.max_scheduled_tokens = max_scheduled_tokens
     cfg.max_batch_size = max_batch_size
     cfg.num_device_pages = num_device_pages
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id="full_attention",
             rows_per_page=prefix_granularity,
             entry_stride_tokens=1,
             total_pages=num_device_pages,
-            retention=PagedCacheRetention.FullHistory,
-            family=PagedCacheGroupFamily.History,
+            retention=CacheRetention.FullHistory,
+            family=CacheGroupFamily.History,
         )
     ]
     return cfg

--- a/tokenspeed-scheduler/python/tests/test_kv_cache.py
+++ b/tokenspeed-scheduler/python/tests/test_kv_cache.py
@@ -42,24 +42,24 @@ def _make_config() -> ts.SchedulerConfig:
     cfg.disable_l2_cache = True
     cfg.disable_prefix_cache = True
 
-    full = ts.PagedCacheGroupConfig(
+    full = ts.CacheGroupConfig(
         group_id="full",
         rows_per_page=cfg.prefix_granularity,
         entry_stride_tokens=1,
         total_pages=cfg.num_device_pages,
-        retention=ts.PagedCacheRetention.FullHistory,
-        family=ts.PagedCacheGroupFamily.History,
+        retention=ts.CacheRetention.FullHistory,
+        family=ts.CacheGroupFamily.History,
     )
-    swa = ts.PagedCacheGroupConfig(
+    swa = ts.CacheGroupConfig(
         group_id="swa",
         rows_per_page=cfg.prefix_granularity,
         entry_stride_tokens=1,
         total_pages=cfg.num_device_pages,
-        retention=ts.PagedCacheRetention.SlidingWindow,
+        retention=ts.CacheRetention.SlidingWindow,
         sliding_window_tokens=4,
-        family=ts.PagedCacheGroupFamily.State,
+        family=ts.CacheGroupFamily.State,
     )
-    cfg.paged_cache_groups = [full, swa]
+    cfg.cache_groups = [full, swa]
     return cfg
 
 
@@ -187,7 +187,7 @@ def _make_k3_128k_config(num_device_pages: int) -> ts.SchedulerConfig:
     cfg.num_device_pages = num_device_pages
     cfg.max_scheduled_tokens = 8_192
     cfg.max_batch_size = 1
-    for group in cfg.paged_cache_groups:
+    for group in cfg.cache_groups:
         group.rows_per_page = cfg.prefix_granularity
         group.cache_blocks_per_lcm_block = (
             12 if group.group_id == K3_GROUP_IDS[0] else 1

--- a/tokenspeed-scheduler/python/tests/test_pd_binding.py
+++ b/tokenspeed-scheduler/python/tests/test_pd_binding.py
@@ -22,10 +22,10 @@
 
 from tokenspeed_scheduler import (
     PD,
+    CacheGroupConfig,
+    CacheGroupFamily,
+    CacheRetention,
     ExecutionEvent,
-    PagedCacheGroupConfig,
-    PagedCacheGroupFamily,
-    PagedCacheRetention,
     RequestSpec,
     Scheduler,
     SchedulerConfig,
@@ -38,14 +38,14 @@ def make_scheduler() -> Scheduler:
     cfg.max_scheduled_tokens = 32
     cfg.max_batch_size = 4
     cfg.num_device_pages = 1024
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id="full_attention",
             rows_per_page=cfg.prefix_granularity,
             entry_stride_tokens=1,
             total_pages=cfg.num_device_pages,
-            retention=PagedCacheRetention.FullHistory,
-            family=PagedCacheGroupFamily.History,
+            retention=CacheRetention.FullHistory,
+            family=CacheGroupFamily.History,
         )
     ]
     return Scheduler(cfg)

--- a/tokenspeed-scheduler/python/tests/test_req_pool_indices.py
+++ b/tokenspeed-scheduler/python/tests/test_req_pool_indices.py
@@ -28,11 +28,11 @@ Covers:
 """
 
 from tokenspeed_scheduler import (
+    CacheGroupConfig,
+    CacheGroupFamily,
+    CacheRetention,
     ExecutionEvent,
     ForwardEvent,
-    PagedCacheGroupConfig,
-    PagedCacheGroupFamily,
-    PagedCacheRetention,
     RequestSpec,
     Scheduler,
     SchedulerConfig,
@@ -50,14 +50,14 @@ def make_config(
     cfg.max_scheduled_tokens = max_scheduled_tokens
     cfg.max_batch_size = max_batch_size
     cfg.num_device_pages = num_device_pages
-    cfg.paged_cache_groups = [
-        PagedCacheGroupConfig(
+    cfg.cache_groups = [
+        CacheGroupConfig(
             group_id="full_attention",
             rows_per_page=prefix_granularity,
             entry_stride_tokens=1,
             total_pages=num_device_pages,
-            retention=PagedCacheRetention.FullHistory,
-            family=PagedCacheGroupFamily.History,
+            retention=CacheRetention.FullHistory,
+            family=CacheGroupFamily.History,
         )
     ]
     return cfg

--- a/tokenspeed-scheduler/python/tokenspeed_scheduler/__init__.py
+++ b/tokenspeed-scheduler/python/tokenspeed_scheduler/__init__.py
@@ -22,12 +22,12 @@
 
 import tokenspeed_scheduler.tokenspeed_scheduler_ext as _ext
 from tokenspeed_scheduler.tokenspeed_scheduler_ext import (  # Core; Execution plan; Events
+    CacheGroupConfig,
+    CacheGroupFamily,
+    CacheRetention,
+    CacheTransferPolicy,
     ExecutionEvent,
     ExecutionPlan,
-    PagedCacheGroupConfig,
-    PagedCacheGroupFamily,
-    PagedCacheRetention,
-    PagedCacheTransferPolicy,
     RequestSpec,
     Scheduler,
     SchedulerConfig,
@@ -61,10 +61,10 @@ __all__ = [
     "Scheduler",
     "SchedulerConfig",
     "RequestSpec",
-    "PagedCacheRetention",
-    "PagedCacheGroupConfig",
-    "PagedCacheGroupFamily",
-    "PagedCacheTransferPolicy",
+    "CacheRetention",
+    "CacheGroupConfig",
+    "CacheGroupFamily",
+    "CacheTransferPolicy",
     # Execution plan & operations
     "ExecutionPlan",
     "Forward",

--- a/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
+++ b/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
@@ -49,13 +49,13 @@ protected:
         cfg.max_scheduled_tokens = 64;
         cfg.max_batch_size = 8;
         cfg.enable_l3_storage = false;
-        cfg.paged_cache_groups.push_back(PagedCacheGroupConfig{
+        cfg.cache_groups.push_back(CacheGroupConfig{
             .group_id = "full_attention",
             .rows_per_page = cfg.prefix_granularity,
             .entry_stride_tokens = 1,
             .total_pages = cfg.device_allocator.total_pages,
-            .retention = PagedCacheGroupConfig::Retention::FullHistory,
-            .family = PagedCacheGroupFamily::History,
+            .retention = CacheGroupConfig::Retention::FullHistory,
+            .family = CacheGroupFamily::History,
         });
         return cfg;
     }
@@ -209,14 +209,14 @@ protected:
         cfg.disable_prefix_cache = false;
 
         for (std::size_t i = 0; i < GroupIds().size(); ++i) {
-            PagedCacheGroupConfig group;
+            CacheGroupConfig group;
             group.group_id = GroupIds()[i];
             group.rows_per_page = cfg.prefix_granularity;
             group.entry_stride_tokens = 1;
             group.total_pages = cfg.device_allocator.total_pages;
-            group.retention = PagedCacheGroupConfig::Retention::FullHistory;
-            group.family = i == 0 ? PagedCacheGroupFamily::History : PagedCacheGroupFamily::State;
-            cfg.paged_cache_groups.push_back(std::move(group));
+            group.retention = CacheGroupConfig::Retention::FullHistory;
+            group.family = i == 0 ? CacheGroupFamily::History : CacheGroupFamily::State;
+            cfg.cache_groups.push_back(std::move(group));
         }
         return cfg;
     }

--- a/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
@@ -2974,7 +2974,7 @@ TEST(CacheCoordinatorHostExtension, MultiWindowCascadeConvergesToZeroExtension) 
 
 // ---------------------------------------------------------------------------
 // Mamba-analog semantics: vLLM reduces a mamba/linear-attention group to the
-// paged machinery via (a) hit = ONE aligned state snapshot found right-to-left,
+// cache machinery via (a) hit = ONE aligned state snapshot found right-to-left,
 // padded with nulls ([null]*i + [state]); (b) retention = only the last token's
 // state lives (skipped = n-1, exactly our W=2 slide rule); (c) L2 = sliding
 // window of one block. These tests pin that our SwaManager with a one-page

--- a/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
@@ -95,13 +95,13 @@ TEST(CacheOperationTest, DecodeCanStartWithoutHostL2) {
         config.max_scheduled_tokens = 2;
         config.max_batch_size = 1;
         config.role = Role::kD;
-        config.paged_cache_groups.push_back(PagedCacheGroupConfig{
+        config.cache_groups.push_back(CacheGroupConfig{
             .group_id = "full",
             .rows_per_page = 2,
             .entry_stride_tokens = 1,
             .total_pages = 4,
-            .retention = PagedCacheGroupConfig::Retention::FullHistory,
-            .family = PagedCacheGroupFamily::History,
+            .retention = CacheGroupConfig::Retention::FullHistory,
+            .family = CacheGroupFamily::History,
         });
         return config;
     };
@@ -124,13 +124,13 @@ TEST(CacheOperationTest, DeviceRequestLimitDoesNotDependOnHostCapacity) {
         config.max_scheduled_tokens = 8;
         config.max_batch_size = 2;
         config.role = Role::kD;
-        config.paged_cache_groups.push_back(PagedCacheGroupConfig{
+        config.cache_groups.push_back(CacheGroupConfig{
             .group_id = "full",
             .rows_per_page = 2,
             .entry_stride_tokens = 1,
             .total_pages = 9,
-            .retention = PagedCacheGroupConfig::Retention::FullHistory,
-            .family = PagedCacheGroupFamily::History,
+            .retention = CacheGroupConfig::Retention::FullHistory,
+            .family = CacheGroupFamily::History,
         });
         return config;
     };
@@ -229,13 +229,13 @@ TEST(CacheOperationTest, DecodeRejectsRequestWhoseMaximumExtentCannotFitDevice) 
     config.max_scheduled_tokens = 8;
     config.max_batch_size = 2;
     config.role = Role::kD;
-    config.paged_cache_groups.push_back(PagedCacheGroupConfig{
+    config.cache_groups.push_back(CacheGroupConfig{
         .group_id = "full",
         .rows_per_page = 2,
         .entry_stride_tokens = 1,
         .total_pages = 4,
-        .retention = PagedCacheGroupConfig::Retention::FullHistory,
-        .family = PagedCacheGroupFamily::History,
+        .retention = CacheGroupConfig::Retention::FullHistory,
+        .family = CacheGroupFamily::History,
     });
     Scheduler scheduler{std::move(config)};
     ASSERT_EQ(scheduler.MaxSingleRequestTokens(), 6);
@@ -256,13 +256,13 @@ TEST(CacheOperationTest, PrefillAcceptsPromptThatFitsWithoutReservingDecodeToken
     config.max_scheduled_tokens = 8;
     config.max_batch_size = 2;
     config.role = Role::kP;
-    config.paged_cache_groups.push_back(PagedCacheGroupConfig{
+    config.cache_groups.push_back(CacheGroupConfig{
         .group_id = "full",
         .rows_per_page = 2,
         .entry_stride_tokens = 1,
         .total_pages = 4,
-        .retention = PagedCacheGroupConfig::Retention::FullHistory,
-        .family = PagedCacheGroupFamily::History,
+        .retention = CacheGroupConfig::Retention::FullHistory,
+        .family = CacheGroupFamily::History,
     });
     Scheduler scheduler{std::move(config)};
     ASSERT_EQ(scheduler.MaxSingleRequestTokens(), 6);

--- a/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
@@ -64,10 +64,10 @@ std::pair<bool, std::string> ClearL1CacheWithCapturedLog(Scheduler* scheduler) {
     return {cleared, output.str()};
 }
 
-PagedCacheGroupConfig MakeGroup(const std::string& id, std::int32_t block_granularity, std::int32_t total_pages,
-                                PagedCacheGroupConfig::Retention retention, PagedCacheGroupFamily family,
-                                std::int32_t sliding_window_tokens = 0) {
-    PagedCacheGroupConfig g;
+CacheGroupConfig MakeGroup(const std::string& id, std::int32_t block_granularity, std::int32_t total_pages,
+                           CacheGroupConfig::Retention retention, CacheGroupFamily family,
+                           std::int32_t sliding_window_tokens = 0) {
+    CacheGroupConfig g;
     g.group_id = id;
     g.rows_per_page = block_granularity;
     g.entry_stride_tokens = 1;
@@ -109,11 +109,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/4),
         };
         return cfg;
@@ -168,11 +168,11 @@ protected:
         cfg.enable_l3_storage = false;
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("state", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::State),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::State),
         };
         return cfg;
     }
@@ -252,11 +252,11 @@ TEST(MambaChunkAlignmentConfigTest, RejectsBudgetSmallerThanStatePage) {
     cfg.max_batch_size = 8;
     cfg.disable_l2_cache = true;
     cfg.disable_prefix_cache = true;
-    cfg.paged_cache_groups = {
+    cfg.cache_groups = {
         MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                  PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                  CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
         MakeGroup("state", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                  PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::State),
+                  CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::State),
     };
 
     EXPECT_THROW((void)Scheduler(std::move(cfg)), std::invalid_argument);
@@ -279,14 +279,14 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa_small", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/4),
             MakeGroup("swa_big", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/8),
         };
         return cfg;
@@ -340,14 +340,14 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa_w3", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/3),
             MakeGroup("swa_w5", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/5),
         };
         return cfg;
@@ -421,11 +421,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full_a", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("full_b", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
         };
         return cfg;
     }
@@ -475,11 +475,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/4),
         };
         return cfg;
@@ -655,11 +655,11 @@ protected:
         cfg.disable_prefix_cache = true;
         cfg.enable_mixed_prefill_decode = true;  // decode + prefill in one plan
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/4),
         };
         return cfg;
@@ -769,11 +769,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/2),
         };
         return cfg;
@@ -841,11 +841,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/4),
         };
         return cfg;
@@ -907,11 +907,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/4),
         };
         return cfg;
@@ -1088,11 +1088,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full_a", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("full_b", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
         };
         return cfg;
     }
@@ -1233,11 +1233,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full_a", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("full_b", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
         };
         return cfg;
     }
@@ -1478,7 +1478,7 @@ protected:
         cfg.device_allocator.total_pages = 19;
         cfg.host_allocator.total_pages = 20;
         cfg.max_scheduled_tokens = 8;
-        for (auto& group : cfg.paged_cache_groups) {
+        for (auto& group : cfg.cache_groups) {
             group.total_pages = cfg.device_allocator.total_pages;
         }
         return cfg;
@@ -1517,7 +1517,7 @@ protected:
         // 9 physical pages -> 8 usable: one 3-page prompt charges exactly the pool.
         cfg.device_allocator.total_pages = 9;
         cfg.host_allocator.total_pages = 10;
-        for (auto& g : cfg.paged_cache_groups) {
+        for (auto& g : cfg.cache_groups) {
             g.total_pages = cfg.device_allocator.total_pages;
         }
         return cfg;
@@ -1532,7 +1532,7 @@ TEST_F(RetractExactFitSuite, ReportsSingleRequestTokenCapacity) {
 
 TEST_F(RetractExactFitSuite, ReportsCapacityUsingEachGroupsBlockGranularity) {
     SchedulerConfig config = MakeConfig();
-    config.paged_cache_groups[1].rows_per_page = 1;
+    config.cache_groups[1].rows_per_page = 1;
     Scheduler scheduler{std::move(config)};
 
     // Eight parents fit ceil(tokens / 2) pages for the first group and one
@@ -1561,17 +1561,17 @@ TEST(PdSlidingCapacityTest, CountsPrefixIslandPhasePageAndGroupPacking) {
     cfg.enable_pd_cache = true;
     cfg.disable_l2_cache = true;
 
-    PagedCacheGroupConfig sliding;
+    CacheGroupConfig sliding;
     sliding.group_id = "sliding";
     sliding.rows_per_page = 2;  // group q=2 while scheduler P=4
     sliding.entry_stride_tokens = 1;
     sliding.total_pages = 5;  // null + two parents packing two children each
     sliding.cache_blocks_per_lcm_block = 2;
-    sliding.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+    sliding.retention = CacheGroupConfig::Retention::SlidingWindow;
     sliding.sliding_window_tokens = 4;
-    sliding.family = PagedCacheGroupFamily::State;
-    sliding.transfer_policy = PagedCacheTransferPolicy::FullSuffix;
-    cfg.paged_cache_groups = {sliding};
+    sliding.family = CacheGroupFamily::State;
+    sliding.transfer_policy = CacheTransferPolicy::FullSuffix;
+    cfg.cache_groups = {sliding};
 
     Scheduler scheduler{std::move(cfg)};
 
@@ -1625,7 +1625,7 @@ protected:
         // 25 physical pages -> 24 usable: r1 charges 10, r2 8, r3 6 = the pool.
         cfg.device_allocator.total_pages = 25;
         cfg.host_allocator.total_pages = 26;
-        for (auto& g : cfg.paged_cache_groups) {
+        for (auto& g : cfg.cache_groups) {
             g.total_pages = cfg.device_allocator.total_pages;
         }
         return cfg;
@@ -1713,11 +1713,11 @@ protected:
         SchedulerConfig cfg = RetractSuite::MakeConfig();
         cfg.device_allocator.total_pages = 9;  // 8 usable
         cfg.host_allocator.total_pages = 10;
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("state", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::State),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::State),
         };
         return cfg;
     }
@@ -1809,11 +1809,11 @@ protected:
         cfg.enable_l3_storage = false;
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = false;
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("state", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::State),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::State),
         };
         return cfg;
     }
@@ -2124,11 +2124,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full_a", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("full_b", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
         };
         return cfg;
     }
@@ -2224,12 +2224,11 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = DisablePrefixCache();
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
-                      SlidingWindowTokens()),
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State, SlidingWindowTokens()),
         };
         return cfg;
     }
@@ -2549,15 +2548,13 @@ protected:
         cfg.disable_prefix_cache = false;
         cfg.prefix_replay_tokens = 8;
 
-        PagedCacheGroupConfig history =
-            MakeGroup("history", /*block_granularity=*/8, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History);
-        PagedCacheGroupConfig state =
-            MakeGroup("state", /*block_granularity=*/2, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
-                      /*sliding_window_tokens=*/32);
+        CacheGroupConfig history = MakeGroup("history", /*block_granularity=*/8, cfg.device_allocator.total_pages,
+                                             CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History);
+        CacheGroupConfig state = MakeGroup("state", /*block_granularity=*/2, cfg.device_allocator.total_pages,
+                                           CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
+                                           /*sliding_window_tokens=*/32);
         state.cache_blocks_per_lcm_block = 4;
-        cfg.paged_cache_groups = {history, state};
+        cfg.cache_groups = {history, state};
         return cfg;
     }
 };
@@ -2600,9 +2597,9 @@ TEST(PrefixReplayConfigTest, RejectsNegativeReplayTokens) {
     cfg.max_scheduled_tokens = 8;
     cfg.max_batch_size = 1;
     cfg.prefix_replay_tokens = -1;
-    cfg.paged_cache_groups = {
+    cfg.cache_groups = {
         MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                  PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                  CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
     };
     EXPECT_THROW((void)Scheduler(std::move(cfg)), std::invalid_argument);
 }
@@ -3110,11 +3107,11 @@ protected:
         cfg.disable_l2_cache = false;
         cfg.disable_prefix_cache = true;
 
-        cfg.paged_cache_groups = {
+        cfg.cache_groups = {
             MakeGroup("full", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::FullHistory, PagedCacheGroupFamily::History),
+                      CacheGroupConfig::Retention::FullHistory, CacheGroupFamily::History),
             MakeGroup("swa", cfg.prefix_granularity, cfg.device_allocator.total_pages,
-                      PagedCacheGroupConfig::Retention::SlidingWindow, PagedCacheGroupFamily::State,
+                      CacheGroupConfig::Retention::SlidingWindow, CacheGroupFamily::State,
                       /*sliding_window_tokens=*/4),
         };
         return cfg;
@@ -3311,7 +3308,7 @@ protected:
         // (10 prefill + 2 reserve) spans the whole free list, recycling r1's 6 cached pages.
         cfg.device_allocator.total_pages = 13;
         cfg.host_allocator.total_pages = 33;  // ample (+null page 0): r1's 6 + the churn's 7 entries fit un-evicted
-        for (auto& g : cfg.paged_cache_groups) {
+        for (auto& g : cfg.cache_groups) {
             g.total_pages = cfg.device_allocator.total_pages;
         }
         return cfg;
@@ -3571,7 +3568,7 @@ protected:
         // 21 -> 20 free: r2's first chunk holds 10 (6 ext + 4 fresh) and its second
         // chunk charges 6 with zero slide credit (ticket-held punches don't count).
         cfg.device_allocator.total_pages = 21;
-        for (auto& g : cfg.paged_cache_groups) {
+        for (auto& g : cfg.cache_groups) {
             g.total_pages = cfg.device_allocator.total_pages;
         }
         return cfg;

--- a/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -365,21 +366,21 @@ TEST(ForwardCacheOpsDecode, AdmissionWithEmptyHashesOnlySlidesAndAllocates) {
     }
 }
 
-TEST(MakeSpecsFromConfigTest, TranslatesPagedCacheGroups) {
+TEST(MakeSpecsFromConfigTest, TranslatesCacheGroups) {
     SchedulerConfig config;
     config.prefix_granularity = 16;
-    PagedCacheGroupConfig full_grp;
+    CacheGroupConfig full_grp;
     full_grp.group_id = "full";
     full_grp.rows_per_page = 16;
     full_grp.entry_stride_tokens = 1;
-    full_grp.retention = PagedCacheGroupConfig::Retention::FullHistory;
-    PagedCacheGroupConfig swa_grp;
+    full_grp.retention = CacheGroupConfig::Retention::FullHistory;
+    CacheGroupConfig swa_grp;
     swa_grp.group_id = "swa";
     swa_grp.rows_per_page = 16;
     swa_grp.entry_stride_tokens = 1;
-    swa_grp.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+    swa_grp.retention = CacheGroupConfig::Retention::SlidingWindow;
     swa_grp.sliding_window_tokens = 128;
-    config.paged_cache_groups = {full_grp, swa_grp};
+    config.cache_groups = {full_grp, swa_grp};
 
     std::vector<CacheGroupSpec> specs = MakeSpecsFromConfig(config);
     ASSERT_EQ(specs.size(), 2u);
@@ -394,17 +395,17 @@ TEST(MakeSpecsFromConfigTest, TranslatesPagedCacheGroups) {
 TEST(MakeSpecsFromConfigTest, StateFamilyMapsToMambaStateKind) {
     SchedulerConfig config;
     config.prefix_granularity = 4;
-    PagedCacheGroupConfig full_grp;
+    CacheGroupConfig full_grp;
     full_grp.group_id = "full_attention";
     full_grp.rows_per_page = 4;
     full_grp.entry_stride_tokens = 1;
-    full_grp.retention = PagedCacheGroupConfig::Retention::FullHistory;
-    PagedCacheGroupConfig state_grp;
+    full_grp.retention = CacheGroupConfig::Retention::FullHistory;
+    CacheGroupConfig state_grp;
     state_grp.group_id = "linear_attention";
     state_grp.rows_per_page = 4;
     state_grp.entry_stride_tokens = 1;
-    state_grp.family = PagedCacheGroupFamily::State;
-    config.paged_cache_groups = {full_grp, state_grp};
+    state_grp.family = CacheGroupFamily::State;
+    config.cache_groups = {full_grp, state_grp};
 
     std::vector<CacheGroupSpec> specs = MakeSpecsFromConfig(config);
     ASSERT_EQ(specs.size(), 2u);
@@ -417,21 +418,21 @@ TEST(MakeSpecsFromConfigTest, StateFamilyMapsToMambaStateKind) {
 TEST(MakeSpecsFromConfigTest, Qwen35Fp8UsesOneLogicalPAndPerGroupPacking) {
     SchedulerConfig config;
     config.prefix_granularity = 128;
-    PagedCacheGroupConfig full;
+    CacheGroupConfig full;
     full.group_id = "full";
     full.rows_per_page = 128;
     full.entry_stride_tokens = 1;
     full.cache_blocks_per_lcm_block = 16;
-    PagedCacheGroupConfig state0;
+    CacheGroupConfig state0;
     state0.group_id = "state0";
     state0.rows_per_page = 128;
     state0.entry_stride_tokens = 1;
-    state0.family = PagedCacheGroupFamily::State;
-    PagedCacheGroupConfig state1 = state0;
+    state0.family = CacheGroupFamily::State;
+    CacheGroupConfig state1 = state0;
     state1.group_id = "state1";
-    PagedCacheGroupConfig state2 = state0;
+    CacheGroupConfig state2 = state0;
     state2.group_id = "state2";
-    config.paged_cache_groups = {full, state0, state1, state2};
+    config.cache_groups = {full, state0, state1, state2};
 
     std::vector<CacheGroupSpec> specs = MakeSpecsFromConfig(config);
 
@@ -445,16 +446,16 @@ TEST(MakeSpecsFromConfigTest, Qwen35Fp8UsesOneLogicalPAndPerGroupPacking) {
 TEST(MakeSpecsFromConfigTest, PreservesPerGroupCachePageTokens) {
     SchedulerConfig config;
     config.prefix_granularity = 256;
-    PagedCacheGroupConfig history;
+    CacheGroupConfig history;
     history.group_id = "history";
     history.rows_per_page = 64;
     history.entry_stride_tokens = 4;
-    PagedCacheGroupConfig state;
+    CacheGroupConfig state;
     state.group_id = "compressor_state";
-    state.family = PagedCacheGroupFamily::State;
+    state.family = CacheGroupFamily::State;
     state.rows_per_page = 4;
     state.entry_stride_tokens = 1;
-    config.paged_cache_groups = {history, state};
+    config.cache_groups = {history, state};
 
     const std::vector<CacheGroupSpec> specs = MakeSpecsFromConfig(config);
 
@@ -463,68 +464,108 @@ TEST(MakeSpecsFromConfigTest, PreservesPerGroupCachePageTokens) {
     EXPECT_EQ(specs[1].block_granularity, 4);
 }
 
-TEST(MakeSpecsFromConfigTest, RejectsNonPositiveGlobalP) {
-    SchedulerConfig config;
-    config.prefix_granularity = 0;
-    config.paged_cache_groups.resize(1);
-    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
-
-    config.prefix_granularity = -1;
-    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
-}
-
-TEST(MakeSpecsFromConfigTest, RejectsNonPositivePerGroupPacking) {
+// A configuration SchedulerConfig::Validate() accepts, so that each rejection
+// test below can perturb exactly one field.
+SchedulerConfig MakeValidConfig() {
     SchedulerConfig config;
     config.prefix_granularity = 128;
-    config.paged_cache_groups.resize(1);
-    config.paged_cache_groups[0].cache_blocks_per_lcm_block = 0;
-    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
-
-    config.paged_cache_groups[0].cache_blocks_per_lcm_block = -1;
-    EXPECT_THROW(MakeSpecsFromConfig(config), std::runtime_error);
-}
-
-TEST(MakeSpecsFromConfigTest, RejectsMissingSlidingWindowWithGroupId) {
-    SchedulerConfig config;
-    config.prefix_granularity = 128;
-    PagedCacheGroupConfig group;
-    group.group_id = "missing_window";
+    config.device_allocator.total_pages = 32;
+    config.max_scheduled_tokens = 1024;
+    config.max_batch_size = 8;
+    CacheGroupConfig group;
+    group.group_id = "full";
     group.rows_per_page = 128;
     group.entry_stride_tokens = 1;
-    group.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
-    config.paged_cache_groups = {group};
+    group.total_pages = config.device_allocator.total_pages;
+    config.cache_groups = {group};
+    return config;
+}
 
+// Every message naming a group must identify which one: a model mixes several.
+void ExpectRejectedNamingGroup(const SchedulerConfig& config, const std::string& group_id) {
     try {
-        (void)MakeSpecsFromConfig(config);
-        FAIL() << "missing sliding_window_tokens was accepted";
+        config.Validate();
+        FAIL() << "invalid config was accepted";
     } catch (const std::invalid_argument& error) {
-        EXPECT_NE(std::string{error.what()}.find(group.group_id), std::string::npos);
+        EXPECT_NE(std::string{error.what()}.find(group_id), std::string::npos) << error.what();
     }
 }
 
-TEST(MakeSpecsFromConfigTest, RejectsNonPositiveSlidingWindowWithGroupId) {
-    SchedulerConfig config;
-    config.prefix_granularity = 128;
-    PagedCacheGroupConfig group;
-    group.group_id = "nonpositive_window";
-    group.rows_per_page = 128;
-    group.entry_stride_tokens = 1;
-    group.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
-    config.paged_cache_groups = {group};
+TEST(SchedulerConfigValidateTest, AcceptsAValidConfig) {
+    EXPECT_NO_THROW(MakeValidConfig().Validate());
+}
 
+TEST(SchedulerConfigValidateTest, RejectsNonPositiveGlobalP) {
+    SchedulerConfig config = MakeValidConfig();
+    for (const std::int32_t prefix_granularity : {0, -1}) {
+        config.prefix_granularity = prefix_granularity;
+        EXPECT_THROW(config.Validate(), std::invalid_argument);
+    }
+}
+
+TEST(SchedulerConfigValidateTest, RejectsNonPositivePerGroupPacking) {
+    SchedulerConfig config = MakeValidConfig();
+    for (const std::int32_t packing : {0, -1}) {
+        config.cache_groups[0].cache_blocks_per_lcm_block = packing;
+        ExpectRejectedNamingGroup(config, config.cache_groups[0].group_id);
+    }
+}
+
+TEST(SchedulerConfigValidateTest, RejectsBlockGranularityThatDoesNotDivideP) {
+    SchedulerConfig config = MakeValidConfig();
+    config.cache_groups[0].rows_per_page = 48;
+    ExpectRejectedNamingGroup(config, config.cache_groups[0].group_id);
+}
+
+TEST(SchedulerConfigValidateTest, RejectsMissingSlidingWindowWithGroupId) {
+    SchedulerConfig config = MakeValidConfig();
+    config.cache_groups[0].group_id = "missing_window";
+    config.cache_groups[0].retention = CacheGroupConfig::Retention::SlidingWindow;
+    ExpectRejectedNamingGroup(config, "missing_window");
+}
+
+TEST(SchedulerConfigValidateTest, RejectsNonPositiveSlidingWindowWithGroupId) {
+    SchedulerConfig config = MakeValidConfig();
+    config.cache_groups[0].group_id = "nonpositive_window";
+    config.cache_groups[0].retention = CacheGroupConfig::Retention::SlidingWindow;
     for (const std::int32_t window : {0, -1}) {
-        config.paged_cache_groups[0].sliding_window_tokens = window;
-        try {
-            (void)MakeSpecsFromConfig(config);
-            FAIL() << "sliding_window_tokens=" << window << " was accepted";
-        } catch (const std::invalid_argument& error) {
-            EXPECT_NE(std::string{error.what()}.find(group.group_id), std::string::npos);
-        }
+        config.cache_groups[0].sliding_window_tokens = window;
+        ExpectRejectedNamingGroup(config, "nonpositive_window");
     }
 }
 
-TEST(MakeSpecsFromConfigTest, PagedCacheGroupConfigRejectsNonPositivePacking) {
-    PagedCacheGroupConfig group;
+TEST(SchedulerConfigValidateTest, RejectsSnapshotStateGroupBelowOneCacheBlock) {
+    SchedulerConfig config = MakeValidConfig();
+    config.cache_groups[0].family = CacheGroupFamily::State;
+    config.max_scheduled_tokens = config.prefix_granularity - 1;
+    EXPECT_THROW(config.Validate(), std::invalid_argument);
+
+    config.max_scheduled_tokens = config.prefix_granularity;
+    EXPECT_NO_THROW(config.Validate());
+}
+
+TEST(SchedulerConfigValidateTest, RejectsPdTransferPolicyMismatch) {
+    SchedulerConfig config = MakeValidConfig();
+    config.enable_pd_cache = true;
+    CacheGroupConfig& history = config.cache_groups[0];
+
+    // A History group ships its full suffix; leaving the policy to the default
+    // or claiming a snapshot layout are both rejected.
+    ExpectRejectedNamingGroup(config, history.group_id);
+    history.transfer_policy = CacheTransferPolicy::LatestSnapshot;
+    ExpectRejectedNamingGroup(config, history.group_id);
+    history.transfer_policy = CacheTransferPolicy::FullSuffix;
+    EXPECT_NO_THROW(config.Validate());
+
+    // A snapshot-state group is the mirror image.
+    history.family = CacheGroupFamily::State;
+    ExpectRejectedNamingGroup(config, history.group_id);
+    history.transfer_policy = CacheTransferPolicy::LatestSnapshot;
+    EXPECT_NO_THROW(config.Validate());
+}
+
+TEST(SchedulerConfigValidateTest, CacheGroupConfigRejectsNonPositivePacking) {
+    CacheGroupConfig group;
     group.group_id = "full";
     group.rows_per_page = 1;
     group.entry_stride_tokens = 1;

--- a/tokenspeed-scheduler/tests/cpp/test_kv_cache_lifecycle.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_kv_cache_lifecycle.cpp
@@ -19,7 +19,7 @@
 // SOFTWARE.
 
 // End-to-end lifecycle tests for the two-level KV-cache FSM path.
-// Config: two paged-cache groups (full + sliding-window), no L2/L3.
+// Config: two cache groups (full + sliding-window), no L2/L3.
 
 #include <algorithm>
 #include <array>
@@ -43,25 +43,25 @@ protected:
         cfg.disable_l2_cache = true;
         cfg.disable_prefix_cache = true;
 
-        PagedCacheGroupConfig full_grp;
+        CacheGroupConfig full_grp;
         full_grp.group_id = "full";
         full_grp.rows_per_page = cfg.prefix_granularity;
         full_grp.entry_stride_tokens = 1;
         full_grp.total_pages = cfg.device_allocator.total_pages;
         full_grp.cache_blocks_per_lcm_block = 2;
-        full_grp.retention = PagedCacheGroupConfig::Retention::FullHistory;
-        full_grp.family = PagedCacheGroupFamily::History;
+        full_grp.retention = CacheGroupConfig::Retention::FullHistory;
+        full_grp.family = CacheGroupFamily::History;
 
-        PagedCacheGroupConfig swa_grp;
+        CacheGroupConfig swa_grp;
         swa_grp.group_id = "swa";
         swa_grp.rows_per_page = cfg.prefix_granularity;
         swa_grp.entry_stride_tokens = 1;
         swa_grp.total_pages = cfg.device_allocator.total_pages;
-        swa_grp.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+        swa_grp.retention = CacheGroupConfig::Retention::SlidingWindow;
         swa_grp.sliding_window_tokens = 4;
-        swa_grp.family = PagedCacheGroupFamily::State;
+        swa_grp.family = CacheGroupFamily::State;
 
-        cfg.paged_cache_groups = {full_grp, swa_grp};
+        cfg.cache_groups = {full_grp, swa_grp};
         return cfg;
     }
 };

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -139,15 +139,15 @@ protected:
         cfg.disable_l2_cache = false;
         cfg.disable_prefix_cache = true;
 
-        PagedCacheGroupConfig full;
+        CacheGroupConfig full;
         full.group_id = "full";
         full.rows_per_page = cfg.prefix_granularity;
         full.entry_stride_tokens = 1;
         full.total_pages = cfg.device_allocator.total_pages;
-        full.retention = PagedCacheGroupConfig::Retention::FullHistory;
-        full.family = PagedCacheGroupFamily::History;
-        full.transfer_policy = PagedCacheTransferPolicy::FullSuffix;
-        cfg.paged_cache_groups = {full};
+        full.retention = CacheGroupConfig::Retention::FullHistory;
+        full.family = CacheGroupFamily::History;
+        full.transfer_policy = CacheTransferPolicy::FullSuffix;
+        cfg.cache_groups = {full};
         return cfg;
     }
 
@@ -194,7 +194,7 @@ protected:
         SchedulerConfig cfg = DisaggDecodeAdmissionTestSuite::MakeConfig();
         cfg.device_allocator.total_pages = 5;
         cfg.max_batch_size = 2;
-        cfg.paged_cache_groups.front().total_pages = cfg.device_allocator.total_pages;
+        cfg.cache_groups.front().total_pages = cfg.device_allocator.total_pages;
         return cfg;
     }
 };
@@ -232,7 +232,7 @@ protected:
         cfg.disable_l2_cache = false;
         cfg.disable_prefix_cache = false;
         cfg.device_allocator.total_pages = 5;  // null parent + one four-page recovery working set
-        cfg.paged_cache_groups.front().total_pages = cfg.device_allocator.total_pages;
+        cfg.cache_groups.front().total_pages = cfg.device_allocator.total_pages;
         return cfg;
     }
 };
@@ -244,7 +244,7 @@ protected:
         cfg.device_allocator.total_pages = 16;
         cfg.host_allocator.total_pages = 6;  // null parent + five retraction parents
         cfg.max_batch_size = 3;
-        cfg.paged_cache_groups.front().total_pages = cfg.device_allocator.total_pages;
+        cfg.cache_groups.front().total_pages = cfg.device_allocator.total_pages;
         return cfg;
     }
 };
@@ -254,7 +254,7 @@ protected:
     SchedulerConfig MakeConfig() override {
         SchedulerConfig cfg = DecodeRetractionL2TestSuite::MakeConfig();
         cfg.device_allocator.total_pages = 6;
-        cfg.paged_cache_groups.front().total_pages = cfg.device_allocator.total_pages;
+        cfg.cache_groups.front().total_pages = cfg.device_allocator.total_pages;
         cfg.max_batch_size = 2;
         return cfg;
     }
@@ -609,19 +609,19 @@ protected:
         cfg.enable_pd_cache = true;
         cfg.disable_prefix_cache = false;
 
-        PagedCacheGroupConfig full = cfg.paged_cache_groups.front();
+        CacheGroupConfig full = cfg.cache_groups.front();
         full.group_id = "full";
         full.total_pages = 13;
         full.cache_blocks_per_lcm_block = 2;
-        full.transfer_policy = PagedCacheTransferPolicy::FullSuffix;
+        full.transfer_policy = CacheTransferPolicy::FullSuffix;
 
-        PagedCacheGroupConfig state = full;
+        CacheGroupConfig state = full;
         state.group_id = "state";
         state.total_pages = 7;
         state.cache_blocks_per_lcm_block = 1;
-        state.family = PagedCacheGroupFamily::State;
-        state.transfer_policy = PagedCacheTransferPolicy::LatestSnapshot;
-        cfg.paged_cache_groups = {full, state};
+        state.family = CacheGroupFamily::State;
+        state.transfer_policy = CacheTransferPolicy::LatestSnapshot;
+        cfg.cache_groups = {full, state};
         return cfg;
     }
 };
@@ -631,8 +631,8 @@ protected:
     SchedulerConfig MakeConfig() override {
         SchedulerConfig cfg = PdSparseDecodeAdmissionTestSuite::MakeConfig();
         cfg.device_allocator.total_pages = 8;
-        cfg.paged_cache_groups[0].total_pages = 15;
-        cfg.paged_cache_groups[1].total_pages = 8;
+        cfg.cache_groups[0].total_pages = 15;
+        cfg.cache_groups[1].total_pages = 8;
         cfg.disable_prefix_cache = true;
         return cfg;
     }
@@ -642,7 +642,7 @@ class PdSmallStatePagesTestSuite : public PdSparseDecodeAdmissionTestSuite {
 protected:
     SchedulerConfig MakeConfig() override {
         SchedulerConfig cfg = PdSparseDecodeAdmissionTestSuite::MakeConfig();
-        auto& state = cfg.paged_cache_groups[1];
+        auto& state = cfg.cache_groups[1];
         state.rows_per_page = 1;
         state.total_pages = 13;
         state.cache_blocks_per_lcm_block = 2;
@@ -656,8 +656,8 @@ protected:
         SchedulerConfig cfg = PdSparseDecodeAdmissionTestSuite::MakeConfig();
         cfg.device_allocator.total_pages = 9;  // null parent + eight usable parents
         cfg.max_scheduled_tokens = 8;
-        cfg.paged_cache_groups[0].total_pages = 17;
-        cfg.paged_cache_groups[1].total_pages = 9;
+        cfg.cache_groups[0].total_pages = 17;
+        cfg.cache_groups[1].total_pages = 9;
         return cfg;
     }
 };
@@ -673,16 +673,16 @@ protected:
         cfg.enable_pd_cache = true;
         cfg.disable_prefix_cache = false;
 
-        PagedCacheGroupConfig sliding;
+        CacheGroupConfig sliding;
         sliding.group_id = "sliding";
         sliding.rows_per_page = 2;
         sliding.entry_stride_tokens = 1;
         sliding.total_pages = cfg.device_allocator.total_pages;
-        sliding.retention = PagedCacheGroupConfig::Retention::SlidingWindow;
+        sliding.retention = CacheGroupConfig::Retention::SlidingWindow;
         sliding.sliding_window_tokens = 4;
-        sliding.family = PagedCacheGroupFamily::State;
-        sliding.transfer_policy = PagedCacheTransferPolicy::FullSuffix;
-        cfg.paged_cache_groups = {sliding};
+        sliding.family = CacheGroupFamily::State;
+        sliding.transfer_policy = CacheTransferPolicy::FullSuffix;
+        cfg.cache_groups = {sliding};
         return cfg;
     }
 };

--- a/tokenspeed-scheduler/tests/cpp/test_scheduler_plan.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_scheduler_plan.cpp
@@ -20,6 +20,8 @@
 
 #include "integration_test_helper.h"
 
+#include <stdexcept>
+#include <string>
 #include <unordered_set>
 
 namespace tokenspeed::test {
@@ -254,9 +256,9 @@ protected:
         cfg.device_allocator.total_pages = 8;
         cfg.disable_l2_cache = true;
         cfg.enable_kv_cache_events = true;
-        PagedCacheGroupConfig second = cfg.paged_cache_groups.front();
+        CacheGroupConfig second = cfg.cache_groups.front();
         second.group_id = "full_attention_1";
-        cfg.paged_cache_groups.push_back(std::move(second));
+        cfg.cache_groups.push_back(std::move(second));
         return cfg;
     }
 };
@@ -278,7 +280,7 @@ protected:
     SchedulerConfig MakeConfig() override {
         SchedulerConfig cfg = SchedulerKvCacheEventTestSuite::MakeConfig();
         cfg.device_allocator.total_pages = 4;
-        auto& group = cfg.paged_cache_groups.front();
+        auto& group = cfg.cache_groups.front();
         group.rows_per_page = 1;
         group.total_pages = 2 * cfg.device_allocator.total_pages;
         group.cache_blocks_per_lcm_block = 2;
@@ -347,10 +349,10 @@ protected:
         cfg.device_allocator.total_pages = 128;
         cfg.disable_l2_cache = true;
         for (std::int32_t i = 0; i < 3; ++i) {
-            PagedCacheGroupConfig state = cfg.paged_cache_groups.front();
+            CacheGroupConfig state = cfg.cache_groups.front();
             state.group_id = "linear_attention_" + std::to_string(i);
-            state.family = PagedCacheGroupFamily::State;
-            cfg.paged_cache_groups.push_back(std::move(state));
+            state.family = CacheGroupFamily::State;
+            cfg.cache_groups.push_back(std::move(state));
         }
         return cfg;
     }
@@ -390,6 +392,27 @@ TEST_F(HybridPrefixPromotionTestSuite, ThirdRequestReusesPromotedStateBoundary) 
     ASSERT_NE(reuse, nullptr);
     ASSERT_EQ(reuse->request_ids, std::vector<std::string>{"reuse"});
     EXPECT_EQ(reuse->extend_prefix_lens, std::vector<std::int32_t>{8});
+}
+
+TEST(SchedulerConstructionTest, ValidatesConfigBeforeBuildingPools) {
+    SchedulerConfig cfg{};
+    cfg.prefix_granularity = 2;
+    cfg.max_scheduled_tokens = 64;
+    cfg.max_batch_size = 8;
+    cfg.cache_groups.push_back(CacheGroupConfig{
+        .group_id = "full_attention",
+        .rows_per_page = cfg.prefix_granularity,
+        .entry_stride_tokens = 1,
+        .total_pages = 32,
+    });
+    // device_allocator.total_pages stays 0, so the block pool would be built
+    // with a negative usable count and assert before the config diagnostic.
+    try {
+        Scheduler scheduler{cfg};
+        FAIL() << "a device cache without usable capacity was accepted";
+    } catch (const std::invalid_argument& error) {
+        EXPECT_NE(std::string{error.what()}.find("device cache"), std::string::npos) << error.what();
+    }
 }
 
 }  // namespace tokenspeed::test


### PR DESCRIPTION
## Why

The cache layer had one pipeline and many names for it. Every model family ran the
same four stages, but each restated the order through its own free functions —
~26 of them, family-prefixed (`prepare_kimi_k3_cache`,
`kimi_k3_token_capacity_for_cache_pool`, `build_v4_cache_specs`,
`solve_deepseek_v4_memory_layout`, …). Around them had accumulated the usual
consequences: the same quantity owned in several places and reconciled afterwards,
a `Paged` prefix on types whose contents contradicted it, and a wrapper class doing
three jobs of which one was live.

This series names the pipeline, writes it once, and removes the reconciliations by
making the mismatches unconstructible.

## The pipeline

```
layers --group--> groups --pack--> CacheLayout --bind--> CacheMemoryPlan
```

`CacheRecipe.setup()` is the one place those four stages appear in order. A family
fills in uniformly named seams (`layer_types`, `group_ids`, `fields_for_layer`,
`packing`, `check_layout`, `num_lcm_blocks`, `token_capacity`, `parents_needed`,
`workspace_bytes`, `pool_options`) and never restates the order. Subclasses mark
every seam with `@override`, so a renamed seam fails type checking instead of
silently falling back to the base default.

## Commits

| | |
|---|---|
| `refactor(cache)!` | drop "paged" from the cache-group vocabulary (Python + C++/pybind), make `SchedulerConfig::Validate()` the single config gate |
| `refactor(cache)` | let one arena own the allocation and the contract; `CachePool` becomes a typed layer window |
| `refactor(cache)` | one pipeline per family — layers, group, pack, bind |
| `refactor(deepseek-v4)` | split kernel geometry from the cache recipe, by dependency direction |
| `refactor(cache)` | a draft view is a layer window, not a wrapper |
| `test+docs` | follow the cache pipeline vocabulary |

## What stops being possible

Not checks that were deleted — states that can no longer be built:

* The plan's group set equals the declared one, because `pack` consumes the
  `(spec, fields)` pairs that `setup()` publishes the specs from. `CachePoolSpec`'s
  group-set assertion is gone because its failure mode is unconstructible.
* `CacheFieldSpec` loses `group_id` and `CacheGroupSpec` loses
  `cache_blocks_per_lcm_block`. A field never names its group; packing is the
  plan's answer. Neither can be stated twice and disagree.
* Capacity has two shapes, not five: the flat product on the base class, plus
  `parents_needed` + one shared binary search for families whose per-group demand
  differs (K3, V4). `scheduler_limits` is the single place a recipe reads the
  scheduler's concurrency. `CachePoolSpec.pool_size` — a fourth copy of
  `num_lcm_blocks × max_packing × P` — is deleted.
* Geometry has one owner. `CacheArena` holds the buffer, the field views, the plan,
  the contract and the scalars; a pool forwards nothing, so consumers write
  `pool.arena.plan` and cannot read a stale copy.

## Bugs found on the way

* `glm5`, `dflash` and `model_executor` read `prefix_granularity`/`kv_page_size`
  off a pool. `LayerMappedKVPool` had been mirroring both back onto the view, and
  glm5 takes the DSA path with **no wrapper** — that read would have been an
  `AttributeError` in production.
* `create_attn_components` returned a token count the caller overwrote with
  `geometry.token_capacity` on the very next line.
* A draft view could be handed a global layer id and offset it a second time,
  silently addressing another model's planes. `_field_layer_id` now rejects
  out-of-window ids.
* Two test files were passing only because `importorskip` swallowed an
  `ImportError`; with imports fixed they ran and failed against APIs deleted long
  ago (`_build_mrope_positions_override`, `forward_op.prefill_lengths`).

## Verification

**Unit** — `test/runtime`: 1810 passed / 8 failed. Four are `MLA prefill not
implemented for arch=sm_90a` (K3 MLA prefill needs Blackwell; this host is H20);
four fail identically on pristine `origin/main`. C++ 409/409, scheduler python
bindings 58/58.

**E2E** — 12 configurations, each compared against its pre-refactor baseline run.
No regressions:

| config | acc | base | accept | base |
|---|---|---|---|---|
| v32 nospec graph | 1.0 | 1.0 | — | — |
| v32 nospec eager | 1.0 | 1.0 | — | — |
| v32 mtp3 graph | 1.0 | 1.0 | 2.03¹ | 2.13 |
| v32 mtp3 eager | 1.0 | 0.95 | 2.16 | 2.22 |
| r1 nospec graph | 1.0 | 1.0 | — | — |
| r1 nospec eager | 1.0 | 1.0 | — | — |
| r1 mtp3 graph | 1.0 | 1.0 | 2.65 | 2.67 |
| r1 mtp3 eager | 1.0 | 1.0 | 2.66 | 2.66 |
| v4 nospec graph | 0.55 | 0.5 | — | — |
| v4 nospec eager | 0.5 | 0.55 | — | — |
| v4 dspark graph | 0.5 | 0.55 | 1.39 | 1.36 |
| v4 dspark eager | 0.55 | 0.55 | 1.36 | 1.39 |

¹ long-set value; the short set had zero accept samples this run.

DeepSeek V3.2 (DSA), R1 (MLA + flashmla) and V4-Flash (DSA indexer + DSpark),
each × {CUDA graph, eager} × {spec, no spec}, single node TP8 on H20. V4's absolute
accuracy is bounded by the 4096 `max-model-len` eval harness, not by this change —
it matches its own baseline.

## Breaking

`SchedulerConfig.paged_cache_groups` → `.cache_groups`, `PagedCacheGroupConfig` →
`CacheGroupConfig`. The PD handshake keeps its wire keys, so P and D must run
matching versions.
