### PR TITLE
perf(cache): sparsify and budget Kimi-K3 state cache

### DIFF
--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -147,11 +147,12 @@ Consumers outside the cache layer treat the ids as opaque.
 Logical width does not imply dense physical residency. Full-history KV and
 retained sliding-window rows materialize every block their kernels read, but a
 full-history snapshot-state prefill needs only its input checkpoint, final
-output checkpoint, and decode/overlap reservations. Its table therefore keeps
-absolute slot positions while representing skipped intermediate checkpoints as
-null holes (`0`). State consumers may gather only the declared input/output
-slots; compacting the row or publishing an unwritten intermediate checkpoint
-would break position identity.
+output checkpoint. The next decode admission allocates its destination after
+prefill scheduling and rolls the expired input page forward, including under
+overlap scheduling. Its table therefore keeps absolute slot positions while
+representing skipped intermediate checkpoints as null holes (`0`). State
+consumers may gather only the declared input/output slots; compacting the row or
+publishing an unwritten intermediate checkpoint would break position identity.
 
 ### Python runtime: maps logical to physical, perceives as little as possible
 

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -154,6 +154,12 @@ representing skipped intermediate checkpoints as null holes (`0`). State
 consumers may gather only the declared input/output slots; compacting the row or
 publishing an unwritten intermediate checkpoint would break position identity.
 
+Speculative KDA verification keeps its candidate recurrent states in a dense,
+graph-stable workspace outside the cache arena. The Kimi-K3 recipe reserves
+that workspace before sizing the arena (`max_bs * (draft_tokens + 1)` state
+rows), so two rolling persistent pages do not make speculative state memory
+disappear from the GPU budget.
+
 ### Python runtime: maps logical to physical, perceives as little as possible
 
 The Python side owns the translation from the scheduler's cache-block tables

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -409,6 +409,25 @@ from `_capacity_from_parents`, one monotonic binary search shared by all.
 `scheduler_limits` is the single place a recipe reads the scheduler's
 concurrency, so demand and capacity cannot size against different numbers.
 
+The runtime's global `max_num_seqs` is divided across attention DP ranks to
+produce each scheduler's rank-local `max_batch_size`. These values limit
+simultaneous sequence slots; they do **not** reserve enough history cache for
+that many maximum-length requests. Aggregate prompt and decode growth must
+still fit the recipe's reported token capacity. When that dynamic pool is
+overcommitted, admission can fail even though the batch still has a free
+sequence slot.
+
+For a fused scheduler without Host L2, such a failure may directly retract a
+resident request and release its Device pages. Direct retraction enters a
+capacity-drain phase: already-resident `Prefilling`, `PrefillDone`, and
+`Decoding` requests continue, while `Submitted` requests (including the
+requeued victim) cannot consume the released pages. Admission resumes
+automatically after that resident cohort finishes. This prevents an
+overcommitted workload from repeatedly rebuilding a prompt, decoding briefly,
+and retracting it again. Best-effort L2 writeback, PD Decode recovery, and
+ordinary capacity-fit continuous batching do not use this fused direct-drain
+path.
+
 ## Code placement
 
 * Prefix-matching code (prefix hashing, match/lookup, reuse boundaries) lives

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -144,6 +144,15 @@ entry *values*, however, are **`CacheBlock` ids** — handles to the physical
 storage the cache layer allocated. The scheduler owns allocation, so its output names that storage directly.
 Consumers outside the cache layer treat the ids as opaque.
 
+Logical width does not imply dense physical residency. Full-history KV and
+retained sliding-window rows materialize every block their kernels read, but a
+full-history snapshot-state prefill needs only its input checkpoint, final
+output checkpoint, and decode/overlap reservations. Its table therefore keeps
+absolute slot positions while representing skipped intermediate checkpoints as
+null holes (`0`). State consumers may gather only the declared input/output
+slots; compacting the row or publishing an unwritten intermediate checkpoint
+would break position identity.
+
 ### Python runtime: maps logical to physical, perceives as little as possible
 
 The Python side owns the translation from the scheduler's cache-block tables

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
@@ -328,8 +328,8 @@ class KimiK3Recipe(CacheRecipe):
         protected_pages = max_live_requests * math.ceil(
             depth * limits["decode_input_tokens"] / page_tokens
         )
-        scheduled_pages = math.ceil(
-            min(limits["max_scheduled_tokens"], token_capacity) / page_tokens
+        decode_reservation_pages = max_live_requests * math.ceil(
+            limits["decode_input_tokens"] / page_tokens
         )
         parents = 0
         for group_id, packing in layout.group_packing:
@@ -341,6 +341,10 @@ class KimiK3Recipe(CacheRecipe):
                     + protected_pages
                 )
             else:
-                child_pages = 2 * max_live_requests + scheduled_pages + protected_pages
+                # Sparse state prefill keeps input/output checkpoints and the
+                # first decode destination, independent of the chunk width.
+                child_pages = (
+                    2 * max_live_requests + decode_reservation_pages + protected_pages
+                )
             parents += math.ceil(child_pages / packing)
         return parents

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
@@ -328,9 +328,6 @@ class KimiK3Recipe(CacheRecipe):
         protected_pages = max_live_requests * math.ceil(
             depth * limits["decode_input_tokens"] / page_tokens
         )
-        decode_reservation_pages = max_live_requests * math.ceil(
-            limits["decode_input_tokens"] / page_tokens
-        )
         parents = 0
         for group_id, packing in layout.group_packing:
             if group_id == FULL_ATTENTION:
@@ -341,10 +338,7 @@ class KimiK3Recipe(CacheRecipe):
                     + protected_pages
                 )
             else:
-                # Sparse state prefill keeps input/output checkpoints and the
-                # first decode destination, independent of the chunk width.
-                child_pages = (
-                    2 * max_live_requests + decode_reservation_pages + protected_pages
-                )
+                # Snapshot state rolls between two pages per live request.
+                child_pages = 2 * max_live_requests
             parents += math.ceil(child_pages / packing)
         return parents

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
@@ -291,6 +291,23 @@ class KimiK3Recipe(CacheRecipe):
                 f"{len(layout.plane_bytes)}"
             )
 
+    # ---- extras ----
+
+    @override
+    def workspace_bytes(self) -> int:
+        """Dense KDA state rows staged by speculative target verification."""
+        if getattr(self.server_args, "speculative_algorithm", None) is None:
+            return 0
+        verify_rows = self.attn_config.max_bs * (
+            int(self.server_args.speculative_num_draft_tokens) + 1
+        )
+        return verify_rows * sum(
+            field.payload_bytes
+            for spec, fields in self.groups()
+            if spec.group_id != FULL_ATTENTION
+            for field in fields
+        )
+
     # ---- capacity: the scheduler's concurrency decides, then a search ----
 
     @override

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
@@ -216,16 +216,7 @@ def compute_cache_group_page_counts(
         # (the C++ side keys it the same way); V4's sliding-window state tail
         # buffers keep the sliding-window formula below.
         if spec.family == "state" and spec.retention == "full_history":
-            decode_reservation_pages = max_live_requests * _ceil_div(
-                decode_input_tokens, block_granularity
-            )
-            total = (
-                max_live_requests * 2
-                + decode_reservation_pages
-                + protected_pages
-                + _CACHE_GROUP_DUMMY_PAGES
-                + safety_margin
-            )
+            total = max_live_requests * 2 + _CACHE_GROUP_DUMMY_PAGES + safety_margin
         elif spec.retention == "full_history":
             full_pages = _ceil_div(max_total_tokens, block_granularity)
             total = (

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
@@ -216,24 +216,16 @@ def compute_cache_group_page_counts(
         # (the C++ side keys it the same way); V4's sliding-window state tail
         # buffers keep the sliding-window formula below.
         if spec.family == "state" and spec.retention == "full_history":
-            # State group: 2 live pages/request (the W=2 write window) +
-            # floor(T/P) snapshot pages (snapshots are bounded by the shared
-            # page-id space), capped at the full-history count.
-            full_history_total = (
-                _ceil_div(max_total_tokens, block_granularity)
-                + max_live_requests
-                + protected_pages
-                + _CACHE_GROUP_DUMMY_PAGES
-                + safety_margin
+            decode_reservation_pages = max_live_requests * _ceil_div(
+                decode_input_tokens, block_granularity
             )
-            state_total = (
+            total = (
                 max_live_requests * 2
-                + max_total_tokens // block_granularity
+                + decode_reservation_pages
                 + protected_pages
                 + _CACHE_GROUP_DUMMY_PAGES
                 + safety_margin
             )
-            total = min(state_total, full_history_total)
         elif spec.retention == "full_history":
             full_pages = _ceil_div(max_total_tokens, block_granularity)
             total = (

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -667,12 +667,12 @@ def _prepare_verify_workspace(
     config,
     backend,
     draft_backend,
-    is_qwen_gdn: bool,
+    uses_paged_state_verify: bool,
     is_inkling: bool,
     expected_bytes: int,
 ) -> None:
-    if is_qwen_gdn and expected_bytes:
-        model_name = "GDN"
+    if uses_paged_state_verify and expected_bytes:
+        model_name = "paged-state"
         actual_bytes = backend.linear_attn_backend.preallocate_verify_workspace(
             config.max_bs,
             int(server_args.speculative_num_draft_tokens),
@@ -968,7 +968,7 @@ def create_attn_components(
         config=config,
         backend=backend,
         draft_backend=draft_attn_backend,
-        is_qwen_gdn=use_cache_gdn,
+        uses_paged_state_verify=use_cache_gdn or use_cache_k3,
         is_inkling=use_cache_inkling,
         expected_bytes=fixed_workspace_bytes,
     )

--- a/test/runtime/conftest.py
+++ b/test/runtime/conftest.py
@@ -42,6 +42,8 @@ def kimi_recipe(
     context_len: int = 4096,
     decode_input_tokens: int = 1,
     overlap_schedule_depth: int = 0,
+    speculative_algorithm: str | None = None,
+    speculative_num_draft_tokens: int = 1,
 ):
     """A Kimi-K3 recipe over the reference config, with tiny scheduler limits."""
     from types import SimpleNamespace
@@ -73,7 +75,10 @@ def kimi_recipe(
     )
     return KimiK3Recipe(
         server_args=SimpleNamespace(
-            max_total_tokens=None, chunked_prefill_size=max_scheduled_tokens
+            max_total_tokens=None,
+            chunked_prefill_size=max_scheduled_tokens,
+            speculative_algorithm=speculative_algorithm,
+            speculative_num_draft_tokens=speculative_num_draft_tokens,
         ),
         model_config=SimpleNamespace(
             hf_config=SimpleNamespace(text_config=text_config)

--- a/test/runtime/test_gdn_state_paging.py
+++ b/test/runtime/test_gdn_state_paging.py
@@ -103,6 +103,11 @@ class ComputeStatePageIndicesTest(unittest.TestCase):
         self.assertEqual(state_in.tolist(), [5])
         self.assertEqual(state_out.tolist(), [8])
 
+    def test_sparse_prefill_ignores_intermediate_holes(self):
+        state_in, state_out = self._run([[7, 0, 0, 0, 9]], [4], [20])
+        self.assertEqual(state_in.tolist(), [7])
+        self.assertEqual(state_out.tolist(), [9])
+
     def test_batch_mixed(self):
         # Distinct rows per request: out pages are exclusive per batch (the scheduler
         # invariant the validate path enforces).

--- a/test/runtime/test_kimi_k3_cache_spec.py
+++ b/test/runtime/test_kimi_k3_cache_spec.py
@@ -79,6 +79,38 @@ def test_lcm_geometry_packs_two_kda_pages_at_tp16() -> None:
     assert conv.shape[0] == 3 * 96 * 128 // 16
 
 
+def test_speculative_verify_workspace_is_reserved_outside_the_arena() -> None:
+    recipe, _, layout = kimi_tp8_layout(
+        draft_layers=5,
+        max_bs=4,
+        speculative_algorithm="DSPARK",
+        speculative_num_draft_tokens=8,
+    )
+
+    # Four requests, each with one committed seed row and eight candidate rows,
+    # across all 69 target KDA layers.
+    expected_workspace_bytes = 2_022_174_720
+    assert recipe.workspace_bytes() == expected_workspace_bytes
+
+    setup = recipe.setup()
+    assert setup.fixed_workspace_bytes == expected_workspace_bytes
+    expected_parents = (
+        recipe.cache_budget_bytes - expected_workspace_bytes
+    ) // layout.lcm_block_bytes - 1
+    assert setup.spec.memory_plan.num_lcm_blocks == expected_parents
+
+
+def test_non_speculative_kimi_reserves_no_verify_workspace() -> None:
+    recipe, _, _ = kimi_tp8_layout(
+        draft_layers=5,
+        max_bs=4,
+        speculative_algorithm=None,
+        speculative_num_draft_tokens=8,
+    )
+
+    assert recipe.workspace_bytes() == 0
+
+
 def test_lcm_parent_demand_uses_per_group_packing() -> None:
     recipe, _, layout = kimi_tp8_layout(max_bs=1, max_scheduled_tokens=8_192)
 

--- a/test/runtime/test_kimi_k3_cache_spec.py
+++ b/test/runtime/test_kimi_k3_cache_spec.py
@@ -82,14 +82,38 @@ def test_lcm_geometry_packs_two_kda_pages_at_tp16() -> None:
 def test_lcm_parent_demand_uses_per_group_packing() -> None:
     recipe, _, layout = kimi_tp8_layout(max_bs=1, max_scheduled_tokens=8_192)
 
-    # 131_072 tokens at this concurrency needs exactly 284 parents; the search
-    # inverts that demand -- what 284 parents admit needs no more than 284,
+    # Sparse state prefill needs one input, one output, and one decode-reserve
+    # block per KDA group, independent of the 8K chunk width.
+    # The search inverts that demand -- what 95 parents admit needs no more,
     # and one parent fewer admits strictly less.
-    assert recipe.parents_needed(layout, 131_072) == 284
-    admitted = recipe.token_capacity(layout, 284)
+    assert recipe.parents_needed(layout, 131_072) == 95
+    admitted = recipe.token_capacity(layout, 95)
     assert admitted >= 131_072
-    assert recipe.parents_needed(layout, admitted) <= 284
-    assert recipe.token_capacity(layout, 283) < admitted
+    assert recipe.parents_needed(layout, admitted) <= 95
+    assert recipe.token_capacity(layout, 94) < admitted
+
+
+def test_sparse_state_parent_demand_tracks_decode_and_overlap_width() -> None:
+    baseline, _, layout = kimi_tp8_layout(
+        max_bs=3,
+        max_scheduled_tokens=8_192,
+        decode_input_tokens=128,
+        overlap_schedule_depth=0,
+    )
+    overlapped, _, _ = kimi_tp8_layout(
+        max_bs=3,
+        max_scheduled_tokens=8_192,
+        decode_input_tokens=128,
+        overlap_schedule_depth=1,
+    )
+
+    # Three KDA groups with packing 1: overlap protects one extra state block
+    # per live request in every group.
+    assert (
+        overlapped.parents_needed(layout, 131_072)
+        - baseline.parents_needed(layout, 131_072)
+        == 3 * 3
+    )
 
 
 def test_k3_merged_solve_with_draft_shares_page_ids():

--- a/test/runtime/test_kimi_k3_cache_spec.py
+++ b/test/runtime/test_kimi_k3_cache_spec.py
@@ -82,15 +82,15 @@ def test_lcm_geometry_packs_two_kda_pages_at_tp16() -> None:
 def test_lcm_parent_demand_uses_per_group_packing() -> None:
     recipe, _, layout = kimi_tp8_layout(max_bs=1, max_scheduled_tokens=8_192)
 
-    # Sparse state prefill needs one input, one output, and one decode-reserve
-    # block per KDA group, independent of the 8K chunk width.
-    # The search inverts that demand -- what 95 parents admit needs no more,
+    # Non-overlap sparse state prefill needs one input and one output block per
+    # KDA group; the next decode allocates its destination after completion.
+    # The search inverts that demand -- what 92 parents admit needs no more,
     # and one parent fewer admits strictly less.
-    assert recipe.parents_needed(layout, 131_072) == 95
-    admitted = recipe.token_capacity(layout, 95)
+    assert recipe.parents_needed(layout, 131_072) == 92
+    admitted = recipe.token_capacity(layout, 92)
     assert admitted >= 131_072
-    assert recipe.parents_needed(layout, admitted) <= 95
-    assert recipe.token_capacity(layout, 94) < admitted
+    assert recipe.parents_needed(layout, admitted) <= 92
+    assert recipe.token_capacity(layout, 91) < admitted
 
 
 def test_sparse_state_parent_demand_tracks_decode_and_overlap_width() -> None:
@@ -107,12 +107,12 @@ def test_sparse_state_parent_demand_tracks_decode_and_overlap_width() -> None:
         overlap_schedule_depth=1,
     )
 
-    # Three KDA groups with packing 1: overlap protects one extra state block
-    # per live request in every group.
+    # KDA state uses the same two rolling pages with or without overlap. The
+    # small full-attention protection term still fits in the same packed parent.
     assert (
         overlapped.parents_needed(layout, 131_072)
         - baseline.parents_needed(layout, 131_072)
-        == 3 * 3
+        == 0
     )
 
 

--- a/test/runtime/test_unified_kv_slab_pool.py
+++ b/test/runtime/test_unified_kv_slab_pool.py
@@ -468,8 +468,8 @@ class MLAPoolAllocationHookTest(unittest.TestCase):
 class StateCacheGroupPageCountTest(unittest.TestCase):
     """compute_cache_group_page_counts: the family="state" branch is
     positive and bounded by the full-history formula for the same inputs
-    (state rows keep <= 2 live pages per request -- the W=2 write window --
-    and snapshots are bounded by the shared page-id space).
+    (sparse state prefill keeps input/output checkpoints plus decode and
+    overlap reservations, independent of the prefill chunk width).
     The direct-loaded module still imports ceil_div from the real package
     at call time, so this skips on a bare interpreter.
     """
@@ -501,12 +501,12 @@ class StateCacheGroupPageCountTest(unittest.TestCase):
         self.assertGreater(counts["linear_attention"], 0)
         self.assertLessEqual(counts["linear_attention"], counts["full_attention"])
 
-    def test_state_branch_departs_from_full_history_formula(self):
-        # B=0 with a non-page-multiple T distinguishes the state branch
-        # (floor(T/P) + 0 live) from the full-history one (ceil(T/P) + B):
-        # 1000/16 -> state 62+1=63 < full 63+1=64.
-        counts = self._counts(max_live_requests=0, max_total_tokens=1000)
-        self.assertLess(counts["linear_attention"], counts["full_attention"])
+    def test_state_branch_is_independent_of_chunk_and_total_token_width(self):
+        small = self._counts(max_scheduled_tokens=16, max_total_tokens=128)
+        large = self._counts(max_scheduled_tokens=4096, max_total_tokens=1 << 20)
+        self.assertEqual(small["linear_attention"], large["linear_attention"])
+        # R=2: two input/output blocks + one decode reservation each + dummy.
+        self.assertEqual(small["linear_attention"], 2 * 2 + 2 + 1)
 
 
 class CachePoolFieldBindingTest(unittest.TestCase):

--- a/test/runtime/test_unified_kv_slab_pool.py
+++ b/test/runtime/test_unified_kv_slab_pool.py
@@ -468,8 +468,8 @@ class MLAPoolAllocationHookTest(unittest.TestCase):
 class StateCacheGroupPageCountTest(unittest.TestCase):
     """compute_cache_group_page_counts: the family="state" branch is
     positive and bounded by the full-history formula for the same inputs
-    (sparse state prefill keeps input/output checkpoints plus decode and
-    overlap reservations, independent of the prefill chunk width).
+    (sparse state uses two rolling checkpoints independent of overlap and
+    prefill chunk width).
     The direct-loaded module still imports ceil_div from the real package
     at call time, so this skips on a bare interpreter.
     """
@@ -505,8 +505,13 @@ class StateCacheGroupPageCountTest(unittest.TestCase):
         small = self._counts(max_scheduled_tokens=16, max_total_tokens=128)
         large = self._counts(max_scheduled_tokens=4096, max_total_tokens=1 << 20)
         self.assertEqual(small["linear_attention"], large["linear_attention"])
-        # R=2: two input/output blocks + one decode reservation each + dummy.
-        self.assertEqual(small["linear_attention"], 2 * 2 + 2 + 1)
+        # R=2: two input/output blocks each plus one allocator dummy page.
+        self.assertEqual(small["linear_attention"], 2 * 2 + 1)
+
+    def test_state_branch_is_independent_of_overlap(self):
+        baseline = self._counts(overlap_schedule_depth=0, decode_input_tokens=1)
+        overlapped = self._counts(overlap_schedule_depth=1, decode_input_tokens=1)
+        self.assertEqual(baseline["linear_attention"], overlapped["linear_attention"])
 
 
 class CachePoolFieldBindingTest(unittest.TestCase):

--- a/tokenspeed-scheduler/csrc/cache/allocator/group_allocator.h
+++ b/tokenspeed-scheduler/csrc/cache/allocator/group_allocator.h
@@ -78,12 +78,17 @@ public:
     void ClaimHitBlocks(BlockTable& table, PrefixMatch&& hit) {
         _assert(table.blocks_.empty(), "ClaimHitBlocks requires a fresh (empty) table");
         table.blocks_ = std::move(hit.blocks);
+        while (table.reclaimed_prefix_blocks_ < table.NumBlocks() &&
+               !table.blocks_[static_cast<std::size_t>(table.reclaimed_prefix_blocks_)]) {
+            ++table.reclaimed_prefix_blocks_;
+        }
     }
 
     // Executes a GroupGeometry plan: acquires plan.num_blocks fresh blocks,
     // places them (dense append or sparse suffix), and stores the planned
     // bookkeeping. Returns false without mutation when the pool is short.
     bool Acquire(BlockPool& pool, BlockTable& table, const AcquirePlan& plan) {
+        const std::int32_t old_num_blocks = table.NumBlocks();
         std::vector<CacheBlockRef> block_refs;
         if (plan.num_blocks > 0) {
             block_refs = pool.AcquireBlocks(group_id_, cache_blocks_per_lcm_block_, plan.num_blocks);
@@ -101,6 +106,9 @@ public:
             _assert(plan.suffix_start + plan.num_blocks <= plan.table_blocks_after,
                     "sparse suffix exceeds the planned table size");
             table.blocks_.resize(static_cast<std::size_t>(plan.table_blocks_after));
+            if (old_num_blocks == 0) {
+                table.reclaimed_prefix_blocks_ = plan.suffix_start;
+            }
             for (std::size_t i = 0; i < block_refs.size(); ++i) {
                 table.blocks_[static_cast<std::size_t>(plan.suffix_start) + i] = std::move(block_refs[i]);
             }
@@ -142,12 +150,10 @@ public:
     // How many blocks expired is retention policy (GroupGeometry).
     void ReclaimExpired(BlockPool& /*pool*/, BlockTable& table, std::int32_t num_expired_blocks) {
         const std::int32_t expired = std::min(num_expired_blocks, table.NumBlocks());
-        for (std::int32_t i = expired - 1; i >= 0; --i) {
-            CacheBlockRef old = table.EvictToNull(i);
-            if (!old) {
-                break;  // already null -> earlier slots are null too
-            }
+        for (std::int32_t i = table.reclaimed_prefix_blocks_; i < expired; ++i) {
+            table.EvictToNull(i).reset();
         }
+        table.reclaimed_prefix_blocks_ = std::max(table.reclaimed_prefix_blocks_, expired);
     }
 
     // Only blocks uniquely owned by this table reach the free list, so shared ones don't count.
@@ -155,10 +161,10 @@ public:
                                      std::int32_t num_expired_blocks, bool count_uncached) const {
         const std::int32_t expired = std::min(num_expired_blocks, table.NumBlocks());
         std::int32_t freed = 0;
-        for (std::int32_t i = expired - 1; i >= 0; --i) {
+        for (std::int32_t i = table.ReclaimedPrefixBlocks(); i < expired; ++i) {
             const CacheBlockRef& block = table.Blocks()[static_cast<std::size_t>(i)];
             if (!block) {
-                break;  // already null -> earlier slots are null too
+                continue;
             }
             const bool cached = index.Contains(block);
             const bool only_table_and_cache_owners = cached && block.use_count() == 2;
@@ -174,10 +180,10 @@ public:
         std::span<const CacheBlockLocation> released_locations) const {
         const std::int32_t expired = std::min(num_expired_blocks, table.NumBlocks());
         std::vector<CacheBlockLocation> locations;
-        for (std::int32_t i = expired - 1; i >= 0; --i) {
+        for (std::int32_t i = table.ReclaimedPrefixBlocks(); i < expired; ++i) {
             const CacheBlockRef& block = table.Blocks()[static_cast<std::size_t>(i)];
             if (!block) {
-                break;
+                continue;
             }
             const bool cached = index.Contains(block);
             const std::uint32_t released_owners =
@@ -203,6 +209,7 @@ public:
         }
         table.blocks_.clear();
         table.available_tokens_ = 0;
+        table.reclaimed_prefix_blocks_ = 0;
     }
 
 private:

--- a/tokenspeed-scheduler/csrc/cache/core/block_table.h
+++ b/tokenspeed-scheduler/csrc/cache/core/block_table.h
@@ -44,6 +44,7 @@ public:
     std::span<const CacheBlockRef> Blocks() const noexcept { return blocks_; }
     std::int32_t NumBlocks() const { return static_cast<std::int32_t>(blocks_.size()); }
     std::int32_t AvailableTokens() const { return available_tokens_; }
+    std::int32_t ReclaimedPrefixBlocks() const { return reclaimed_prefix_blocks_; }
 
     CacheBlockRef EvictToNull(std::int32_t index) {
         _assert(0 <= index && index < static_cast<std::int32_t>(blocks_.size()), "EvictToNull index out of range");
@@ -59,6 +60,10 @@ private:
     // Unconsumed capacity at the logical tail. This may span multiple blocks
     // when admission preallocates a later decode/MTP step.
     std::int32_t available_tokens_{0};
+    // Slots below this monotonic frontier have already released their request
+    // ownership. Sparse state tables may contain holes between live islands,
+    // so reclaim cannot infer this frontier from the first null slot.
+    std::int32_t reclaimed_prefix_blocks_{0};
 };
 
 // LCM ownership ids for scheduler accounting/debugging. Kernel-facing page

--- a/tokenspeed-scheduler/csrc/cache/core/cache_types.h
+++ b/tokenspeed-scheduler/csrc/cache/core/cache_types.h
@@ -98,7 +98,8 @@ struct GroupDemand {
     std::int32_t reserve_tokens{0};
     // -1 materializes the ordinary dense suffix. A non-negative value keeps
     // earlier logical slots as null holes and materializes only this suffix.
-    // Decode-side PD uses this for latest snapshots and retained sliding tails.
+    // Snapshot-state local prefill uses an absolute endpoint here; Decode-side
+    // PD also uses it for latest snapshots and retained sliding tails.
     std::int32_t materialized_suffix_start{-1};
 };
 

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -543,6 +543,9 @@ void Scheduler::retractForCapacity(PlanBuildContext& context, const std::vector<
         return;
     }
     request_to_retract->Apply(fsm::RetractEvent{&coordinator_});
+    if (!config_.HasHostCache()) {
+        fused_capacity_drain_ = true;
+    }
     spdlog::info("[Scheduler] retract: released request {} ({} tokens) for cache capacity", request_to_retract->Id(),
                  request_to_retract->TokenSize());
 }
@@ -561,6 +564,14 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
         Request* request = findRequest(*recovery_barrier_);
         if (request == nullptr || request->Is<fsm::Finished>() || request->Is<fsm::Retracted>()) {
             recovery_barrier_.reset();
+        }
+    }
+    if (fused_capacity_drain_) {
+        const bool has_resident = std::ranges::any_of(candidates, [](const Request* request) {
+            return request->Is<fsm::Prefilling>() || request->Is<fsm::PrefillDone>() || request->Is<fsm::Decoding>();
+        });
+        if (!has_resident) {
+            fused_capacity_drain_ = false;
         }
     }
     const auto priority = [this](const Request* request) {
@@ -654,6 +665,9 @@ std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Schedul
     for (Request* request : candidates) {
         if (token_budget <= 0 || operations.size() == static_cast<std::size_t>(config_.max_batch_size)) {
             break;
+        }
+        if (fused_capacity_drain_ && request->Is<fsm::Submitted>()) {
+            continue;
         }
         if (build_prefill_handoff_batch && !request->Is<fsm::PrefillDone>()) {
             break;

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -64,6 +64,20 @@ std::vector<GroupDemand> makeGroupDemands(std::vector<BlockTable>& tables, Group
     return demands;
 }
 
+void makeSnapshotStatePrefillSparse(std::span<GroupDemand> demands, std::span<const CacheGroupConfig> cache_groups,
+                                    const CacheCoordinator& coordinator, std::int32_t after_tokens) {
+    _assert(demands.size() == cache_groups.size(), "demands/cache groups size mismatch");
+    _assert(after_tokens > 0, "snapshot-state prefill requires a positive endpoint");
+    for (std::size_t i = 0; i < demands.size(); ++i) {
+        if (!cache_groups[i].IsSnapshotStateGroup()) {
+            continue;
+        }
+        const std::int32_t block_granularity = coordinator.GroupBlockGranularity(static_cast<std::int32_t>(i));
+        demands[i].num_tokens = after_tokens;
+        demands[i].materialized_suffix_start = (after_tokens - 1) / block_granularity;
+    }
+}
+
 void appendCompletedPrefixHashes(std::vector<std::string>& prefix_hashes,
                                  const std::vector<std::span<const std::int32_t>>& prefix_pages,
                                  std::int32_t filled_prefix_pages) {
@@ -275,13 +289,16 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
 
     const bool completes_prefill = tokens_this_round == unscheduled;
     const std::int32_t decode_reserve = completes_prefill ? decode_input_tokens : 0;
-    std::vector<BlockTable> tables(static_cast<std::size_t>(coordinator_.NumGroups()));
-    std::vector<GroupDemand> demands =
-        makeGroupDemands(tables, GroupDemand{.num_tokens = tokens_this_round, .reserve_tokens = decode_reserve});
-
     const fsm::PrefillSource source = config_.role == Role::kD && request->Is<fsm::Submitted>()
                                           ? fsm::PrefillSource::kRemote
                                           : fsm::PrefillSource::kLocal;
+    std::vector<BlockTable> tables(static_cast<std::size_t>(coordinator_.NumGroups()));
+    std::vector<GroupDemand> demands =
+        makeGroupDemands(tables, GroupDemand{.num_tokens = tokens_this_round, .reserve_tokens = decode_reserve});
+    if (source == fsm::PrefillSource::kLocal) {
+        makeSnapshotStatePrefillSparse(demands, config_.cache_groups, coordinator_, hit_tokens + tokens_this_round);
+    }
+
     if (config_.enable_pd_cache && source == fsm::PrefillSource::kRemote) {
         for (std::size_t i = 0; i < demands.size(); ++i) {
             const CacheGroupConfig& group = config_.cache_groups[i];
@@ -298,7 +315,6 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
             }
         }
     }
-
     std::vector<CacheKey> event_keys = registerKvEventPrefixPages(*request, match.candidate_prefix_hashes, 0);
     std::optional<CacheCoordinator::AdmissionResult> admission = admit(context, std::move(match.probe), demands);
     if (!admission) {
@@ -363,6 +379,9 @@ std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
                                      .num_computed_tokens = num_computed_tokens,
                                      .reserve_tokens = decode_reserve,
                                  });
+    if (request->PrefillSource() == fsm::PrefillSource::kLocal) {
+        makeSnapshotStatePrefillSparse(demands, config_.cache_groups, coordinator_, first_pos + tokens_this_round);
+    }
     if (!admitWithKvEventTracking(context, *request, cache_progress, completed.first_new_prefix_page, demands)) {
         context.capacity_blocker = request->Id();
         return std::nullopt;

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -78,6 +78,16 @@ void makeSnapshotStatePrefillSparse(std::span<GroupDemand> demands, std::span<co
     }
 }
 
+void deferSnapshotStateDecodeReservation(std::span<GroupDemand> demands,
+                                         std::span<const CacheGroupConfig> cache_groups) {
+    _assert(demands.size() == cache_groups.size(), "demands/cache groups size mismatch");
+    for (std::size_t i = 0; i < demands.size(); ++i) {
+        if (cache_groups[i].IsSnapshotStateGroup()) {
+            demands[i].reserve_tokens = 0;
+        }
+    }
+}
+
 void appendCompletedPrefixHashes(std::vector<std::string>& prefix_hashes,
                                  const std::vector<std::span<const std::int32_t>>& prefix_pages,
                                  std::int32_t filled_prefix_pages) {
@@ -315,6 +325,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
             }
         }
     }
+    deferSnapshotStateDecodeReservation(demands, config_.cache_groups);
     std::vector<CacheKey> event_keys = registerKvEventPrefixPages(*request, match.candidate_prefix_hashes, 0);
     std::optional<CacheCoordinator::AdmissionResult> admission = admit(context, std::move(match.probe), demands);
     if (!admission) {
@@ -382,6 +393,7 @@ std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
     if (request->PrefillSource() == fsm::PrefillSource::kLocal) {
         makeSnapshotStatePrefillSparse(demands, config_.cache_groups, coordinator_, first_pos + tokens_this_round);
     }
+    deferSnapshotStateDecodeReservation(demands, config_.cache_groups);
     if (!admitWithKvEventTracking(context, *request, cache_progress, completed.first_new_prefix_page, demands)) {
         context.capacity_blocker = request->Id();
         return std::nullopt;

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -122,14 +122,10 @@ std::int64_t Scheduler::singleRequestLcmBlocksRequired(std::int32_t token_limit)
         const CacheGroupConfig& group = config_.cache_groups[static_cast<std::size_t>(i)];
         const auto local_prefill_peak = [&] {
             if (group.IsSnapshotStateGroup()) {
-                if (max_prompt_tokens == 0) {
-                    return ceilDiv(decode_width + protected_tokens, block_granularity);
-                }
-                const std::int64_t output_and_reservations =
-                    1 + ceilDiv(decode_width + protected_tokens, block_granularity);
+                if (token_limit == 0) return std::int64_t{0};
                 const std::int64_t input_lookback =
                     max_prompt_tokens > chunk_tokens ? coordinator_.GroupBoundaryLookbackPages(i) : 0;
-                return input_lookback + output_and_reservations;
+                return std::max<std::int64_t>(2, input_lookback + 1);
             }
             // Across every prompt up to max_prompt_tokens, retain the largest
             // resident window seen by either the first chunk or a later chunk.
@@ -151,11 +147,7 @@ std::int64_t Scheduler::singleRequestLcmBlocksRequired(std::int32_t token_limit)
             const bool latest_snapshot =
                 config_.enable_pd_cache && group.transfer_policy == CacheTransferPolicy::LatestSnapshot;
             if (latest_snapshot) {
-                // The final prompt page may be full, so a non-zero decode
-                // reservation can span one more page than its own page count.
-                const std::int64_t reserved_tokens = decode_width + protected_tokens;
-                const std::int64_t snapshot_pages =
-                    reserved_tokens == 0 ? 1 : 1 + ceilDiv(reserved_tokens, block_granularity);
+                const std::int64_t snapshot_pages = token_limit == 0 ? 0 : 1;
                 // A retracted Decode request may recover by locally
                 // recomputing its suffix. Old State checkpoints are
                 // evictable, but one recovery chunk and its lookback must fit.

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -119,7 +119,18 @@ std::int64_t Scheduler::singleRequestLcmBlocksRequired(std::int32_t token_limit)
     std::vector<std::int64_t> group_pages(static_cast<std::size_t>(coordinator_.NumGroups()));
     for (std::int32_t i = 0; i < coordinator_.NumGroups(); ++i) {
         const std::int64_t block_granularity = coordinator_.GroupBlockGranularity(i);
+        const CacheGroupConfig& group = config_.cache_groups[static_cast<std::size_t>(i)];
         const auto local_prefill_peak = [&] {
+            if (group.IsSnapshotStateGroup()) {
+                if (max_prompt_tokens == 0) {
+                    return ceilDiv(decode_width + protected_tokens, block_granularity);
+                }
+                const std::int64_t output_and_reservations =
+                    1 + ceilDiv(decode_width + protected_tokens, block_granularity);
+                const std::int64_t input_lookback =
+                    max_prompt_tokens > chunk_tokens ? coordinator_.GroupBoundaryLookbackPages(i) : 0;
+                return input_lookback + output_and_reservations;
+            }
             // Across every prompt up to max_prompt_tokens, retain the largest
             // resident window seen by either the first chunk or a later chunk.
             const std::int64_t first_prompt = std::min(max_prompt_tokens, chunk_tokens);
@@ -137,7 +148,6 @@ std::int64_t Scheduler::singleRequestLcmBlocksRequired(std::int32_t token_limit)
         if (coordinator_.GroupIsPrefixClosed(i)) {
             child_pages = ceilDiv(static_cast<std::int64_t>(token_limit) + protected_tokens, block_granularity);
         } else if (config_.role == Role::kD) {
-            const CacheGroupConfig& group = config_.cache_groups[static_cast<std::size_t>(i)];
             const bool latest_snapshot =
                 config_.enable_pd_cache && group.transfer_policy == CacheTransferPolicy::LatestSnapshot;
             if (latest_snapshot) {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -171,6 +171,7 @@ private:
     std::unordered_set<std::string> pd_transfer_pins_;
     std::deque<std::string> recovery_queue_;
     std::optional<std::string> recovery_barrier_;
+    bool fused_capacity_drain_{false};
 
     std::unordered_map<std::string, std::unique_ptr<Request>> requests_;
     std::vector<KvCacheEvent> kv_events_;

--- a/tokenspeed-scheduler/python/tests/test_kv_cache.py
+++ b/tokenspeed-scheduler/python/tests/test_kv_cache.py
@@ -199,23 +199,24 @@ def _make_k3_128k_config(num_device_pages: int) -> ts.SchedulerConfig:
 
 
 def test_k3_reports_group_aware_single_request_capacity() -> None:
-    # Each State group peaks at one lookback page plus 64 chunk pages and a
-    # one-token decode reserve: 66 parents. The three groups therefore leave
-    # 86 of the 284 usable parents for Full KV.
-    # K_full=12 and P=128 therefore expose 86 * 12 * 128 tokens.
+    # Each sparse State group needs two rolling checkpoints. The three groups
+    # therefore leave 278 of the 284 usable parents for Full KV.
+    # K_full=12 and P=128 expose 278 * 12 * 128 tokens.
     scheduler = ts.Scheduler(_make_k3_128k_config(285))
-    assert scheduler.max_single_request_tokens() == 132_096
+    assert scheduler.max_single_request_tokens() == 427_008
 
 
 def test_k3_128k_requires_group_aware_shared_pool_geometry() -> None:
     prompt = _spec("128k", list(range(131_072)))
 
-    undersized = ts.Scheduler(_make_k3_128k_config(284))
+    # Six State parents plus 86 Full parents admit 128K; one fewer Full parent
+    # is 512 tokens short because each Full parent carries 12 * 128 tokens.
+    undersized = ts.Scheduler(_make_k3_128k_config(92))
     assert undersized.max_single_request_tokens() < 131_072
 
-    corrected = ts.Scheduler(_make_k3_128k_config(285))
+    corrected = ts.Scheduler(_make_k3_128k_config(93))
     before = corrected.available_kv_pages()
-    assert before == 284
+    assert before == 92
     corrected.submit_requests([prompt])
     completed_tokens = 0
     for chunk in range(32):
@@ -329,9 +330,17 @@ def test_k3_readmit_rebuilds_all_four_tables_and_restores_pages() -> None:
 
         tail = row[prefix_slots:]
         assert len(tail) == 2
-        assert all(page > 0 for page in tail)
         group_tail = _positive_pages(tail)
-        assert len(group_tail) == 2
+        if group_id == K3_GROUP_IDS[0]:
+            # Full history remains dense.
+            assert all(page > 0 for page in tail)
+            assert len(group_tail) == 2
+        else:
+            # Sparse State recovery materializes only the endpoint checkpoint;
+            # the first logical tail slot remains a null hole.
+            assert tail[0] == 0
+            assert tail[1] > 0
+            assert len(group_tail) == 1
         fresh_tail_entries.extend(group_tail)
 
     assert len(set(all_positive_entries)) == len(all_positive_entries)

--- a/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
@@ -3282,6 +3282,44 @@ TEST(DecodeDestinationTest, AdmitMaterializesOnlyRequestedStateSuffix) {
     coordinator.Free(tables);
 }
 
+TEST(SnapshotStateSparsePrefillTest, ReclaimsOldInputAcrossIntermediateHoles) {
+    BlockPool pool(/*num_lcm_blocks=*/4);
+    std::vector<CacheGroupSpec> specs = {
+        {.kind = AttnKind::kMambaState, .sliding_window = 0, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, /*prefix_granularity=*/2, pool);
+    std::vector<BlockTable> tables(coordinator.NumGroups());
+
+    auto admit_endpoint = [&](std::int32_t before, std::int32_t after) {
+        std::vector<GroupDemand> demands{{
+            .table = &tables[0],
+            .num_tokens = after,
+            .num_computed_tokens = before,
+            .materialized_suffix_start = (after - 1) / 2,
+        }};
+        ASSERT_TRUE(coordinator.Admit(coordinator.ProbePrefix({}), demands));
+    };
+
+    admit_endpoint(/*before=*/0, /*after=*/8);
+    ASSERT_EQ(tables[0].NumBlocks(), 4);
+    EXPECT_EQ(tables[0].ReclaimedPrefixBlocks(), 3);
+    EXPECT_TRUE(tables[0].Blocks()[3]);
+
+    admit_endpoint(/*before=*/8, /*after=*/16);
+    ASSERT_EQ(tables[0].NumBlocks(), 8);
+    EXPECT_TRUE(tables[0].Blocks()[3]);
+    EXPECT_TRUE(tables[0].Blocks()[7]);
+    EXPECT_EQ(pool.NumEmptyLcmBlocks(), 2);
+
+    admit_endpoint(/*before=*/16, /*after=*/24);
+    ASSERT_EQ(tables[0].NumBlocks(), 12);
+    EXPECT_FALSE(tables[0].Blocks()[3]);
+    EXPECT_TRUE(tables[0].Blocks()[7]);
+    EXPECT_TRUE(tables[0].Blocks()[11]);
+    EXPECT_EQ(tables[0].ReclaimedPrefixBlocks(), 7);
+    EXPECT_EQ(pool.NumEmptyLcmBlocks(), 2);
+}
+
 TEST(DecodeDestinationTest, HistoryGroupsDeterminePrefixAndStateGetsAlignedHoles) {
     BlockPool pool(/*num_lcm_blocks=*/8);
     std::vector<CacheGroupSpec> specs = {

--- a/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
@@ -192,6 +192,37 @@ TEST_F(MambaChunkAlignmentSuite, PartialPrefillEndsAtStatePageBoundary) {
     }
 }
 
+class MambaSparsePrefillSuite : public MambaChunkAlignmentSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = MambaChunkAlignmentSuite::MakeConfig();
+        cfg.max_scheduled_tokens = 12;
+        return cfg;
+    }
+};
+
+TEST_F(MambaSparsePrefillSuite, LongLocalChunkMaterializesOnlyStateOutputAndDecodeReserve) {
+    Submit(MakeRequestSpec("r1", /*num_pages=*/3));  // 12 tokens
+
+    ExecutionPlan plan = PlanOnce();
+    const ForwardBatch* op = FindForwardBatch(plan);
+    ASSERT_NE(op, nullptr);
+    ASSERT_EQ(op->input_lengths, std::vector<std::int32_t>{12});
+
+    EXPECT_EQ(RealPages(op->block_tables.at("full")).size(), 4u);
+
+    const auto& state = op->block_tables.at("state").at(0);
+    ASSERT_EQ(state.size(), 4u);
+    EXPECT_EQ(state[0], 0);
+    EXPECT_EQ(state[1], 0);
+    EXPECT_GT(state[2], 0);  // final prefill checkpoint
+    EXPECT_GT(state[3], 0);  // first decode reservation
+    EXPECT_EQ(RealPages(op->block_tables.at("state")).size(), 2u);
+
+    ASSERT_EQ(plan.pages_to_zero.count("state"), 1u);
+    EXPECT_EQ(plan.pages_to_zero.at("state").size(), 2u);
+}
+
 class MambaMixedBudgetSuite : public MambaChunkAlignmentSuite {
 protected:
     SchedulerConfig MakeConfig() override {

--- a/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
@@ -201,7 +201,7 @@ protected:
     }
 };
 
-TEST_F(MambaSparsePrefillSuite, LongLocalChunkMaterializesOnlyStateOutputAndDecodeReserve) {
+TEST_F(MambaSparsePrefillSuite, LocalChunkDefersStateDecodeReservationUntilCompletion) {
     Submit(MakeRequestSpec("r1", /*num_pages=*/3));  // 12 tokens
 
     ExecutionPlan plan = PlanOnce();
@@ -212,15 +212,52 @@ TEST_F(MambaSparsePrefillSuite, LongLocalChunkMaterializesOnlyStateOutputAndDeco
     EXPECT_EQ(RealPages(op->block_tables.at("full")).size(), 4u);
 
     const auto& state = op->block_tables.at("state").at(0);
-    ASSERT_EQ(state.size(), 4u);
+    ASSERT_EQ(state.size(), 3u);
     EXPECT_EQ(state[0], 0);
     EXPECT_EQ(state[1], 0);
     EXPECT_GT(state[2], 0);  // final prefill checkpoint
-    EXPECT_GT(state[3], 0);  // first decode reservation
-    EXPECT_EQ(RealPages(op->block_tables.at("state")).size(), 2u);
+    EXPECT_EQ(RealPages(op->block_tables.at("state")).size(), 1u);
 
     ASSERT_EQ(plan.pages_to_zero.count("state"), 1u);
-    EXPECT_EQ(plan.pages_to_zero.at("state").size(), 2u);
+    EXPECT_EQ(plan.pages_to_zero.at("state").size(), 1u);
+
+    SendForwardDone("r1", {42});
+    ExecutionPlan decode_plan = PlanOnce();
+    const ForwardBatch* decode = FindForwardBatch(decode_plan);
+    ASSERT_NE(decode, nullptr);
+    const auto& decode_state = decode->block_tables.at("state").at(0);
+    ASSERT_EQ(decode_state.size(), 4u);
+    EXPECT_GT(decode_state[2], 0);
+    EXPECT_GT(decode_state[3], 0);
+    ASSERT_EQ(decode_plan.pages_to_zero.count("state"), 1u);
+    EXPECT_EQ(decode_plan.pages_to_zero.at("state").size(), 1u);
+}
+
+class MambaOverlapRollingStateSuite : public MambaSparsePrefillSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = MambaSparsePrefillSuite::MakeConfig();
+        cfg.overlap_schedule_depth = 1;
+        return cfg;
+    }
+};
+
+TEST_F(MambaOverlapRollingStateSuite, FinalPrefillUsesInputAndOutputWithoutDecodeReserve) {
+    Submit(MakeRequestSpec("r1", /*num_pages=*/4));  // 16 tokens
+
+    ASSERT_NE(FindForwardBatch(PlanOnce()), nullptr);
+    ExecutionPlan final_prefill = PlanOnce();
+    const ForwardBatch* op = FindForwardBatch(final_prefill);
+    ASSERT_NE(op, nullptr);
+    ASSERT_EQ(op->input_lengths, std::vector<std::int32_t>{4});
+
+    const auto& state = op->block_tables.at("state").at(0);
+    ASSERT_EQ(state.size(), 4u);
+    EXPECT_EQ(state[0], 0);
+    EXPECT_EQ(state[1], 0);
+    EXPECT_GT(state[2], 0);  // rolling input
+    EXPECT_GT(state[3], 0);  // final prefill output
+    EXPECT_EQ(RealPages(op->block_tables.at("state")).size(), 2u);
 }
 
 class MambaMixedBudgetSuite : public MambaChunkAlignmentSuite {

--- a/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
@@ -1239,6 +1239,58 @@ TEST_F(CapacityBlockSuite, RetractsLargestRunningRequestImmediately) {
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), 12);
 }
 
+class MambaFusedRetractionDrainSuite : public MambaSparsePrefillSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = MambaSparsePrefillSuite::MakeConfig();
+        cfg.device_allocator.total_pages = 9;
+        cfg.host_allocator.total_pages = 9;
+        cfg.max_scheduled_tokens = 64;
+        for (auto& group : cfg.cache_groups) {
+            group.total_pages = cfg.device_allocator.total_pages;
+        }
+        return cfg;
+    }
+};
+
+TEST_F(MambaFusedRetractionDrainSuite, RetractionDrainsResidentBeforeReadmittingVictim) {
+    ASSERT_EQ(scheduler_->PoolFreeBlocks(), 8);
+
+    Submit(MakeRequestSpec("a", /*num_pages=*/2));
+    Submit(MakeRequestSpec("b", /*num_pages=*/2, /*start=*/101));
+    Submit(MakeRequestSpec("c", /*num_pages=*/2, /*start=*/201));
+
+    ExecutionPlan prefill = PlanOnce();
+    const ForwardBatch* prefill_op = FindForwardBatch(prefill);
+    ASSERT_NE(prefill_op, nullptr);
+    ASSERT_EQ(prefill_op->request_ids, (std::vector<std::string>{"a", "b"}));
+    SendForwardDone("a", {42});
+    SendForwardDone("b", {142});
+
+    ExecutionPlan retract_round = PlanOnce();
+    const ForwardBatch* retract_op = FindForwardBatch(retract_round);
+    ASSERT_NE(retract_op, nullptr);
+    ASSERT_TRUE(retract_op->request_ids.empty());
+    ASSERT_EQ(scheduler_->WaitingSize(), 2u);
+    ASSERT_EQ(scheduler_->DecodingSize(), 0u);
+    ASSERT_EQ(scheduler_->PrefillSize(), 1u);
+
+    ExecutionPlan drain_round = PlanOnce();
+    const ForwardBatch* drain_op = FindForwardBatch(drain_round);
+    ASSERT_NE(drain_op, nullptr);
+    ASSERT_EQ(drain_op->request_ids, (std::vector<std::string>{"b"}))
+        << "the resident survivor must decode before the victim re-prefills";
+
+    SendForwardDone("b", {143});
+    SendFinish("b");
+    ExecutionPlan resumed_admission = PlanOnce();
+    const ForwardBatch* resumed_op = FindForwardBatch(resumed_admission);
+    ASSERT_NE(resumed_op, nullptr);
+    EXPECT_EQ(resumed_op->request_ids, (std::vector<std::string>{"a", "c"}));
+    EXPECT_EQ(resumed_op->input_lengths, (std::vector<std::int32_t>{9, 8}));
+    EXPECT_EQ(resumed_op->prefill_lengths, (std::vector<std::int32_t>{9, 8}));
+}
+
 class FusedRetractionL2TestSuite : public CapacityBlockSuite {
 protected:
     SchedulerConfig MakeConfig() override {

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -688,10 +688,10 @@ protected:
 };
 
 TEST_F(PdLocalRecoveryCapacityTestSuite, SingleRequestCapacityIncludesLocalRecoveryWorkingSet) {
-    // Full KV uses ceil(tokens / 4) parents. Sparse local recovery needs three
-    // State parents: input checkpoint, final output, and decode reservation.
-    // Eight usable parents therefore admit at most 20 total tokens.
-    EXPECT_EQ(scheduler_->MaxSingleRequestTokens(), 20);
+    // Full KV uses ceil(tokens / 4) parents. Non-overlap sparse local recovery
+    // needs two State parents: input checkpoint and final output. Eight usable
+    // parents therefore admit at most 24 total tokens.
+    EXPECT_EQ(scheduler_->MaxSingleRequestTokens(), 24);
 }
 
 TEST_F(PdSparseDecodeAdmissionTestSuite, MaterializesHistoryAndLatestStateSnapshotAtomically) {
@@ -706,16 +706,15 @@ TEST_F(PdSparseDecodeAdmissionTestSuite, MaterializesHistoryAndLatestStateSnapsh
     EXPECT_TRUE(std::ranges::all_of(full, [](std::int32_t page_id) { return page_id > 0; }));
 
     const auto& state = destination->block_tables.at("state").at(0);
-    ASSERT_EQ(state.size(), 5u);
+    ASSERT_EQ(state.size(), 4u);
     EXPECT_EQ(state[0], 0);
     EXPECT_EQ(state[1], 0);
     EXPECT_EQ(state[2], 0);
     EXPECT_GT(state[3], 0);
-    EXPECT_GT(state[4], 0);
     ASSERT_EQ(plan.pages_to_zero.size(), 2u);
     EXPECT_EQ(plan.pages_to_zero.at("full"), full);
-    EXPECT_EQ(plan.pages_to_zero.at("state"), (std::vector<std::int32_t>{state[3], state[4]}));
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), 1);
+    EXPECT_EQ(plan.pages_to_zero.at("state"), (std::vector<std::int32_t>{state[3]}));
+    EXPECT_EQ(scheduler_->PoolFreeBlocks(), 2);
     EXPECT_TRUE(scheduler_->PdTransferPinned("r0"));
 
     SendRemotePrefillDone("r0", /*bootstrap_token=*/42);
@@ -723,7 +722,10 @@ TEST_F(PdSparseDecodeAdmissionTestSuite, MaterializesHistoryAndLatestStateSnapsh
     const ExecutionPlan decode_plan = PlanOnce();
     const ForwardBatch* decode = FindForwardBatch(decode_plan.Operations());
     ASSERT_NE(decode, nullptr);
-    EXPECT_EQ(decode->block_tables, destination->block_tables);
+    const auto& decode_state = decode->block_tables.at("state").at(0);
+    ASSERT_EQ(decode_state.size(), 5u);
+    EXPECT_EQ(decode_state[3], state[3]);
+    EXPECT_GT(decode_state[4], 0);
 
     ExecutionEvent succeeded;
     succeeded.With(pd::SucceededEvent{"r0"});
@@ -740,9 +742,8 @@ TEST_F(PdSmallStatePagesTestSuite, LatestSnapshotUsesTheStateGroupsBlockGranular
     ASSERT_NE(destination, nullptr);
 
     const auto& state = destination->block_tables.at("state").at(0);
-    ASSERT_EQ(state.size(), 9u);
-    EXPECT_TRUE(std::ranges::all_of(state.begin(), state.end() - 2, [](std::int32_t page_id) { return page_id == 0; }));
-    EXPECT_GT(state[state.size() - 2], 0);
+    ASSERT_EQ(state.size(), 8u);
+    EXPECT_TRUE(std::ranges::all_of(state.begin(), state.end() - 1, [](std::int32_t page_id) { return page_id == 0; }));
     EXPECT_GT(state.back(), 0);
 }
 
@@ -769,12 +770,11 @@ TEST_F(PdSparseDecodeAdmissionTestSuite, ReusesHistoryPrefixAndLeavesStatePrefix
     EXPECT_TRUE(std::ranges::all_of(full, [](std::int32_t page_id) { return page_id > 0; }));
 
     const auto& state = destination->block_tables.at("state").at(0);
-    ASSERT_EQ(state.size(), 5u);
+    ASSERT_EQ(state.size(), 4u);
     EXPECT_EQ(state[0], 0);
     EXPECT_EQ(state[1], 0);
     EXPECT_EQ(state[2], 0);
     EXPECT_GT(state[3], 0);
-    EXPECT_GT(state[4], 0);
 }
 
 TEST_F(PdSlidingSparseDecodeAdmissionTestSuite, KeepsCachedPrefixIslandWhileMaterializingRemoteTail) {

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -688,11 +688,10 @@ protected:
 };
 
 TEST_F(PdLocalRecoveryCapacityTestSuite, SingleRequestCapacityIncludesLocalRecoveryWorkingSet) {
-    // Full KV uses ceil(tokens / 4) parents. A local-recovery chunk peaks at
-    // five State parents: one lookback plus four pages for an eight-token
-    // chunk, including the final decode reservation where applicable.
-    // Eight usable parents therefore admit at most 12 total tokens.
-    EXPECT_EQ(scheduler_->MaxSingleRequestTokens(), 12);
+    // Full KV uses ceil(tokens / 4) parents. Sparse local recovery needs three
+    // State parents: input checkpoint, final output, and decode reservation.
+    // Eight usable parents therefore admit at most 20 total tokens.
+    EXPECT_EQ(scheduler_->MaxSingleRequestTokens(), 20);
 }
 
 TEST_F(PdSparseDecodeAdmissionTestSuite, MaterializesHistoryAndLatestStateSnapshotAtomically) {


### PR DESCRIPTION
## Summary

### 1. Sparsify snapshot-state prefill allocation

KDA prefill only needs the incoming recurrent checkpoint and the checkpoint produced at the end of the chunk. Intermediate logical checkpoints are consumed by the recurrence and are not resumable states, so materializing one cache block for every checkpoint in a long prefill chunk wastes arena capacity.

This change keeps the block table in absolute logical-slot coordinates but materializes only the endpoint suffix, leaving skipped intermediate checkpoints as null holes. The allocator now tracks a monotonic reclaimed-prefix frontier so it can reclaim old live checkpoints across those holes, and the runtime continues to gather only the declared input/output slots.

As a result, KDA state demand no longer grows with `max_scheduled_tokens`; the old dense `scheduled_pages` term is removed from capacity sizing.

### 2. Roll snapshot state through a two-page decode working set

Final prefill previously reserved the first decode destination in advance, while overlap scheduling also reserved another protected state page. That conservatively guaranteed the next decode admission, but made each live request hold more recurrent-state storage than the kernels actually need.

Snapshot-state prefill now defers its decode reservation. The destination is allocated by the real decode admission after the previous input checkpoint has expired: admission publishes any completed boundary, reclaims the expired input ownership, and then acquires the next output checkpoint. The output becomes the following round's input, so each request rolls between two persistent checkpoints even with the currently supported one-step overlap.

For KDA groups this changes the child-block model from:

```text
2 * max_live_requests + scheduled_pages + protected_pages
```

to:

```text
2 * max_live_requests
```

The optimization is limited to snapshot-state groups. Full-attention MLA history still scales with token capacity and retains its overlap-protection term.

### 3. Reserve speculative KDA verify workspace outside the arena

The two-page model covers persistent KDA checkpoints in the cache arena, but DSpark target verification separately stages one committed seed row plus every candidate row for all target KDA layers in a dense, graph-stable workspace. This allocation was previously created during CUDA Graph warmup without being deducted from the advertised cache budget.

The Kimi-K3 recipe now computes that fixed workspace as:

```text
max_bs * (speculative_num_draft_tokens + 1) * total KDA state payload
```

and subtracts it before solving the LCM arena size. Startup preallocates the workspace and verifies that the planned byte count exactly matches the allocated tensors. This keeps the higher sparse-state capacity honest and prevents the arena from consuming memory required by speculative verification.

### 4. Drain resident requests after fused direct retraction

`max_num_seqs` limits sequence slots; it does not guarantee enough aggregate history capacity for that many maximum-length requests. A 32-way stress workload with `102400` input and `2560` output tokens requests 3,358,720 aggregate tokens, while the tested DSpark configuration exposes `max_total_num_tokens=1,581,696`, so capacity retraction is expected.

The previous fused scheduling path could nevertheless turn that expected retraction into severe thrashing. An admission failure directly changed the largest resident victim back to `Submitted` and released its Device pages. Because unfinished `Prefilling` and new/requeued `Submitted` requests are considered before non-mixed `PrefillDone`/`Decoding` requests, the released pages could immediately rebuild another long prompt—or the victim's full accepted history—rather than allowing the remaining resident cohort to finish. Once the pool filled again, the rebuilt long request could be retracted again after making only about one token of useful progress.

Fused direct retraction without Host L2 now enters a capacity-drain phase. During the drain, requests that already own cache (`Prefilling`, `PrefillDone`, and `Decoding`) continue to run, while all `Submitted` requests—including the requeued victim—are held back. Admission resumes automatically when no resident remains. This preserves progress under sustained overcommit without changing capacity-fit continuous batching, best-effort Host L2 writeback, PD Decode recovery, or victim selection.

A deterministic Mamba/KDA regression fills an eight-block pool with two residents and one waiter. Without the gate, the victim immediately re-prefills from the four released blocks; with the drain, the surviving resident decodes first and both waiting requests are admitted only after it finishes.

## Test plan

- [x] `pre-commit run --all-files`
- [x] focused Kimi-K3 Python cache tests (`12 passed` on B300)
- [x] TokenSpeed scheduler Python tests (`8 passed` on B300)
- [x] full TokenSpeed scheduler C++ suite (`413 passed` on B300)
- [x] 32 × (`102400` input + `2560` output) overcommit stress test (`32/32` succeeded; resident drain prevented immediate re-prefill thrashing)
- [x] 32 × (`45000` input + `2560` output) capacity-fit stress test (`32/32` succeeded; no additional retraction or OOM)