### PR TITLE
perf(kimi3): avoid packed KDA QKV copies

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -1397,6 +1397,9 @@ class MambaAttnBackend(AttentionBackend):
         if fused_out is not None:
             return fused_out
 
+        # Stride-aware fused decoders consume packed projection views directly.
+        # Preserve the shared fallback's established compact input layout.
+        mixed_qkv = mixed_qkv.contiguous()
         mixed_qkv = causal_conv1d_update(
             mixed_qkv,
             conv_states,

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -694,9 +694,6 @@ class KimiKDAMergedProj(nn.Module):
         out = decode_gemv(x, self.weight)
         p = self.proj_local
         mixed_qkv = out[:, : 3 * p]
-        # No-op at decode (single row); prefill pays a small copy for the conv.
-        if not mixed_qkv.is_contiguous():
-            mixed_qkv = mixed_qkv.contiguous()
         f_a_end = 4 * p + self.head_dim
         return (
             mixed_qkv,
@@ -858,8 +855,6 @@ class KimiLinearKDA(nn.Module):
             )
         f_a_end = 4 * proj_local + self.head_dim
         mixed_qkv = output[:, : 3 * proj_local]
-        if not mixed_qkv.is_contiguous():
-            mixed_qkv = mixed_qkv.contiguous()
         return (
             mixed_qkv,
             output[:, 3 * proj_local : 4 * proj_local],
@@ -914,6 +909,10 @@ class KimiLinearKDA(nn.Module):
         mixed_qkv, out_gate, f_a_out, beta = self._project_qkvfab(
             h, attnres_partial_args
         )
+        # Prefill consumes compact QKV; perform this copy in the captured
+        # projection segment rather than inside the eager attention break.
+        if not ctx.forward_mode.is_decode():
+            mixed_qkv = mixed_qkv.contiguous()
         # f_b runs inside the backend: fused into the decode scan kernel, a
         # plain GEMV on the prefill path.
         # Fused [3*proj, k] conv kernel bank, built once in post_load_weights.

--- a/test/runtime/test_kimi_k3_attn_res.py
+++ b/test/runtime/test_kimi_k3_attn_res.py
@@ -668,7 +668,12 @@ class KimiKDAMergedProjTests(unittest.TestCase):
                     [ref(ws["q"], pl), ref(ws["k"], pl), ref(ws["v"], pl)], dim=-1
                 ),
             )
-            self.assertTrue(mixed_qkv.is_contiguous())
+            self.assertFalse(mixed_qkv.is_contiguous())
+            self.assertEqual(mixed_qkv.stride(), (m.weight.shape[0], 1))
+            self.assertEqual(
+                mixed_qkv.untyped_storage().data_ptr(),
+                gate.untyped_storage().data_ptr(),
+            )
             torch.testing.assert_close(gate, ref(ws["g"], pl))
             # f_a is replicated: full output on every rank.
             torch.testing.assert_close(f_a_out, x @ ws["f_a"].t())
@@ -681,9 +686,13 @@ class KimiKDAMergedProjTests(unittest.TestCase):
             hidden_size=8, proj=8, num_heads=2, head_dim=4, tp_rank=0, tp_size=1
         )
         torch.nn.init.normal_(m.weight)
-        mixed, _, _, _ = m(torch.randn(1, 8, dtype=torch.bfloat16))
+        mixed, gate, _, _ = m(torch.randn(1, 8, dtype=torch.bfloat16))
         # [1, 3p] slice of a [1, total] row is already contiguous: no copy.
         self.assertTrue(mixed.is_contiguous())
+        self.assertEqual(
+            mixed.untyped_storage().data_ptr(),
+            gate.untyped_storage().data_ptr(),
+        )
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -317,7 +317,77 @@ class KimiK3RegistrationTests(unittest.TestCase):
             beta,
             torch.nn.functional.linear(hidden_states, beta_weight),
         )
-        self.assertTrue(mixed_qkv.is_contiguous())
+        self.assertFalse(mixed_qkv.is_contiguous())
+        self.assertEqual(
+            mixed_qkv.untyped_storage().data_ptr(),
+            gate.untyped_storage().data_ptr(),
+        )
+
+    def test_kda_compacts_prefill_qkv_before_backend_break(self):
+        from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+        from tokenspeed.runtime.models.kimi_k3 import KimiLinearKDA
+
+        config = KimiLinearConfig(
+            hidden_size=64,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            linear_attn_config={
+                "kda_layers": [1],
+                "full_attn_layers": [],
+                "num_heads": 4,
+                "head_dim": 16,
+                "short_conv_kernel_size": 4,
+                "gate_lower_bound": -5.0,
+                "use_full_rank_gate": True,
+            },
+        )
+        mapping = SimpleNamespace(
+            attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=(0,))
+        )
+        layer = KimiLinearKDA(config, mapping, layer_id=0)
+        rows, projection_width = 4, 64
+        packed = torch.randn(rows, 288, dtype=torch.bfloat16)
+        projection_outputs = (
+            packed[:, : 3 * projection_width],
+            packed[:, 3 * projection_width : 4 * projection_width],
+            packed[:, 4 * projection_width : 4 * projection_width + 16],
+            packed[:, 4 * projection_width + 16 : 4 * projection_width + 20],
+        )
+
+        class BackendCalled(Exception):
+            pass
+
+        for mode, expect_contiguous in (
+            (ForwardMode.EXTEND, True),
+            (ForwardMode.DECODE, False),
+        ):
+            with self.subTest(mode=mode):
+                captured = []
+
+                def capture_backend(**kwargs):
+                    captured.append(kwargs["mixed_qkv"])
+                    raise BackendCalled
+
+                ctx = SimpleNamespace(
+                    forward_mode=mode,
+                    bs=rows,
+                    attn_backend=SimpleNamespace(forward=capture_backend),
+                    token_to_kv_pool=None,
+                )
+                with mock.patch.object(
+                    layer, "_project_qkvfab", return_value=projection_outputs
+                ):
+                    with self.assertRaises(BackendCalled):
+                        layer(
+                            positions=torch.empty(rows, dtype=torch.int64),
+                            hidden_states=torch.empty(rows, 64, dtype=torch.bfloat16),
+                            ctx=ctx,
+                            out_cache_loc=torch.empty(0, dtype=torch.int64),
+                            comm_manager=None,
+                        )
+
+                self.assertEqual(captured[0].is_contiguous(), expect_contiguous)
 
     def test_ep_kimi_moe_combines_shared_and_routed_reductions(self):
         import tokenspeed.runtime.models.kimi_k3 as kimi_k3

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -237,20 +237,28 @@ def test_kda_paged_decode_graph_padding_and_page_stride() -> None:
     )
 
 
-def test_kda_fused_paged_decode_matches_reference() -> None:
+@pytest.mark.parametrize(
+    ("batch", "active"),
+    [(1, 1), (2, 2), (4, 2), (8, 8), (16, 16), (32, 32)],
+)
+def test_kda_fused_paged_decode_matches_reference(batch: int, active: int) -> None:
     """The K3 megafusion preserves state paging and its fused norm epilogue."""
     if not current_platform().is_cdna4:
         pytest.skip("gfx950 KDA fusion test")
 
     torch.manual_seed(31)
-    batch, active, heads, head_dim, pages = 4, 2, 12, 128, 6
+    heads, head_dim, pages = 12, 128, 2 * active
     projection_width = heads * head_dim
-    mixed_qkv = torch.randn(
+    used_width = 4 * projection_width + head_dim + heads
+    packed_width = (used_width + 15) // 16 * 16
+    packed_projection = torch.randn(
         batch,
-        3 * projection_width,
+        packed_width,
         device="cuda",
         dtype=torch.bfloat16,
     )
+    mixed_qkv = packed_projection[:, : 3 * projection_width]
+    assert mixed_qkv.stride() == (packed_width, 1)
     conv_weights = 0.1 * torch.randn(
         3 * projection_width,
         4,
@@ -266,32 +274,19 @@ def test_kda_fused_paged_decode_matches_reference() -> None:
     )
     initial_conv_states = conv_states.clone()
     expected_conv_states = conv_states.clone()
-    f_a_out = torch.randn(
-        batch,
-        head_dim,
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
+    f_a_start = 4 * projection_width
+    f_a_out = packed_projection[:, f_a_start : f_a_start + head_dim]
     f_b_weight = 0.1 * torch.randn(
         projection_width,
         head_dim,
         device="cuda",
         dtype=torch.bfloat16,
     )
-    beta_logits = torch.randn(
-        batch,
-        heads,
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
+    beta_start = f_a_start + head_dim
+    beta_logits = packed_projection[:, beta_start : beta_start + heads]
     a_log = torch.randn(heads, device="cuda", dtype=torch.float32)
     dt_bias = torch.randn(projection_width, device="cuda", dtype=torch.float32)
-    output_gate = torch.randn(
-        batch,
-        projection_width,
-        device="cuda",
-        dtype=torch.bfloat16,
-    )
+    output_gate = packed_projection[:, 3 * projection_width : f_a_start]
     norm_weight = torch.randn(head_dim, device="cuda", dtype=torch.bfloat16)
     norm_eps = 1e-6
     state_pool = 0.01 * torch.randn(
@@ -304,9 +299,18 @@ def test_kda_fused_paged_decode_matches_reference() -> None:
     )
     initial_state_pool = state_pool.clone()
     expected_state_pool = state_pool.clone()
-    read_indices = torch.tensor([0, 1, -1, -1], device="cuda", dtype=torch.int32)
-    write_indices = torch.tensor([2, 3, -1, -1], device="cuda", dtype=torch.int32)
-    cu_seqlens = torch.tensor([0, 1, 2, 2, 2], device="cuda", dtype=torch.int32)
+    read_indices = torch.full((batch,), -1, device="cuda", dtype=torch.int32)
+    write_indices = torch.full((batch,), -1, device="cuda", dtype=torch.int32)
+    read_indices[:active] = torch.arange(active, device="cuda", dtype=torch.int32)
+    write_indices[:active] = torch.arange(
+        active, 2 * active, device="cuda", dtype=torch.int32
+    )
+    cu_seqlens = torch.cat(
+        (
+            torch.arange(active + 1, device="cuda", dtype=torch.int32),
+            torch.full((batch - active,), active, device="cuda", dtype=torch.int32),
+        )
+    )
 
     raw_g = torch.nn.functional.linear(f_a_out, f_b_weight)
     expected_out = torch.zeros(


### PR DESCRIPTION
Keep the merged KDA projection output packed and pass its QKV view directly to the stride-aware fused decode kernel, eliminating one device copy per KDA layer for multi-request decode. Materialize compact QKV only for multi-token and fallback paths that require it.

- Cover packed projection aliasing and numerical parity for single- and multi-row outputs.
- Exercise gfx950 fused KDA decode with packed row strides at graph batch sizes 1, 2, 4, 8, 16, and 32.

Benchmark (8x AMD Instinct MI355X, Kimi-K3 TP8/EP8, FP8 KV): EvalScope random workload with fixed 4096-token inputs and 1024-token outputs. Graph-mode decode without speculative decoding
- B1/C1: 71.03 -> 70.93 output tok/s (-0.1%)
- B2/C2: 88.14 -> 89.22 output tok/s (+1.2%)
- B4/C4: 164.07 -> 165.60 output tok/s (+0.9%)
- B8/C8: 240.53 -> 242.74 output tok/s (+0.9%)
- B16/C16: 344.29 -> 346.79 output tok/s (+0.7%)
