### PR TITLE
fix(comm): stop forcing NCCL's NVLS and cuMem paths off

### DIFF
--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -483,9 +483,27 @@ def _set_socket_interface(server_args: ServerArgs):
 def _set_envs_and_config(server_args: ServerArgs):
     # Set global environments
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
-    os.environ["NCCL_CUMEM_ENABLE"] = str(int(server_args.enable_symm_mem))
-    if not server_args.enable_symm_mem:
-        os.environ["NCCL_NVLS_ENABLE"] = str(int(server_args.enable_nccl_nvls))
+    # NCCL's NVLS and cuMem paths are worth 2.7x on a 112 MiB all-reduce at
+    # world 16 (506us vs 1350us) and 19% of K3 prefill TTFT, so only turn them
+    # off when asked, and never overwrite an operator's own setting. The probe
+    # checks NVLS multicast and, for a world wider than one host, a real fabric
+    # allocation: hosts without the IMEX stack advertise multicast and then hang
+    # in rendezvous. Without a capable fabric, set nothing -- NCCL's own default
+    # beats a guess of ours.
+    if server_args.disable_symm_mem:
+        os.environ["NCCL_CUMEM_ENABLE"] = "0"
+    if server_args.disable_nccl_nvls:
+        os.environ["NCCL_NVLS_ENABLE"] = "0"
+    if not (server_args.disable_symm_mem and server_args.disable_nccl_nvls):
+        from tokenspeed_kernel.ops.communication.trtllm import (
+            _mnnvl_locally_available,
+        )
+
+        if _mnnvl_locally_available(server_args.mapping.world_size):
+            if not server_args.disable_symm_mem:
+                os.environ.setdefault("NCCL_CUMEM_ENABLE", "1")
+            if not server_args.disable_nccl_nvls:
+                os.environ.setdefault("NCCL_NVLS_ENABLE", "1")
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "4"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
     if not server_args.disable_tf32:

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -483,27 +483,10 @@ def _set_socket_interface(server_args: ServerArgs):
 def _set_envs_and_config(server_args: ServerArgs):
     # Set global environments
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
-    # NCCL's NVLS and cuMem paths are worth 2.7x on a 112 MiB all-reduce at
-    # world 16 (506us vs 1350us) and 19% of K3 prefill TTFT, so only turn them
-    # off when asked, and never overwrite an operator's own setting. The probe
-    # checks NVLS multicast and, for a world wider than one host, a real fabric
-    # allocation: hosts without the IMEX stack advertise multicast and then hang
-    # in rendezvous. Without a capable fabric, set nothing -- NCCL's own default
-    # beats a guess of ours.
     if server_args.disable_symm_mem:
         os.environ["NCCL_CUMEM_ENABLE"] = "0"
     if server_args.disable_nccl_nvls:
         os.environ["NCCL_NVLS_ENABLE"] = "0"
-    if not (server_args.disable_symm_mem and server_args.disable_nccl_nvls):
-        from tokenspeed_kernel.ops.communication.trtllm import (
-            _mnnvl_locally_available,
-        )
-
-        if _mnnvl_locally_available(server_args.mapping.world_size):
-            if not server_args.disable_symm_mem:
-                os.environ.setdefault("NCCL_CUMEM_ENABLE", "1")
-            if not server_args.disable_nccl_nvls:
-                os.environ.setdefault("NCCL_NVLS_ENABLE", "1")
     os.environ["CUDA_DEVICE_MAX_CONNECTIONS"] = "4"
     os.environ["CUDA_MODULE_LOADING"] = "AUTO"
     if not server_args.disable_tf32:

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -292,8 +292,8 @@ class ServerArgs:
     disable_cuda_graph_padding: bool = False
     disable_autotune: bool = False
     enable_cudagraph_gc: bool = False
-    enable_nccl_nvls: bool = False
-    enable_symm_mem: bool = False
+    disable_nccl_nvls: bool = False
+    disable_symm_mem: bool = False
     disable_overlap_schedule: bool = False
     disable_tf32: bool = False
     force_deterministic_rsag: bool = False
@@ -1772,14 +1772,14 @@ class ServerArgs:
             help="Enable garbage collection during CUDA graph capture. If disabled (default), GC is frozen during capture to speed up the process.",
         )
         parser.add_argument(
-            "--enable-nccl-nvls",
+            "--disable-nccl-nvls",
             action="store_true",
-            help="Enable NCCL NVLS for prefill heavy requests when available.",
+            help="Disable NCCL NVLS even when an MNNVL-capable fabric is detected.",
         )
         parser.add_argument(
-            "--enable-symm-mem",
+            "--disable-symm-mem",
             action="store_true",
-            help="Enable NCCL symmetric memory for fast collectives.",
+            help="Disable NCCL cuMem support even when an MNNVL-capable fabric is detected.",
         )
         parser.add_argument(
             "--disable-overlap-schedule",


### PR DESCRIPTION
engine.py assigned NCCL_CUMEM_ENABLE and NCCL_NVLS_ENABLE unconditionally from two flags that both default to false, so on an MNNVL fabric every deployment ran with NCCL's fast paths disabled and an operator's own setting was silently overwritten. Serving profiles show the consequence: main-branch all-reduces landed on ncclDevKernel_AllReduce_Sum_bf16_RING_LL, the low-latency protocol, at a payload where it wastes half the wire.

Measured at world 16 across four GB200 nodes, one 112 MiB all-reduce:

  NCCL defaults                    506 us
  NVLS + cuMem forced off         1350 us

and end-to-end on Kimi-K3 prefill at bs=64, 4096-in/1024-out, both arms in one interleaved session:

  forced off (today's behaviour)  8057 ms TTFT
  left enabled                    6497 ms TTFT  (-19.4%)

Flip the flags to opt-out and set the variables with setdefault, only after the existing kernel capability probe passes: it checks NVLS multicast and, for a world wider than one host, performs a real fabric allocation, because hosts without the IMEX stack advertise multicast and then hang in rendezvous rather than failing. When the probe does not pass we set nothing at all - NCCL's own default beats a guess of ours.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
