### PR TITLE
(WIP) perf(kimi3): join TP MoE reductions

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -59,6 +59,9 @@ InputProjector = Callable[
     [torch.Tensor, torch.Tensor | None],
     tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None,
 ]
+# Joint decode uses the same packed projection but returns the activated shared
+# input so the selected expert kernel can own the shared down projection.
+JointInputProjector = InputProjector
 _SUPPORTED_EP_SIZES = {1, 2, 4, 8}
 
 
@@ -241,12 +244,7 @@ class Kimi3MoEExecutionPlan:
                 and alt_stream is not None
                 and mapping.moe.tp_ep_size == 1
             ),
-            joint_moe_reduce=(
-                use_native
-                and mapping.moe.tp_size == 1
-                and mapping.moe.ep_size > 1
-                and mapping.moe.ep_group == mapping.moe.tp_ep_group
-            ),
+            joint_moe_reduce=use_native and mapping.moe.tp_ep_size > 1,
         )
 
     def prepare_latent_fusion(
@@ -478,12 +476,26 @@ class LatentMoELayer(nn.Module):
         joint_reduce: bool = False,
         shared_expert_stream: torch.cuda.Stream | None = None,
         expert_parallel_group: tuple[int, ...] | None = None,
+        joint_reduce_group: tuple[int, ...] | None = None,
         return_separate_outputs: bool = False,
         input_projections: InputProjector | None = None,
+        joint_input_projections: JointInputProjector | None = None,
+        joint_shared_weight: torch.Tensor | None = None,
+        joint_expert_shared_max_tokens: int = 0,
     ) -> None:
         super().__init__()
         if input_projections is not None and shared_experts is None:
             raise ValueError("input_projections requires shared_experts")
+        if (joint_input_projections is None) != (joint_shared_weight is None):
+            raise ValueError(
+                "joint input projections and shared weight must be provided together"
+            )
+        if joint_input_projections is not None and not joint_reduce:
+            raise ValueError("joint expert/shared projection requires joint_reduce")
+        if joint_input_projections is not None and joint_expert_shared_max_tokens <= 0:
+            raise ValueError("joint expert/shared projection requires a token limit")
+        if joint_input_projections is None and joint_expert_shared_max_tokens:
+            raise ValueError("joint expert/shared token limit requires projections")
         if shared_reduce is not None and shared_experts is None:
             raise ValueError("shared_reduce requires shared_experts")
         if joint_reduce and shared_experts is None:
@@ -510,8 +522,12 @@ class LatentMoELayer(nn.Module):
                     "expert_parallel_group size must match experts.ep_size: "
                     f"{len(expert_parallel_group)} != {expert_parallel_size}"
                 )
-        if joint_reduce and expert_parallel_group is None:
-            raise ValueError("joint_reduce requires expert_parallel_group")
+        if joint_reduce_group is not None:
+            joint_reduce_group = tuple(joint_reduce_group)
+        if joint_reduce and joint_reduce_group is None:
+            joint_reduce_group = expert_parallel_group
+        if joint_reduce and joint_reduce_group is None:
+            raise ValueError("joint_reduce requires a reduction group")
         if expert_parallel_size > 1 and latent_reduce is None and not joint_reduce:
             if expert_parallel_group is None:
                 raise ValueError(
@@ -530,9 +546,13 @@ class LatentMoELayer(nn.Module):
         self.shared_reduce = shared_reduce
         self.joint_reduce = joint_reduce
         self.expert_parallel_group = expert_parallel_group
+        self.joint_reduce_group = joint_reduce_group
         self.stream_fork = StreamFork(shared_expert_stream)
         self.return_separate_outputs = return_separate_outputs
         self.input_projections = input_projections
+        self.joint_input_projections = joint_input_projections
+        self.joint_shared_weight = joint_shared_weight
+        self.joint_expert_shared_max_tokens = joint_expert_shared_max_tokens
 
     def finalize_output(
         self,
@@ -594,7 +614,7 @@ class LatentMoELayer(nn.Module):
             acquire_all_reduce_outputs(
                 (output_shape, (num_tokens, int(self.experts.hidden_size))),
                 hidden_states,
-                self.expert_parallel_group,
+                self.joint_reduce_group,
             )
             if self.joint_reduce and num_tokens > 0
             else None
@@ -618,7 +638,20 @@ class LatentMoELayer(nn.Module):
         # shared branch against the routed one by construction, so it is only
         # worth taking when the branches were not going to overlap anyway.
         packed = None
-        if self.input_projections is not None and not overlap_shared and num_tokens > 0:
+        fuse_expert_shared = (
+            self.joint_input_projections is not None
+            and not overlap_shared
+            and 0 < num_tokens <= self.joint_expert_shared_max_tokens
+        )
+        if fuse_expert_shared:
+            packed = self.joint_input_projections(hidden_states, shared_target)
+            fuse_expert_shared = packed is not None
+        if (
+            packed is None
+            and self.input_projections is not None
+            and not overlap_shared
+            and num_tokens > 0
+        ):
             packed = self.input_projections(hidden_states, shared_target)
         packed_router, packed_routed, packed_shared = (
             (None, None, None) if packed is None else packed
@@ -627,6 +660,8 @@ class LatentMoELayer(nn.Module):
         def run_shared_branch() -> None:
             nonlocal shared_output, shared_reduction_applied
             if self.shared_experts is None:
+                return
+            if fuse_expert_shared:
                 return
             # This helper is entered through ``fork.branch()`` below.  With
             # overlap enabled, the full-width H->FFN->H shared-expert MLP runs
@@ -693,15 +728,33 @@ class LatentMoELayer(nn.Module):
             if routed_target is not None:
                 self.experts._situ_output_buffer = routed_target
             try:
-                routed_latent = self.experts(
+                expert_kwargs = (
+                    {
+                        "shared_input": packed_shared,
+                        "shared_weight": self.joint_shared_weight,
+                        "shared_out": shared_target,
+                    }
+                    if fuse_expert_shared
+                    else {}
+                )
+                expert_result = self.experts(
                     hidden_states=routed_input,
                     topk_output=topk_output,
                     num_global_tokens=num_global_tokens,
                     max_num_tokens_per_gpu=max_num_tokens_per_gpu,
+                    **expert_kwargs,
                 )
             finally:
                 if routed_target is not None:
                     self.experts._situ_output_buffer = previous_output
+            if fuse_expert_shared:
+                if not isinstance(expert_result, tuple):
+                    raise RuntimeError(
+                        "joint expert/shared kernel did not return both outputs"
+                    )
+                routed_latent, shared_output = expert_result
+            else:
+                routed_latent = expert_result
             _check_shape(routed_latent, latent_shape, "routed experts")
 
         # Spin-wait collectives cannot safely overlap an all-device GEMM.
@@ -716,7 +769,7 @@ class LatentMoELayer(nn.Module):
         if reduction_outputs is not None:
             shared_output, routed_latent = all_reduce(
                 reduction_outputs,
-                self.expert_parallel_group,
+                self.joint_reduce_group,
             )
             _check_shape(shared_output, output_shape, "joint shared output")
             _check_shape(routed_latent, latent_shape, "joint routed latent")

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1299,6 +1299,7 @@ class KimiLinearMoEGate(nn.Module):
 # this is a prefill chunk and takes the unsplit path; the scratch buffers are
 # allocated to exactly this many rows. Raise together with --max-num-seqs.
 ATTNRES_FAST_PATH_MAX_TOKENS = 32
+JOINT_EXPERT_SHARED_MAX_TOKENS = 4
 # Paired MI350 measurements show that stream scheduling costs more than the
 # available attention/AttnRes overlap through M=16. Preserve NVIDIA's policy.
 ATTNRES_STREAM_FORK_THRESHOLD = 16 if current_platform().is_amd else 0
@@ -1553,6 +1554,10 @@ class KimiLinearMoE(nn.Module):
             activation_situ_linear_beta=situ_linear_beta,
         )
         self.packed_input_projection_weight: torch.Tensor | None = None
+        joint_expert_shared = (
+            self.experts.plan.get("apply_kernel_name")
+            == "gluon_mxfp4_a8w4_situ_precomputed_moe_apply"
+        )
         self.native_latent_moe = (
             LatentMoELayer(
                 router=self.gate,
@@ -1565,14 +1570,34 @@ class KimiLinearMoE(nn.Module):
                 shared_reduce=(
                     None
                     if self.execution_plan.joint_moe_reduce
-                    else self._reduce_shared
+                    else self._reduce_moe_partial
+                ),
+                # MoE TP shards W13/W2 along the intermediate dimension, so
+                # each rank's W2 result is only a routed-latent partial.
+                latent_reduce=(
+                    self._reduce_moe_partial
+                    if mapping.moe.tp_size > 1
+                    and not self.execution_plan.joint_moe_reduce
+                    else None
                 ),
                 joint_reduce=self.execution_plan.joint_moe_reduce,
                 shared_expert_stream=(
                     alt_stream if self.execution_plan.overlap_shared_experts else None
                 ),
                 expert_parallel_group=mapping.moe.ep_group,
+                joint_reduce_group=mapping.moe.tp_ep_group,
                 input_projections=self._latent_input_projections,
+                joint_input_projections=(
+                    self._latent_input_activations if joint_expert_shared else None
+                ),
+                joint_shared_weight=(
+                    self.shared_experts.down_proj.weight
+                    if joint_expert_shared
+                    else None
+                ),
+                joint_expert_shared_max_tokens=(
+                    JOINT_EXPERT_SHARED_MAX_TOKENS if joint_expert_shared else 0
+                ),
             )
             if self.execution_plan.use_native
             else None
@@ -1646,19 +1671,16 @@ class KimiLinearMoE(nn.Module):
             )
             offset += rows
 
-    def _latent_input_projections(
+    def _latent_input_activations(
         self,
         hidden_states: torch.Tensor,
-        shared_out: torch.Tensor | None = None,
+        _shared_out: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
-        """Project the router, routed latent, and shared partial in one pass.
+        """Project the router, routed latent, and activated shared input."""
 
-        Returns ``None`` before the projection weights are concatenated, which
-        leaves the caller on the separate per-module projections.
-        """
         if self.packed_input_projection_weight is None:
             return None
-        router_logits, routed_input, shared_input = latent_moe_input_projections(
+        return latent_moe_input_projections(
             hidden_states,
             self.gate.weight,
             self.routed_expert_down_proj.weight,
@@ -1666,6 +1688,18 @@ class KimiLinearMoE(nn.Module):
             gate_clamp=self.shared_experts.act_fn.beta,
             up_clamp=self.shared_experts.act_fn.linear_beta,
         )
+
+    def _latent_input_projections(
+        self,
+        hidden_states: torch.Tensor,
+        shared_out: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        """Project the router, routed latent, and shared partial in one pass."""
+
+        projected = self._latent_input_activations(hidden_states)
+        if projected is None:
+            return None
+        router_logits, routed_input, shared_input = projected
         # The shared experts hold reduce_results=False, so this partial is
         # reduced by the layer's shared or joint reducer, not here.
         shared_output = kimi3_shared_down_projection(
@@ -1885,9 +1919,9 @@ class KimiLinearMoE(nn.Module):
         # keeps only its slice (a no-op view when no gather happened).
         return output[local_offset : local_offset + local_num_tokens]
 
-    def _reduce_shared(self, shared_partial: torch.Tensor) -> torch.Tensor:
-        """Reduce the shared experts' TP partial (delegates to K3MoeTailComm)."""
-        return self.comm.reduce_shared(shared_partial)
+    def _reduce_moe_partial(self, partial: torch.Tensor) -> torch.Tensor:
+        """Reduce a tensor-sharded MoE partial through K3MoeTailComm."""
+        return self.comm.reduce_shared(partial)
 
 
 class KimiLinearDecoderLayer(nn.Module):

--- a/test/runtime/layers/test_latent_moe.py
+++ b/test/runtime/layers/test_latent_moe.py
@@ -129,6 +129,30 @@ class _Experts(nn.Module):
         return result
 
 
+class _JointExperts(_Experts):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: StandardTopKOutput,
+        num_global_tokens: int,
+        max_num_tokens_per_gpu: int,
+        shared_input: torch.Tensor | None = None,
+        shared_weight: torch.Tensor | None = None,
+        shared_out: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        routed = super().forward(
+            hidden_states,
+            topk_output,
+            num_global_tokens,
+            max_num_tokens_per_gpu,
+        )
+        if shared_input is None:
+            return routed
+        assert shared_weight is not None and shared_out is not None
+        shared_out.copy_(shared_input)
+        return routed, shared_out
+
+
 def test_kimi3_join_reduce_moe_selects_lane_norm(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -318,6 +342,37 @@ def test_kimi3_moe_execution_policy_is_selected_outside_model() -> None:
     assert plan.joint_moe_reduce
 
 
+def test_kimi3_tp_moe_joins_tensor_parallel_reductions() -> None:
+    group = tuple(range(8))
+    mapping = SimpleNamespace(
+        moe=SimpleNamespace(
+            tp_size=8,
+            ep_size=1,
+            ep_group=(0,),
+            tp_ep_size=8,
+            tp_ep_group=group,
+        )
+    )
+    backend = SimpleNamespace(
+        is_auto=lambda: True,
+        is_flashinfer_trtllm=lambda: False,
+    )
+
+    with mock.patch.object(
+        latent_module,
+        "native_latent_moe_available",
+        return_value=True,
+    ):
+        plan = Kimi3MoEExecutionPlan.build(
+            mapping,
+            backend,
+            alt_stream=None,
+            enforce_eager=False,
+        )
+
+    assert plan.joint_moe_reduce
+
+
 def test_kimi3_moe_execution_policy_preserves_nvidia_trtllm() -> None:
     mapping = SimpleNamespace(
         moe=SimpleNamespace(
@@ -474,6 +529,58 @@ def test_latent_moe_falls_back_when_input_projections_declines() -> None:
     input_projections.assert_called_once_with(hidden_states, None)
 
 
+@pytest.mark.parametrize(
+    ("tokens", "uses_joint"),
+    [(1, True), (2, True), (3, True), (4, True), (8, False)],
+)
+def test_latent_moe_applies_joint_projection_through_tuned_token_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    tokens: int,
+    uses_joint: bool,
+) -> None:
+    monkeypatch.setattr(
+        latent_module,
+        "acquire_all_reduce_outputs",
+        lambda shapes, like, _group: tuple(like.new_empty(shape) for shape in shapes),
+    )
+    monkeypatch.setattr(
+        latent_module,
+        "all_reduce",
+        lambda outputs, _group: outputs,
+    )
+    hidden_states = torch.arange(tokens * 4, dtype=torch.float32).view(tokens, 4)
+    joint_projector = mock.Mock(
+        return_value=(
+            hidden_states[:, :2].float(),
+            hidden_states[:, :2] + 10,
+            hidden_states * 6,
+        )
+    )
+    layer = _layer(
+        experts=_JointExperts(),
+        routed_norm=_Norm(),
+        shared_experts=_Shared(),
+        joint_reduce=True,
+        joint_reduce_group=(0,),
+        joint_input_projections=joint_projector,
+        joint_shared_weight=torch.ones(1),
+        joint_expert_shared_max_tokens=4,
+    )
+
+    actual = layer(hidden_states)
+
+    if uses_joint:
+        latent = hidden_states[:, :2] + 14
+        shared = hidden_states * 6
+        joint_projector.assert_called_once()
+    else:
+        latent = hidden_states[:, :2] + 4
+        shared = hidden_states * 4
+        joint_projector.assert_not_called()
+    expected = torch.cat((latent, torch.zeros_like(latent)), dim=-1) + shared
+    torch.testing.assert_close(actual, expected)
+
+
 def test_latent_moe_rejects_input_projections_without_shared_experts() -> None:
     with pytest.raises(ValueError, match="input_projections requires shared_experts"):
         _layer(input_projections=lambda hidden_states, shared_out: None)
@@ -485,14 +592,14 @@ def test_latent_moe_acquires_shared_and_routed_outputs(
     acquisitions = []
 
     def acquire_outputs(shapes, like, group):
-        assert group == (0,)
+        assert group == (0, 1)
         outputs = tuple(like.new_empty(shape) for shape in shapes)
         acquisitions.append(outputs)
         return outputs
 
     def reduce_outputs(outputs, group):
         assert outputs is acquisitions[0]
-        assert group == (0,)
+        assert group == (0, 1)
         return outputs[0] + 5, outputs[1] * 2
 
     monkeypatch.setattr(latent_module, "acquire_all_reduce_outputs", acquire_outputs)
@@ -503,6 +610,7 @@ def test_latent_moe_acquires_shared_and_routed_outputs(
         shared_experts=_Shared(),
         joint_reduce=True,
         expert_parallel_group=(0,),
+        joint_reduce_group=(0, 1),
     )
     hidden_states = torch.arange(12, dtype=torch.float32).view(3, 4)
 


### PR DESCRIPTION
Summary

- enable joint routed/shared reduction for native TP as well as EP layouts
- acquire producer-direct outputs from the TP-EP reduction group
- pass activated shared inputs through the tuned M<=4 A8W4 expert kernel

Performance

Exact parent `a1a0f8e7` → head `30cac366`, 4K/1K TP8/EP1 CUDA graphs, median of three:

| M | Parent tok/s | Head tok/s | Change | Parent TPOT | Head TPOT |
|---:|---:|---:|---:|---:|---:|
| 2 | 97.17 | 103.64 | +6.66% | 19.939 ms | 18.621 ms |
| 4 | 175.34 | 185.64 | +5.88% | 21.693 ms | 20.380 ms |

Each run had one first-repetition TTFT disturbance; the two steady repetitions agreed closely and the reported median rejects that startup effect.

Tests

- TP8 execution policy and reduction-group coverage pass
- joint projection/output reuse is covered for M=1/2/3/4/8
- targeted suite: 6 passed, 28 deselected
- all 18 measured requests per boundary completed with valid 4096-token prompts and 1024-token outputs

Stack

- depends on #1142