### PR TITLE
perf(comm): extend fused AttnRes through M16

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -2337,10 +2337,11 @@ class KimiLinearDecoderLayer(nn.Module):
             else None
         )
         attnres_partial_args = None
-        if next_mix is not None and self._hoist_next_mlp and num_tokens == 1:
+        if next_mix is not None and self._hoist_next_mlp:
             next_layer, _ = next_mix
             # This layer's attention projection writes both block partials
             # hoisted for the next layer, which consumes their scratch slots.
+            # Kernel availability below is the token-count capability gate.
             candidate_args = (
                 block_residual[:mlp_valid_blocks],
                 next_layer._mlp_wp,
@@ -2361,6 +2362,12 @@ class KimiLinearDecoderLayer(nn.Module):
                     self.k3_comm.state.attn_ar_fusion_ok
                     and num_tokens
                     <= global_server_args_dict["comm_fusion_max_num_tokens"]
+                )
+                or (
+                    # The gfx950 fused reducer consumes the AttnRes scratch
+                    # through M=16, so its producer stream must join first.
+                    current_platform().is_cdna4
+                    and num_tokens <= ATTNRES_STREAM_FORK_THRESHOLD
                 )
             )
         )

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -412,7 +412,7 @@ class K3AttnComm:
             )
             if residual_out is not None:
                 return residual_out, None
-        if combine is not None and prefix_sum is not None and num_tokens == 1:
+        if combine is not None and prefix_sum is not None and num_tokens > 0:
             scratch, _, _, out_norm_w, eps = combine
             if out_norm_w is not None:
                 from tokenspeed_kernel.ops.communication.triton import (

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -46,7 +46,7 @@ from enum import IntEnum
 
 import torch
 import torch.distributed as dist
-from tokenspeed_kernel.ops.activation.triton import add3, attnres_combine
+from tokenspeed_kernel.ops.activation.triton import add3
 from tokenspeed_kernel.ops.communication import allreduce_fusion_lane
 from tokenspeed_kernel.ops.communication.fabric import fabric_allocation_supported
 from tokenspeed_kernel.ops.communication.multimem import (
@@ -445,19 +445,7 @@ class K3AttnComm:
                         local_world_size=self.mapping.nprocs_per_node,
                         eps=eps,
                     )
-                else:
-                    residual_out = prefix_sum + all_reduce(
-                        attn_partial, self.mapping.attn.tp_group
-                    )
-                    h = attnres_combine(
-                        residual_out,
-                        mlp_wp,
-                        out_norm_w,
-                        eps,
-                        scratch,
-                        torch.empty_like(residual_out),
-                    )
-                return residual_out, h
+                    return residual_out, h
         reduced = all_reduce(attn_partial, self.mapping.attn.tp_group)
         return (reduced if prefix_sum is None else prefix_sum + reduced), None
 

--- a/test/runtime/test_kimi_k3_attn_res.py
+++ b/test/runtime/test_kimi_k3_attn_res.py
@@ -127,6 +127,55 @@ class AttnResTests(unittest.TestCase):
         self.assertIs(supported.call_args.args[2], mlp_wp)
         fused.assert_called_once()
 
+    def test_unsupported_iris_reduce_defers_attnres_combine(self):
+        import tokenspeed_kernel.ops.communication.triton as triton_comm
+
+        import tokenspeed.runtime.models.kimi_k3_comm as kimi_k3_comm
+
+        group = object()
+        state = SimpleNamespace(
+            attn_ar_fusion_ok=False,
+            mapping=SimpleNamespace(
+                nprocs_per_node=8,
+                attn=SimpleNamespace(tp_rank=0, tp_group=tuple(range(8))),
+            ),
+        )
+        comm = kimi_k3_comm.K3AttnComm(state)
+        partial = torch.randn(17, _HIDDEN, dtype=torch.bfloat16)
+        prefix = torch.randn_like(partial)
+        reduced = torch.randn_like(partial)
+        combine = (
+            (object(), object(), object()),
+            object(),
+            object(),
+            torch.randn(_HIDDEN, dtype=torch.bfloat16),
+            _EPS,
+        )
+
+        with (
+            mock.patch.object(kimi_k3_comm, "_get_process_group", return_value=group),
+            mock.patch.object(
+                triton_comm,
+                "allreduce_residual_attnres_combine_supported",
+                return_value=False,
+            ),
+            mock.patch.object(
+                kimi_k3_comm,
+                "all_reduce",
+                return_value=reduced,
+            ) as fallback_reduce,
+        ):
+            residual, hidden = comm.attn_reduce(
+                partial,
+                prefix,
+                combine,
+                mlp_wp=torch.randn(_HIDDEN, dtype=torch.bfloat16),
+            )
+
+        torch.testing.assert_close(residual, prefix + reduced)
+        self.assertIsNone(hidden)
+        fallback_reduce.assert_called_once_with(partial, state.mapping.attn.tp_group)
+
     def test_torch_fallback_matches_reference(self):
         prefix_sum, block_residual, proj, norm = _make_inputs(17)
         got = torch_attn_res_fwd(

--- a/test/runtime/test_kimi_k3_attn_res.py
+++ b/test/runtime/test_kimi_k3_attn_res.py
@@ -76,6 +76,57 @@ def _reference_apply_attn_res(prefix_sum, block_residual, proj, norm):
 
 
 class AttnResTests(unittest.TestCase):
+    def test_batched_iris_reduce_consumes_attnres_combine(self):
+        import tokenspeed_kernel.ops.communication.triton as triton_comm
+
+        import tokenspeed.runtime.models.kimi_k3_comm as kimi_k3_comm
+
+        group = object()
+        state = SimpleNamespace(
+            attn_ar_fusion_ok=False,
+            mapping=SimpleNamespace(
+                nprocs_per_node=8,
+                attn=SimpleNamespace(tp_rank=0, tp_group=tuple(range(8))),
+            ),
+        )
+        comm = kimi_k3_comm.K3AttnComm(state)
+        partial = torch.randn(4, _HIDDEN, dtype=torch.bfloat16)
+        prefix = torch.randn_like(partial)
+        scratch = (object(), object(), object())
+        mlp_wp = torch.randn(_HIDDEN, dtype=torch.bfloat16)
+        out_weight = torch.randn(_HIDDEN, dtype=torch.bfloat16)
+        combine = (scratch, object(), object(), out_weight, _EPS)
+        expected_h = torch.randn_like(partial)
+        expected_residual = torch.randn_like(partial)
+
+        with (
+            mock.patch.object(kimi_k3_comm, "_get_process_group", return_value=group),
+            mock.patch.object(
+                triton_comm,
+                "allreduce_residual_attnres_combine_supported",
+                return_value=True,
+            ) as supported,
+            mock.patch.object(
+                triton_comm,
+                "allreduce_residual_attnres_combine",
+                return_value=(expected_h, expected_residual),
+            ) as fused,
+        ):
+            residual, hidden = comm.attn_reduce(
+                partial,
+                prefix,
+                combine,
+                mlp_wp=mlp_wp,
+            )
+
+        self.assertIs(residual, expected_residual)
+        self.assertIs(hidden, expected_h)
+        supported.assert_called_once()
+        self.assertIs(supported.call_args.args[0], partial)
+        self.assertIs(supported.call_args.args[1], prefix)
+        self.assertIs(supported.call_args.args[2], mlp_wp)
+        fused.assert_called_once()
+
     def test_torch_fallback_matches_reference(self):
         prefix_sum, block_residual, proj, norm = _make_inputs(17)
         got = torch_attn_res_fwd(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -382,6 +382,13 @@ class IrisAllReduce(object):
         assert len(group_ranks) == self.world_size
         assert group_ranks[rank_in_group] == dist.get_rank()
         self._input_buf = self._ctx.zeros((max_numel,), dtype=dtype)
+        self._attnres_input_buf = self._ctx.zeros((2, max_numel), dtype=dtype)
+        self._attnres_ready_flags = self._ctx.zeros(
+            (32, self.world_size), dtype=torch.int32
+        )
+        self._attnres_consumed_flags = self._ctx.zeros(
+            (32, self.world_size), dtype=torch.int32
+        )
         self._producer_direct_scratch_buf = self._ctx.zeros((max_numel,), dtype=dtype)
         self._producer_direct_output_buf = torch.empty(
             max_numel, dtype=dtype, device=self.device
@@ -579,7 +586,9 @@ class IrisAllReduce(object):
             op = dist.ReduceOp.SUM
         assert op == dist.ReduceOp.SUM, f"Iris all-reduce only supports SUM, got {op}"
         assert _platform.is_cdna4 and self.world_size == 8
-        assert partial.shape == residual.shape == (1, 7168)
+        num_tokens = partial.shape[0]
+        assert 0 < num_tokens <= 32
+        assert partial.shape == residual.shape == (num_tokens, 7168)
         assert partial.dtype == residual.dtype == self.dtype == torch.bfloat16
         assert partial.device == residual.device == self.device
         assert partial.is_contiguous() and residual.is_contiguous()
@@ -592,8 +601,8 @@ class IrisAllReduce(object):
         assert score_weight.device == output_weight.device == self.device
         assert score_weight.is_contiguous() and output_weight.is_contiguous()
         m, s_, acc = scratch
-        assert m.shape == s_.shape == (1,)
-        assert acc.shape == (1, 7168)
+        assert m.shape == s_.shape == (num_tokens,)
+        assert acc.shape == (num_tokens, 7168)
         assert m.dtype == s_.dtype == acc.dtype == torch.float32
         assert m.device == s_.device == acc.device == self.device
         assert m.is_contiguous() and s_.is_contiguous() and acc.is_contiguous()
@@ -601,10 +610,10 @@ class IrisAllReduce(object):
 
         hidden = torch.empty_like(partial)
         residual_out = torch.empty_like(residual)
-        iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel[(1,)](
+        iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel[(num_tokens,)](
             partial,
             residual,
-            self._input_buf,
+            self._attnres_input_buf,
             score_weight,
             output_weight,
             m,
@@ -612,12 +621,15 @@ class IrisAllReduce(object):
             acc,
             hidden,
             residual_out,
-            self._ready_flags,
+            self._attnres_ready_flags,
+            self._attnres_consumed_flags,
             *self._heap_base_addresses,
             RANK=self._iris_rank,
             WORLD_SIZE=self.world_size,
+            M=num_tokens,
             HIDDEN=7168,
             BLOCK=8192,
+            INPUT_SLOT_STRIDE=self.max_numel,
             EPS=eps,
             ELEMENTS_PER_THREAD=1,
             NUM_WARPS=4,
@@ -1158,6 +1170,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
     hidden_ptr,
     residual_out_ptr,
     ready_flags,
+    consumed_flags,
     heap_base_0,
     heap_base_1,
     heap_base_2,
@@ -1168,19 +1181,23 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
     heap_base_7,
     RANK: gl.constexpr,
     WORLD_SIZE: gl.constexpr,
+    M: gl.constexpr,
     HIDDEN: gl.constexpr,
     BLOCK: gl.constexpr,
+    INPUT_SLOT_STRIDE: gl.constexpr,
     EPS: gl.constexpr,
     ELEMENTS_PER_THREAD: gl.constexpr,
     NUM_WARPS: gl.constexpr,
 ):
     """Kimi-K3 attention AR, residual, and split AttnRes combine."""
+    row = gl.program_id(0)
     layout: gl.constexpr = gl.BlockedLayout(
         [ELEMENTS_PER_THREAD], [64], [NUM_WARPS], [0]
     )
     offset = gl.arange(0, BLOCK, layout=layout)
     mask = offset < HIDDEN
-    offset_i32 = offset.to(gl.int32)
+    offset_i32 = (row * HIDDEN + offset).to(gl.int32)
+    weight_offset_i32 = offset.to(gl.int32)
 
     local = gl.amd.cdna4.buffer_load(
         partial_ptr,
@@ -1188,19 +1205,8 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         mask=mask,
         other=0.0,
     ).to(gl.float32)
-    gl.amd.cdna4.buffer_store(
-        local.to(input_sym_ptr.dtype.element_ty),
-        input_sym_ptr,
-        offset_i32,
-        mask=mask,
-        cache=".wt",
-    )
-    gl.barrier()
-
-    local_ready = ready_flags + RANK
+    local_ready = ready_flags + row * WORLD_SIZE + RANK
     epoch = gl.load(local_ready).to(gl.int32) + 1
-    gl.atomic_xchg(local_ready, epoch, sem="release", scope="sys")
-
     local_heap = _iris_heap_base(
         RANK,
         heap_base_0,
@@ -1212,10 +1218,11 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         heap_base_6,
         heap_base_7,
     )
+    reuse_epoch = gl.maximum(epoch - 2, 0)
     _iris_sync_rank_epoch(
-        ready_flags,
-        0,
-        epoch,
+        consumed_flags,
+        row,
+        reuse_epoch,
         local_heap,
         heap_base_0,
         heap_base_1,
@@ -1231,7 +1238,37 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         PUBLISH=False,
     )
 
-    input_heap_offset = tl.cast(input_sym_ptr, gl.uint64) - local_heap
+    input_slot_ptr = input_sym_ptr + (epoch & 1) * INPUT_SLOT_STRIDE
+    gl.amd.cdna4.buffer_store(
+        local.to(input_slot_ptr.dtype.element_ty),
+        input_slot_ptr,
+        offset_i32,
+        mask=mask,
+        cache=".wt",
+    )
+    gl.barrier()
+
+    gl.atomic_xchg(local_ready, epoch, sem="release", scope="sys")
+    _iris_sync_rank_epoch(
+        ready_flags,
+        row,
+        epoch,
+        local_heap,
+        heap_base_0,
+        heap_base_1,
+        heap_base_2,
+        heap_base_3,
+        heap_base_4,
+        heap_base_5,
+        heap_base_6,
+        heap_base_7,
+        RANK,
+        WORLD_SIZE,
+        NUM_WARPS,
+        PUBLISH=True,
+    )
+
+    input_heap_offset = tl.cast(input_slot_ptr, gl.uint64) - local_heap
     reduced = local
     for peer in gl.static_range(0, WORLD_SIZE):
         if peer != RANK:
@@ -1258,30 +1295,11 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
                 cache=".cg",
             ).to(gl.float32)
 
-    # Wait until every peer has consumed this rank's symmetric staging before
-    # a subsequent collective can reuse it.
+    # Publish consumption without serializing this epilogue. Reuse waits only
+    # when a later invocation wraps back to the same staging slot.
     gl.barrier()
-    read_done = ready_flags + WORLD_SIZE + RANK
-    read_epoch = gl.load(read_done).to(gl.int32) + 1
-    gl.atomic_xchg(read_done, read_epoch, sem="release", scope="sys")
-    _iris_sync_rank_epoch(
-        ready_flags,
-        1,
-        read_epoch,
-        local_heap,
-        heap_base_0,
-        heap_base_1,
-        heap_base_2,
-        heap_base_3,
-        heap_base_4,
-        heap_base_5,
-        heap_base_6,
-        heap_base_7,
-        RANK,
-        WORLD_SIZE,
-        NUM_WARPS,
-        PUBLISH=False,
-    )
+    consumed = consumed_flags + row * WORLD_SIZE + RANK
+    gl.atomic_xchg(consumed, epoch, sem="release", scope="sys")
 
     reduced = reduced.to(gl.bfloat16).to(gl.float32)
     residual = gl.amd.cdna4.buffer_load(
@@ -1300,7 +1318,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
 
     score_weight = gl.amd.cdna4.buffer_load(
         score_weight_ptr,
-        offset_i32,
+        weight_offset_i32,
         mask=mask,
         other=0.0,
     ).to(gl.float32)
@@ -1308,8 +1326,8 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
     dot = gl.sum(gl.where(mask, prefix * score_weight, 0.0), axis=0)
     prefix_logit = dot * gl.rsqrt(square_sum / HIDDEN + EPS)
 
-    block_m = gl.load(scratch_m_ptr)
-    block_s = gl.load(scratch_s_ptr)
+    block_m = gl.load(scratch_m_ptr + row)
+    block_s = gl.load(scratch_s_ptr + row)
     maximum = gl.maximum(block_m, prefix_logit)
     block_correction = gl.exp(block_m - maximum)
     prefix_weight = gl.exp(prefix_logit - maximum)
@@ -1330,7 +1348,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
     inverse_rms = gl.rsqrt(output_square_sum / HIDDEN + EPS)
     output_weight = gl.amd.cdna4.buffer_load(
         output_weight_ptr,
-        offset_i32,
+        weight_offset_i32,
         mask=mask,
         other=0.0,
     ).to(gl.float32)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
@@ -2072,14 +2072,16 @@ def _all_reduce_residual_attnres_can_run(
         op = torch.distributed.ReduceOp.SUM
     m, s_, acc = scratch
     platform = current_platform()
+    num_tokens = partial.shape[0] if partial.ndim == 2 else 0
     return (
         platform.is_cdna4
         and state.world_size == 8
         and op == torch.distributed.ReduceOp.SUM
-        and partial.shape == residual.shape == (1, 7168)
+        and 0 < num_tokens <= 16
+        and partial.shape == residual.shape == (num_tokens, 7168)
         and score_weight.shape == output_weight.shape == (7168,)
-        and m.shape == s_.shape == (1,)
-        and acc.shape == (1, 7168)
+        and m.shape == s_.shape == (num_tokens,)
+        and acc.shape == (num_tokens, 7168)
         and partial.dtype
         == residual.dtype
         == score_weight.dtype
@@ -2124,20 +2126,20 @@ def _all_reduce_residual_attnres(
 
     Args:
         state: Initialized communication state for the tensor-parallel group.
-        partial: Contiguous local BF16 attention partial shaped ``[1, 7168]``.
-        residual: Contiguous BF16 residual stream shaped ``[1, 7168]``.
+        partial: Contiguous local BF16 attention partial shaped ``[M, 7168]``.
+        residual: Contiguous BF16 residual stream shaped ``[M, 7168]``.
         score_weight: Contiguous BF16 AttnRes score weight shaped ``[7168]``.
         output_weight: Contiguous BF16 output RMSNorm weight shaped ``[7168]``.
         scratch: Contiguous FP32 ``(max_logit, exp_sum, weighted_sum)`` tensors
-            for the historical AttnRes candidates, shaped ``[1]``, ``[1]``,
-            and ``[1, 7168]``.
+            for the historical AttnRes candidates, shaped ``[M]``, ``[M]``,
+            and ``[M, 7168]``.
         eps: Positive epsilon used for AttnRes scoring and output RMSNorm.
         op: Reduction operation; only ``SUM`` is supported.
 
     Returns:
         A pair containing the normalized AttnRes mixture and the BF16 sum of
         ``residual`` with the all-reduced attention partial, both shaped
-        ``[1, 7168]``.
+        ``[M, 7168]``.
     """
     assert _all_reduce_residual_attnres_can_run(
         state,
@@ -2168,12 +2170,14 @@ def _attnres_comm_state(
     rank: int,
     group: dist.ProcessGroup,
 ) -> TritonCommState:
+    max_numel = input_tensor.numel()
     return TritonCommState(
         group=group,
         rank_in_group=rank,
         world_size=group.size(),
         device=input_tensor.device,
-        max_numel=input_tensor.numel(),
+        max_numel=max_numel,
+        max_bytes=max_numel * input_tensor.dtype.itemsize,
     )
 
 
@@ -2227,8 +2231,8 @@ def allreduce_residual_attnres_combine(
     """Run the fused Kimi-K3 Iris all-reduce and AttnRes epilogue.
 
     Args:
-        input_tensor: Per-rank BF16 attention partial shaped ``[1, 7168]``.
-        residual: Running BF16 residual stream shaped ``[1, 7168]``.
+        input_tensor: Per-rank BF16 attention partial shaped ``[M, 7168]``.
+        residual: Running BF16 residual stream shaped ``[M, 7168]``.
         score_weight: Precomputed AttnRes score weight shaped ``[7168]``.
         output_weight: Output RMSNorm weight shaped ``[7168]``.
         scratch: FP32 ``(max_logit, exp_sum, weighted_sum)`` partials.

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -443,44 +443,40 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
         allreduce_residual_attnres_combine_supported,
     )
 
-    torch.manual_seed(101)
-    hidden = 7168
-    blocks = (torch.randn(4, 1, hidden, device=device) * 0.1).to(torch.bfloat16)
-    score_weight = (torch.randn(hidden, device=device) * 0.02).to(torch.bfloat16)
-    output_weight = (1.0 + torch.randn(hidden, device=device) * 0.02).to(torch.bfloat16)
-    residual = (torch.randn(1, hidden, device=device) * 0.1).to(torch.bfloat16)
-    local = (torch.randn(1, hidden, device=device) * 0.01 + (rank + 1) * 0.002).to(
-        torch.bfloat16
-    )
-    scratch = (
-        torch.empty(1, device=device, dtype=torch.float32),
-        torch.empty(1, device=device, dtype=torch.float32),
-        torch.empty(1, hidden, device=device, dtype=torch.float32),
-    )
-    attnres_partial(blocks, score_weight, 1e-6, scratch)
+    for num_tokens in (1, 2, 4, 8, 16):
+        torch.manual_seed(101 + num_tokens)
+        hidden = 7168
+        blocks = (torch.randn(4, num_tokens, hidden, device=device) * 0.1).to(
+            torch.bfloat16
+        )
+        score_weight = (torch.randn(hidden, device=device) * 0.02).to(torch.bfloat16)
+        output_weight = (1.0 + torch.randn(hidden, device=device) * 0.02).to(
+            torch.bfloat16
+        )
+        residual = (torch.randn(num_tokens, hidden, device=device) * 0.1).to(
+            torch.bfloat16
+        )
+        local = (
+            torch.randn(num_tokens, hidden, device=device) * 0.01 + (rank + 1) * 0.002
+        ).to(torch.bfloat16)
+        scratch = (
+            torch.empty(num_tokens, device=device, dtype=torch.float32),
+            torch.empty(num_tokens, device=device, dtype=torch.float32),
+            torch.empty(num_tokens, hidden, device=device, dtype=torch.float32),
+        )
+        attnres_partial(blocks, score_weight, 1e-6, scratch)
 
-    reduced = iris_all_reduce(state, local.clone(), safe=False)
-    expected_residual = residual + reduced
-    expected_hidden = attnres_combine(
-        expected_residual,
-        score_weight,
-        output_weight,
-        1e-6,
-        scratch,
-        torch.empty_like(residual),
-    )
-    assert allreduce_residual_attnres_combine_supported(
-        local,
-        residual,
-        score_weight,
-        output_weight,
-        scratch,
-        rank=rank,
-        group=state.group,
-        local_world_size=8,
-    )
-    for _ in range(4):
-        actual_hidden, actual_residual = allreduce_residual_attnres_combine(
+        reduced = iris_all_reduce(state, local.clone(), safe=False)
+        expected_residual = residual + reduced
+        expected_hidden = attnres_combine(
+            expected_residual,
+            score_weight,
+            output_weight,
+            1e-6,
+            scratch,
+            torch.empty_like(residual),
+        )
+        assert allreduce_residual_attnres_combine_supported(
             local,
             residual,
             score_weight,
@@ -489,28 +485,43 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
             rank=rank,
             group=state.group,
             local_world_size=8,
-            eps=1e-6,
         )
-        torch.testing.assert_close(actual_residual, expected_residual, atol=0, rtol=0)
-        torch.testing.assert_close(actual_hidden, expected_hidden, atol=2e-2, rtol=2e-2)
+        for _ in range(4):
+            actual_hidden, actual_residual = allreduce_residual_attnres_combine(
+                local,
+                residual,
+                score_weight,
+                output_weight,
+                scratch,
+                rank=rank,
+                group=state.group,
+                local_world_size=8,
+                eps=1e-6,
+            )
+            torch.testing.assert_close(
+                actual_residual, expected_residual, atol=0, rtol=0
+            )
+            torch.testing.assert_close(
+                actual_hidden, expected_hidden, atol=2e-2, rtol=2e-2
+            )
 
-    graph = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph):
-        graph_hidden, graph_residual = allreduce_residual_attnres_combine(
-            local,
-            residual,
-            score_weight,
-            output_weight,
-            scratch,
-            rank=rank,
-            group=state.group,
-            local_world_size=8,
-            eps=1e-6,
-        )
-    graph.replay()
-    torch.cuda.synchronize()
-    torch.testing.assert_close(graph_residual, expected_residual, atol=0, rtol=0)
-    torch.testing.assert_close(graph_hidden, expected_hidden, atol=2e-2, rtol=2e-2)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            graph_hidden, graph_residual = allreduce_residual_attnres_combine(
+                local,
+                residual,
+                score_weight,
+                output_weight,
+                scratch,
+                rank=rank,
+                group=state.group,
+                local_world_size=8,
+                eps=1e-6,
+            )
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(graph_residual, expected_residual, atol=0, rtol=0)
+        torch.testing.assert_close(graph_hidden, expected_hidden, atol=2e-2, rtol=2e-2)
 
 
 def _run_ar_test(world_size: int) -> None:


### PR DESCRIPTION
Summary

- extend the fused Iris attention all-reduce plus AttnRes epilogue from M=1 to M=1..16
- use per-token double-buffered staging with separate ready and consumed epochs
- keep the public communication wrapper shape-driven

Performance

Isolated fused world-size-8 CUDA-graph latency at head `a1a0f8e7`:

| M | Fused all-reduce + AttnRes |
|---:|---:|
| 1 | 13.69 µs |
| 2 | 14.52 µs |
| 4 | 16.23 µs |
| 8 | 17.38 µs |
| 16 | 21.79 µs |

Exact parent → head 4K/1K TP8/EP8 M=2, median of three, is flat: 93.98→93.95 tok/s (-0.04%) and 20.534→20.565 ms TPOT (+0.15%). This is expected at this stack boundary because the Kimi runtime still gates batched AttnRes fusion to M=1. #1146 removes that runtime gate; this PR provides and validates the batched kernel capability.

Tests

- world-size-8 numerical comparison against the split all-reduce + AttnRes reference passes for M=1/2/4/8/16
- each M is exercised repeatedly in eager mode and through CUDA-graph capture/replay
- all 12 measured 4K/1K A/B requests completed with valid lengths

Stack

- depends on #1141
- runtime activation for batched decode is in #1146