### PR TITLE
perf(comm): add two-stage producer-direct reduction

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -88,6 +88,24 @@ _PRODUCER_DIRECT_GL_DTYPES = {
 }
 
 
+def _use_two_stage_producer_direct(
+    world_size: int,
+    total_numel: int,
+    dtype: torch.dtype,
+) -> bool:
+    if world_size == 8:
+        min_bytes = 96 << 10
+    elif world_size == 4:
+        min_bytes = 160 << 10
+    else:
+        return False
+    elements_per_word = 8 // dtype.itemsize
+    return (
+        total_numel * dtype.itemsize >= min_bytes
+        and total_numel % (world_size * elements_per_word) == 0
+    )
+
+
 def _get_available_gpu_memory(gpu_id: int, empty_cache: bool = True) -> float:
     if torch.cuda.is_available():
         with torch.cuda.device(gpu_id):
@@ -364,6 +382,7 @@ class IrisAllReduce(object):
         assert len(group_ranks) == self.world_size
         assert group_ranks[rank_in_group] == dist.get_rank()
         self._input_buf = self._ctx.zeros((max_numel,), dtype=dtype)
+        self._producer_direct_scratch_buf = self._ctx.zeros((max_numel,), dtype=dtype)
         self._producer_direct_output_buf = torch.empty(
             max_numel, dtype=dtype, device=self.device
         )
@@ -373,8 +392,10 @@ class IrisAllReduce(object):
             (self._max_blocks, self.world_size), dtype=torch.int32
         )
         self._producer_direct_block_size = 512
-        # Keep the tuned M=1 grid resident; larger inputs iterate over tiles.
-        self._producer_direct_max_programs = 21
+        # Use one program per tile for small payloads, capped to limit contention.
+        self._producer_direct_max_programs = 84
+        # Experimental alternative: publish readiness into peer-local memory.
+        self._producer_direct_publish_ready = False
         self._producer_direct_ready_flags = self._ctx.zeros(
             (self._producer_direct_max_programs, self.world_size),
             dtype=torch.int32,
@@ -488,28 +509,59 @@ class IrisAllReduce(object):
             raise RuntimeError("producer-direct Iris all-reduce requires CDNA4")
 
         total_numel = sum(tensor.numel() for tensor in tensors)
-        num_tiles = triton.cdiv(total_numel, self._producer_direct_block_size)
-        num_programs = min(num_tiles, self._producer_direct_max_programs)
         outputs = self._views(
             self._producer_direct_output_buf,
             tuple(tuple(tensor.shape) for tensor in tensors),
         )
-        iris_reduce_symmetric_gluon_kernel[(num_programs,)](
-            self._input_buf,
-            self._producer_direct_output_buf,
-            self._producer_direct_ready_flags,
-            *self._heap_base_addresses,
-            RANK=self._iris_rank,
-            WORLD_SIZE=self.world_size,
-            TOTAL_NUMEL=total_numel,
-            BLOCK_SIZE=self._producer_direct_block_size,
-            NUM_PROGRAMS=num_programs,
-            NUM_TILES=num_tiles,
-            NUM_WARPS=1,
-            ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
-            ELEMENTS_PER_WORD=self._elements_per_word,
-            num_warps=1,
+        use_two_stage = _use_two_stage_producer_direct(
+            self.world_size,
+            total_numel,
+            self.dtype,
         )
+        if use_two_stage:
+            partition_numel = total_numel // self.world_size
+            partition_words = partition_numel // self._elements_per_word
+            # 512 threads move 16 bytes each, split evenly across ranks.
+            block_words = 1024 // self.world_size
+            num_tiles = triton.cdiv(partition_words, block_words)
+            num_programs = min(num_tiles, self._producer_direct_max_programs)
+            iris_reduce_symmetric_two_stage_gluon_kernel[(num_programs,)](
+                self._input_buf,
+                self._producer_direct_scratch_buf,
+                self._producer_direct_output_buf,
+                self._producer_direct_ready_flags,
+                *self._heap_base_addresses,
+                RANK=self._iris_rank,
+                WORLD_SIZE=self.world_size,
+                PARTITION_WORDS=partition_words,
+                BLOCK_WORDS=block_words,
+                NUM_PROGRAMS=num_programs,
+                NUM_TILES=num_tiles,
+                NUM_WARPS=8,
+                ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
+                ELEMENTS_PER_WORD=self._elements_per_word,
+                num_warps=8,
+            )
+        else:
+            num_tiles = triton.cdiv(total_numel, self._producer_direct_block_size)
+            num_programs = min(num_tiles, self._producer_direct_max_programs)
+            iris_reduce_symmetric_gluon_kernel[(num_programs,)](
+                self._input_buf,
+                self._producer_direct_output_buf,
+                self._producer_direct_ready_flags,
+                *self._heap_base_addresses,
+                RANK=self._iris_rank,
+                WORLD_SIZE=self.world_size,
+                TOTAL_NUMEL=total_numel,
+                BLOCK_SIZE=self._producer_direct_block_size,
+                NUM_PROGRAMS=num_programs,
+                NUM_TILES=num_tiles,
+                NUM_WARPS=1,
+                PUBLISH_READY=self._producer_direct_publish_ready,
+                ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
+                ELEMENTS_PER_WORD=self._elements_per_word,
+                num_warps=1,
+            )
         return outputs
 
     def all_reduce_residual_attnres(
@@ -658,7 +710,7 @@ def _iris_heap_base(
 
 
 @gluon.jit
-def _iris_wait_for_rank_epoch(
+def _iris_sync_rank_epoch(
     ready_flags,
     block_id,
     epoch,
@@ -674,8 +726,9 @@ def _iris_wait_for_rank_epoch(
     RANK: gl.constexpr,
     WORLD_SIZE: gl.constexpr,
     NUM_WARPS: gl.constexpr,
+    PUBLISH: gl.constexpr,
 ):
-    """Poll rank epochs with a layout matching the specialized launch."""
+    """Synchronize by polling peer epochs or publishing them locally."""
     ready_layout: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
     peer_ids = gl.arange(0, WORLD_SIZE, layout=ready_layout)
     peer_heaps = gl.where(peer_ids == 0, heap_base_0, heap_base_7)
@@ -686,16 +739,30 @@ def _iris_wait_for_rank_epoch(
     peer_heaps = gl.where(peer_ids == 5, heap_base_5, peer_heaps)
     peer_heaps = gl.where(peer_ids == 6, heap_base_6, peer_heaps)
     flags_heap_offset = tl.cast(ready_flags, gl.uint64) - local_heap
-    peer_flags = tl.cast(
-        peer_heaps + flags_heap_offset,
-        gl.pointer_type(gl.int32),
-    )
-    peer_flags += block_id * WORLD_SIZE + peer_ids
     peer_mask = peer_ids != RANK
+    if PUBLISH:
+        remote_flags = tl.cast(
+            peer_heaps + flags_heap_offset,
+            gl.pointer_type(gl.int32),
+        )
+        remote_flags += block_id * WORLD_SIZE + RANK
+        gl.store(
+            remote_flags,
+            epoch,
+            mask=peer_mask,
+            cache_modifier=".wt",
+        )
+        wait_flags = ready_flags + block_id * WORLD_SIZE + peer_ids
+    else:
+        wait_flags = tl.cast(
+            peer_heaps + flags_heap_offset,
+            gl.pointer_type(gl.int32),
+        )
+        wait_flags += block_id * WORLD_SIZE + peer_ids
     seen = gl.full([WORLD_SIZE], 0, gl.int32, layout=ready_layout)
     while gl.min(gl.where(peer_mask, seen, epoch), axis=0) < epoch:
         seen = gl.load(
-            peer_flags,
+            wait_flags,
             mask=peer_mask,
             other=epoch,
             cache_modifier=".cv",
@@ -775,6 +842,7 @@ def iris_reduce_symmetric_gluon_kernel(
     NUM_PROGRAMS: gl.constexpr,
     NUM_TILES: gl.constexpr,
     NUM_WARPS: gl.constexpr,
+    PUBLISH_READY: gl.constexpr,
     ELEMENT_DTYPE: gl.constexpr,
     ELEMENTS_PER_WORD: gl.constexpr,
 ):
@@ -793,7 +861,7 @@ def iris_reduce_symmetric_gluon_kernel(
     )
     epoch_ptr = ready_flags + block_id * WORLD_SIZE + RANK
     epoch = gl.atomic_add(epoch_ptr, 1, sem="release", scope="sys") + 1
-    _iris_wait_for_rank_epoch(
+    _iris_sync_rank_epoch(
         ready_flags,
         block_id,
         epoch,
@@ -809,6 +877,7 @@ def iris_reduce_symmetric_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        PUBLISH=PUBLISH_READY,
     )
 
     input_heap_offset = tl.cast(input_sym_ptr, gl.uint64) - local_heap
@@ -878,7 +947,7 @@ def iris_reduce_symmetric_gluon_kernel(
     # Do not return while a peer program can still be reading this rank's
     # input. The next producer reuses the same symmetric buffer.
     completion_epoch = gl.atomic_add(epoch_ptr, 1, sem="release", scope="sys") + 1
-    _iris_wait_for_rank_epoch(
+    _iris_sync_rank_epoch(
         ready_flags,
         block_id,
         completion_epoch,
@@ -894,7 +963,186 @@ def iris_reduce_symmetric_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        PUBLISH=PUBLISH_READY,
     )
+
+
+@gluon.jit
+def iris_reduce_symmetric_two_stage_gluon_kernel(
+    input_sym_ptr,
+    scratch_sym_ptr,
+    output_ptr,
+    ready_flags,
+    heap_base_0,
+    heap_base_1,
+    heap_base_2,
+    heap_base_3,
+    heap_base_4,
+    heap_base_5,
+    heap_base_6,
+    heap_base_7,
+    RANK: gl.constexpr,
+    WORLD_SIZE: gl.constexpr,
+    PARTITION_WORDS: gl.constexpr,
+    BLOCK_WORDS: gl.constexpr,
+    NUM_PROGRAMS: gl.constexpr,
+    NUM_TILES: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    ELEMENT_DTYPE: gl.constexpr,
+    ELEMENTS_PER_WORD: gl.constexpr,
+):
+    """Reduce-scatter producer outputs, then all-gather the rank partitions."""
+    block_id = gl.program_id(0)
+    local_heap = _iris_heap_base(
+        RANK,
+        heap_base_0,
+        heap_base_1,
+        heap_base_2,
+        heap_base_3,
+        heap_base_4,
+        heap_base_5,
+        heap_base_6,
+        heap_base_7,
+    )
+    epoch_ptr = ready_flags + block_id * WORLD_SIZE + RANK
+    epoch = gl.atomic_add(epoch_ptr, 1, sem="release", scope="sys") + 1
+    _iris_sync_rank_epoch(
+        ready_flags,
+        block_id,
+        epoch,
+        local_heap,
+        heap_base_0,
+        heap_base_1,
+        heap_base_2,
+        heap_base_3,
+        heap_base_4,
+        heap_base_5,
+        heap_base_6,
+        heap_base_7,
+        RANK,
+        WORLD_SIZE,
+        NUM_WARPS,
+        PUBLISH=True,
+    )
+
+    input_heap_offset = tl.cast(input_sym_ptr, gl.uint64) - local_heap
+    scratch_heap_offset = tl.cast(scratch_sym_ptr, gl.uint64) - local_heap
+    load_layout: gl.constexpr = gl.BlockedLayout(
+        [1, 2], [1, 64], [WORLD_SIZE, NUM_WARPS // WORLD_SIZE], [1, 0]
+    )
+    reduce_layout: gl.constexpr = gl.BlockedLayout(
+        [WORLD_SIZE, 1], [1, 64], [1, NUM_WARPS], [0, 1]
+    )
+    peer_layout: gl.constexpr = gl.SliceLayout(1, load_layout)
+    word_layout: gl.constexpr = gl.SliceLayout(0, load_layout)
+    reduce_word_layout: gl.constexpr = gl.SliceLayout(0, reduce_layout)
+    peer_ids = gl.arange(0, WORLD_SIZE, layout=peer_layout)
+    words = gl.arange(0, BLOCK_WORDS, layout=word_layout)
+    reduce_words = gl.arange(0, BLOCK_WORDS, layout=reduce_word_layout)
+    peer_heaps = gl.where(peer_ids == 0, heap_base_0, heap_base_7)
+    peer_heaps = gl.where(peer_ids == 1, heap_base_1, peer_heaps)
+    peer_heaps = gl.where(peer_ids == 2, heap_base_2, peer_heaps)
+    peer_heaps = gl.where(peer_ids == 3, heap_base_3, peer_heaps)
+    peer_heaps = gl.where(peer_ids == 4, heap_base_4, peer_heaps)
+    peer_heaps = gl.where(peer_ids == 5, heap_base_5, peer_heaps)
+    peer_heaps = gl.where(peer_ids == 6, heap_base_6, peer_heaps)
+    peer_inputs = tl.cast(
+        gl.expand_dims(peer_heaps, 1) + input_heap_offset,
+        gl.pointer_type(gl.uint64),
+    )
+    peer_scratch = tl.cast(
+        gl.expand_dims(peer_heaps, 1) + scratch_heap_offset,
+        gl.pointer_type(gl.uint64),
+    )
+    shared_layout: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[32, 4]],
+        [WORLD_SIZE, BLOCK_WORDS],
+        [1, 0],
+    )
+    peer_values = gl.allocate_shared_memory(
+        gl.uint64,
+        [WORLD_SIZE, BLOCK_WORDS],
+        shared_layout,
+    )
+    rank_start: gl.constexpr = RANK * PARTITION_WORDS
+
+    # Reduce only this rank's partition of the full input into symmetric scratch.
+    tile_id = block_id
+    while tile_id < NUM_TILES:
+        partition_offset = tile_id * BLOCK_WORDS + words
+        input_offset = rank_start + partition_offset
+        mask = partition_offset < PARTITION_WORDS
+        values = gl.load(
+            peer_inputs + gl.expand_dims(input_offset.to(gl.int32), 0),
+            mask=gl.expand_dims(mask, 0),
+            other=0,
+            cache_modifier=".cg",
+        )
+        peer_values.store(values)
+        gl.barrier()
+
+        packed = peer_values.load(reduce_layout)
+        value_0, value_1, value_2, value_3 = _unpack_word(
+            packed, ELEMENT_DTYPE, ELEMENTS_PER_WORD
+        )
+        reduced = _pack_word(
+            gl.sum(value_0, axis=0),
+            gl.sum(value_1, axis=0),
+            gl.sum(value_2, axis=0),
+            gl.sum(value_3, axis=0),
+            ELEMENT_DTYPE,
+            ELEMENTS_PER_WORD,
+        )
+        gl.amd.cdna4.buffer_store(
+            reduced,
+            tl.cast(scratch_sym_ptr, gl.pointer_type(gl.uint64)),
+            (tile_id * BLOCK_WORDS + reduce_words).to(gl.int32),
+            mask=tile_id * BLOCK_WORDS + reduce_words < PARTITION_WORDS,
+            cache=".wt",
+        )
+        gl.barrier()
+        tile_id += NUM_PROGRAMS
+
+    partitions_ready = gl.atomic_add(epoch_ptr, 1, sem="release", scope="sys") + 1
+    _iris_sync_rank_epoch(
+        ready_flags,
+        block_id,
+        partitions_ready,
+        local_heap,
+        heap_base_0,
+        heap_base_1,
+        heap_base_2,
+        heap_base_3,
+        heap_base_4,
+        heap_base_5,
+        heap_base_6,
+        heap_base_7,
+        RANK,
+        WORLD_SIZE,
+        NUM_WARPS,
+        PUBLISH=True,
+    )
+
+    # Gather one reduced partition from every rank into the local output.
+    tile_id = block_id
+    while tile_id < NUM_TILES:
+        partition_offset = tile_id * BLOCK_WORDS + words
+        mask = partition_offset < PARTITION_WORDS
+        values = gl.load(
+            peer_scratch + gl.expand_dims(partition_offset.to(gl.int32), 0),
+            mask=gl.expand_dims(mask, 0),
+            other=0,
+            cache_modifier=".cg",
+        )
+        output_offset = gl.expand_dims(peer_ids * PARTITION_WORDS, 1) + gl.expand_dims(
+            partition_offset, 0
+        )
+        gl.store(
+            tl.cast(output_ptr, gl.pointer_type(gl.uint64)) + output_offset,
+            values,
+            mask=gl.expand_dims(mask, 0),
+        )
+        tile_id += NUM_PROGRAMS
 
 
 @gluon.jit
@@ -964,7 +1212,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         heap_base_6,
         heap_base_7,
     )
-    _iris_wait_for_rank_epoch(
+    _iris_sync_rank_epoch(
         ready_flags,
         0,
         epoch,
@@ -980,6 +1228,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        PUBLISH=False,
     )
 
     input_heap_offset = tl.cast(input_sym_ptr, gl.uint64) - local_heap
@@ -1015,7 +1264,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
     read_done = ready_flags + WORLD_SIZE + RANK
     read_epoch = gl.load(read_done).to(gl.int32) + 1
     gl.atomic_xchg(read_done, read_epoch, sem="release", scope="sys")
-    _iris_wait_for_rank_epoch(
+    _iris_sync_rank_epoch(
         ready_flags,
         1,
         read_epoch,
@@ -1031,6 +1280,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        PUBLISH=False,
     )
 
     reduced = reduced.to(gl.bfloat16).to(gl.float32)

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -194,6 +194,31 @@ def test_producer_direct_admission_is_cdna4_only(monkeypatch):
     )
 
 
+@pytest.mark.parametrize(
+    ("world_size", "dtype", "min_bytes"),
+    [
+        (4, torch.bfloat16, 160 << 10),
+        (4, torch.float32, 160 << 10),
+        (8, torch.bfloat16, 96 << 10),
+        (8, torch.float32, 96 << 10),
+    ],
+)
+def test_producer_direct_two_stage_threshold(world_size, dtype, min_bytes):
+    try:
+        from tokenspeed_kernel.ops.communication.iris import (
+            _use_two_stage_producer_direct,
+        )
+    except ImportError:
+        pytest.skip("iris is not installed")
+
+    alignment = world_size * (8 // dtype.itemsize)
+    min_numel = min_bytes // dtype.itemsize
+    assert _use_two_stage_producer_direct(world_size, min_numel, dtype)
+    assert not _use_two_stage_producer_direct(world_size, min_numel - alignment, dtype)
+    assert not _use_two_stage_producer_direct(world_size, min_numel + 1, dtype)
+    assert not _use_two_stage_producer_direct(2, min_numel, dtype)
+
+
 # ---------------------------------------------------------------------------
 # Suite 1: iris_all_reduce
 # ---------------------------------------------------------------------------
@@ -286,6 +311,14 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             ((3, 5), (1, 1)),
             device,
         )
+        if world_size > 2:
+            _check_all_reduce_symmetric_outputs(
+                fp16_state,
+                rank,
+                world_size,
+                ((16, 7168), (16, 3584)),
+                device,
+            )
 
         fp32_state = create_iris_state(
             group=dist.group.WORLD,
@@ -300,6 +333,14 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             ((3, 5), (1, 1)),
             device,
         )
+        if world_size > 2:
+            _check_all_reduce_symmetric_outputs(
+                fp32_state,
+                rank,
+                world_size,
+                ((16, 7168), (16, 3584)),
+                device,
+            )
         if world_size == 8:
             _check_all_reduce_residual_attnres(state, rank, device)
     finally:
@@ -377,7 +418,8 @@ def _check_all_reduce_symmetric_outputs(
             output.fill_(index * (rank + 1))
         graph_results = iris_all_reduce_symmetric(state, outputs)
     dist.barrier()
-    graph.replay()
+    for _ in range(4):
+        graph.replay()
     torch.cuda.synchronize()
     for index, (output, result) in enumerate(zip(outputs, graph_results), start=1):
         torch.testing.assert_close(
@@ -513,7 +555,7 @@ def _ar_subgroup_worker_fn(rank, world_size, port, error_dict):
         state = create_iris_state(
             group=group,
             rank_in_group=group_rank,
-            max_numel=32,
+            max_numel=8 * (7168 + 3584),
             dtype=torch.bfloat16,
         )
         _check_all_reduce(
@@ -528,6 +570,13 @@ def _ar_subgroup_worker_fn(rank, world_size, port, error_dict):
             group_rank,
             len(groups[group_index]),
             ((3, 5), (1, 1)),
+            device,
+        )
+        _check_all_reduce_symmetric_outputs(
+            state,
+            group_rank,
+            len(groups[group_index]),
+            ((8, 7168), (8, 3584)),
             device,
         )
     except Exception:


### PR DESCRIPTION
Summary

- keep one-stage Iris reduction for small producer-direct payloads
- switch world-size 4/8 payloads above the dtype-aware threshold to reduce-scatter plus all-gather
- retain BF16, FP16, and FP32 packing behind the existing symmetric-output API

Performance

Exact parent `2ebd8f81` → head `60babeb9`, world-size 8 BF16 producer-direct reduction under CUDA-graph replay, critical-rank p50:

| Payload | M | Parent | Head | Reduction |
|---|---:|---:|---:|---:|
| AttnRes [M,7168] | 2 | 9.26 µs | 7.96 µs | 14.0% |
| AttnRes [M,7168] | 4 | 10.68 µs | 8.70 µs | 18.6% |
| AttnRes [M,7168] | 8 | 14.52 µs | 10.25 µs | 29.4% |
| AttnRes [M,7168] | 16 | 21.04 µs | 10.47 µs | 50.2% |
| Joint MoE [M,3584]+[M,7168] | 2 | 9.31 µs | 8.30 µs | 10.8% |
| Joint MoE [M,3584]+[M,7168] | 4 | 11.93 µs | 9.68 µs | 18.9% |
| Joint MoE [M,3584]+[M,7168] | 8 | 16.88 µs | 10.41 µs | 38.3% |
| Joint MoE [M,3584]+[M,7168] | 16 | 26.99 µs | 10.75 µs | 60.2% |

M=2/4 remain on the one-stage path; M=8/16 cross the world-size-8 BF16 two-stage threshold.

Tests

- threshold, world-size 4/8, noncontiguous subgroup, large-payload, dtype, and repeated graph-replay coverage: 7 passed
- benchmark validates exact reduced values before timing each eager/captured operation

Stack

- depends on #1140