### PR TITLE
fix dp timeline

### DIFF
--- a/python/tokenspeed/runtime/engine/data_parallel_controller.py
+++ b/python/tokenspeed/runtime/engine/data_parallel_controller.py
@@ -31,7 +31,6 @@ from enum import Enum, auto
 import psutil
 import setproctitle
 import zmq
-
 from tokenspeed.runtime.engine.event_loop import run_event_loop
 from tokenspeed.runtime.engine.io_struct import (
     BlockReqInput,
@@ -166,13 +165,9 @@ class DataParallelController:
 
         self.launch_dp_schedulers(server_args, port_args)
 
-        # Workers are already created in launch_dp_schedulers before starting scheduler threads
-
-        if server_args.mapping.has_attn_dp:
-            self.control_message_step = server_args.mapping.attn.tp_size
-        else:
-            self.control_message_step = 1
-
+        # Each worker represents one attention-DP shard. Its local TP rank 0
+        # receives messages from this controller and broadcasts them to the
+        # remaining ranks in that TP group.
         self.init_dispatcher()
 
     def send_to_all_workers(self, obj):
@@ -180,8 +175,13 @@ class DataParallelController:
             worker.send_pyobj(obj)
 
     def send_control_message(self, obj):
-        # Send control messages to first worker of tp group
-        for worker in self.workers[:: self.control_message_step]:
+        """Broadcast a control request to every attention-DP worker.
+
+        ``self.workers`` is indexed by attention-DP rank, not tensor-parallel
+        rank. Each worker endpoint is consumed by TP rank 0 of that DP shard,
+        which broadcasts the request within its local TP group.
+        """
+        for worker in self.workers:
             worker.send_pyobj(obj)
 
     def handle_load_update_req(self, obj):

--- a/python/tokenspeed/runtime/engine/data_parallel_controller.py
+++ b/python/tokenspeed/runtime/engine/data_parallel_controller.py
@@ -31,6 +31,7 @@ from enum import Enum, auto
 import psutil
 import setproctitle
 import zmq
+
 from tokenspeed.runtime.engine.event_loop import run_event_loop
 from tokenspeed.runtime.engine.io_struct import (
     BlockReqInput,


### PR DESCRIPTION
## Summary

DataParallelController.workers is indexed by attention-DP rank and contains one ingress endpoint per DP shard (consumed by local TP rank 0), not one endpoint per TP rank. The previous workers[::attn_tp_size] selection therefore sent fallback control requests only to DP rank 0 whenever attention DP was enabled.
RequestHandler.recv_reqs() broadcasts only inside the local attention-TP group, so there is no later world-group broadcast to deliver the request to other DP shards. Fan out fallback control requests to every DP ingress, allowing each shard leader to perform its existing local TP broadcast.
This fixes profiling on all DP shards and restores consistent behavior for other fallback control operations, including cache flush, pause/resume, and memory occupation operations. Generate/embedding dispatch and load-update routing are unchanged.
