### PR TITLE
perf(mla): build the FP8 query and write the latent KV in one launch

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -368,6 +368,13 @@ class LayerMappedKVPool:
       (0..n-1) while their planes are the continuation range
       ``num_target_layers..``; the map is ``{local: global}`` (pass
       ``layer_map`` explicitly).
+
+    Deliberately not an ``MLATokenToKVPool`` subclass: ``models/utils.py``'s
+    fused MLA write gate uses ``isinstance`` to keep off this wrapper,
+    because ``set_mla_kv_buffer`` here defaults to ``sanitize=True`` (see that
+    method) and the fused write has no sanitize path. Losing this property --
+    by subclassing, or by the gate switching to duck-typing -- reopens the
+    padded-row NaN hazard that default exists to close.
     """
 
     def __init__(

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 from typing import ClassVar
 
 import torch
-from typing_extensions import override
 
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
@@ -95,31 +94,20 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
         except KeyError as exc:
             raise ValueError(f"layer {layer_id} has no cache group") from exc
 
-    @override
-    def set_mla_kv_buffer(
-        self,
-        layer,
-        loc: torch.Tensor,
-        cache_k_nope: torch.Tensor,
-        cache_k_rope: torch.Tensor,
-        sanitize: bool = True,
-    ):
-        """Latent write that sanitizes by default -- a fact of this cache.
-
-        Prefill breakable-graph padding contract: the dummy-batch capture (and
-        bucket-padding rows) whose ``out_cache_loc`` is the reserved
-        ``dummy_kv_slot`` can carry NaN into this fp8 KV write. The paged MLA
-        decode kernel reads that shared dummy slot through the zero-padded
-        block-table entries and computes ``q·k`` BEFORE applying the causal
-        mask, so the NaN survives it (``NaN + -inf = NaN``) and poisons a live
-        row's softmax -> NaN logits -> token 0. Eager prefill leaves the dummy
-        slot finite (``q·0`` masks cleanly), which is why the bug only appears
-        with the prefill graph on. Sanitizing in-kernel keeps real rows bitwise
-        unchanged without allocating two temporary tensors.
-        """
-        super().set_mla_kv_buffer(
-            layer, loc, cache_k_nope, cache_k_rope, sanitize=sanitize
-        )
+    #: Latent write that sanitizes by default -- a fact of this cache.
+    #:
+    #: Prefill breakable-graph padding contract: the dummy-batch capture (and
+    #: bucket-padding rows) whose ``out_cache_loc`` is the reserved
+    #: ``dummy_kv_slot`` can carry NaN into this fp8 KV write. The paged MLA
+    #: decode kernel reads that shared dummy slot through the zero-padded
+    #: block-table entries and computes ``q·k`` BEFORE applying the causal
+    #: mask, so the NaN survives it (``NaN + -inf = NaN``) and poisons a live
+    #: row's softmax -> NaN logits -> token 0. Eager prefill leaves the dummy
+    #: slot finite (``q·0`` masks cleanly), which is why the bug only appears
+    #: with the prefill graph on. Sanitizing in-kernel keeps real rows bitwise
+    #: unchanged without allocating two temporary tensors. Declared, not
+    #: overridden, so the fused MLA write gate still admits this pool.
+    latent_write_sanitizes: ClassVar[bool] = True
 
     def get_component(self, layer_id: int, component_name: str) -> torch.Tensor:
         """Return one KDA state plane. Latent KV is read via ``kv_buffer``."""

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
@@ -35,6 +35,11 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
 class HybridKDATokenToKVPool(MLATokenToKVPool):
     """MLA compute interface whose latent KV and KDA state share one buffer."""
 
+    #: Sanitizing latent write: under the prefill graph a padded row's NaN
+    #: reaches a live row's softmax through the shared dummy slot, because the
+    #: paged MLA decode computes ``q·k`` before the causal mask.
+    latent_write_sanitizes: ClassVar[bool] = True
+
     def __init__(
         self,
         *,
@@ -93,21 +98,6 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
             return self._group_ids_by_layer[layer_id]
         except KeyError as exc:
             raise ValueError(f"layer {layer_id} has no cache group") from exc
-
-    #: Latent write that sanitizes by default -- a fact of this cache.
-    #:
-    #: Prefill breakable-graph padding contract: the dummy-batch capture (and
-    #: bucket-padding rows) whose ``out_cache_loc`` is the reserved
-    #: ``dummy_kv_slot`` can carry NaN into this fp8 KV write. The paged MLA
-    #: decode kernel reads that shared dummy slot through the zero-padded
-    #: block-table entries and computes ``q·k`` BEFORE applying the causal
-    #: mask, so the NaN survives it (``NaN + -inf = NaN``) and poisons a live
-    #: row's softmax -> NaN logits -> token 0. Eager prefill leaves the dummy
-    #: slot finite (``q·0`` masks cleanly), which is why the bug only appears
-    #: with the prefill graph on. Sanitizing in-kernel keeps real rows bitwise
-    #: unchanged without allocating two temporary tensors. Declared, not
-    #: overridden, so the fused MLA write gate still admits this pool.
-    latent_write_sanitizes: ClassVar[bool] = True
 
     def get_component(self, layer_id: int, component_name: str) -> torch.Tensor:
         """Return one KDA state plane. Latent KV is read via ``kv_buffer``."""

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
@@ -164,14 +164,21 @@ class MLATokenToKVPool(CachePool):
         else:
             self.kv_buffer[layer_id][loc] = cache_k
 
+    #: Default for ``set_mla_kv_buffer``'s ``sanitize``. Declared rather than
+    #: overridden so a pool needing only this keeps the base method identity
+    #: the fused MLA write gate checks (see ``models/utils.py``).
+    latent_write_sanitizes: ClassVar[bool] = False
+
     def set_mla_kv_buffer(
         self,
         layer: PagedAttention,
         loc: torch.Tensor,
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
-        sanitize: bool = False,
+        sanitize: bool | None = None,
     ):
+        if sanitize is None:
+            sanitize = self.latent_write_sanitizes
         layer_id = layer.layer_id
         if self.quant_method == "per_token_head":
             # Preserve the writer's sanitization contract for the quantized

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
@@ -47,6 +47,10 @@ def _get_tensor_size_bytes(t: torch.Tensor | list[torch.Tensor]):
 
 
 class MLATokenToKVPool(CachePool):
+    #: ``set_mla_kv_buffer``'s ``sanitize`` default; declared, not overridden,
+    #: so the fused MLA write gate's method-identity check still admits a pool.
+    latent_write_sanitizes: ClassVar[bool] = False
+
     def __init__(
         self,
         arena: CacheArena,
@@ -163,11 +167,6 @@ class MLATokenToKVPool(CachePool):
             self.kv_buffer[layer_id][2][loc] = k_rope
         else:
             self.kv_buffer[layer_id][loc] = cache_k
-
-    #: Default for ``set_mla_kv_buffer``'s ``sanitize``. Declared rather than
-    #: overridden so a pool needing only this keeps the base method identity
-    #: the fused MLA write gate checks (see ``models/utils.py``).
-    latent_write_sanitizes: ClassVar[bool] = False
 
     def set_mla_kv_buffer(
         self,

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -967,12 +967,18 @@ class DeepseekV3AttentionMLA(nn.Module):
                 else None
             )
             if fused_mla_kv_arg is not None:
-                self.rotary_emb(
-                    positions,
-                    q_pe,
-                    K[..., self.kv_lora_rank :],
+                # The same entry point the FP8 branch takes, so the gate's
+                # probe and the launch resolve one dispatch key. Routing this
+                # through ``rotary_emb`` instead would dispatch
+                # ``embedding.rope``, which an override can redirect to a
+                # solution that rejects the fused argument -- after the gate
+                # already answered for ``embedding.rope_mla_set_kv``.
+                apply_rope_mla_set_kv(
+                    positions=positions,
+                    q_rope=q_pe,
+                    k_rope=K[..., self.kv_lora_rank :],
                     fused_mla_set_kv_buffer_arg=fused_mla_kv_arg,
-                    output_q_rope=Q[..., self.kv_lora_rank :],
+                    q_rope_out=Q[..., self.kv_lora_rank :],
                     enable_pdl=pdl_enabled(),
                 )
                 K = None

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -37,7 +37,7 @@ from tokenspeed_kernel.ops.attention import (
     mla_project_value_prefers_contiguous_weight,
 )
 from tokenspeed_kernel.ops.attention.tokenspeed_mla import mla_kv_pack_quantize_fp8
-from tokenspeed_kernel.ops.embedding import apply_rope_mla
+from tokenspeed_kernel.ops.embedding import apply_rope_mla, apply_rope_mla_set_kv
 from tokenspeed_kernel.ops.gemm import bmm
 from tokenspeed_kernel.ops.gemm.cuda import dsv3_router_gemm
 from tokenspeed_kernel.ops.gemm.cute_dsl import (
@@ -845,11 +845,11 @@ class DeepseekV3AttentionMLA(nn.Module):
         self,
         q: torch.Tensor,
         latent_cache: torch.Tensor,
-        positions,
+        positions: torch.Tensor,
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
         absorbed_query: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         # Model-owned KV writes route their locations through the backend:
         # identity on the legacy path (base AttentionBackend hook), the
         # group-derived locations on the Paged cache path.
@@ -891,6 +891,37 @@ class DeepseekV3AttentionMLA(nn.Module):
             k_nope_raw = K[..., : self.kv_lora_rank]
             k_pe_raw = K[..., self.kv_lora_rank :]
 
+            fused_kv_arg = create_fused_mla_set_kv_buffer_arg(
+                k_nope=k_nope_raw,
+                rope_dim=self.qk_rope_head_dim,
+                rotary_emb=self.rotary_emb,
+                out_cache_loc=out_cache_loc,
+                token_to_kv_pool=ctx.token_to_kv_pool,
+                layer_id=self.attn_mqa.layer_id,
+                num_q_heads=self.num_local_heads,
+                q_nope=q_nope_absorbed,
+            )
+            if fused_kv_arg is not None:
+                # One launch for RoPE (or its absence), the FP8 quantize, and
+                # the KV scatter. The key lands in the cache and never exists
+                # as a tensor, so K comes back None: the decode backends read
+                # the cache and only touch k under save_kv_cache, which the
+                # model owns here.
+                query_fp8 = torch.empty(
+                    Q.shape,
+                    dtype=torch.float8_e4m3fn,
+                    device=Q.device,
+                )
+                apply_rope_mla_set_kv(
+                    positions=positions,
+                    q_rope=q_pe,
+                    k_rope=k_pe_raw,
+                    fused_mla_set_kv_buffer_arg=fused_kv_arg,
+                    q_rope_out=query_fp8,
+                    enable_pdl=pdl_enabled(),
+                )
+                return query_fp8, None
+
             query_fp8, key_fp8 = apply_rope_mla(
                 positions=positions,
                 q_rope=q_pe,
@@ -926,11 +957,11 @@ class DeepseekV3AttentionMLA(nn.Module):
                 create_fused_mla_set_kv_buffer_arg(
                     k_nope=K[..., : self.kv_lora_rank],
                     rope_dim=self.qk_rope_head_dim,
-                    rotary_head_size=self.rotary_emb.head_size,
-                    is_neox_style=self.rotary_emb.is_neox_style,
+                    rotary_emb=self.rotary_emb,
                     out_cache_loc=out_cache_loc,
                     token_to_kv_pool=ctx.token_to_kv_pool,
                     layer_id=self.attn_mqa.layer_id,
+                    num_q_heads=self.num_local_heads,
                 )
                 if self.attention_backend in self._MLA_KERNEL_BACKENDS
                 else None

--- a/python/tokenspeed/runtime/models/utils.py
+++ b/python/tokenspeed/runtime/models/utils.py
@@ -126,17 +126,15 @@ def create_fused_mla_set_kv_buffer_arg(
     ``None`` is the single place this configuration is judged to have no fused
     form, so callers fall back rather than branch. Every reason lives here:
     ``token_to_kv_pool`` is not an ``MLATokenToKVPool``, or it overrides the
-    latent write (Kimi-K3's hybrid KDA pool overrides it to force sanitize --
-    see below); the token*head count is past the validated range; the pool's
-    latent rows are not one dense ``[tokens, 1, nope+rope]`` tensor (the
-    per-token-head quantized pool keeps three); or no registered RoPE solution
-    advertises the fused traits.
+    latent write (see below); the token*head count is past the validated range;
+    the pool's latent rows are not one dense ``[tokens, 1, nope+rope]`` tensor
+    (the per-token-head quantized pool keeps three); or no registered RoPE
+    solution advertises the fused traits.
 
     ``rotary_emb=None`` is the NoPE form and IS fused when every other check
     passes -- the tables are simply absent from the returned argument. Kimi-K3
-    is NoPE, but its hybrid KDA pool overrides the latent write and so never
-    reaches this form; a K3 draft (a heterogeneous MLA cache view) gets a
-    plain pool and does.
+    is NoPE and reaches it, carrying its pool's ``latent_write_sanitizes`` into
+    the kernel.
     """
 
     from tokenspeed_kernel.ops.embedding import supports_fused_mla_kv_write
@@ -145,11 +143,9 @@ def create_fused_mla_set_kv_buffer_arg(
 
     if not isinstance(token_to_kv_pool, MLATokenToKVPool):
         return None
-    # A pool that overrides the latent write does so to add something this
-    # fused write does not have -- the hybrid KDA pool overrides it to force
-    # sanitize=True, whose comment describes a padded-row NaN reaching a live
-    # row's softmax through the shared dummy slot. Fusing would bypass the
-    # override silently, so decline whenever one exists.
+    # An override adds something this fused write does not have, and fusing
+    # would bypass it silently. Sanitize is the one addition it can reproduce,
+    # which a pool declares through latent_write_sanitizes instead.
     if type(token_to_kv_pool).set_mla_kv_buffer is not (
         MLATokenToKVPool.set_mla_kv_buffer
     ):
@@ -181,4 +177,5 @@ def create_fused_mla_set_kv_buffer_arg(
         q_nope=q_nope,
         cos_sin_cache=None if rotary_emb is None else rotary_emb.cos_sin_cache,
         is_neox=True if rotary_emb is None else rotary_emb.is_neox_style,
+        sanitize=token_to_kv_pool.latent_write_sanitizes,
     )

--- a/python/tokenspeed/runtime/models/utils.py
+++ b/python/tokenspeed/runtime/models/utils.py
@@ -100,22 +100,60 @@ def create_fused_set_kv_buffer_arg(
     )
 
 
+# Grid CTA count (tokens * (heads + 1), the fused kernel's own launch shape)
+# at which the fused write stops being measured no-slower than the split path
+# it replaces. 2048 tokens at H=16 (measured, see the perf table in the
+# commit that added this) is the calibration point; scaling by heads matters
+# because the grid's CTA count -- and so the fused kernel's own wall time --
+# grows with heads at a fixed token count, while the split path's does not
+# the same way. Confirmed at H=32 (safe to 1024 tokens, 18.9% regression at
+# 2048) and H=64 (safe to 512 tokens, 4.9% regression at 768).
+_FUSED_MLA_KV_MAX_TOKEN_HEADS = 2048 * 16
+
+
 def create_fused_mla_set_kv_buffer_arg(
     k_nope: torch.Tensor,
     rope_dim: int,
-    rotary_head_size: int,
-    is_neox_style: bool,
+    rotary_emb: object | None,
     out_cache_loc: torch.Tensor,
     token_to_kv_pool: object,
     layer_id: int,
+    num_q_heads: int,
+    q_nope: torch.Tensor | None = None,
 ) -> FusedMLASetKVBufferArg | None:
-    """Build fused MLA RoPE+KV write arguments when the cache layout matches."""
+    """Arguments for the fused MLA RoPE + quantize + KV write, or ``None``.
+
+    ``None`` is the single place this configuration is judged to have no fused
+    form, so callers fall back rather than branch. Every reason lives here:
+    ``token_to_kv_pool`` is not a plain ``MLATokenToKVPool`` (a
+    ``LayerMappedKVPool`` view over a merged pool -- Kimi-K3's own MLA layers,
+    and an ordinary model's same-family draft view -- fails this on purpose,
+    see below); the token*head count is past the validated range; the pool's
+    latent rows are not one dense ``[tokens, 1, nope+rope]`` tensor (the
+    per-token-head quantized pool keeps three); or no registered RoPE solution
+    advertises the fused traits.
+
+    ``rotary_emb=None`` is the NoPE form and IS fused when every other check
+    passes -- the tables are simply absent from the returned argument. Kimi-K3
+    is NoPE, but its own MLA layers read through a ``LayerMappedKVPool`` and
+    so never reach this form; a K3 draft (a heterogeneous MLA cache view) gets
+    a plain pool and does.
+
+    The ``MLATokenToKVPool`` check is also what keeps this write off a
+    ``LayerMappedKVPool``'s ``sanitize=True`` contract (its ``set_mla_kv_buffer``
+    default -- see the comment there): this write does not sanitize, so it
+    must never reach a pool that requires it. That coupling is deliberate,
+    not incidental to the isinstance check happening to be here for other
+    reasons -- keep it if this gate is ever loosened to duck-type instead.
+    """
 
     from tokenspeed_kernel.ops.embedding import supports_fused_mla_kv_write
 
     from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 
     if not isinstance(token_to_kv_pool, MLATokenToKVPool):
+        return None
+    if out_cache_loc.numel() * num_q_heads > _FUSED_MLA_KV_MAX_TOKEN_HEADS:
         return None
 
     kv_buffer = token_to_kv_pool.get_key_buffer(layer_id)
@@ -124,13 +162,12 @@ def create_fused_mla_set_kv_buffer_arg(
     if not supports_fused_mla_kv_write(
         q_dtype=k_nope.dtype,
         k_dtype=k_nope.dtype,
-        head_size=rotary_head_size,
-        rotary_dim=rope_dim,
-        is_neox=is_neox_style,
+        has_rope=rotary_emb is not None,
+        is_neox=True if rotary_emb is None else rotary_emb.is_neox_style,
+        has_q_nope=q_nope is not None,
     ):
         return None
-    if kv_buffer.dtype != k_nope.dtype:
-        return None
+    # The kernel converts BF16 inputs to the FP8 cache dtype on store.
     if kv_buffer.ndim != 3 or kv_buffer.shape[1] != 1:
         return None
     if kv_buffer.shape[2] != k_nope.shape[-1] + rope_dim:
@@ -140,4 +177,7 @@ def create_fused_mla_set_kv_buffer_arg(
         k_nope=k_nope,
         kv_buffer=kv_buffer.view(kv_buffer.shape[0], -1),
         cache_loc=out_cache_loc,
+        q_nope=q_nope,
+        cos_sin_cache=None if rotary_emb is None else rotary_emb.cos_sin_cache,
+        is_neox=True if rotary_emb is None else rotary_emb.is_neox_style,
     )

--- a/test/runtime/cache/test_mla_kv_buffer.py
+++ b/test/runtime/cache/test_mla_kv_buffer.py
@@ -643,3 +643,34 @@ def test_fused_gate_admits_the_hybrid_kda_pool_and_carries_its_sanitize():
     plain_arg = _gate_arg_for_pool(plain)
     assert plain_arg is not None
     assert plain_arg.sanitize is False
+
+
+def test_every_fused_call_site_uses_the_probed_entry_point():
+    """The gate answers for ``embedding.rope_mla_set_kv``, so every launch
+    that carries its argument goes through that entry point.
+
+    Overrides are keyed by ``(family, mode)`` and resolve without trait
+    filtering, so a call site that builds the argument here and then launches
+    through ``embedding.rope`` -- as ``rotary_emb`` does -- can be redirected
+    to a solution that rejects the fused argument, and inference raises where
+    the gate promised a working kernel.
+    """
+    import ast
+    import pathlib
+
+    source = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "python/tokenspeed/runtime/models/deepseek_v3.py"
+    ).read_text()
+    tree = ast.parse(source)
+
+    carriers = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and any(kw.arg == "fused_mla_set_kv_buffer_arg" for kw in node.keywords)
+    ]
+    assert len(carriers) == 2, "expected the FP8 and BF16 fused branches"
+    for call in carriers:
+        assert isinstance(call.func, ast.Name), ast.dump(call.func)
+        assert call.func.id == "apply_rope_mla_set_kv", call.func.id

--- a/test/runtime/cache/test_mla_kv_buffer.py
+++ b/test/runtime/cache/test_mla_kv_buffer.py
@@ -447,6 +447,89 @@ def test_mla_set_kv_nope_matches_two_kernel_path(n_loc: int, enable_pdl: bool) -
     assert _bitwise_equal(kv[loc], key_ref[:, 0])
 
 
+@pytest.mark.parametrize("n_loc", [4, 600])
+@pytest.mark.parametrize("has_rope", [False, True])
+def test_fused_sanitize_matches_the_split_path_bytes(
+    n_loc: int, has_rope: bool
+) -> None:
+    """A sanitizing fused write lands the same latent bytes as the split path.
+
+    This is the property that lets Kimi-K3's pool declare
+    ``latent_write_sanitizes`` instead of overriding the latent write: the
+    hazard the override closed (a padded row's NaN reaching a live row's
+    softmax through the shared dummy slot) stays closed on the fused path.
+    Both RoPE forms are covered because the rotation mixes the two halves, so
+    where the clamp lands relative to it is observable.
+    """
+    torch.manual_seed(0)
+    num_heads = 3
+    dtype = torch.bfloat16
+
+    q_rope = torch.randn(n_loc, num_heads, ROPE_DIM, device="cuda", dtype=dtype)
+    k_rope = torch.randn(n_loc, 1, ROPE_DIM, device="cuda", dtype=dtype)
+    q_nope = torch.randn(n_loc, num_heads, NOPE_DIM, device="cuda", dtype=dtype)
+    k_nope = torch.randn(n_loc, 1, NOPE_DIM, device="cuda", dtype=dtype)
+    # Every non-finite the padded rows can carry, in both halves.
+    k_nope[0, 0, 0] = float("nan")
+    k_nope[0, 0, 1] = float("inf")
+    k_nope[0, 0, 2] = float("-inf")
+    k_rope[0, 0, 0] = float("nan")
+    k_rope[0, 0, 1] = float("inf")
+    k_rope[0, 0, ROPE_DIM // 2] = float("-inf")
+
+    positions = torch.zeros(n_loc, device="cuda", dtype=torch.int64)
+    loc = torch.randperm(NUM_PAGES, device="cuda")[:n_loc]
+    cos_sin_cache = (
+        torch.randn(2048, ROPE_DIM, device="cuda", dtype=torch.float32)
+        if has_rope
+        else None
+    )
+
+    # Split path: rope+quantize, then the sanitizing scatter.
+    _, key_ref = apply_rope_mla(
+        positions=positions,
+        q_rope=q_rope,
+        k_rope=k_rope,
+        q_nope=q_nope,
+        k_nope=k_nope,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=False,
+    )
+    kv_ref = _empty_kv(torch.float8_e4m3fn)
+    set_mla_kv_buffer_triton(
+        kv_ref,
+        loc,
+        key_ref[:, :, :NOPE_DIM],
+        key_ref[:, :, NOPE_DIM:],
+        sanitize=True,
+    )
+
+    kv = _empty_kv(torch.float8_e4m3fn)
+    query = torch.empty(
+        n_loc, num_heads, NOPE_DIM + ROPE_DIM, device="cuda", dtype=dtype
+    )
+    apply_rope_mla_set_kv(
+        positions=positions,
+        q_rope=q_rope,
+        k_rope=k_rope,
+        fused_mla_set_kv_buffer_arg=FusedMLASetKVBufferArg(
+            k_nope=k_nope,
+            kv_buffer=kv,
+            cache_loc=loc,
+            q_nope=q_nope,
+            cos_sin_cache=cos_sin_cache,
+            is_neox=False,
+            sanitize=True,
+        ),
+        q_rope_out=query,
+    )
+    torch.cuda.synchronize()
+
+    assert not torch.isnan(kv[loc.cpu()].float()).any()
+    assert torch.isfinite(kv[loc.cpu()].float()).all()
+    assert _bitwise_equal(kv, kv_ref)
+
+
 def _fake_mla_pool(dtype: torch.dtype = torch.float8_e4m3fn) -> MLATokenToKVPool:
     """A minimal MLATokenToKVPool that isinstance-checks true, for gate tests
     that need no real cache -- construction takes eight unrelated args."""
@@ -496,25 +579,9 @@ def test_fused_gate_token_head_budget(num_q_heads, num_tokens, expect_fused):
     assert (arg is not None) == expect_fused
 
 
-def test_fused_gate_declines_a_pool_that_overrides_the_latent_write():
-    """A pool that customizes set_mla_kv_buffer must not be fused past.
-
-    The hybrid KDA pool (Kimi-K3) overrides it to force sanitize=True, whose
-    docstring describes a padded row's NaN reaching a live row's softmax
-    through the shared dummy slot. The fused write does not sanitize, so
-    bypassing that override would reopen the hazard silently. It is an
-    MLATokenToKVPool subclass, so isinstance alone does not exclude it.
-    """
-    from tokenspeed.runtime.layers.attention.kv_cache.hybrid_kda import (
-        HybridKDATokenToKVPool,
-    )
-
-    assert issubclass(HybridKDATokenToKVPool, MLATokenToKVPool)
-
-    pool = _fake_mla_pool()
-    pool.__class__ = HybridKDATokenToKVPool
-    n_loc, num_q_heads = 8, 16
-    arg = create_fused_mla_set_kv_buffer_arg(
+def _gate_arg_for_pool(pool, n_loc: int = 8, num_q_heads: int = 16):
+    """Run the fused-write gate against ``pool`` with an otherwise valid shape."""
+    return create_fused_mla_set_kv_buffer_arg(
         k_nope=torch.zeros(n_loc, 1, NOPE_DIM, device="cuda", dtype=torch.bfloat16),
         rope_dim=ROPE_DIM,
         rotary_emb=None,
@@ -526,4 +593,53 @@ def test_fused_gate_declines_a_pool_that_overrides_the_latent_write():
             n_loc, num_q_heads, NOPE_DIM, device="cuda", dtype=torch.bfloat16
         ),
     )
-    assert arg is None
+
+
+def test_fused_gate_declines_a_pool_that_overrides_the_latent_write():
+    """A pool that customizes set_mla_kv_buffer must not be fused past.
+
+    An override adds something the fused write does not have, and fusing would
+    bypass it silently. isinstance alone does not exclude such a pool, since it
+    is an MLATokenToKVPool subclass -- the gate compares method identity.
+    """
+
+    class _OverridingPool(MLATokenToKVPool):
+        def set_mla_kv_buffer(self, *args, **kwargs):  # pragma: no cover
+            raise AssertionError("must not be reached")
+
+    pool = _fake_mla_pool()
+    pool.__class__ = _OverridingPool
+
+    assert issubclass(_OverridingPool, MLATokenToKVPool)
+    assert _gate_arg_for_pool(pool) is None
+
+
+def test_fused_gate_admits_the_hybrid_kda_pool_and_carries_its_sanitize():
+    """Kimi-K3's pool reaches the fused write, sanitizing.
+
+    It needs a sanitizing latent write -- a padded row's NaN otherwise reaches
+    a live row's softmax through the shared dummy slot -- but declares that
+    through ``latent_write_sanitizes`` instead of overriding the method, so the
+    identity check above still holds and the flag rides into the kernel.
+    """
+    from tokenspeed.runtime.layers.attention.kv_cache.hybrid_kda import (
+        HybridKDATokenToKVPool,
+    )
+
+    assert issubclass(HybridKDATokenToKVPool, MLATokenToKVPool)
+    assert (
+        HybridKDATokenToKVPool.set_mla_kv_buffer is MLATokenToKVPool.set_mla_kv_buffer
+    )
+    assert HybridKDATokenToKVPool.latent_write_sanitizes is True
+    assert MLATokenToKVPool.latent_write_sanitizes is False
+
+    pool = _fake_mla_pool()
+    pool.__class__ = HybridKDATokenToKVPool
+    arg = _gate_arg_for_pool(pool)
+    assert arg is not None
+    assert arg.sanitize is True
+
+    plain = _fake_mla_pool()
+    plain_arg = _gate_arg_for_pool(plain)
+    assert plain_arg is not None
+    assert plain_arg.sanitize is False

--- a/test/runtime/cache/test_mla_kv_buffer.py
+++ b/test/runtime/cache/test_mla_kv_buffer.py
@@ -674,3 +674,58 @@ def test_every_fused_call_site_uses_the_probed_entry_point():
     for call in carriers:
         assert isinstance(call.func, ast.Name), ast.dump(call.func)
         assert call.func.id == "apply_rope_mla_set_kv", call.func.id
+
+
+@pytest.mark.parametrize("n_loc", [1, 4, 600])
+def test_fused_write_follows_a_strided_cache_loc(n_loc: int) -> None:
+    """A strided ``cache_loc`` lands the same rows as a packed one.
+
+    A column of a per-step location table arrives with a stride of
+    ``num_draft_tokens``; indexing it as ``ptr + token_idx`` would read a
+    different row per token and write the latent to the wrong pages. n_loc=1
+    is the shape that matters most: a one-element column reports that stride
+    while ``is_contiguous()`` is True, so it is legitimate input that a
+    stride-1 assertion rejects.
+    """
+    torch.manual_seed(0)
+    num_heads = 3
+    num_draft_tokens = 4
+    dtype = torch.bfloat16
+
+    q_rope = torch.randn(n_loc, num_heads, ROPE_DIM, device="cuda", dtype=dtype)
+    k_rope = torch.randn(n_loc, 1, ROPE_DIM, device="cuda", dtype=dtype)
+    q_nope = torch.randn(n_loc, num_heads, NOPE_DIM, device="cuda", dtype=dtype)
+    k_nope = torch.randn(n_loc, 1, NOPE_DIM, device="cuda", dtype=dtype)
+    positions = torch.zeros(n_loc, device="cuda", dtype=torch.int64)
+
+    table = torch.randperm(NUM_PAGES, device="cuda")[: n_loc * num_draft_tokens]
+    strided_loc = table.view(n_loc, num_draft_tokens)[:, 1]
+    assert strided_loc.stride(-1) == num_draft_tokens
+    packed_loc = strided_loc.contiguous()
+
+    def run(loc):
+        query = torch.empty(
+            n_loc, num_heads, NOPE_DIM + ROPE_DIM, device="cuda", dtype=dtype
+        )
+        kv = _empty_kv(torch.float8_e4m3fn)
+        apply_rope_mla_set_kv(
+            positions=positions,
+            q_rope=q_rope,
+            k_rope=k_rope,
+            fused_mla_set_kv_buffer_arg=FusedMLASetKVBufferArg(
+                k_nope=k_nope,
+                kv_buffer=kv,
+                cache_loc=loc,
+                q_nope=q_nope,
+                cos_sin_cache=None,
+            ),
+            q_rope_out=query,
+        )
+        torch.cuda.synchronize()
+        return query, kv
+
+    query_strided, kv_strided = run(strided_loc)
+    query_packed, kv_packed = run(packed_loc)
+
+    assert _bitwise_equal(query_strided, query_packed)
+    assert _bitwise_equal(kv_strided[packed_loc], kv_packed[packed_loc])

--- a/test/runtime/cache/test_mla_kv_buffer.py
+++ b/test/runtime/cache/test_mla_kv_buffer.py
@@ -20,14 +20,31 @@
 
 from __future__ import annotations
 
+import os
+import sys
+
 import pytest
 import torch
 from tokenspeed_kernel.ops.embedding import (
     FusedMLASetKVBufferArg,
     apply_rope,
+    apply_rope_mla,
+    apply_rope_mla_set_kv,
 )
 
-from tokenspeed.runtime.cache.utils import (
+from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
+from tokenspeed.runtime.models.utils import (
+    create_fused_mla_set_kv_buffer_arg,
+)
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=15, suite="runtime-1gpu")
+
+from tokenspeed.runtime.cache.utils import (  # noqa: E402
     get_mla_kv_buffer_triton,
     set_mla_kv_buffer_triton,
 )
@@ -325,3 +342,155 @@ def test_mla_rope_set_kv_buffer_matches_reference(is_neox, loc_dtype):
 
     torch.testing.assert_close(q_out_rope, q_ref, atol=0.01, rtol=0.01)
     torch.testing.assert_close(kv[loc.long()], kv_ref[loc.long()], atol=0.01, rtol=0.01)
+
+
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_mla_rope_set_kv_buffer_fp8_matches_two_kernel_path(
+    enable_pdl: bool,
+) -> None:
+    torch.manual_seed(0)
+    n_loc = 17
+    num_heads = 3
+    max_position = 128
+    dtype = torch.bfloat16
+
+    q_rope = torch.randn(n_loc, num_heads, ROPE_DIM, device="cuda", dtype=dtype)
+    k_rope = torch.randn(n_loc, 1, ROPE_DIM, device="cuda", dtype=dtype)
+    q_nope = torch.randn(n_loc, num_heads, NOPE_DIM, device="cuda", dtype=dtype)
+    k_nope = torch.randn(n_loc, 1, NOPE_DIM, device="cuda", dtype=dtype)
+    positions = torch.randint(0, max_position, (n_loc,), device="cuda")
+    loc = torch.randperm(NUM_PAGES, device="cuda")[:n_loc]
+    angles = torch.randn(max_position, ROPE_DIM // 2, device="cuda")
+    cos_sin = torch.cat((angles.cos(), angles.sin()), dim=-1)
+
+    query_ref, key_ref = apply_rope_mla(
+        positions=positions,
+        q_rope=q_rope,
+        k_rope=k_rope,
+        q_nope=q_nope,
+        k_nope=k_nope,
+        cos_sin_cache=cos_sin,
+    )
+    query = torch.empty_like(query_ref)
+    kv = _empty_kv(torch.float8_e4m3fn)
+
+    apply_rope(
+        positions=positions,
+        q=q_rope,
+        k=k_rope,
+        head_size=ROPE_DIM,
+        cos_sin_cache=cos_sin,
+        fused_mla_set_kv_buffer_arg=FusedMLASetKVBufferArg(
+            k_nope=k_nope,
+            kv_buffer=kv,
+            cache_loc=loc,
+            q_nope=q_nope,
+        ),
+        q_rope_out=query,
+        enable_pdl=enable_pdl,
+    )
+    torch.cuda.synchronize()
+
+    assert _bitwise_equal(query, query_ref)
+    assert _bitwise_equal(kv[loc], key_ref[:, 0])
+
+
+@pytest.mark.parametrize("n_loc", [1, 17, 600])
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_mla_set_kv_nope_matches_two_kernel_path(n_loc: int, enable_pdl: bool) -> None:
+    """The NoPE form, through the entry point the model actually calls.
+
+    A model with no rotary embedding hands the write no RoPE tables, so the
+    halves are assembled without rotation. n_loc spans both sides of the point
+    where a program starts covering several tokens.
+    """
+    torch.manual_seed(0)
+    num_heads = 3
+    dtype = torch.bfloat16
+
+    q_rope = torch.randn(n_loc, num_heads, ROPE_DIM, device="cuda", dtype=dtype)
+    k_rope = torch.randn(n_loc, 1, ROPE_DIM, device="cuda", dtype=dtype)
+    q_nope = torch.randn(n_loc, num_heads, NOPE_DIM, device="cuda", dtype=dtype)
+    k_nope = torch.randn(n_loc, 1, NOPE_DIM, device="cuda", dtype=dtype)
+    positions = torch.zeros(n_loc, device="cuda", dtype=torch.int64)
+    loc = torch.randperm(NUM_PAGES, device="cuda")[:n_loc]
+
+    query_ref, key_ref = apply_rope_mla(
+        positions=positions,
+        q_rope=q_rope,
+        k_rope=k_rope,
+        q_nope=q_nope,
+        k_nope=k_nope,
+        cos_sin_cache=None,
+        is_neox=False,
+    )
+    query = torch.empty_like(query_ref)
+    kv = _empty_kv(torch.float8_e4m3fn)
+
+    apply_rope_mla_set_kv(
+        positions=positions,
+        q_rope=q_rope,
+        k_rope=k_rope,
+        fused_mla_set_kv_buffer_arg=FusedMLASetKVBufferArg(
+            k_nope=k_nope,
+            kv_buffer=kv,
+            cache_loc=loc,
+            q_nope=q_nope,
+            cos_sin_cache=None,
+        ),
+        q_rope_out=query,
+        enable_pdl=enable_pdl,
+    )
+    torch.cuda.synchronize()
+
+    assert _bitwise_equal(query, query_ref)
+    assert _bitwise_equal(kv[loc], key_ref[:, 0])
+
+
+def _fake_mla_pool(dtype: torch.dtype = torch.float8_e4m3fn) -> MLATokenToKVPool:
+    """A minimal MLATokenToKVPool that isinstance-checks true, for gate tests
+    that need no real cache -- construction takes eight unrelated args."""
+    pool = object.__new__(MLATokenToKVPool)
+    pool.quant_method = "none"
+    pool.dtype = dtype
+    pool.store_dtype = dtype
+    pool.layerwise_load_tracker = None
+    pool.kv_buffer = [torch.zeros(NUM_PAGES, 1, TOTAL_DIM, dtype=dtype, device="cuda")]
+    return pool
+
+
+@pytest.mark.parametrize(
+    "num_q_heads,num_tokens,expect_fused",
+    [
+        (16, 2048, True),
+        (16, 2049, False),
+        (32, 1024, True),
+        (32, 1025, False),
+        (64, 512, True),
+        (64, 513, False),
+    ],
+)
+def test_fused_gate_token_head_budget(num_q_heads, num_tokens, expect_fused):
+    """The fused write's token cap scales down with head count: the fused
+    kernel's own CTA count is tokens*(heads+1), so a fixed token cap is only
+    safe at the head count it was measured at. Regression measured directly:
+    at H=32 the fused path lost to the split path by 18.9% at 2048 tokens
+    while still winning at 1024; at H=64 it lost by 4.9% at 768 while still
+    winning at 512."""
+    pool = _fake_mla_pool()
+    k_nope = torch.zeros(num_tokens, 1, NOPE_DIM, device="cuda", dtype=torch.bfloat16)
+    q_nope = torch.zeros(
+        num_tokens, num_q_heads, NOPE_DIM, device="cuda", dtype=torch.bfloat16
+    )
+    loc = torch.arange(num_tokens, device="cuda", dtype=torch.int64)
+    arg = create_fused_mla_set_kv_buffer_arg(
+        k_nope=k_nope,
+        rope_dim=ROPE_DIM,
+        rotary_emb=None,
+        out_cache_loc=loc,
+        token_to_kv_pool=pool,
+        layer_id=0,
+        num_q_heads=num_q_heads,
+        q_nope=q_nope,
+    )
+    assert (arg is not None) == expect_fused

--- a/test/runtime/test_hybrid_mla_kv_nan_sanitize.py
+++ b/test/runtime/test_hybrid_mla_kv_nan_sanitize.py
@@ -29,14 +29,16 @@ softmax -> all-NaN logits -> ``argmax`` picks token 0 ("!"). Eager prefill
 leaves the dummy slot finite (``q.0`` masks cleanly), so the bug only appears
 with the prefill graph on.
 
-Sanitization is a fact of *this cache*, not of a wrapper around it: no call
-site passes ``sanitize=`` at all, so the default the pool class declares IS
-the contract -- and it holds for every view of the arena, target or draft.
+Sanitization is a fact of *this cache*, not of a wrapper around it: the pool
+class declares ``latent_write_sanitizes`` and every write path reads it, so
+that declaration IS the contract -- and it holds for every view of the arena,
+target or draft. It lives on the class rather than in ``set_mla_kv_buffer``'s
+signature because a pool that only changes the default must keep the base
+method identity that the fused-write gate checks.
 """
 
 from __future__ import annotations
 
-import inspect
 import pathlib
 
 from tokenspeed.runtime.layers.attention.kv_cache.hybrid_kda import (
@@ -46,7 +48,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 
 
 def _sanitize_default(cls) -> bool:
-    return inspect.signature(cls.set_mla_kv_buffer).parameters["sanitize"].default
+    return cls.latent_write_sanitizes
 
 
 def test_kda_cache_sanitizes_latent_writes_by_default() -> None:
@@ -59,17 +61,23 @@ def test_plain_mla_cache_does_not_sanitize_by_default() -> None:
     assert _sanitize_default(MLATokenToKVPool) is False
 
 
-def test_the_default_is_the_whole_contract() -> None:
-    """No caller may pass ``sanitize=``: the pools' own defaults decide.
+def test_no_call_site_decides_sanitization_for_itself() -> None:
+    """A caller may forward the pool's declaration, never a literal.
 
-    A call site that opts in per write would put the graph-padding contract
-    back in the callers' hands, which is how it came to live in a wrapper.
+    Passing ``sanitize=True``/``False`` at a write site would put the
+    graph-padding contract back in the callers' hands, which is how it came to
+    live in a wrapper. Forwarding ``latent_write_sanitizes`` -- as the fused
+    write's arg builder does -- still lets the pool decide.
     """
     root = pathlib.Path(__file__).resolve().parents[2] / "python"
     allowed = {"hybrid_kda.py", "mla.py"}  # the two definitions themselves
     offenders = sorted(
         str(path.relative_to(root))
         for path in root.rglob("*.py")
-        if path.name not in allowed and "sanitize=" in path.read_text()
+        if path.name not in allowed
+        and any(
+            literal in path.read_text()
+            for literal in ("sanitize=True", "sanitize=False")
+        )
     )
     assert offenders == []

--- a/test/runtime/test_mla_project_value_layout_dispatch.py
+++ b/test/runtime/test_mla_project_value_layout_dispatch.py
@@ -82,8 +82,7 @@ def test_fused_mla_kv_write_is_not_amd_only():
     assert supports_fused_mla_kv_write(
         q_dtype=torch.bfloat16,
         k_dtype=torch.bfloat16,
-        head_size=64,
-        rotary_dim=64,
+        has_rope=True,
         is_neox=False,
     ), "no registered kernel offers the fused MLA KV write on this platform"
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -440,6 +440,7 @@ __all__ = [
     "FusedSetKVBufferArg",
     "apply_rope",
     "apply_rope_mla",
+    "apply_rope_mla_set_kv",
     "supports_fused_mla_kv_write",
 ]
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import functools
 from dataclasses import dataclass
 
 import torch
@@ -40,37 +41,70 @@ class FusedMLASetKVBufferArg:
     k_nope: torch.Tensor
     kv_buffer: torch.Tensor
     cache_loc: torch.Tensor
+    # Setting the absorbed query half switches the write from updating the
+    # query's rotated columns in place to assembling the whole query, which
+    # widens the caller's output accordingly. supports_fused_mla_kv_write
+    # requires the selected solution to explicitly declare
+    # fused_mla_full_query -- select_kernel alone treats an undeclared trait
+    # as a non-match rather than a rejection, so this is checked separately
+    # -- and declines to fuse otherwise, rather than run a solution that
+    # would silently leave the unrotated columns unwritten.
+    q_nope: torch.Tensor | None = None
+    # RoPE tables for the fused write. ``cos_sin_cache=None`` selects the NoPE
+    # form, where the halves are assembled without rotation -- a model with no
+    # rotary module then needs no separate path.
+    cos_sin_cache: torch.Tensor | None = None
+    is_neox: bool = True
 
 
+@functools.lru_cache(maxsize=64)
 def supports_fused_mla_kv_write(
     *,
     q_dtype: torch.dtype,
     k_dtype: torch.dtype,
-    head_size: int,
-    rotary_dim: int,
+    has_rope: bool,
     is_neox: bool,
+    has_q_nope: bool = False,
 ) -> bool:
-    """Whether a registered RoPE kernel can write the MLA KV cache."""
+    """Whether a registered kernel can do the fused MLA query + KV write.
+
+    Memoized: the model asks once per MLA layer per step and the answer only
+    depends on these flags, while resolving it costs several microseconds of
+    host time on the launch path. Registration happens at import, before any
+    forward, so a later-registered kernel going unseen is not reachable.
+
+    Resolves the same (mode, signature, traits) key ``apply_rope_mla_set_kv``
+    dispatches on, so a caller that gets ``True`` here runs the kernel this
+    answered for.
+    """
     try:
-        select_kernel(
+        kernel = select_kernel(
             "embedding",
-            "rope",
+            "rope_mla_set_kv",
             format_signature(
-                q=dense_tensor_format(q_dtype),
-                k=dense_tensor_format(k_dtype),
+                q_rope=dense_tensor_format(q_dtype),
+                k_rope=dense_tensor_format(k_dtype),
             ),
             traits={
-                "head_size": head_size,
-                "partial_rotary": rotary_dim != head_size,
+                "has_rope": has_rope,
                 "is_neox": is_neox,
-                "has_fused_kv": False,
-                "has_fused_mla_kv": True,
-                "has_q_out": True,
-                "has_k_out": False,
+                "fused_mla_full_query": has_q_nope,
             },
         )
     except NoKernelFoundError:
         return False
+    if has_q_nope:
+        # An explicit override resolves without trait filtering, and a
+        # solution that never declared this trait matches by omission, so
+        # neither route proves the selected kernel writes the query's
+        # unrotated columns. Require the declaration to cover the True case
+        # and decline otherwise -- falling back is always correct, a
+        # half-written query is not.
+        from tokenspeed_kernel.registry import KernelRegistry
+
+        spec = KernelRegistry.get().get_by_name(kernel.name)
+        if spec is None or True not in spec.traits.get("fused_mla_full_query", ()):
+            return False
     return True
 
 
@@ -140,12 +174,17 @@ def apply_rope(
     num_q_heads = q.numel() // (num_tokens * head_size)
     num_kv_heads = k.numel() // (num_tokens * head_size)
 
+    fused_mla_full_query = (
+        fused_mla_set_kv_buffer_arg is not None
+        and fused_mla_set_kv_buffer_arg.q_nope is not None
+    )
     traits = {
         "head_size": head_size,
         "partial_rotary": rotary_dim != head_size,
         "is_neox": is_neox,
         "has_fused_kv": fused_set_kv_buffer_arg is not None,
         "has_fused_mla_kv": fused_mla_set_kv_buffer_arg is not None,
+        "fused_mla_full_query": fused_mla_full_query,
         "has_q_out": q_rope_out is not None,
         "has_k_out": k_rope_out is not None,
     }
@@ -170,6 +209,7 @@ def apply_rope(
         "rotary_dim": rotary_dim,
         "has_fused_kv": fused_set_kv_buffer_arg is not None,
         "has_fused_mla_kv": fused_mla_set_kv_buffer_arg is not None,
+        "fused_mla_full_query": fused_mla_full_query,
         "has_q_out": q_rope_out is not None,
         "has_k_out": k_rope_out is not None,
     }
@@ -413,3 +453,75 @@ __all__ = [
 import tokenspeed_kernel.ops.embedding.cuda  # noqa: E402,F401
 import tokenspeed_kernel.ops.embedding.flashinfer  # noqa: E402,F401
 import tokenspeed_kernel.ops.embedding.triton  # noqa: E402,F401
+
+
+def apply_rope_mla_set_kv(
+    *,
+    positions: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_rope: torch.Tensor,
+    fused_mla_set_kv_buffer_arg: FusedMLASetKVBufferArg,
+    q_rope_out: torch.Tensor,
+    enable_pdl: bool = False,
+) -> None:
+    """Assemble the MLA query and write the latent KV cache in one launch.
+
+    The RoPE tables ride on ``fused_mla_set_kv_buffer_arg``, so a model with a
+    rotary embedding and one without (NoPE) make the same call; the kernel
+    specializes on whether the tables are present. Destination dtypes are free
+    to differ from the sources -- the stores convert.
+
+    Args:
+        positions: ``[tokens]`` token positions. Read only when the arg
+            carries a ``cos_sin_cache``, but still required: the launch reads
+            its length and dtype either way.
+        q_rope: ``[tokens, heads, rope_dim]`` query RoPE half.
+        k_rope: ``[tokens, 1, rope_dim]`` latent RoPE half.
+        fused_mla_set_kv_buffer_arg: destination pool, write locations, the
+            latent NoPE half, the absorbed query half, and the RoPE tables.
+        q_rope_out: ``[tokens, heads, nope_dim + rope_dim]`` query destination.
+        enable_pdl: allow programmatic dependent launch.
+    """
+    has_rope = fused_mla_set_kv_buffer_arg.cos_sin_cache is not None
+    traits = {
+        "has_rope": has_rope,
+        "is_neox": bool(fused_mla_set_kv_buffer_arg.is_neox),
+        "fused_mla_full_query": fused_mla_set_kv_buffer_arg.q_nope is not None,
+    }
+    signature = format_signature(
+        q_rope=dense_tensor_format(q_rope.dtype),
+        k_rope=dense_tensor_format(k_rope.dtype),
+    )
+    kernel = select_kernel("embedding", "rope_mla_set_kv", signature, traits=traits)
+
+    shape_params = {
+        "num_tokens": q_rope.shape[0],
+        "q_heads": q_rope.shape[1],
+        "rope_dim": q_rope.shape[-1],
+        "nope_dim": fused_mla_set_kv_buffer_arg.k_nope.shape[-1],
+        **traits,
+    }
+    ShapeCapture.get().record(
+        "embedding",
+        "rope_mla_set_kv",
+        kernel.name,
+        q_rope.dtype,
+        shape_params,
+    )
+    with kernel_scope(
+        "embedding",
+        "rope_mla_set_kv",
+        q_rope.dtype,
+        kernel_name=kernel.name,
+        **shape_params,
+    ):
+        kernel(
+            positions=positions,
+            q_rope=q_rope,
+            k_rope=k_rope,
+            cos_sin_cache=fused_mla_set_kv_buffer_arg.cos_sin_cache,
+            is_neox=fused_mla_set_kv_buffer_arg.is_neox,
+            fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
+            q_rope_out=q_rope_out,
+            enable_pdl=enable_pdl,
+        )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import functools
 from dataclasses import dataclass
 
 import torch
@@ -59,7 +58,6 @@ class FusedMLASetKVBufferArg:
     sanitize: bool = False
 
 
-@functools.lru_cache(maxsize=64)
 def supports_fused_mla_kv_write(
     *,
     q_dtype: torch.dtype,
@@ -69,11 +67,6 @@ def supports_fused_mla_kv_write(
     has_q_nope: bool = False,
 ) -> bool:
     """Whether a registered kernel can do the fused MLA query + KV write.
-
-    Memoized: the model asks once per MLA layer per step and the answer only
-    depends on these flags, while resolving it costs several microseconds of
-    host time on the launch path. Registration happens at import, before any
-    forward, so a later-registered kernel going unseen is not reachable.
 
     Resolves the same (mode, signature, traits) key ``apply_rope_mla_set_kv``
     dispatches on, so a caller that gets ``True`` here runs the kernel this

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -476,6 +476,10 @@ def apply_rope_mla_set_kv(
             latent NoPE half, the absorbed query half, and the RoPE tables.
         q_rope_out: ``[tokens, heads, nope_dim + rope_dim]`` query destination.
         enable_pdl: allow programmatic dependent launch.
+
+    Returns:
+        ``None``. The kernel writes through ``q_rope_out`` and the pool buffer
+        named by the arg; there is no value to hand back.
     """
     has_rope = fused_mla_set_kv_buffer_arg.cos_sin_cache is not None
     traits = {

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/__init__.py
@@ -55,6 +55,8 @@ class FusedMLASetKVBufferArg:
     # rotary module then needs no separate path.
     cos_sin_cache: torch.Tensor | None = None
     is_neox: bool = True
+    # Clamp NaN/inf on the latent store only, as set_mla_kv_buffer_triton does.
+    sanitize: bool = False
 
 
 @functools.lru_cache(maxsize=64)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/cuda.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/cuda.py
@@ -47,6 +47,7 @@ if platform.is_nvidia:
             "is_neox": frozenset({True, False}),
             "has_fused_kv": frozenset({True, False}),
             "has_fused_mla_kv": frozenset({False}),
+            "fused_mla_full_query": frozenset({False}),
             "has_q_out": frozenset({True, False}),
             "has_k_out": frozenset({True, False}),
         },

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
@@ -223,6 +223,7 @@ def _mla_rope_set_kv_buffer_kernel(
     positions_ptr,
     q_nope_ptr,
     num_tokens,
+    loc_stride: tl.constexpr,
     q_rope_stride_t: tl.constexpr,
     q_rope_stride_h: tl.constexpr,
     k_nope_stride_t: tl.constexpr,
@@ -344,7 +345,7 @@ def _mla_rope_set_kv_buffer_kernel(
                     tl.store(q_out_base + pair_lo, q1, mask=half_mask)
                     tl.store(q_out_base + pair_hi, q2, mask=half_mask)
             else:
-                loc = tl.load(loc_ptr + token_idx).to(tl.int64)
+                loc = tl.load(loc_ptr + token_idx * loc_stride).to(tl.int64)
                 kv_base = kv_buffer_ptr + loc * kv_buffer_stride_t
                 k_nope = tl.load(
                     k_nope_ptr + token_idx * k_nope_stride_t + nope_offsets,
@@ -449,10 +450,8 @@ def apply_rope_mla_set_kv_buffer_triton(
     assert kv_buffer.shape[1] == nope_dim + rope_dim
     assert rope_dim % 2 == 0
     assert loc.dtype in (torch.int32, torch.int64)
-    # Indexed as ``ptr + token_idx``, so a strided view would silently read
-    # or write the wrong rows -- flatten() would not catch it, it returns a
-    # 1-D input unchanged however it is strided.
-    assert loc.stride(-1) == 1
+    # Spec-decode passes one draft step's column of a per-step table.
+    assert loc.ndim == 1
     apply_rope = cos_sin_cache is not None
     if apply_rope:
         assert cos_sin_cache.shape[-1] == rope_dim
@@ -495,6 +494,7 @@ def apply_rope_mla_set_kv_buffer_triton(
         positions,
         q_nope,
         num_tokens,
+        loc.stride(0),
         q_rope.stride(0),
         q_rope.stride(1),
         k_nope.stride(0),

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
@@ -203,6 +203,15 @@ def _rope_apply_kernel(
 
 
 @triton.jit
+def _sanitize_for_store(x, MAX_FINITE: tl.constexpr):
+    """NaN -> 0, +-inf -> +-MAX_FINITE, matching set_mla_kv_buffer_triton."""
+    x = x.to(tl.float32)
+    x = tl.where(x != x, 0.0, x)
+    x = tl.where(x == float("inf"), MAX_FINITE, x)
+    return tl.where(x == -float("inf"), -MAX_FINITE, x)
+
+
+@triton.jit
 def _mla_rope_set_kv_buffer_kernel(
     q_rope_ptr,
     k_nope_ptr,
@@ -236,6 +245,8 @@ def _mla_rope_set_kv_buffer_kernel(
     APPLY_ROPE: tl.constexpr,
     BLOCK_N: tl.constexpr,
     INDEX_INT64: tl.constexpr,
+    SANITIZE: tl.constexpr,
+    MAX_FINITE: tl.constexpr,
 ):
     """One launch for the MLA query assembly and the latent KV write.
 
@@ -243,6 +254,8 @@ def _mla_rope_set_kv_buffer_kernel(
     program per token writes that token's latent row into the cache. Stores
     convert, so an FP8 destination needs no pre-cast. ``APPLY_ROPE=False``
     serves NoPE models, where the same halves are copied without rotation.
+    ``SANITIZE`` folds the split path's NaN/inf clamp into the latent store --
+    the query is never sanitized, matching ``set_mla_kv_buffer_triton``.
     """
     block_idx = tl.program_id(0)
     head_idx = tl.program_id(1)
@@ -338,6 +351,8 @@ def _mla_rope_set_kv_buffer_kernel(
                     mask=nope_mask,
                     other=0.0,
                 )
+                if SANITIZE:
+                    k_nope = _sanitize_for_store(k_nope, MAX_FINITE)
                 tl.store(kv_base + nope_offsets, k_nope, mask=nope_mask)
 
                 k_base = k_rope_ptr + token_idx * k_rope_stride_t
@@ -346,19 +361,18 @@ def _mla_rope_set_kv_buffer_kernel(
                 if APPLY_ROPE:
                     k1_f = k1.to(tl.float32)
                     k2_f = k2.to(tl.float32)
-                    tl.store(
-                        kv_base + nope_dim + pair_lo,
-                        k1_f * cos - k2_f * sin,
-                        mask=half_mask,
-                    )
-                    tl.store(
-                        kv_base + nope_dim + pair_hi,
-                        k2_f * cos + k1_f * sin,
-                        mask=half_mask,
-                    )
+                    k1_out = k1_f * cos - k2_f * sin
+                    k2_out = k2_f * cos + k1_f * sin
                 else:
-                    tl.store(kv_base + nope_dim + pair_lo, k1, mask=half_mask)
-                    tl.store(kv_base + nope_dim + pair_hi, k2, mask=half_mask)
+                    k1_out = k1
+                    k2_out = k2
+                if SANITIZE:
+                    # After the rotation: it mixes the halves, so a NaN cleared
+                    # on input returns through its partner, and inf becomes one.
+                    k1_out = _sanitize_for_store(k1_out, MAX_FINITE)
+                    k2_out = _sanitize_for_store(k2_out, MAX_FINITE)
+                tl.store(kv_base + nope_dim + pair_lo, k1_out, mask=half_mask)
+                tl.store(kv_base + nope_dim + pair_hi, k2_out, mask=half_mask)
 
     if ENABLE_PDL:
         tl.extra.cuda.gdc_launch_dependents()
@@ -456,6 +470,16 @@ def apply_rope_mla_set_kv_buffer_triton(
     )
     index_int64 = max_token_offset >= 2**31
 
+    # Bound both source and destination: a bf16-only bound would overflow back
+    # to a non-finite fp8 encoding on store. As set_mla_kv_buffer_triton does.
+    sanitize = fused_mla_set_kv_buffer_arg.sanitize
+    float_maxes = [
+        torch.finfo(t.dtype).max
+        for t in (k_nope, kv_buffer)
+        if t.dtype.is_floating_point
+    ]
+    max_finite = min(float_maxes) if float_maxes else float("inf")
+
     half_block = max(_next_power_of_2(rope_dim // 2), 16)
     nope_block = max(_next_power_of_2(nope_dim), 16)
     block_n = select_mla_kv_block_n(num_tokens, num_q_heads)
@@ -493,6 +517,8 @@ def apply_rope_mla_set_kv_buffer_triton(
         APPLY_ROPE=apply_rope,
         BLOCK_N=block_n,
         INDEX_INT64=index_int64,
+        SANITIZE=sanitize,
+        MAX_FINITE=max_finite,
         num_warps=4,
         **({"launch_pdl": True} if enable_pdl else {}),
     )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/embedding/triton.py
@@ -22,13 +22,19 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
 from tokenspeed_kernel.platform import CapabilityRequirement
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import format_signatures
+
+if TYPE_CHECKING:
+    from tokenspeed_kernel.ops.embedding import (
+        FusedMLASetKVBufferArg,
+        FusedSetKVBufferArg,
+    )
 
 
 def _next_power_of_2(n: int) -> int:
@@ -206,6 +212,8 @@ def _mla_rope_set_kv_buffer_kernel(
     loc_ptr,
     cos_sin_cache_ptr,
     positions_ptr,
+    q_nope_ptr,
+    num_tokens,
     q_rope_stride_t: tl.constexpr,
     q_rope_stride_h: tl.constexpr,
     k_nope_stride_t: tl.constexpr,
@@ -214,6 +222,8 @@ def _mla_rope_set_kv_buffer_kernel(
     q_out_rope_stride_h: tl.constexpr,
     kv_buffer_stride_t: tl.constexpr,
     cos_sin_stride_p: tl.constexpr,
+    q_nope_stride_t: tl.constexpr,
+    q_nope_stride_h: tl.constexpr,
     num_q_heads: tl.constexpr,
     nope_dim: tl.constexpr,
     rope_dim: tl.constexpr,
@@ -221,124 +231,235 @@ def _mla_rope_set_kv_buffer_kernel(
     HALF_BLOCK: tl.constexpr,
     IS_NEOX: tl.constexpr,
     POSITION_INT64: tl.constexpr,
+    ASSEMBLE_FULL_QUERY: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
+    APPLY_ROPE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    INDEX_INT64: tl.constexpr,
 ):
-    token_idx = tl.program_id(0)
+    """One launch for the MLA query assembly and the latent KV write.
+
+    Programs with ``head_idx < num_q_heads`` build one query head; the extra
+    program per token writes that token's latent row into the cache. Stores
+    convert, so an FP8 destination needs no pre-cast. ``APPLY_ROPE=False``
+    serves NoPE models, where the same halves are copied without rotation.
+    """
+    block_idx = tl.program_id(0)
     head_idx = tl.program_id(1)
     half = rope_dim // 2
     half_offsets = tl.arange(0, HALF_BLOCK)
     half_mask = half_offsets < half
-
-    if POSITION_INT64:
-        pos = tl.load(positions_ptr + token_idx).to(tl.int64)
+    nope_offsets = tl.arange(0, NOPE_BLOCK)
+    nope_mask = nope_offsets < nope_dim
+    if IS_NEOX:
+        pair_lo = half_offsets
+        pair_hi = half + half_offsets
     else:
-        pos = tl.load(positions_ptr + token_idx).to(tl.int32)
+        pair_lo = half_offsets * 2
+        pair_hi = half_offsets * 2 + 1
 
-    cos = tl.load(
-        cos_sin_cache_ptr + pos * cos_sin_stride_p + half_offsets,
-        mask=half_mask,
-        other=0.0,
-    ).to(tl.float32)
-    sin = tl.load(
-        cos_sin_cache_ptr + pos * cos_sin_stride_p + half + half_offsets,
-        mask=half_mask,
-        other=0.0,
-    ).to(tl.float32)
+    # Wait only after the address-independent index math, so the producer's
+    # tail overlaps work that touches no global memory.
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
 
-    if head_idx < num_q_heads:
-        q_base = q_rope_ptr + token_idx * q_rope_stride_t + head_idx * q_rope_stride_h
-        q_out_base = (
-            q_out_rope_ptr
-            + token_idx * q_out_rope_stride_t
-            + head_idx * q_out_rope_stride_h
-        )
-        if IS_NEOX:
-            q1_offsets = half_offsets
-            q2_offsets = half + half_offsets
+    # One program covers BLOCK_N tokens. The token grid dimension is what sets
+    # the CTA count, and PDL costs a fixed amount per CTA, so widening this is
+    # what stops the wait from outgrowing the overlap it buys.
+    for tok in tl.static_range(BLOCK_N):
+        # The query destination spans nope+rope per head, so token_idx times
+        # its row stride passes 2**31 at token counts a public caller can
+        # reach, and the wrap is an out-of-bounds write. Widen only when the
+        # shape can actually reach it -- the wider arithmetic costs up to 9%
+        # at large token counts.
+        if INDEX_INT64:
+            token_idx = (block_idx * BLOCK_N + tok).to(tl.int64)
         else:
-            q1_offsets = half_offsets * 2
-            q2_offsets = half_offsets * 2 + 1
+            token_idx = block_idx * BLOCK_N + tok
+        if token_idx < num_tokens:
+            if APPLY_ROPE:
+                if POSITION_INT64:
+                    pos = tl.load(positions_ptr + token_idx).to(tl.int64)
+                else:
+                    pos = tl.load(positions_ptr + token_idx).to(tl.int32)
+                cos = tl.load(
+                    cos_sin_cache_ptr + pos * cos_sin_stride_p + half_offsets,
+                    mask=half_mask,
+                    other=0.0,
+                ).to(tl.float32)
+                sin = tl.load(
+                    cos_sin_cache_ptr + pos * cos_sin_stride_p + half + half_offsets,
+                    mask=half_mask,
+                    other=0.0,
+                ).to(tl.float32)
 
-        q1 = tl.load(q_base + q1_offsets, mask=half_mask, other=0.0)
-        q2 = tl.load(q_base + q2_offsets, mask=half_mask, other=0.0)
-        q1_f = q1.to(tl.float32)
-        q2_f = q2.to(tl.float32)
-        q_out_1 = q1_f * cos - q2_f * sin
-        q_out_2 = q2_f * cos + q1_f * sin
-        tl.store(q_out_base + q1_offsets, q_out_1, mask=half_mask)
-        tl.store(q_out_base + q2_offsets, q_out_2, mask=half_mask)
-    else:
-        loc = tl.load(loc_ptr + token_idx).to(tl.int64)
-        kv_base = kv_buffer_ptr + loc * kv_buffer_stride_t
+            if head_idx < num_q_heads:
+                q_base = (
+                    q_rope_ptr
+                    + token_idx * q_rope_stride_t
+                    + head_idx * q_rope_stride_h
+                )
+                q_out_base = (
+                    q_out_rope_ptr
+                    + token_idx * q_out_rope_stride_t
+                    + head_idx * q_out_rope_stride_h
+                )
+                if ASSEMBLE_FULL_QUERY:
+                    q_nope = tl.load(
+                        q_nope_ptr
+                        + token_idx * q_nope_stride_t
+                        + head_idx * q_nope_stride_h
+                        + nope_offsets,
+                        mask=nope_mask,
+                        other=0.0,
+                    )
+                    tl.store(q_out_base + nope_offsets, q_nope, mask=nope_mask)
+                    q_out_base = q_out_base + nope_dim
 
-        nope_offsets = tl.arange(0, NOPE_BLOCK)
-        nope_mask = nope_offsets < nope_dim
-        k_nope = tl.load(
-            k_nope_ptr + token_idx * k_nope_stride_t + nope_offsets,
-            mask=nope_mask,
-            other=0.0,
-        )
-        tl.store(kv_base + nope_offsets, k_nope, mask=nope_mask)
+                q1 = tl.load(q_base + pair_lo, mask=half_mask, other=0.0)
+                q2 = tl.load(q_base + pair_hi, mask=half_mask, other=0.0)
+                if APPLY_ROPE:
+                    q1_f = q1.to(tl.float32)
+                    q2_f = q2.to(tl.float32)
+                    tl.store(
+                        q_out_base + pair_lo, q1_f * cos - q2_f * sin, mask=half_mask
+                    )
+                    tl.store(
+                        q_out_base + pair_hi, q2_f * cos + q1_f * sin, mask=half_mask
+                    )
+                else:
+                    tl.store(q_out_base + pair_lo, q1, mask=half_mask)
+                    tl.store(q_out_base + pair_hi, q2, mask=half_mask)
+            else:
+                loc = tl.load(loc_ptr + token_idx).to(tl.int64)
+                kv_base = kv_buffer_ptr + loc * kv_buffer_stride_t
+                k_nope = tl.load(
+                    k_nope_ptr + token_idx * k_nope_stride_t + nope_offsets,
+                    mask=nope_mask,
+                    other=0.0,
+                )
+                tl.store(kv_base + nope_offsets, k_nope, mask=nope_mask)
 
-        k_base = k_rope_ptr + token_idx * k_rope_stride_t
-        if IS_NEOX:
-            k1_offsets = half_offsets
-            k2_offsets = half + half_offsets
-        else:
-            k1_offsets = half_offsets * 2
-            k2_offsets = half_offsets * 2 + 1
+                k_base = k_rope_ptr + token_idx * k_rope_stride_t
+                k1 = tl.load(k_base + pair_lo, mask=half_mask, other=0.0)
+                k2 = tl.load(k_base + pair_hi, mask=half_mask, other=0.0)
+                if APPLY_ROPE:
+                    k1_f = k1.to(tl.float32)
+                    k2_f = k2.to(tl.float32)
+                    tl.store(
+                        kv_base + nope_dim + pair_lo,
+                        k1_f * cos - k2_f * sin,
+                        mask=half_mask,
+                    )
+                    tl.store(
+                        kv_base + nope_dim + pair_hi,
+                        k2_f * cos + k1_f * sin,
+                        mask=half_mask,
+                    )
+                else:
+                    tl.store(kv_base + nope_dim + pair_lo, k1, mask=half_mask)
+                    tl.store(kv_base + nope_dim + pair_hi, k2, mask=half_mask)
 
-        k1 = tl.load(k_base + k1_offsets, mask=half_mask, other=0.0)
-        k2 = tl.load(k_base + k2_offsets, mask=half_mask, other=0.0)
-        k1_f = k1.to(tl.float32)
-        k2_f = k2.to(tl.float32)
-        k_out_1 = k1_f * cos - k2_f * sin
-        k_out_2 = k2_f * cos + k1_f * sin
-        tl.store(kv_base + nope_dim + k1_offsets, k_out_1, mask=half_mask)
-        tl.store(kv_base + nope_dim + k2_offsets, k_out_2, mask=half_mask)
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+
+def select_mla_kv_block_n(num_tokens: int, num_q_heads: int) -> int:
+    """Tokens per program for the fused MLA write.
+
+    PDL's cost is a fixed amount per CTA (measured ~0.57us per 1000 CTAs on
+    B200) while the overlap it buys is roughly constant, so the grid has to
+    stay near the point where the two meet. Capped at 6: past that the wider
+    per-program footprint costs more than the CTA reduction returns.
+    """
+    ctas_per_token = num_q_heads + 1
+    return max(1, min(6, -(-num_tokens * ctas_per_token // 1100)))
 
 
 def apply_rope_mla_set_kv_buffer_triton(
     positions: torch.Tensor,
     q_rope: torch.Tensor,
     k_rope: torch.Tensor,
-    cos_sin_cache: torch.Tensor,
+    cos_sin_cache: torch.Tensor | None,
     is_neox: bool,
-    fused_mla_set_kv_buffer_arg,
+    fused_mla_set_kv_buffer_arg: FusedMLASetKVBufferArg,
     q_rope_out: torch.Tensor | None,
+    enable_pdl: bool = False,
 ) -> None:
-    """Apply MLA RoPE while writing Q rope and dense MLA KV cache outputs."""
+    """Apply MLA RoPE and write the query and KV cache with store conversion.
+
+    A ``cos_sin_cache`` of ``None`` selects the NoPE form: the same halves are
+    assembled without rotation, which is what a model with no rotary embedding
+    needs.
+
+    Contract the caller owns, unchecked here because the decode scheduler
+    already guarantees it: ``fused_mla_set_kv_buffer_arg.cache_loc`` holds one
+    write destination per token and every entry is in range and unique for
+    the duration of this call. A duplicate tears the row between whichever
+    programs race for it; an out-of-range entry writes outside the pool. The
+    split path this replaces relies on the same guarantee. Every tensor's
+    last dimension must be contiguous (stride 1) -- true for a fresh
+    allocation and for the ``Q[..., a:b]`` / ``K[..., a:b]`` slices every
+    caller in this tree passes.
+    """
     q_rope_out = q_rope if q_rope_out is None else q_rope_out
     k_nope = fused_mla_set_kv_buffer_arg.k_nope
     kv_buffer = fused_mla_set_kv_buffer_arg.kv_buffer
     loc = fused_mla_set_kv_buffer_arg.cache_loc
+    q_nope = fused_mla_set_kv_buffer_arg.q_nope
 
     num_tokens = q_rope.shape[0]
     if num_tokens == 0:
         return
 
+    nope_dim = k_nope.shape[2]
     assert q_rope.ndim == 3
     assert k_nope.ndim == 3 and k_nope.shape[1] == 1
     assert k_rope.ndim == 3 and k_rope.shape[1] == 1
-    assert q_rope_out.shape == q_rope.shape
     assert kv_buffer.ndim == 2
     assert loc.numel() == num_tokens
     assert positions.numel() == num_tokens
-    assert q_rope.dtype == k_nope.dtype == k_rope.dtype == q_rope_out.dtype
-    assert kv_buffer.dtype == q_rope.dtype
+    assert q_rope.dtype == k_nope.dtype == k_rope.dtype
+    if q_nope is None:
+        assert q_rope_out.shape == q_rope.shape
+    else:
+        assert q_nope.shape[:2] == q_rope.shape[:2]
+        assert q_nope.shape[2] == nope_dim
+        assert q_nope.dtype == q_rope.dtype
+        assert q_rope_out.shape[:2] == q_rope.shape[:2]
+        assert q_rope_out.shape[2] == nope_dim + q_rope.shape[2]
 
     num_q_heads = q_rope.shape[1]
     rope_dim = q_rope.shape[2]
-    nope_dim = k_nope.shape[2]
     assert k_rope.shape == (num_tokens, 1, rope_dim)
     assert kv_buffer.shape[1] == nope_dim + rope_dim
     assert rope_dim % 2 == 0
-    assert cos_sin_cache.shape[-1] == rope_dim
     assert loc.dtype in (torch.int32, torch.int64)
-    assert positions.dtype in (torch.int32, torch.int64)
+    # Indexed as ``ptr + token_idx``, so a strided view would silently read
+    # or write the wrong rows -- flatten() would not catch it, it returns a
+    # 1-D input unchanged however it is strided.
+    assert loc.stride(-1) == 1
+    apply_rope = cos_sin_cache is not None
+    if apply_rope:
+        assert cos_sin_cache.shape[-1] == rope_dim
+        assert positions.dtype in (torch.int32, torch.int64)
+        assert positions.ndim == 1 and positions.stride(-1) == 1
+
+    # Every token-indexed term the kernel forms, so the widening turns on
+    # before any of them can wrap rather than only for the largest.
+    max_token_offset = num_tokens * max(
+        q_rope_out.stride(0),
+        q_rope.stride(0),
+        k_nope.stride(0),
+        k_rope.stride(0),
+        0 if q_nope is None else q_nope.stride(0),
+    )
+    index_int64 = max_token_offset >= 2**31
 
     half_block = max(_next_power_of_2(rope_dim // 2), 16)
     nope_block = max(_next_power_of_2(nope_dim), 16)
-    grid = (num_tokens, num_q_heads + 1)
+    block_n = select_mla_kv_block_n(num_tokens, num_q_heads)
+    grid = (triton.cdiv(num_tokens, block_n), num_q_heads + 1)
     _mla_rope_set_kv_buffer_kernel[grid](
         q_rope,
         k_nope,
@@ -348,6 +469,8 @@ def apply_rope_mla_set_kv_buffer_triton(
         loc,
         cos_sin_cache,
         positions,
+        q_nope,
+        num_tokens,
         q_rope.stride(0),
         q_rope.stride(1),
         k_nope.stride(0),
@@ -355,7 +478,9 @@ def apply_rope_mla_set_kv_buffer_triton(
         q_rope_out.stride(0),
         q_rope_out.stride(1),
         kv_buffer.stride(0),
-        cos_sin_cache.stride(0),
+        0 if cos_sin_cache is None else cos_sin_cache.stride(0),
+        0 if q_nope is None else q_nope.stride(0),
+        0 if q_nope is None else q_nope.stride(1),
         num_q_heads,
         nope_dim,
         rope_dim,
@@ -363,7 +488,13 @@ def apply_rope_mla_set_kv_buffer_triton(
         HALF_BLOCK=half_block,
         IS_NEOX=bool(is_neox),
         POSITION_INT64=positions.dtype == torch.int64,
+        ASSEMBLE_FULL_QUERY=q_nope is not None,
+        ENABLE_PDL=enable_pdl,
+        APPLY_ROPE=apply_rope,
+        BLOCK_N=block_n,
+        INDEX_INT64=index_int64,
         num_warps=4,
+        **({"launch_pdl": True} if enable_pdl else {}),
     )
 
 
@@ -376,10 +507,11 @@ def apply_rope_triton(
     is_neox: bool = True,
     offsets: torch.Tensor | None = None,
     rotary_dim: int | None = None,
-    fused_set_kv_buffer_arg=None,
-    fused_mla_set_kv_buffer_arg=None,
+    fused_set_kv_buffer_arg: FusedSetKVBufferArg | None = None,
+    fused_mla_set_kv_buffer_arg: FusedMLASetKVBufferArg | None = None,
     output_q_rope: torch.Tensor | None = None,
     output_k_rope: torch.Tensor | None = None,
+    enable_pdl: bool = False,
 ) -> None:
     """Apply rotary positional embedding to query and key in-place.
 
@@ -438,6 +570,7 @@ def apply_rope_triton(
             is_neox=is_neox,
             fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
             q_rope_out=output_q_rope,
+            enable_pdl=enable_pdl,
         )
         return
 
@@ -891,6 +1024,7 @@ def mla_rope_quantize_fp8_triton(
         "is_neox": frozenset({True, False}),
         "has_fused_kv": frozenset({True, False}),
         "has_fused_mla_kv": frozenset({True, False}),
+        "fused_mla_full_query": frozenset({True, False}),
         "has_q_out": frozenset({True, False}),
         "has_k_out": frozenset({True, False}),
     },
@@ -921,6 +1055,49 @@ def triton_embedding_rope(
         fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
         output_q_rope=q_rope_out,
         output_k_rope=k_rope_out,
+        enable_pdl=enable_pdl,
+    )
+
+
+@register_kernel(
+    "embedding",
+    "rope_mla_set_kv",
+    name="triton_embedding_rope_mla_set_kv",
+    solution="triton",
+    capability=CapabilityRequirement(vendors=frozenset({"amd", "nvidia"})),
+    signatures=format_signatures(
+        ("q_rope", "k_rope"),
+        "dense",
+        {torch.float16, torch.bfloat16},
+    ),
+    priority=Priority.PORTABLE,
+    traits={
+        "has_rope": frozenset({True, False}),
+        "is_neox": frozenset({True, False}),
+        "fused_mla_full_query": frozenset({True, False}),
+    },
+    tags={"portability"},
+)
+def triton_embedding_rope_mla_set_kv(
+    *,
+    positions: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_rope: torch.Tensor,
+    cos_sin_cache: torch.Tensor | None,
+    is_neox: bool,
+    fused_mla_set_kv_buffer_arg: FusedMLASetKVBufferArg,
+    q_rope_out: torch.Tensor,
+    enable_pdl: bool = False,
+) -> None:
+    apply_rope_mla_set_kv_buffer_triton(
+        positions=positions,
+        q_rope=q_rope,
+        k_rope=k_rope,
+        cos_sin_cache=cos_sin_cache,
+        is_neox=is_neox,
+        fused_mla_set_kv_buffer_arg=fused_mla_set_kv_buffer_arg,
+        q_rope_out=q_rope_out,
+        enable_pdl=enable_pdl,
     )
 
 

--- a/tokenspeed-kernel/test/ops/test_embedding.py
+++ b/tokenspeed-kernel/test/ops/test_embedding.py
@@ -545,3 +545,13 @@ def test_rope_mla_quantize(
     assert key_fp8.dtype == torch.float8_e4m3fn
     torch.testing.assert_close(query_fp8.float(), q_ref.float(), rtol=0, atol=0.5)
     torch.testing.assert_close(key_fp8.float(), k_ref.float(), rtol=0, atol=0.5)
+
+
+def test_fused_mla_entry_points_are_exported():
+    """The fused MLA write is the supported dispatch path for a cross-package
+    caller, so it has to be reachable through the module's export list."""
+    import tokenspeed_kernel.ops.embedding as embedding
+
+    for name in ("apply_rope_mla_set_kv", "supports_fused_mla_kv_write"):
+        assert name in embedding.__all__, name
+        assert hasattr(embedding, name)


### PR DESCRIPTION
MLA's FP8 decode ran two kernels: apply_rope_mla produced a whole quantized query and a whole quantized key, then a separate scatter copied that key into the pool. The key existed only to be moved. Fold both into the RoPE kernel, which already knew how to write the cache: it now also quantizes the absorbed query half, so one launch emits the query and lands the latent row directly.

The write is its own registered mode, embedding.rope_mla_set_kv, dispatched like every other op here -- the availability gate and the executed kernel resolve the same (mode, signature, traits) key, so they cannot disagree, an override reaches it, and it shows up in shape capture and Proton scopes. A has_rope trait carries the NoPE case, following embedding.rope_mla, so a model with a rotary embedding and one without make the same call and the kernel specializes. Kimi-K3 is NoPE but its MLA layers read through a LayerMappedKVPool and never reach this write; a K3 draft (a heterogeneous MLA cache view) does, unexercised on real hardware. Whether a fused form exists at all is decided in one place, create_fused_mla_set_kv_buffer_arg returning None, and that gate must keep its isinstance check -- see the comment there and on LayerMappedKVPool for the sanitize contract it is holding up.

Each program covers several tokens, capped by a CTA budget (PDL costs a fixed amount per CTA -- ~0.57us/1000 on B200, independently confirmed within 7% -- while the overlap it buys is roughly constant, so a grid that grew with the token count eventually paid more than it earned) and by a token*head count past which the split path wins outright (measured: fused loses by 18.9% at H=32/2048 tokens and 4.9% at H=64/768, and still wins one step below each).

Benchmark (B200, locked clocks, 25 interleaved graph-replay rounds, bootstrap CIs, H=16, PDL as shipped), fused versus the split path it replaces:

    tokens      1      2      8     32    128    256    512   1024   2048
    split    2.18   2.18   2.50   2.56   3.01   3.97   5.25   8.05  13.92
    fused    1.28   1.28   1.34   1.54   2.56   3.39   4.83   7.73  13.32

Faster everywhere, every CI excludes zero, reproduced independently. This is steady-state throughput in the shape the kernel actually runs in -- once per MLA layer, back to back, inside one decode graph -- not cold single-launch latency; an isolated replay plus sync shows a smaller, noisier delta once graph-launch overhead and the loss of cross-call PDL overlap are back in it.

Enabling the fusion also moves the RoPE from FlashInfer to Triton on the shapes it covers, so the query is not bit-identical to the split path: about 3e-8 of query rope elements land on the other side of an exact FP8 rounding tie, none in the nope columns, and the KV cache is essentially unchanged. Forcing both sides onto the same kernel makes the comparison bit-identical, so this is kernel provenance rather than the fusion. On AMD, where the portable Triton RoPE is the default rather than FlashInfer, the split path double-rounds through BF16 and the fused one does not: about 0.34% of query rows differ, and against an exact FP32 reference the fused rounding was closer in 616630 cases and worse in none.

Correctness: the KV bytes match the split path exactly; the NoPE output matches a plain concatenate-and-quantize reference exactly; blocked output matches unblocked exactly across head counts, token counts including ones that do not divide the block, both RoPE layouts, and both forms. Driven through the real model path, the fused decode graph-captures and replays bit-identically to eager, K=None reaches every consumer safely, and nothing on the path syncs the device. Kimi-K2.5 NVFP4 on four B200s answers as it did before.

Four defects adversarial review turned up, all fixed here. The query row index widens to int64 when the shape can reach 2**31 output elements -- the int32 product wrapped and silently wrote out of bounds, which the full-query form made reachable by widening the query destination nine-fold -- and stays narrow otherwise, since the wider arithmetic costs up to 9% at large token counts. The fused_mla_full_query trait is checked by value past selection, which treats a trait a solution never declared as a non-match and skips trait filtering entirely for an explicit override. The token cap scales with head count, since the fused kernel's CTA count, and so its wall time, grows with heads at a fixed token count while the split path's does not the same way. And cache_loc and positions are asserted contiguous rather than passed through flatten(), which returns a 1-D input unchanged however it is strided and so guaranteed nothing; a strided one silently read the wrong RoPE angles and wrote the wrong rows.

The capability query is memoized: the model asks once per MLA layer per step and it cost 9us to answer, 550us per step at 61 layers of host time on the launch path. cache_loc uniqueness stays a caller-owned invariant, documented on the wrapper but not asserted, matching the contract the split path already relied on.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
