### PR TITLE
(WIP) perf(kimi3): shard the TP MoE final projection

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -384,6 +384,29 @@ class Kimi3LatentProjection(ReplicatedLinear):
         )
         return self._gather_shards(output), None
 
+    def project_shard_add_(
+        self,
+        hidden_states: torch.Tensor,
+        shared_output: torch.Tensor,
+        *,
+        norm_weight: torch.Tensor | None = None,
+        eps: float | None = None,
+    ) -> torch.Tensor:
+        """Project this rank's column shard into its shared-output slice."""
+
+        if self.shard_group is None:
+            raise ValueError("project_shard_add_ requires a sharded projection")
+        start, width = self.shard_slice
+        output = shared_output.narrow(-1, start, width)
+        return tokenspeed_kernel.kimi3_latent_projection_add(
+            hidden_states,
+            self.weight,
+            output,
+            norm_weight=norm_weight,
+            eps=eps,
+            out=output,
+        )
+
     def forward_add3(
         self,
         hidden_states: torch.Tensor,
@@ -482,6 +505,7 @@ class LatentMoELayer(nn.Module):
         joint_input_projections: JointInputProjector | None = None,
         joint_shared_weight: torch.Tensor | None = None,
         joint_expert_shared_max_tokens: int = 0,
+        sharded_output_min_tokens: int = 0,
     ) -> None:
         super().__init__()
         if input_projections is not None and shared_experts is None:
@@ -496,6 +520,10 @@ class LatentMoELayer(nn.Module):
             raise ValueError("joint expert/shared projection requires a token limit")
         if joint_input_projections is None and joint_expert_shared_max_tokens:
             raise ValueError("joint expert/shared token limit requires projections")
+        if sharded_output_min_tokens < 0:
+            raise ValueError("sharded output token limit must be nonnegative")
+        if sharded_output_min_tokens and not joint_reduce:
+            raise ValueError("sharded output projection requires joint_reduce")
         if shared_reduce is not None and shared_experts is None:
             raise ValueError("shared_reduce requires shared_experts")
         if joint_reduce and shared_experts is None:
@@ -553,6 +581,7 @@ class LatentMoELayer(nn.Module):
         self.joint_input_projections = joint_input_projections
         self.joint_shared_weight = joint_shared_weight
         self.joint_expert_shared_max_tokens = joint_expert_shared_max_tokens
+        self.sharded_output_min_tokens = sharded_output_min_tokens
 
     def finalize_output(
         self,
@@ -610,13 +639,19 @@ class LatentMoELayer(nn.Module):
         )
 
         output_shape = (num_tokens, hidden_size)
+        use_sharded_output = (
+            self.sharded_output_min_tokens > 0
+            and num_tokens >= self.sharded_output_min_tokens
+            and prefix_sum is not None
+            and getattr(self.routed_up_proj, "shard_group", None) is not None
+        )
         reduction_outputs = (
             acquire_all_reduce_outputs(
                 (output_shape, (num_tokens, int(self.experts.hidden_size))),
                 hidden_states,
                 self.joint_reduce_group,
             )
-            if self.joint_reduce and num_tokens > 0
+            if self.joint_reduce and not use_sharded_output and num_tokens > 0
             else None
         )
         shared_target, routed_target = (
@@ -774,6 +809,9 @@ class LatentMoELayer(nn.Module):
             _check_shape(shared_output, output_shape, "joint shared output")
             _check_shape(routed_latent, latent_shape, "joint routed latent")
             shared_reduction_applied = True
+        elif use_sharded_output:
+            routed_latent = all_reduce(routed_latent, self.joint_reduce_group)
+            _check_shape(routed_latent, latent_shape, "latent_reduce")
         elif self.latent_reduce is not None:
             routed_latent = self.latent_reduce(routed_latent)
             _check_shape(routed_latent, latent_shape, "latent_reduce")
@@ -784,6 +822,20 @@ class LatentMoELayer(nn.Module):
             routed_output = _module_tensor_output(self.routed_up_proj, routed_latent)
             _check_shape(routed_output, output_shape, "routed_up_proj")
             return routed_output
+        if use_sharded_output:
+            norm_weight = None if self.routed_norm is None else self.routed_norm.weight
+            eps = (
+                None if self.routed_norm is None else self.routed_norm.variance_epsilon
+            )
+            self.routed_up_proj.project_shard_add_(
+                routed_latent,
+                shared_output,
+                norm_weight=norm_weight,
+                eps=eps,
+            )
+            shared_output = all_reduce(shared_output, self.joint_reduce_group)
+            _check_shape(shared_output, output_shape, "sharded output reduce")
+            return prefix_sum + shared_output
         if prefix_sum is None:
             if self.routed_norm is not None:
                 routed_latent = _module_tensor_output(self.routed_norm, routed_latent)

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -781,11 +781,18 @@ def _assemble_fp8_fused_qkv_a(
 
 
 def _shard_k3_up_projection(mapping: Mapping, hidden_size: int) -> bool:
-    """Whether to column-shard K3's routed up projection on NVIDIA."""
+    """Whether the active K3 tail can consume a column-sharded projection."""
     return (
-        torch.version.hip is None
-        and mapping.moe.tp_ep_size > 1
+        mapping.moe.tp_ep_size > 1
         and hidden_size % mapping.moe.tp_ep_size == 0
+        and (
+            torch.version.hip is None
+            or (
+                current_platform().is_cdna4
+                and mapping.moe.tp_size == 8
+                and mapping.moe.ep_size == 1
+            )
+        )
     )
 
 
@@ -1597,6 +1604,11 @@ class KimiLinearMoE(nn.Module):
                 ),
                 joint_expert_shared_max_tokens=(
                     JOINT_EXPERT_SHARED_MAX_TOKENS if joint_expert_shared else 0
+                ),
+                sharded_output_min_tokens=(
+                    8
+                    if current_platform().is_cdna4 and self._shard_up_projection
+                    else 0
                 ),
             )
             if self.execution_plan.use_native

--- a/test/runtime/layers/test_latent_moe.py
+++ b/test/runtime/layers/test_latent_moe.py
@@ -75,6 +75,25 @@ class _Add3Up(nn.Module):
         return prefix_sum + routed_output + shared_output
 
 
+class _ShardUp(_Add3Up):
+    shard_group = (0, 1)
+
+    def project_shard_add_(
+        self,
+        routed_latent: torch.Tensor,
+        shared_output: torch.Tensor,
+        *,
+        norm_weight: torch.Tensor | None = None,
+        eps: float | None = None,
+    ) -> torch.Tensor:
+        if norm_weight is not None:
+            assert eps == 1e-6
+            routed_latent = routed_latent + 3
+        output = shared_output[:, :2]
+        output.add_(routed_latent)
+        return output
+
+
 class _WeightedNorm(_Norm):
     def __init__(self) -> None:
         super().__init__()
@@ -621,6 +640,44 @@ def test_latent_moe_acquires_shared_and_routed_outputs(
     expected = routed + hidden_states * 4 + 5
     torch.testing.assert_close(actual, expected)
     assert len(acquisitions) == 1
+
+
+def test_latent_moe_shards_projection_before_final_reduce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def reduce_output(value, group):
+        assert group == (0, 1)
+        calls.append(tuple(value.shape))
+        return value * 2
+
+    monkeypatch.setattr(latent_module, "all_reduce", reduce_output)
+    monkeypatch.setattr(
+        latent_module,
+        "acquire_all_reduce_outputs",
+        lambda *_args, **_kwargs: pytest.fail("sharded tail uses ordered reductions"),
+    )
+    layer = _layer(
+        routed_norm=_WeightedNorm(),
+        routed_up_proj=_ShardUp(),
+        shared_experts=_Shared(),
+        joint_reduce=True,
+        expert_parallel_group=(0,),
+        joint_reduce_group=(0, 1),
+        sharded_output_min_tokens=2,
+    )
+    hidden_states = torch.arange(8, dtype=torch.float32).view(2, 4)
+    prefix_sum = torch.full_like(hidden_states, 7)
+
+    actual = layer(hidden_states, prefix_sum=prefix_sum)
+
+    routed = (hidden_states[:, :2] + 1) * 2 + 3
+    shared = hidden_states * 4
+    shared[:, :2] += routed
+    expected = prefix_sum + shared * 2
+    torch.testing.assert_close(actual, expected)
+    assert calls == [(2, 2), (2, 4)]
 
 
 def test_latent_moe_can_return_separate_residual_components() -> None:

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -495,6 +495,40 @@ class KimiK3RegistrationTests(unittest.TestCase):
             layer.native_latent_moe.components["expert_parallel_group"], ep_group
         )
 
+    def test_kimi_moe_shards_amd_up_projection_only_for_tp8(self):
+        import tokenspeed.runtime.models.kimi_k3 as kimi_k3
+
+        def mapping(tp_size, ep_size):
+            return SimpleNamespace(
+                moe=SimpleNamespace(
+                    tp_size=tp_size,
+                    ep_size=ep_size,
+                    tp_ep_size=tp_size * ep_size,
+                )
+            )
+
+        with (
+            mock.patch.object(kimi_k3.torch.version, "hip", "6.4"),
+            mock.patch.object(
+                kimi_k3,
+                "current_platform",
+                return_value=SimpleNamespace(is_cdna4=True),
+            ),
+        ):
+            self.assertTrue(kimi_k3._shard_k3_up_projection(mapping(8, 1), 64))
+            self.assertFalse(kimi_k3._shard_k3_up_projection(mapping(4, 1), 64))
+            self.assertFalse(kimi_k3._shard_k3_up_projection(mapping(1, 8), 64))
+
+        with (
+            mock.patch.object(kimi_k3.torch.version, "hip", None),
+            mock.patch.object(
+                kimi_k3,
+                "current_platform",
+                return_value=SimpleNamespace(is_cdna4=False),
+            ),
+        ):
+            self.assertTrue(kimi_k3._shard_k3_up_projection(mapping(1, 8), 64))
+
     def test_cross_dp_ep_gather_uses_dp_group_and_returns_local_offset(self):
         from tokenspeed.runtime.models.kimi_k3 import KimiLinearMoE
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/gemm/fp16/rmsnorm_linear_add.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/gemm/fp16/rmsnorm_linear_add.py
@@ -45,6 +45,7 @@ def _rmsnorm_linear_add_kernel(
     shared_stride_m,
     output_stride_m,
     eps,
+    HAS_RESIDUAL: gl.constexpr,
 ):
     pid_m = gl.program_id(0)
     pid_n = gl.program_id(1)
@@ -108,9 +109,10 @@ def _rmsnorm_linear_add_kernel(
     residual_offset = pid_m * residual_stride_m + offs_n
     shared_offset = pid_m * shared_stride_m + offs_n
     output_offset = pid_m * output_stride_m + offs_n
-    acc += gl.amd.cdna4.buffer_load(residual_ptr, residual_offset.to(gl.int32)).to(
-        gl.float32
-    )
+    if HAS_RESIDUAL:
+        acc += gl.amd.cdna4.buffer_load(residual_ptr, residual_offset.to(gl.int32)).to(
+            gl.float32
+        )
     acc += gl.amd.cdna4.buffer_load(shared_ptr, shared_offset.to(gl.int32)).to(
         gl.float32
     )
@@ -121,27 +123,29 @@ def gluon_rmsnorm_linear_add_gfx950(
     latent: torch.Tensor,
     norm_weight: torch.Tensor,
     projection_weight: torch.Tensor,
-    residual: torch.Tensor,
+    residual: torch.Tensor | None,
     shared: torch.Tensor,
     *,
     eps: float,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     if out is None:
-        out = torch.empty_like(residual)
+        out = torch.empty_like(shared)
     m = latent.shape[0]
+    residual_ptr = shared if residual is None else residual
     _rmsnorm_linear_add_kernel[(m, projection_weight.shape[0] // _BLOCK_N)](
         latent,
         norm_weight,
         projection_weight,
-        residual,
+        residual_ptr,
         shared,
         out,
         latent.stride(0),
-        residual.stride(0),
+        0 if residual is None else residual.stride(0),
         shared.stride(0),
         out.stride(0),
         float(eps),
+        HAS_RESIDUAL=residual is not None,
         num_warps=8,
         num_stages=1,
         waves_per_eu=0,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -56,6 +56,7 @@ from tokenspeed_kernel.ops.attention import (
 from tokenspeed_kernel.ops.gemm import (
     bmm,
     kimi3_latent_projection,
+    kimi3_latent_projection_add,
     kimi3_latent_projection_add3,
     kimi3_mla_qkv_gate_projection,
     kimi3_qkvfab_projection,
@@ -89,6 +90,7 @@ __all__ = [
     # gemm
     "bmm",
     "kimi3_latent_projection",
+    "kimi3_latent_projection_add",
     "kimi3_mla_qkv_gate_projection",
     "kimi3_latent_projection_add3",
     "kimi3_qkvfab_projection",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
@@ -32,6 +32,7 @@ import tokenspeed_kernel.ops.gemm.trtllm  # noqa: F401
 import torch
 from tokenspeed_kernel.ops.gemm.kimi3 import (
     kimi3_latent_projection,
+    kimi3_latent_projection_add,
     kimi3_latent_projection_add3,
     kimi3_mla_qkv_gate_projection,
     kimi3_qkvfab_projection,
@@ -61,6 +62,7 @@ __all__ = [
     "linear_attnres_partials",
     "linear_attnres_partials_available",
     "kimi3_latent_projection",
+    "kimi3_latent_projection_add",
     "kimi3_mla_qkv_gate_projection",
     "kimi3_latent_projection_add3",
     "kimi3_qkvfab_projection",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -578,6 +578,98 @@ def kimi3_latent_projection_add3(
     return add3(prefix, projected, shared_output)
 
 
+def kimi3_latent_projection_add(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    addend: torch.Tensor,
+    *,
+    norm_weight: torch.Tensor | None = None,
+    eps: float | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Project K3 latent rows and add one possibly strided output slice.
+
+    Args:
+        hidden_states: Contiguous latent rows shaped ``[M, K]``.
+        weight: Contiguous projection weight shaped ``[N, K]``.
+        addend: Output addend shaped ``[M, N]`` with unit inner stride.
+        norm_weight: Optional contiguous RMSNorm weight shaped ``[K]``.
+        eps: Positive RMSNorm epsilon required with ``norm_weight``.
+        out: Optional output shaped like ``addend``; it may alias ``addend``.
+
+    Returns:
+        ``hidden_states @ weight.T + addend``, optionally written to ``out``.
+    """
+
+    m, n, k = _validate_fallback_projection(
+        hidden_states,
+        weight,
+        None,
+        name="Kimi K3 latent projection-add",
+    )
+    expected_shape = (m, n)
+    for name, tensor in (("addend", addend), ("out", out)):
+        if tensor is None:
+            continue
+        if (
+            tensor.shape != expected_shape
+            or tensor.dtype != hidden_states.dtype
+            or tensor.device != hidden_states.device
+            or tensor.stride(1) != 1
+        ):
+            raise ValueError(
+                f"Kimi K3 latent projection {name} must match the input and "
+                f"have shape {expected_shape} with unit inner stride"
+            )
+    if norm_weight is not None:
+        if (
+            norm_weight.shape != (k,)
+            or norm_weight.dtype != hidden_states.dtype
+            or norm_weight.device != hidden_states.device
+            or not norm_weight.is_contiguous()
+        ):
+            raise ValueError("Kimi K3 norm weight must match the latent input")
+        if eps is None or eps <= 0:
+            raise ValueError("Kimi K3 RMSNorm epsilon must be positive")
+        if (
+            Platform.get().is_cdna4
+            and hidden_states.is_cuda
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and k == KIMI3_LATENT_SIZE
+            and n % 32 == 0
+        ):
+            from tokenspeed_kernel_amd.ops.gfx950.gemm.fp16.rmsnorm_linear_add import (
+                gluon_rmsnorm_linear_add_gfx950,
+            )
+
+            return gluon_rmsnorm_linear_add_gfx950(
+                hidden_states,
+                norm_weight,
+                weight,
+                None,
+                addend,
+                eps=eps,
+                out=out,
+            )
+        source = hidden_states.float()
+        hidden_states = (
+            source
+            * torch.rsqrt(source.square().mean(dim=-1, keepdim=True) + eps)
+            * norm_weight.float()
+        ).to(hidden_states.dtype)
+    elif eps is not None:
+        raise ValueError("Kimi K3 RMSNorm epsilon requires a norm weight")
+    if out is None:
+        return torch.addmm(addend, hidden_states, weight.T)
+    if out.data_ptr() != addend.data_ptr():
+        out.copy_(addend)
+    out.addmm_(hidden_states, weight.T)
+    return out
+
+
 def kimi3_shared_situ_projection(
     hidden_states: torch.Tensor,
     gate_up_weight: torch.Tensor,
@@ -1009,6 +1101,7 @@ __all__ = [
     "KIMI3_SHARED_LOCAL_SIZE",
     "Kimi3MLAQKVGateProjection",
     "kimi3_latent_projection",
+    "kimi3_latent_projection_add",
     "kimi3_latent_projection_add3",
     "kimi3_mla_qkv_gate_projection",
     "kimi3_qkvfab_projection",

--- a/tokenspeed-kernel/test/ops/test_kimi3_projection_gfx950.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_projection_gfx950.py
@@ -188,6 +188,43 @@ def test_kimi3_rmsnorm_linear_add_matches_composed_and_captures(
     torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
 
 
+@pytest.mark.parametrize("num_tokens", [8, 16])
+def test_kimi3_rmsnorm_linear_add_shard_updates_strided_slice(
+    num_tokens: int,
+) -> None:
+    torch.manual_seed(41)
+    latent = torch.randn(num_tokens, 3584, device="cuda", dtype=torch.bfloat16)
+    norm_weight = torch.randn(3584, device="cuda", dtype=torch.bfloat16)
+    projection_weight = torch.randn(896, 3584, device="cuda", dtype=torch.bfloat16)
+    shared = torch.randn(num_tokens, 7168, device="cuda", dtype=torch.bfloat16)
+    output = shared[:, 896:1792]
+    addend = output.clone()
+    source = latent.float()
+    normalized = (
+        source
+        * torch.rsqrt(source.square().mean(dim=-1, keepdim=True) + 1e-6)
+        * norm_weight.float()
+    ).to(latent.dtype)
+    projected = torch.nn.functional.linear(normalized, projection_weight)
+    expected = (projected.float() + addend.float()).to(latent.dtype)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = tokenspeed_kernel.kimi3_latent_projection_add(
+            latent,
+            projection_weight,
+            output,
+            norm_weight=norm_weight,
+            eps=1e-6,
+            out=output,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
 def test_kimi3_latent_projection_rejects_forced_kernel_for_non_k3_shape() -> None:
     hidden_states = torch.empty(1, 128, device="cuda", dtype=torch.bfloat16)
     weight = torch.empty(64, 128, device="cuda", dtype=torch.bfloat16)


### PR DESCRIPTION
Summary

- enable column-sharded routed up-projection weights for gfx950 TP8/EP1
- reduce routed latents before projecting each local column shard for M>=8
- fold each shard into the shared partial so the final all-reduce assembles the full output

Validation result

This WIP is not ready to land: the intended M=8 crossover regresses full-model performance.

Exact parent `30cac366` → head `8ad030df`, 4K/1K TP8/EP1 CUDA graphs, median of three:

| M | Parent tok/s | Head tok/s | Change | Parent TPOT | Head TPOT |
|---:|---:|---:|---:|---:|---:|
| 8 | 312.48 | 272.01 | -13.0% | 23.196 ms | 25.688 ms |

The three head repetitions agree closely. The result indicates that the extra latent reduction plus sharded projection/final assembly costs more than the replicated tail it replaces at M=8. The M>=8 selector should not be enabled without a different implementation or a newly measured crossover.

Tests

- ordered projection-before-reduction behavior: 1 passed
- AMD TP8-only platform selection: 1 passed
- gfx950 strided shard update and CUDA-graph capture at M=8/16: 2 passed
- all 48 measured A/B requests completed with valid lengths

Stack

- depends on #1144

WIP blocker

- remove/disable the regressing runtime selection or rework the sharded tail and remeasure before landing