### PR TITLE
(WIP) perf(kimi3): enable batched AttnRes runtime fusion

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -2316,10 +2316,11 @@ class KimiLinearDecoderLayer(nn.Module):
             else None
         )
         attnres_partial_args = None
-        if next_mix is not None and self._hoist_next_mlp and num_tokens == 1:
+        if next_mix is not None and self._hoist_next_mlp:
             next_layer, _ = next_mix
             # This layer's attention projection writes both block partials
             # hoisted for the next layer, which consumes their scratch slots.
+            # Kernel availability below is the token-count capability gate.
             candidate_args = (
                 block_residual[:mlp_valid_blocks],
                 next_layer._mlp_wp,
@@ -2340,6 +2341,12 @@ class KimiLinearDecoderLayer(nn.Module):
                     self.k3_comm.state.attn_ar_fusion_ok
                     and num_tokens
                     <= global_server_args_dict["comm_fusion_max_num_tokens"]
+                )
+                or (
+                    # The gfx950 fused reducer consumes the AttnRes scratch
+                    # through M=16, so its producer stream must join first.
+                    current_platform().is_cdna4
+                    and num_tokens <= ATTNRES_STREAM_FORK_THRESHOLD
                 )
             )
         )

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -410,7 +410,7 @@ class K3AttnComm:
             )
             if residual_out is not None:
                 return residual_out, None
-        if combine is not None and prefix_sum is not None and num_tokens == 1:
+        if combine is not None and prefix_sum is not None and num_tokens > 0:
             scratch, _, _, out_norm_w, eps = combine
             if out_norm_w is not None:
                 from tokenspeed_kernel.ops.communication.triton import (

--- a/test/runtime/test_kimi_k3_attn_res.py
+++ b/test/runtime/test_kimi_k3_attn_res.py
@@ -76,6 +76,57 @@ def _reference_apply_attn_res(prefix_sum, block_residual, proj, norm):
 
 
 class AttnResTests(unittest.TestCase):
+    def test_batched_iris_reduce_consumes_attnres_combine(self):
+        import tokenspeed_kernel.ops.communication.triton as triton_comm
+
+        import tokenspeed.runtime.models.kimi_k3_comm as kimi_k3_comm
+
+        group = object()
+        state = SimpleNamespace(
+            attn_ar_fusion_ok=False,
+            mapping=SimpleNamespace(
+                nprocs_per_node=8,
+                attn=SimpleNamespace(tp_rank=0, tp_group=tuple(range(8))),
+            ),
+        )
+        comm = kimi_k3_comm.K3AttnComm(state)
+        partial = torch.randn(4, _HIDDEN, dtype=torch.bfloat16)
+        prefix = torch.randn_like(partial)
+        scratch = (object(), object(), object())
+        mlp_wp = torch.randn(_HIDDEN, dtype=torch.bfloat16)
+        out_weight = torch.randn(_HIDDEN, dtype=torch.bfloat16)
+        combine = (scratch, object(), object(), out_weight, _EPS)
+        expected_h = torch.randn_like(partial)
+        expected_residual = torch.randn_like(partial)
+
+        with (
+            mock.patch.object(kimi_k3_comm, "_get_process_group", return_value=group),
+            mock.patch.object(
+                triton_comm,
+                "allreduce_residual_attnres_combine_supported",
+                return_value=True,
+            ) as supported,
+            mock.patch.object(
+                triton_comm,
+                "allreduce_residual_attnres_combine",
+                return_value=(expected_h, expected_residual),
+            ) as fused,
+        ):
+            residual, hidden = comm.attn_reduce(
+                partial,
+                prefix,
+                combine,
+                mlp_wp=mlp_wp,
+            )
+
+        self.assertIs(residual, expected_residual)
+        self.assertIs(hidden, expected_h)
+        supported.assert_called_once()
+        self.assertIs(supported.call_args.args[0], partial)
+        self.assertIs(supported.call_args.args[1], prefix)
+        self.assertIs(supported.call_args.args[2], mlp_wp)
+        fused.assert_called_once()
+
     def test_torch_fallback_matches_reference(self):
         prefix_sum, block_residual, proj, norm = _make_inputs(17)
         got = torch_attn_res_fwd(


### PR DESCRIPTION
Summary

- allow the backend-selected fused AttnRes combine for supported multi-token decode batches
- hoist next-layer MLP/attention partials whenever the projection kernel reports support
- join the producer stream before gfx950 M<16 reductions that consume AttnRes scratch

Validation result

This WIP is not ready to land: activating the batched fusion regresses end-to-end decode even though the isolated kernel in #1142 is faster.

4K/1K TP8/EP1 CUDA graphs, median of three:

| M | Equivalent parent tok/s | Head tok/s | Change | Parent TPOT | Head TPOT |
|---:|---:|---:|---:|---:|---:|
| 2 | 103.64 | 93.99 | -9.3% | 18.621 ms | 20.308 ms |
| 4 | 185.64 | 172.06 | -7.3% | 20.380 ms | 21.459 ms |

The parent figures are the exact #1144 head. #1145 only selects its sharded tail at M>=8, so M=2/4 are unchanged at the #1146 parent boundary.

The likely issue is orchestration rather than fused-kernel latency: joining the producer stream and consuming AttnRes scratch removes overlap that the prior split path retained. Runtime activation should remain gated until the dependency/stream schedule is redesigned and reprofiled.

Tests

- batched runtime-dispatch test passes and confirms the fused Iris combine is selected when supported
- #1142 covers world-size-8 M=1/2/4/8/16 numerical correctness and CUDA graphs
- all 18 measured head requests completed with valid lengths

Stack

- depends on #1145

WIP blocker

- restore the runtime gate or recover the lost producer/consumer overlap before landing