### PR TITLE
ci(kimi-k3): exercise DSpark in the AIME26 gate

### DIFF
--- a/test/ci/eval/kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -1,11 +1,11 @@
 api_version: ci.tokenspeed.io/v1
-# Kimi-K3 + DSpark on the same AIME26 gate as the speculator-free run, so the
-# two scores are directly comparable. Separate job from
-# eval-kimi-k3-mxfp4-tp8ep8-aime26-amd, which tracks the pure target.
+# Kimi-K3 + DSpark is the per-commit AIME26 gate. The matching speculator-free
+# configuration remains available as a manual control for direct comparison.
 name: eval-kimi-k3-dspark-mxfp4-tp8ep8-aime26-amd
 type: eval
 workflow_stage: model-test
 triggers:
+  - per-commit
   - manual
 runner:
   labels:

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -1,9 +1,10 @@
 api_version: ci.tokenspeed.io/v1
+# Keep the pure target as a manual control; the matching DSpark configuration
+# is the per-commit Kimi-K3 AIME26 gate.
 name: eval-kimi-k3-mxfp4-tp8ep8-aime26-amd
 type: eval
 workflow_stage: model-test
 triggers:
-  - per-commit
   - manual
 runner:
   labels:

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
@@ -1947,23 +1947,31 @@ def all_reduce_can_run(state: TritonCommState, tensor: torch.Tensor, op=None) ->
     )
 
 
+def _get_or_create_iris_state(state: TritonCommState, dtype: torch.dtype):
+    """Return the Iris state sized for this communication backing buffer."""
+    import tokenspeed_kernel.ops.communication.iris as _iris_mod
+
+    key = (id(state.group), state.max_bytes, dtype)
+    iris_state = _iris_mod.IRIS_AR_STATES.get(key)
+    if iris_state is None:
+        iris_state = _iris_mod.create_iris_state(
+            group=state.group,
+            rank_in_group=state.rank_in_group,
+            max_numel=max(state.max_numel, state.max_bytes // dtype.itemsize),
+            dtype=dtype,
+            device=state.device,
+        )
+        _iris_mod.IRIS_AR_STATES[key] = iris_state
+    return iris_state
+
+
 def all_reduce(state: TritonCommState, tensor: torch.Tensor, op=None) -> torch.Tensor:
     assert all_reduce_can_run(state, tensor, op=op)
     platform = current_platform()
     if platform.is_amd:
         import tokenspeed_kernel.ops.communication.iris as _iris_mod
 
-        key = (id(state.group), state.max_bytes, tensor.dtype)
-        iris_state = _iris_mod.IRIS_AR_STATES.get(key)
-        if iris_state is None:
-            iris_state = _iris_mod.create_iris_state(
-                group=state.group,
-                rank_in_group=state.rank_in_group,
-                max_numel=state.max_numel,
-                dtype=tensor.dtype,
-                device=state.device,
-            )
-            _iris_mod.IRIS_AR_STATES[key] = iris_state
+        iris_state = _get_or_create_iris_state(state, tensor.dtype)
         return _iris_mod.iris_all_reduce(iris_state, tensor, op=op, safe=False)
 
     raise AssertionError(f"Unsupported platform: {platform}")
@@ -2015,18 +2023,7 @@ def acquire_symm_outputs(
         raise RuntimeError("unsupported symmetric all-reduce output request")
     import tokenspeed_kernel.ops.communication.iris as _iris_mod
 
-    max_numel = state.max_bytes // dtype.itemsize
-    key = (id(state.group), state.max_bytes, dtype)
-    iris_state = _iris_mod.IRIS_AR_STATES.get(key)
-    if iris_state is None:
-        iris_state = _iris_mod.create_iris_state(
-            group=state.group,
-            rank_in_group=state.rank_in_group,
-            max_numel=max_numel,
-            dtype=dtype,
-            device=state.device,
-        )
-        _iris_mod.IRIS_AR_STATES[key] = iris_state
+    iris_state = _get_or_create_iris_state(state, dtype)
     return _iris_mod.iris_acquire_outputs(iris_state, shapes)
 
 
@@ -2153,17 +2150,7 @@ def _all_reduce_residual_attnres(
     )
     from . import iris as _iris_mod
 
-    key = (id(state.group), state.max_bytes, partial.dtype)
-    iris_state = _iris_mod.IRIS_AR_STATES.get(key)
-    if iris_state is None:
-        iris_state = _iris_mod.create_iris_state(
-            group=state.group,
-            rank_in_group=state.rank_in_group,
-            max_numel=state.max_numel,
-            dtype=partial.dtype,
-            device=state.device,
-        )
-        _iris_mod.IRIS_AR_STATES[key] = iris_state
+    iris_state = _get_or_create_iris_state(state, partial.dtype)
     return _iris_mod.iris_all_reduce_residual_attnres(
         iris_state,
         partial,

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -67,6 +67,39 @@ def _spawn_and_collect(worker_fn, args, world_size: int) -> None:
         raise RuntimeError("\n".join(f"Rank {r}: {e}" for r, e in error_dict.items()))
 
 
+@pytest.mark.parametrize(
+    ("max_numel", "max_bytes", "expected_numel"),
+    [(16, 64, 32), (16, 0, 16)],
+)
+def test_iris_state_uses_backing_capacity(
+    monkeypatch, max_numel, max_bytes, expected_numel
+):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
+    from tokenspeed_kernel.ops.communication import triton as triton_ops
+
+    created = []
+
+    def create_iris_state(**kwargs):
+        created.append(kwargs)
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(iris_ops, "IRIS_AR_STATES", {})
+    monkeypatch.setattr(iris_ops, "create_iris_state", create_iris_state)
+    state = SimpleNamespace(
+        group=object(),
+        rank_in_group=0,
+        max_numel=max_numel,
+        max_bytes=max_bytes,
+        device=torch.device("cpu"),
+    )
+
+    iris_state = triton_ops._get_or_create_iris_state(state, torch.bfloat16)
+
+    assert iris_state.max_numel == expected_numel
+    assert triton_ops._get_or_create_iris_state(state, torch.bfloat16) is iris_state
+    assert len(created) == 1
+
+
 @pytest.mark.parametrize("world_size", [2, 4, 8])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 def test_producer_direct_admission_supported_world_sizes(

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -20,6 +20,7 @@
 
 
 import socket
+import sys
 import traceback
 from types import SimpleNamespace
 from typing import List, Tuple
@@ -74,7 +75,6 @@ def _spawn_and_collect(worker_fn, args, world_size: int) -> None:
 def test_iris_state_uses_backing_capacity(
     monkeypatch, max_numel, max_bytes, expected_numel
 ):
-    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     created = []
@@ -83,8 +83,10 @@ def test_iris_state_uses_backing_capacity(
         created.append(kwargs)
         return SimpleNamespace(**kwargs)
 
-    monkeypatch.setattr(iris_ops, "IRIS_AR_STATES", {})
-    monkeypatch.setattr(iris_ops, "create_iris_state", create_iris_state)
+    iris_ops = SimpleNamespace(IRIS_AR_STATES={}, create_iris_state=create_iris_state)
+    monkeypatch.setitem(
+        sys.modules, "tokenspeed_kernel.ops.communication.iris", iris_ops
+    )
     state = SimpleNamespace(
         group=object(),
         rank_in_group=0,


### PR DESCRIPTION
## Problem

AMD per-commit CI currently exercises only the speculator-free Kimi-K3 AIME26 configuration, while enabling the existing DSpark gate exposed an Iris cache bug: ordinary all-reduce could create a 512 KiB state under the same key later used by the 1 MiB producer-direct path, causing CUDA graph capture to fail with `Iris symmetric outputs exceed the input buffer`.

## Key changes

- Promote `test/ci/eval/kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml` to `per-commit`, making Kimi-K3 + DSpark the regular AMD AIME26 correctness gate.
- Move `test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml` to manual-only, retaining the speculator-free configuration as a comparable control without duplicating the expensive per-commit run.
- In `tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py`, create every cached Iris state with the larger of the ordinary all-reduce capacity and the advertised byte-backed producer-direct capacity, so whichever operation initializes the shared cache first can safely serve both paths while legacy states with `max_bytes=0` retain their original capacity.
- In `tokenspeed-kernel/test/ops/test_iris_communication.py`, cover both the enlarged producer backing and the legacy element-only fallback, including cache reuse.

## Validation

- Local 8x MI350X launch with the CI TP8/EP8 K3 + DSpark server arguments captured decode graphs for batches `1, 2, 4, 8, 16`, completed warmup and a real request, and exercised DSpark with an observed accept length of 4.2.
- Exact CI EvalScope AIME26 command: `0.9333` (28/30), clearing the `0.90` gate; 11m43s evaluation time, 42.8 ms average TPOT.
- `python -m pytest -q tokenspeed-kernel/test/ops/test_iris_communication.py` (`37 passed`)
- `python -m pytest -q test/ci_system/test_pipeline.py` (`78 passed`)
- `pre-commit run --all-files`
