### PR TITLE
perf(kda): consume strided decode projections

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1257,7 +1257,7 @@ class KimiLinearKDA(nn.Module):
             # per-head norm implementation.
             core_out = rmsnorm_gated_sigmoid(
                 core_out.contiguous(),
-                out_gate.contiguous(),
+                out_gate,
                 self.o_norm.weight,
                 self.o_norm.variance_epsilon,
                 hn,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/kda/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/kda/decode.py
@@ -45,6 +45,11 @@ def _kda_recurrent_decode_kernel(
     H: gl.constexpr,
     K: gl.constexpr,
     V: gl.constexpr,
+    Q_TOKEN_STRIDE: gl.constexpr,
+    K_TOKEN_STRIDE: gl.constexpr,
+    V_TOKEN_STRIDE: gl.constexpr,
+    G_TOKEN_STRIDE: gl.constexpr,
+    BETA_TOKEN_STRIDE: gl.constexpr,
     BK: gl.constexpr,
     BV: gl.constexpr,
     NUM_SLOTS: gl.constexpr,
@@ -111,17 +116,17 @@ def _kda_recurrent_decode_kernel(
 
     token_idx = begin
     q_value = gl.load(
-        q + (token_idx * H + head_idx) * K + key_offsets,
+        q + token_idx * Q_TOKEN_STRIDE + head_idx * K + key_offsets,
         mask=key_mask,
         other=0.0,
     ).to(gl.float32)
     k_value = gl.load(
-        k + (token_idx * H + head_idx) * K + key_offsets,
+        k + token_idx * K_TOKEN_STRIDE + head_idx * K + key_offsets,
         mask=key_mask,
         other=0.0,
     ).to(gl.float32)
     gate_value = gl.load(
-        raw_g + (token_idx * H + head_idx) * K + key_offsets,
+        raw_g + token_idx * G_TOKEN_STRIDE + head_idx * K + key_offsets,
         mask=key_mask,
         other=0.0,
     ).to(gl.float32)
@@ -138,7 +143,9 @@ def _kda_recurrent_decode_kernel(
             1.0 + gl.exp(-gl.abs(gate_value))
         )
         log_decay = -a_value * softplus
-    beta_value = gl.load(raw_beta + token_idx * H + head_idx).to(gl.float32)
+    beta_value = gl.load(raw_beta + token_idx * BETA_TOKEN_STRIDE + head_idx).to(
+        gl.float32
+    )
     beta_value = 1.0 / (1.0 + gl.exp(-beta_value))
 
     scale: gl.constexpr = K**-0.5
@@ -157,7 +164,7 @@ def _kda_recurrent_decode_kernel(
         other=0.0,
     ).to(gl.float32)
     v_value = gl.load(
-        v + (token_idx * H + head_idx) * V + value_offsets,
+        v + token_idx * V_TOKEN_STRIDE + head_idx * V + value_offsets,
         mask=value_mask,
         other=0.0,
     ).to(gl.float32)
@@ -480,19 +487,27 @@ def gluon_kda_recurrent_decode_gfx950(
         raise ValueError("state_pool pages must not overlap")
     if A_log.shape != (heads,) or dt_bias.numel() != heads * key_dim:
         raise ValueError("invalid KDA gate parameter shapes")
+    expected_inner_strides = (
+        (q, key_dim),
+        (k, key_dim),
+        (g_raw, key_dim),
+        (v, value_dim),
+    )
+    if any(
+        tensor.stride(-1) != 1 or tensor.stride(-2) != width
+        for tensor, width in expected_inner_strides
+    ):
+        raise ValueError("KDA inputs must have contiguous head vectors")
+    if beta_logits.stride(-1) != 1:
+        raise ValueError("KDA beta logits must have contiguous heads")
 
-    q = q.contiguous()
-    k = k.contiguous()
-    v = v.contiguous()
-    g_raw = g_raw.contiguous()
-    beta_logits = beta_logits.contiguous()
     A_log = A_log.contiguous()
     dt_bias = dt_bias.view(heads, key_dim).contiguous()
     read_indices = read_indices.to(device=q.device, dtype=torch.int32).contiguous()
     write_indices = write_indices.to(device=q.device, dtype=torch.int32).contiguous()
     cu_seqlens = cu_seqlens.to(device=q.device, dtype=torch.int32).contiguous()
 
-    output = torch.empty_like(v)
+    output = torch.empty(v.shape, dtype=v.dtype, device=v.device)
     block_key = triton.next_power_of_2(key_dim)
     block_value = min(32, triton.next_power_of_2(value_dim))
     _kda_recurrent_decode_kernel[(triton.cdiv(value_dim, block_value), tokens * heads)](
@@ -511,6 +526,11 @@ def gluon_kda_recurrent_decode_gfx950(
         H=heads,
         K=key_dim,
         V=value_dim,
+        Q_TOKEN_STRIDE=q.stride(1),
+        K_TOKEN_STRIDE=k.stride(1),
+        V_TOKEN_STRIDE=v.stride(1),
+        G_TOKEN_STRIDE=g_raw.stride(1),
+        BETA_TOKEN_STRIDE=beta_logits.stride(1),
         BK=block_key,
         BV=block_value,
         NUM_SLOTS=state_pool.shape[0],

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
@@ -932,6 +932,7 @@ def _rmsnorm_gated_kernel(
     weight_ptr,
     out_ptr,
     eps,
+    gate_stride,
     num_heads: tl.constexpr,
     head_dim: tl.constexpr,
     BLOCK_H: tl.constexpr,
@@ -945,7 +946,8 @@ def _rmsnorm_gated_kernel(
     var = tl.sum(x * x, axis=1) / head_dim
     rsig = tl.math.rsqrt(var + eps)
     w = tl.load(weight_ptr + offs_d).to(tl.float32)
-    g = tl.load(gate_ptr + idx, mask=mask_h[:, None], other=0.0).to(tl.float32)
+    gate_idx = token * gate_stride + offs_h[:, None] * head_dim + offs_d[None, :]
+    g = tl.load(gate_ptr + gate_idx, mask=mask_h[:, None], other=0.0).to(tl.float32)
     y = x * rsig[:, None] * w[None, :] * tl.sigmoid(g)
     tl.store(out_ptr + idx, y.to(out_ptr.dtype.element_ty), mask=mask_h[:, None])
 
@@ -962,7 +964,7 @@ def rmsnorm_gated_sigmoid(
 
     Args:
         x: ``[num_tokens, num_heads*head_dim]`` bf16 input (contiguous).
-        gate: same shape as ``x``; raw gate logits (sigmoid applied in-kernel).
+        gate: same shape as ``x`` with unit inner stride; raw gate logits.
         weight: ``[head_dim]`` RMSNorm weight.
         eps: RMSNorm epsilon.
         num_heads / head_dim: per-head norm geometry.
@@ -970,7 +972,7 @@ def rmsnorm_gated_sigmoid(
     Returns:
         ``[num_tokens, num_heads*head_dim]`` tensor of ``x``'s dtype.
     """
-    assert x.is_contiguous() and gate.is_contiguous()
+    assert x.is_contiguous() and gate.shape == x.shape and gate.stride(-1) == 1
     out = torch.empty_like(x)
     _rmsnorm_gated_kernel[(x.shape[0],)](
         x,
@@ -978,6 +980,7 @@ def rmsnorm_gated_sigmoid(
         weight,
         out,
         eps,
+        gate.stride(0),
         num_heads=num_heads,
         head_dim=head_dim,
         BLOCK_H=triton.next_power_of_2(num_heads),

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -103,12 +103,14 @@ def test_kda_paged_prefill_uses_canonical_k_major_state() -> None:
 
 
 @pytest.mark.parametrize("lower_bound", [-5.0, None])
+@pytest.mark.parametrize("strided_inputs", [False, True])
 @pytest.mark.parametrize(
     ("heads", "key_dim", "value_dim"),
     [(2, 8, 8), (2, 8, 5), (12, 128, 128)],
 )
 def test_kda_paged_decode_defaults_to_specialized_kernel_on_amd(
     lower_bound: float | None,
+    strided_inputs: bool,
     heads: int,
     key_dim: int,
     value_dim: int,
@@ -121,11 +123,42 @@ def test_kda_paged_decode_defaults_to_specialized_kernel_on_amd(
     device = "cuda"
     torch.manual_seed(13)
     tokens = 3
-    q = torch.randn(1, tokens, heads, key_dim, device=device, dtype=torch.bfloat16)
-    k = torch.randn_like(q)
-    v = torch.randn(1, tokens, heads, value_dim, device=device, dtype=torch.bfloat16)
-    raw_g = torch.randn_like(q)
-    beta = torch.randn(1, tokens, heads, device=device, dtype=torch.bfloat16)
+    if strided_inputs:
+        qkv = torch.randn(
+            1,
+            tokens,
+            heads * (2 * key_dim + value_dim) + 7,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        q_end = heads * key_dim
+        k_end = 2 * q_end
+        v_end = k_end + heads * value_dim
+        q = qkv[..., :q_end].view(1, tokens, heads, key_dim)
+        k = qkv[..., q_end:k_end].view(1, tokens, heads, key_dim)
+        v = qkv[..., k_end:v_end].view(1, tokens, heads, value_dim)
+        raw_g = torch.randn(
+            1,
+            tokens,
+            heads * key_dim + 5,
+            device=device,
+            dtype=torch.bfloat16,
+        )[..., :q_end].view(1, tokens, heads, key_dim)
+        beta = torch.randn(
+            1,
+            tokens,
+            heads + 3,
+            device=device,
+            dtype=torch.bfloat16,
+        )[..., :heads]
+    else:
+        q = torch.randn(1, tokens, heads, key_dim, device=device, dtype=torch.bfloat16)
+        k = torch.randn_like(q)
+        v = torch.randn(
+            1, tokens, heads, value_dim, device=device, dtype=torch.bfloat16
+        )
+        raw_g = torch.randn_like(q)
+        beta = torch.randn(1, tokens, heads, device=device, dtype=torch.bfloat16)
     state_pool = torch.randn(
         6,
         heads,


### PR DESCRIPTION
## Summary

- Let gfx950 KDA decode consume token-strided Q/K/V/gate projections directly.
- Let the gated RMSNorm epilogue consume a token-strided output gate.
- Remove the corresponding model-side contiguous copies.

## Validation

### Current revisions

- Base: `978ed2cf` (current `upstream/main`)
- Head: `0e1c7a72` (merge of current main into the PR branch)

### Correctness and copy removal

- Targeted current-head fused/strided KDA coverage: 8 passed, 16 deselected.
- Parent and head isolated output checksums match exactly.
- Parent profile: one logical `contiguous -> clone -> copy_` sequence.
- Head profile: no contiguous/clone/copy event.

### Isolated KDA performance

Production fused KDA decode at M=2 under CUDA-graph replay, median of seven trials:

| Revision | Median latency | Change |
|---|---:|---:|
| Parent | 23.147 µs | |
| Head | 19.550 µs | -15.5% |

This removes 3.597 µs per KDA layer. Across 69 KDA layers, that predicts about 0.248 ms saved per decode step.

### Current end-to-end performance

MI350X, TP8/EP8, M=2, 4K input / 1K output, CUDA graph capture size 2, median of three:

| Metric | Parent | Head | Change |
|---|---:|---:|---:|
| Output throughput | 82.06 tok/s | 82.05 tok/s | -0.01% |
| TPOT | 23.663 ms | 23.672 ms | +0.04% |

The local copy removal remains measurable and correct, but after merging current main its effect is no longer distinguishable in the full-model benchmark. All 12 measured requests per boundary completed with valid lengths.

## Stack

- Base: current `main`