### PR TITLE
perf(amd): port fused KDA decode to gfx1250

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/decode.py
@@ -180,6 +180,242 @@ def _kda_recurrent_decode_kernel(
     )
 
 
+@gluon.jit
+def _kda_fused_decode_kernel(
+    mixed_qkv,
+    conv_weights,
+    conv_states,
+    raw_g,
+    beta_logits,
+    output_gate,
+    norm_weight,
+    state_pool,
+    read_indices,
+    write_indices,
+    output,
+    cu_seqlens,
+    a_log,
+    dt_bias,
+    H: gl.constexpr,
+    D: gl.constexpr,
+    MIXED_ROW_STRIDE: gl.constexpr,
+    CONV_WEIGHT_ROW_STRIDE: gl.constexpr,
+    CONV_WEIGHT_COL_STRIDE: gl.constexpr,
+    CONV_PAGE_STRIDE: gl.constexpr,
+    CONV_CHANNEL_STRIDE: gl.constexpr,
+    CONV_HISTORY_STRIDE: gl.constexpr,
+    GATE_ROW_STRIDE: gl.constexpr,
+    BETA_ROW_STRIDE: gl.constexpr,
+    OUTPUT_GATE_ROW_STRIDE: gl.constexpr,
+    STATE_PAGE_STRIDE: gl.constexpr,
+    NUM_SLOTS: gl.constexpr,
+    HAS_LOWER_BOUND: gl.constexpr,
+    LOWER_BOUND: gl.constexpr,
+    NORM_EPS: gl.constexpr,
+):
+    """Fuse the K3 decode convolution, recurrence, and gated RMSNorm."""
+    sequence_head = gl.program_id(0)
+    sequence_idx = sequence_head // H
+    head_idx = sequence_head % H
+
+    # Eight Wave32 warps preserve the 64 FP32 state elements per thread used
+    # by the gfx950 fusion while covering the complete 128x128 state matrix.
+    state_layout: gl.constexpr = gl.BlockedLayout(
+        [8, 8],
+        [8, 4],
+        [2, 4],
+        [1, 0],
+    )
+    key_layout: gl.constexpr = gl.SliceLayout(1, state_layout)
+    value_layout: gl.constexpr = gl.SliceLayout(0, state_layout)
+    key_offsets = gl.arange(0, D, layout=key_layout)
+    value_offsets = gl.arange(0, D, layout=value_layout)
+
+    begin = gl.load(cu_seqlens + sequence_idx)
+    end = gl.load(cu_seqlens + sequence_idx + 1)
+    output_offsets = (sequence_idx * H + head_idx) * D + value_offsets
+    if begin == end:
+        gl.store(output + output_offsets, 0.0)
+        return
+
+    read_idx = gl.load(read_indices + sequence_idx)
+    write_idx = gl.load(write_indices + sequence_idx)
+    valid_read = (read_idx >= 0) & (read_idx < NUM_SLOTS)
+    if not valid_read:
+        gl.store(output + output_offsets, 0.0)
+        return
+    read_page_offset = read_idx.to(gl.int64)
+
+    token_idx = begin
+    projection_width: gl.constexpr = H * D
+    q_channel = head_idx * D + key_offsets
+    k_channel = projection_width + q_channel
+    v_channel = 2 * projection_width + head_idx * D + value_offsets
+    q_input = gl.load(mixed_qkv + token_idx * MIXED_ROW_STRIDE + q_channel).to(
+        gl.float32
+    )
+    k_input = gl.load(mixed_qkv + token_idx * MIXED_ROW_STRIDE + k_channel).to(
+        gl.float32
+    )
+    v_input = gl.load(mixed_qkv + token_idx * MIXED_ROW_STRIDE + v_channel).to(
+        gl.float32
+    )
+
+    q_history0 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + q_channel * CONV_CHANNEL_STRIDE
+    ).to(gl.float32)
+    q_history1 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + q_channel * CONV_CHANNEL_STRIDE
+        + CONV_HISTORY_STRIDE
+    ).to(gl.float32)
+    q_history2 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + q_channel * CONV_CHANNEL_STRIDE
+        + 2 * CONV_HISTORY_STRIDE
+    ).to(gl.float32)
+    k_history0 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + k_channel * CONV_CHANNEL_STRIDE
+    ).to(gl.float32)
+    k_history1 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + k_channel * CONV_CHANNEL_STRIDE
+        + CONV_HISTORY_STRIDE
+    ).to(gl.float32)
+    k_history2 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + k_channel * CONV_CHANNEL_STRIDE
+        + 2 * CONV_HISTORY_STRIDE
+    ).to(gl.float32)
+    v_history0 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + v_channel * CONV_CHANNEL_STRIDE
+    ).to(gl.float32)
+    v_history1 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + v_channel * CONV_CHANNEL_STRIDE
+        + CONV_HISTORY_STRIDE
+    ).to(gl.float32)
+    v_history2 = gl.load(
+        conv_states
+        + read_page_offset * CONV_PAGE_STRIDE
+        + v_channel * CONV_CHANNEL_STRIDE
+        + 2 * CONV_HISTORY_STRIDE
+    ).to(gl.float32)
+
+    q_weight_base = conv_weights + q_channel * CONV_WEIGHT_ROW_STRIDE
+    k_weight_base = conv_weights + k_channel * CONV_WEIGHT_ROW_STRIDE
+    v_weight_base = conv_weights + v_channel * CONV_WEIGHT_ROW_STRIDE
+    q_value = (
+        q_history0 * gl.load(q_weight_base)
+        + q_history1 * gl.load(q_weight_base + CONV_WEIGHT_COL_STRIDE)
+        + q_history2 * gl.load(q_weight_base + 2 * CONV_WEIGHT_COL_STRIDE)
+        + q_input * gl.load(q_weight_base + 3 * CONV_WEIGHT_COL_STRIDE)
+    ).to(gl.float32)
+    k_value = (
+        k_history0 * gl.load(k_weight_base)
+        + k_history1 * gl.load(k_weight_base + CONV_WEIGHT_COL_STRIDE)
+        + k_history2 * gl.load(k_weight_base + 2 * CONV_WEIGHT_COL_STRIDE)
+        + k_input * gl.load(k_weight_base + 3 * CONV_WEIGHT_COL_STRIDE)
+    ).to(gl.float32)
+    v_value = (
+        v_history0 * gl.load(v_weight_base)
+        + v_history1 * gl.load(v_weight_base + CONV_WEIGHT_COL_STRIDE)
+        + v_history2 * gl.load(v_weight_base + 2 * CONV_WEIGHT_COL_STRIDE)
+        + v_input * gl.load(v_weight_base + 3 * CONV_WEIGHT_COL_STRIDE)
+    ).to(gl.float32)
+    q_value *= 1.0 / (1.0 + gl.exp(-q_value))
+    k_value *= 1.0 / (1.0 + gl.exp(-k_value))
+    v_value *= 1.0 / (1.0 + gl.exp(-v_value))
+
+    valid_write = (write_idx >= 0) & (write_idx < NUM_SLOTS)
+    safe_write_idx = gl.where(valid_write, write_idx, 0)
+    write_page_offset = safe_write_idx.to(gl.int64)
+    q_write_base = (
+        conv_states
+        + write_page_offset * CONV_PAGE_STRIDE
+        + q_channel * CONV_CHANNEL_STRIDE
+    )
+    k_write_base = (
+        conv_states
+        + write_page_offset * CONV_PAGE_STRIDE
+        + k_channel * CONV_CHANNEL_STRIDE
+    )
+    v_write_base = (
+        conv_states
+        + write_page_offset * CONV_PAGE_STRIDE
+        + v_channel * CONV_CHANNEL_STRIDE
+    )
+    gl.store(q_write_base, q_history1, mask=valid_write)
+    gl.store(q_write_base + CONV_HISTORY_STRIDE, q_history2, mask=valid_write)
+    gl.store(q_write_base + 2 * CONV_HISTORY_STRIDE, q_input, mask=valid_write)
+    gl.store(k_write_base, k_history1, mask=valid_write)
+    gl.store(k_write_base + CONV_HISTORY_STRIDE, k_history2, mask=valid_write)
+    gl.store(k_write_base + 2 * CONV_HISTORY_STRIDE, k_input, mask=valid_write)
+    gl.store(v_write_base, v_history1, mask=valid_write)
+    gl.store(v_write_base + CONV_HISTORY_STRIDE, v_history2, mask=valid_write)
+    gl.store(v_write_base + 2 * CONV_HISTORY_STRIDE, v_input, mask=valid_write)
+
+    gate_value = gl.load(
+        raw_g + token_idx * GATE_ROW_STRIDE + head_idx * D + key_offsets
+    ).to(gl.float32)
+    gate_value += gl.load(dt_bias + head_idx * D + key_offsets).to(gl.float32)
+    a_value = gl.exp(gl.load(a_log + head_idx).to(gl.float32))
+    if HAS_LOWER_BOUND:
+        log_decay = LOWER_BOUND / (1.0 + gl.exp(-(a_value * gate_value)))
+    else:
+        softplus = gl.maximum(gate_value, 0.0) + gl.log(
+            1.0 + gl.exp(-gl.abs(gate_value))
+        )
+        log_decay = -a_value * softplus
+    beta_value = gl.load(beta_logits + token_idx * BETA_ROW_STRIDE + head_idx).to(
+        gl.float32
+    )
+    beta_value = 1.0 / (1.0 + gl.exp(-beta_value))
+
+    q_value *= gl.rsqrt(gl.sum(q_value * q_value, axis=0) + 1e-6) * (D**-0.5)
+    k_value *= gl.rsqrt(gl.sum(k_value * k_value, axis=0) + 1e-6)
+    state_offsets = key_offsets[:, None] * D + value_offsets[None, :]
+    read_base = read_page_offset * STATE_PAGE_STRIDE + head_idx * D * D
+    running = gfx1250.buffer_load(
+        state_pool + read_base,
+        state_offsets.to(gl.int32),
+    ).to(gl.float32)
+    running *= gl.exp(log_decay)[:, None]
+    prediction = gl.sum(running * k_value[:, None], axis=0)
+    prior_output = gl.sum(running * q_value[:, None], axis=0)
+    key_query = gl.sum(k_value * q_value, axis=0)
+    delta = beta_value * (v_value - prediction)
+    running += k_value[:, None] * delta[None, :]
+    out_value = prior_output + delta * key_query
+
+    write_base = write_page_offset * STATE_PAGE_STRIDE + head_idx * D * D
+    gfx1250.buffer_store(
+        running,
+        state_pool + write_base,
+        state_offsets.to(gl.int32),
+        mask=valid_write,
+    )
+
+    inverse_rms = gl.rsqrt(gl.sum(out_value * out_value, axis=0) / D + NORM_EPS)
+    gate = gl.load(
+        output_gate + token_idx * OUTPUT_GATE_ROW_STRIDE + head_idx * D + value_offsets
+    ).to(gl.float32)
+    weight = gl.load(norm_weight + value_offsets).to(gl.float32)
+    out_value *= inverse_rms * weight * (1.0 / (1.0 + gl.exp(-gate)))
+    gl.store(output + output_offsets, out_value.to(output.dtype.element_ty))
+
+
 def gluon_kda_recurrent_decode_gfx1250(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -271,4 +507,176 @@ def gluon_kda_recurrent_decode_gfx1250(
     return output
 
 
-__all__ = ["gluon_kda_recurrent_decode_gfx1250"]
+def gluon_kda_fused_decode_gfx1250(
+    mixed_qkv: torch.Tensor,
+    conv_weights: torch.Tensor,
+    conv_states: torch.Tensor,
+    raw_g: torch.Tensor,
+    beta_logits: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    output_gate: torch.Tensor,
+    norm_weight: torch.Tensor,
+    norm_eps: float,
+    *,
+    state_pool: torch.Tensor,
+    read_indices: torch.Tensor,
+    write_indices: torch.Tensor,
+    num_heads: int,
+    head_dim: int,
+    cu_seqlens: torch.Tensor,
+    lower_bound: float | None,
+) -> torch.Tensor:
+    """Run fused single-token K3 decode against paged convolution/KDA state.
+
+    Args:
+        mixed_qkv: BF16 pre-convolution Q/K/V rows with shape
+            ``[batch, 3 * num_heads * head_dim]``.
+        conv_weights: Contiguous four-tap depthwise convolution weights with
+            shape ``[3 * num_heads * head_dim, 4]``.
+        conv_states: Mutable BF16 convolution state pool with shape
+            ``[pages, 3 * num_heads * head_dim, 3]``.
+        raw_g: Projected decay-gate values with shape
+            ``[batch, num_heads * head_dim]``.
+        beta_logits: Per-token, per-head update logits with shape
+            ``[batch, num_heads]``.
+        A_log: Per-head FP32 decay parameters with shape ``[num_heads]``.
+        dt_bias: Per-head, per-channel FP32 bias with shape
+            ``[num_heads * head_dim]``.
+        output_gate: Gated-RMSNorm logits with shape
+            ``[batch, num_heads * head_dim]``.
+        norm_weight: Gated-RMSNorm weights with shape ``[head_dim]``.
+        norm_eps: Gated-RMSNorm epsilon.
+        state_pool: Mutable FP32 recurrent state with shape
+            ``[pages, num_heads, head_dim, head_dim]``.
+        read_indices: Source state page per batch row.
+        write_indices: Destination state page per batch row.
+        num_heads: Number of local heads; this specialization requires 12.
+        head_dim: Per-head width; this specialization requires 128.
+        cu_seqlens: Packed row boundaries with shape ``[batch + 1]``.
+        lower_bound: Optional safe lower bound for the log-decay gate.
+
+    Returns:
+        Gated-RMSNorm output with shape ``[1, batch, 12, 128]``. Valid
+        destination convolution and recurrent states are updated in place.
+    """
+    tensors = (
+        mixed_qkv,
+        conv_weights,
+        conv_states,
+        raw_g,
+        beta_logits,
+        A_log,
+        dt_bias,
+        output_gate,
+        norm_weight,
+        state_pool,
+        read_indices,
+        write_indices,
+        cu_seqlens,
+    )
+    if not all(tensor.is_cuda for tensor in tensors):
+        raise ValueError("gfx1250 fused KDA decode requires GPU tensors")
+    if num_heads != 12 or head_dim != 128:
+        raise ValueError("gfx1250 fused KDA decode requires 12 heads of width 128")
+
+    tokens = read_indices.numel()
+    projection_width = num_heads * head_dim
+    if mixed_qkv.ndim != 2 or mixed_qkv.shape != (tokens, 3 * projection_width):
+        raise ValueError("mixed_qkv must have shape [batch, 3 * heads * head_dim]")
+    if mixed_qkv.stride(1) != 1:
+        raise ValueError("mixed_qkv channels must be contiguous")
+    if (
+        conv_weights.shape != (3 * projection_width, 4)
+        or not conv_weights.is_contiguous()
+    ):
+        raise ValueError("conv_weights must be contiguous [3 * heads * head_dim, 4]")
+    if conv_states.ndim != 3 or conv_states.shape[1:] != (3 * projection_width, 3):
+        raise ValueError("conv_states must have shape [pages, 3 * heads * head_dim, 3]")
+    if conv_states.stride()[1:] != (3, 1):
+        raise ValueError(
+            "conv_states inner channel/history dimensions must be contiguous"
+        )
+    if raw_g.shape != (tokens, projection_width) or raw_g.stride(1) != 1:
+        raise ValueError("raw_g must have shape [batch, heads * head_dim]")
+    if beta_logits.shape != (tokens, num_heads) or beta_logits.stride(1) != 1:
+        raise ValueError("beta_logits must have shape [batch, heads]")
+    if output_gate.shape != (tokens, projection_width) or output_gate.stride(1) != 1:
+        raise ValueError("output_gate must have shape [batch, heads * head_dim]")
+    if A_log.shape != (num_heads,) or not A_log.is_contiguous():
+        raise ValueError("A_log must have shape [heads]")
+    if dt_bias.shape != (projection_width,) or not dt_bias.is_contiguous():
+        raise ValueError("dt_bias must have shape [heads * head_dim]")
+    if norm_weight.shape != (head_dim,) or not norm_weight.is_contiguous():
+        raise ValueError("norm_weight must have shape [head_dim]")
+    if state_pool.ndim != 4 or state_pool.shape[1:] != (
+        num_heads,
+        head_dim,
+        head_dim,
+    ):
+        raise ValueError(
+            "state_pool must have shape [pages, heads, head_dim, head_dim]"
+        )
+    if state_pool.stride()[1:] != (head_dim * head_dim, head_dim, 1):
+        raise ValueError("state_pool inner dimensions must be contiguous")
+    if conv_states.shape[0] != state_pool.shape[0]:
+        raise ValueError(
+            "convolution and recurrent state pools must have equal capacity"
+        )
+    if read_indices.shape != (tokens,) or write_indices.shape != (tokens,):
+        raise ValueError("read_indices and write_indices must match the decode batch")
+    if read_indices.dtype != torch.int32 or write_indices.dtype != torch.int32:
+        raise ValueError("read_indices and write_indices must be int32")
+    if not read_indices.is_contiguous() or not write_indices.is_contiguous():
+        raise ValueError("read_indices and write_indices must be contiguous")
+    if cu_seqlens.shape != (tokens + 1,) or cu_seqlens.dtype != torch.int32:
+        raise ValueError("cu_seqlens must be an int32 boundary vector")
+    if not cu_seqlens.is_contiguous():
+        raise ValueError("cu_seqlens must be contiguous")
+
+    output = torch.empty(
+        (1, tokens, num_heads, head_dim),
+        dtype=mixed_qkv.dtype,
+        device=mixed_qkv.device,
+    )
+    _kda_fused_decode_kernel[(tokens * num_heads,)](
+        mixed_qkv,
+        conv_weights,
+        conv_states,
+        raw_g,
+        beta_logits,
+        output_gate,
+        norm_weight,
+        state_pool,
+        read_indices,
+        write_indices,
+        output,
+        cu_seqlens,
+        A_log,
+        dt_bias,
+        H=num_heads,
+        D=head_dim,
+        MIXED_ROW_STRIDE=mixed_qkv.stride(0),
+        CONV_WEIGHT_ROW_STRIDE=conv_weights.stride(0),
+        CONV_WEIGHT_COL_STRIDE=conv_weights.stride(1),
+        CONV_PAGE_STRIDE=conv_states.stride(0),
+        CONV_CHANNEL_STRIDE=conv_states.stride(1),
+        CONV_HISTORY_STRIDE=conv_states.stride(2),
+        GATE_ROW_STRIDE=raw_g.stride(0),
+        BETA_ROW_STRIDE=beta_logits.stride(0),
+        OUTPUT_GATE_ROW_STRIDE=output_gate.stride(0),
+        STATE_PAGE_STRIDE=state_pool.stride(0),
+        NUM_SLOTS=state_pool.shape[0],
+        HAS_LOWER_BOUND=lower_bound is not None,
+        LOWER_BOUND=0.0 if lower_bound is None else lower_bound,
+        NORM_EPS=norm_eps,
+        num_warps=8,
+        num_stages=2,
+    )
+    return output
+
+
+__all__ = [
+    "gluon_kda_fused_decode_gfx1250",
+    "gluon_kda_recurrent_decode_gfx1250",
+]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/decode.py
@@ -218,8 +218,6 @@ def _kda_fused_decode_kernel(
     sequence_idx = sequence_head // H
     head_idx = sequence_head % H
 
-    # Eight Wave32 warps preserve the 64 FP32 state elements per thread used
-    # by the gfx950 fusion while covering the complete 128x128 state matrix.
     state_layout: gl.constexpr = gl.BlockedLayout(
         [8, 8],
         [8, 4],

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -122,6 +122,9 @@ if current_platform().is_amd:
         gluon_dsa_prefill_topk_fp8_gfx1250 as _dsa_prefill_topk_gfx1250_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx1250.attention.kda.decode import (
+        gluon_kda_fused_decode_gfx1250 as _kda_fused_decode_gfx1250_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.kda.decode import (
         gluon_kda_recurrent_decode_gfx1250 as _kda_decode_gfx1250_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx1250.attention.kda.prefill import (
@@ -319,6 +322,76 @@ if current_platform().is_amd:
     def gluon_kda_paged_decode_gfx1250(**kwargs):
         """Run specialized gfx1250 KDA decode against the canonical K-major pool."""
         return _kda_decode_gfx1250_impl(**kwargs)
+
+    @register_kernel(
+        "attention",
+        "kda_fused_paged_decode",
+        name="gluon_kda_fused_paged_decode_gfx1250",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(12, 5),
+            max_arch_version=ArchVersion(12, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=format_signatures(
+            ("q", "k", "v"),
+            "dense",
+            {torch.bfloat16},
+        ),
+        priority=Priority.SPECIALIZED,
+        traits={
+            "paged_state": frozenset({True}),
+            "fused_output_norm": frozenset({True}),
+            "num_heads": frozenset({12}),
+            "head_dim": frozenset({128}),
+            "conv_kernel_size": frozenset({4}),
+        },
+        tags={"amd", "gfx1250", "paged_cache", "cuda_graph", "fusion"},
+    )
+    def gluon_kda_fused_paged_decode_gfx1250(
+        mixed_qkv: torch.Tensor,
+        conv_weights: torch.Tensor,
+        conv_states: torch.Tensor,
+        f_a_out: torch.Tensor,
+        f_b_weight: torch.Tensor,
+        beta_logits: torch.Tensor,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        *,
+        state_pool: torch.Tensor,
+        read_indices: torch.Tensor,
+        write_indices: torch.Tensor,
+        num_heads: int,
+        head_dim: int,
+        cu_seqlens: torch.Tensor,
+        lower_bound: float | None,
+        output_gate: torch.Tensor | None,
+        norm_weight: torch.Tensor | None,
+        norm_eps: float | None,
+    ):
+        """Run the decay projection and fused gfx1250 KDA decode epilogue."""
+        if output_gate is None or norm_weight is None or norm_eps is None:
+            raise ValueError("gfx1250 fused KDA decode requires output normalization")
+        raw_g = torch.nn.functional.linear(f_a_out, f_b_weight)
+        return _kda_fused_decode_gfx1250_impl(
+            mixed_qkv=mixed_qkv,
+            conv_weights=conv_weights,
+            conv_states=conv_states,
+            raw_g=raw_g,
+            beta_logits=beta_logits,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            output_gate=output_gate,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+            state_pool=state_pool,
+            read_indices=read_indices,
+            write_indices=write_indices,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            cu_seqlens=cu_seqlens,
+            lower_bound=lower_bound,
+        )
 
     @register_kernel(
         "attention",

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -239,8 +239,8 @@ def test_kda_paged_decode_graph_padding_and_page_stride() -> None:
 
 def test_kda_fused_paged_decode_matches_reference() -> None:
     """The K3 megafusion preserves state paging and its fused norm epilogue."""
-    if not current_platform().is_cdna4:
-        pytest.skip("gfx950 KDA fusion test")
+    if not (current_platform().is_cdna4 or current_platform().is_cdna5):
+        pytest.skip("gfx950/gfx1250 KDA fusion test")
 
     torch.manual_seed(31)
     batch, active, heads, head_dim, pages = 4, 2, 12, 128, 6
@@ -430,8 +430,8 @@ def test_kda_fused_decode_override_preserves_external_output_norm(monkeypatch) -
 
 def test_kda_fused_decode_rejects_unsupported_conv_width() -> None:
     """Unsupported convolution widths must fall back before kernel execution."""
-    if not current_platform().is_cdna4:
-        pytest.skip("gfx950 KDA fusion dispatch test")
+    if not (current_platform().is_cdna4 or current_platform().is_cdna5):
+        pytest.skip("gfx950/gfx1250 KDA fusion dispatch test")
 
     tensor = torch.empty(1, dtype=torch.bfloat16)
     conv_weights = torch.empty(1, 5, dtype=torch.bfloat16)


### PR DESCRIPTION
## Summary
Port the fused Kimi K3 KDA decode kernel from [#1086](https://github.com/lightseekorg/tokenspeed/pull/1086) to gfx1250. Launches the fused kernel with eight warps instead of the gfx950 four-warp configuration.

## Performance
Single-token BF16 decode with 12 heads, head dimension 128, and convolution width 4.
The unfused baseline runs convolution/state update, recurrent KDA decode, and gated RMSNorm separately. The unchanged gate projection is excluded from both measurements.
Median GPU latency from 30 samples with 50 CUDA graph replays per sample.
| Batch | Main (µs) | PR (µs) | Speedup vs. main |
|------:|----------:|--------:|-----------------:|
| 1 | 10.822 | 9.535 | 1.13x |
| 2 | 20.050 | 9.470 | 2.12x |
| 4 | 20.370 | 9.557 | 2.13x |
| 8 | 21.355 | 9.725 | 2.20x |
| 16 | 22.483 | 10.627 | 2.12x |
| 32 | 25.623 | 15.692 | 1.63x |
| 64 | 34.454 | 25.085 | 1.37x |
