### PR TITLE
feat(engine): surface is_sleeping as a GET control endpoint mirroring /is_paused

### DIFF
--- a/python/tokenspeed/runtime/engine/weight_transfer/manager.py
+++ b/python/tokenspeed/runtime/engine/weight_transfer/manager.py
@@ -95,6 +95,14 @@ class WeightTransferManager:
         """Whether generation admission is currently paused."""
         return self._async_llm.weight_transfer_admission_paused()
 
+    async def is_sleeping(self) -> bool:
+        """Whether the engine is in the sleep/wake-up suspended state.
+
+        Mirrors :meth:`is_paused`; delegates to ``AsyncLLM.is_sleeping`` so the
+        sleep/wake-up state is queryable through the same RL-control surface.
+        """
+        return await self._async_llm.is_sleeping()
+
     def get_world_size(self, include_dp: bool = True) -> int:
         """Return the inference world size used to size the NCCL group.
 

--- a/python/tokenspeed/runtime/entrypoints/control_server.py
+++ b/python/tokenspeed/runtime/entrypoints/control_server.py
@@ -436,6 +436,11 @@ async def is_paused(request: Request):
     return await _proxy_to_rl_control(request)
 
 
+@app.get("/is_sleeping")
+async def is_sleeping(request: Request):
+    return await _proxy_to_rl_control(request)
+
+
 # ---------------------------------------------------------------------------
 # RL weight transfer — SGLang dialect, proxied to the same in-engine control app
 #

--- a/python/tokenspeed/runtime/entrypoints/vllm_compat_http.py
+++ b/python/tokenspeed/runtime/entrypoints/vllm_compat_http.py
@@ -230,6 +230,21 @@ async def is_paused(raw_request: Request) -> JSONResponse:
     return JSONResponse(content={"is_paused": paused})
 
 
+@router.get("/is_sleeping")
+async def is_sleeping(raw_request: Request) -> JSONResponse:
+    try:
+        sleeping = await _manager(raw_request).is_sleeping()
+    except HTTPException:
+        raise
+    except Exception as e:  # noqa: BLE001 - defensive
+        logger.exception("Failed to fetch sleep status")
+        return JSONResponse(
+            {"error": f"Failed to fetch sleep status: {e}"},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR.value,
+        )
+    return JSONResponse(content={"is_sleeping": sleeping})
+
+
 @router.get("/get_world_size")
 async def get_world_size(
     raw_request: Request,

--- a/test/runtime/test_control_server.py
+++ b/test/runtime/test_control_server.py
@@ -73,6 +73,25 @@ def _build_mock_smg() -> FastAPI:
     return mock
 
 
+def _build_mock_rl_control() -> FastAPI:
+    """Mock of the in-engine RL-control app (``vllm_compat_http``).
+
+    Only the status routes the sidecar proxies are needed; they return canned
+    booleans so the proxy-parity tests can assert byte-faithful relay.
+    """
+    mock = FastAPI()
+
+    @mock.get("/is_paused")
+    async def is_paused():
+        return JSONResponse({"is_paused": False})
+
+    @mock.get("/is_sleeping")
+    async def is_sleeping():
+        return JSONResponse({"is_sleeping": True})
+
+    return mock
+
+
 def _wait(port, path, timeout=15):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -220,6 +239,73 @@ class TestProxyPassthrough(unittest.TestCase):
         """A non-200 from smg must be relayed, not masked as 200."""
         r = requests.get(self._url("/v1/models"), timeout=10)  # mock has no such route
         self.assertEqual(r.status_code, 404)
+
+
+class TestRlControlProxy(unittest.TestCase):
+    """Proxy parity for the RL-control status routes (``/is_paused``,
+    ``/is_sleeping``).
+
+    The sidecar mounts these as thin proxies to the in-engine RL-control app
+    (``vllm_compat_http``); they must relay the upstream ``{is_<state>: bool}``
+    body byte-faithfully, the same contract as the smg passthrough routes above.
+    """
+
+    RL_PORT = 28340
+    SIDECAR_PORT = 28341
+
+    @classmethod
+    def setUpClass(cls):
+        from tokenspeed.runtime.entrypoints import control_server as hs
+
+        cls.hs = hs
+        # Point the RL-control proxy at our mock; save/restore to keep the
+        # module global clean for the other test classes in this module.
+        cls._orig_rl_control_url = hs._rl_control_url
+        hs._rl_control_url = f"http://127.0.0.1:{cls.RL_PORT}"
+        hs._gateway_url = "http://127.0.0.1:1"  # dead — no smg route hit here
+        hs._engine_grpc_addr = "127.0.0.1:1"
+
+        cls._rl_server = uvicorn.Server(
+            uvicorn.Config(
+                _build_mock_rl_control(),
+                host="127.0.0.1",
+                port=cls.RL_PORT,
+                log_level="error",
+            )
+        )
+        cls._sidecar_server = uvicorn.Server(
+            uvicorn.Config(
+                hs.app, host="127.0.0.1", port=cls.SIDECAR_PORT, log_level="error"
+            )
+        )
+        cls._t_rl = threading.Thread(target=cls._rl_server.run, daemon=True)
+        cls._t_side = threading.Thread(target=cls._sidecar_server.run, daemon=True)
+        cls._t_rl.start()
+        cls._t_side.start()
+        assert _wait(cls.RL_PORT, "/is_paused"), "mock RL control failed to start"
+        assert _wait(cls.SIDECAR_PORT, "/is_paused"), "sidecar failed to start"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._rl_server.should_exit = True
+        cls._sidecar_server.should_exit = True
+        cls.hs._rl_control_url = cls._orig_rl_control_url
+
+    def _url(self, path):
+        return f"http://127.0.0.1:{self.SIDECAR_PORT}{path}"
+
+    def test_is_paused_proxies_faithfully(self):
+        r = requests.get(self._url("/is_paused"), timeout=10)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"is_paused": False})
+
+    def test_is_sleeping_proxies_faithfully(self):
+        """``/is_sleeping`` must be mounted on the sidecar and relay the
+        upstream ``{is_sleeping: bool}`` body unchanged — parity with
+        ``/is_paused``."""
+        r = requests.get(self._url("/is_sleeping"), timeout=10)
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json(), {"is_sleeping": True})
 
 
 class TestGrpcDirect(unittest.TestCase):


### PR DESCRIPTION
## Summary

The Sleep/Wake-Up data-plane is wired end-to-end (`engine.is_sleeping` →
`AsyncLLM.is_sleeping` → `IsSleepingReq` round-trip through the scheduler control
client) and is GPU-tested in `test_sleep_wakeup_gpu.py`, but the only status
route mounted on the HTTP control surface is `/is_paused`. The symmetric
`/is_sleeping` route was missing from both the in-engine RL-control router
(`vllm_compat_http.py`) and the sidecar `control_server.py`, so callers could
poll pause status over HTTP but not sleep status.

This adds the matching `/is_sleeping` endpoint, mirroring `/is_paused`
end-to-end:

- `WeightTransferManager.is_sleeping()` — async accessor delegating to
  `AsyncLLM.is_sleeping()` (mirrors the sync `is_paused()` accessor at
  `manager.py:94`; carries `await` because `AsyncLLM.is_sleeping` is async,
  whereas `AsyncLLM.weight_transfer_admission_paused` is sync).
- `@router.get("/is_sleeping")` on `vllm_compat_http.py` — direct handler
  returning `{"is_sleeping": bool}`, mirroring the `/is_paused` handler.
- `@app.get("/is_sleeping")` on `control_server.py` — thin sidecar proxy to
  the in-engine RL-control app, mirroring the `/is_paused` proxy.

The change is purely additive: no existing route or control-plane behavior is
modified. The read semantics are point-in-time status polling, identical to
`/is_paused`, so the same transient-state reasoning applies to both — this is
parity with the existing route, not a new contract.

## Test Plan

- `TestRlControlProxy` in `test/runtime/test_control_server.py`: spins up a
  mock RL-control app and asserts the sidecar's `/is_sleeping` and `/is_paused`
  routes relay `{"is_sleeping": bool}` / `{"is_paused": bool}` byte-faithfully.
  A missing `/is_sleeping` mount would 404 and fail the assertion, so this is
  a real regression guard for the new route plus parity coverage for `/is_paused`
  (which had no proxy test before).
- `ruff check` and `isort --check-only` clean on all four changed files;
  `python -m py_compile` clean.
- The control-server test suite imports the `tokenspeed` runtime, which pulls
  in `triton` / `torch` / `tokenspeed_kernel`, so it runs in GPU CI rather than
  on a non-GPU host; CI will exercise the new test.