### PR TITLE
feat(loader): add the InstantTensor weight loader, opt-in only

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,7 +37,8 @@ export default defineConfig({
         text: "Guides",
         items: [
           { text: "Getting Started", link: "/guides/getting-started" },
-          { text: "Launching a Server", link: "/guides/launching" }
+          { text: "Launching a Server", link: "/guides/launching" },
+          { text: "InstantTensor Loading", link: "/guides/instanttensor" }
         ]
       },
       {

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -16,7 +16,7 @@ For a compact compatibility table, see
 | `--tokenizer` | Tokenizer path when it differs from the model path. |
 | `--tokenizer-mode` | Select tokenizer behavior. `auto` uses fast tokenizers and model-specific hooks when available. |
 | `--skip-tokenizer-init` | Skip tokenizer initialization for input-ID-only serving paths. |
-| `--load-format` | Weight loading format: `auto`, `pt`, `safetensors`, `npcache`, `dummy`, or `extensible`. |
+| `--load-format` | Weight loading format: `auto`, `pt`, `safetensors`, `instanttensor`, `npcache`, `dummy`, or `extensible`. See [InstantTensor](/guides/instanttensor) for the accelerated NVIDIA loader. |
 | `--trust-remote-code` | Allow custom model code from the model repository. |
 | `--revision` | Model branch, tag, or commit. |
 | `--download-dir` | Hugging Face download/cache directory. |

--- a/docs/guides/instanttensor.md
+++ b/docs/guides/instanttensor.md
@@ -12,11 +12,25 @@ default safetensors loader, so model accuracy is unaffected.
 
 ## Installation
 
-InstantTensor is an optional extra, because it publishes x86_64 wheels only:
+InstantTensor is an optional extra, because PyPI carries x86_64 wheels only:
 
 ```bash
 pip install "tokenspeed[instanttensor]"
 ```
+
+On aarch64 hosts (GB200, GB300) there is no published wheel, but the sdist
+builds from source in about a minute. The extension reaches CUDA, cuFile, and
+NCCL through `dlopen` and vendors its own Boost, libaio, and liburing, so it
+needs a C++ toolchain and `make` -- not `nvcc`, and not a matching CUDA
+toolkit:
+
+```bash
+pip install --no-binary instanttensor "tokenspeed[instanttensor]"
+```
+
+This is why the dependency is an extra rather than a core one: as a core
+dependency every ARM install would compile it, whether or not the format is
+ever requested.
 
 It is imported lazily, so it is loaded only when you select
 `--load-format instanttensor`.
@@ -37,6 +51,19 @@ tokenspeed serve deepseek-ai/DeepSeek-R1 \
   --tensor-parallel-size 8 \
   --enable-expert-parallel
 ```
+
+## Measured effect
+
+Weight-load phase for Kimi-K3 (1.42 TiB over 96 shards, 497k tensors) on two
+GB300 nodes with `--tensor-parallel-size 8`, checkpoint on shared storage:
+
+| `--load-format` | weight-load phase |
+| --- | --- |
+| `auto` (safetensors) | 869-1106 s |
+| `instanttensor` | 231-234 s |
+
+The ranges are run-to-run variance on the shared filesystem. Both formats
+serve identical output, as the loaders are bit-for-bit equivalent.
 
 ## Memory considerations
 

--- a/docs/guides/instanttensor.md
+++ b/docs/guides/instanttensor.md
@@ -1,0 +1,82 @@
+# Loading Weights with InstantTensor
+
+[InstantTensor](https://github.com/scitix/InstantTensor) accelerates loading
+safetensors weights on NVIDIA GPUs through distributed loading, pipelined
+prefetching, and direct I/O. It also supports GPUDirect Storage (GDS) when
+available, which lets it fully utilize the bandwidth of high-speed networked
+storage (e.g. 400 Gbps).
+
+InstantTensor only changes *how* the safetensors shards are read off disk and
+moved onto the GPU — the resulting weights are bit-for-bit identical to the
+default safetensors loader, so model accuracy is unaffected.
+
+## Installation
+
+InstantTensor is an optional extra, because it publishes x86_64 wheels only:
+
+```bash
+pip install "tokenspeed[instanttensor]"
+```
+
+It is imported lazily, so it is loaded only when you select
+`--load-format instanttensor`.
+
+## Usage
+
+Pass `--load-format instanttensor`. It works with any parallelism
+configuration; when the job spans multiple ranks, the world process group is
+handed to InstantTensor so reads are sharded across ranks.
+
+```bash
+tokenspeed serve Qwen/Qwen3-30B-A3B --load-format instanttensor
+```
+
+```bash
+tokenspeed serve deepseek-ai/DeepSeek-R1 \
+  --load-format instanttensor \
+  --tensor-parallel-size 8 \
+  --enable-expert-parallel
+```
+
+## Memory considerations
+
+InstantTensor reads each checkpoint tensor **directly onto the GPU**, whereas
+the default safetensors loader stages the full tensor in host (CPU) memory and
+copies only the current rank's shard to the GPU. InstantTensor's own overhead is
+small: it uses a GPU staging buffer (dynamically sized, configurable) that is
+released before the KV cache is sized, plus a little fixed runtime overhead, so
+its post-load GPU footprint is close to the default loader.
+
+Because tensors land on the GPU, a model's `load_weights` must **consume the
+weight iterator lazily** — copying each tensor into its (pre-allocated)
+parameter and then releasing it. A `load_weights` that instead collects the
+whole iterator into a list keeps every loaded tensor resident on the GPU at once
+and will OOM during loading on large models. This stays hidden with the
+CPU-staging loaders, where the buffered tensors live in plentiful host RAM.
+
+The gpt-oss MXFP4 path streams its expert tensors for this reason. Paths that
+still buffer — notably `_load_normal_weights`, which sorts the iterator, and so
+every bf16 gpt-oss checkpoint — hold the whole checkpoint on the device and are
+correspondingly limited by GPU memory.
+
+Tuning:
+
+- `INSTANTTENSOR_BUFFER_SIZE` / `INSTANTTENSOR_MAX_FREE_MEM_USAGE` bound
+  InstantTensor's GPU I/O staging buffer, trading a little throughput for lower
+  peak memory.
+- `--gpu-memory-utilization` only sizes the KV cache *after* weights are loaded;
+  it does not change peak memory during loading.
+
+## Notes
+
+- InstantTensor requires NVIDIA GPUs. Requesting it on a non-NVIDIA platform
+  raises an error.
+- Only `*.safetensors` checkpoints are supported (same shard selection as
+  `--load-format safetensors`).
+- Checkpoints declaring a sub-byte safetensors dtype (`F4`, `F6_E2M3`,
+  `F6_E3M2`) are rejected up front, because InstantTensor reads them at twice
+  their true length without raising. This does not affect NVFP4 or MXFP4
+  checkpoints, which store their packed 4-bit values as byte-aligned `U8`.
+
+For benchmarks and implementation details, see the
+[InstantTensor repository](https://github.com/scitix/InstantTensor).

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -96,10 +96,7 @@ ts = "tokenspeed.cli:main"
 "Homepage" = "https://github.com/lightseekorg/tokenspeed"
 
 [project.optional-dependencies]
-# x86_64-only wheels (no aarch64 on PyPI as of 0.1.9), so a core dependency here
-# would break `pip install` on ARM whether or not the format is ever requested.
-# Capped: the loader drops its defensive clone because 0.1.9 clones internally,
-# and a release that stops doing so would alias silently rather than fail.
+# Capped: 0.1.9 clones internally, so a release that stops would alias silently.
 instanttensor = ["instanttensor>=0.1.9,<0.2"]
 
 [tool.setuptools]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -95,6 +95,13 @@ ts = "tokenspeed.cli:main"
 [project.urls]
 "Homepage" = "https://github.com/lightseekorg/tokenspeed"
 
+[project.optional-dependencies]
+# x86_64-only wheels (no aarch64 on PyPI as of 0.1.9), so a core dependency here
+# would break `pip install` on ARM whether or not the format is ever requested.
+# Capped: the loader drops its defensive clone because 0.1.9 clones internally,
+# and a release that stops doing so would alias silently rather than fail.
+instanttensor = ["instanttensor>=0.1.9,<0.2"]
+
 [tool.setuptools]
 license-files = ["LICENSE", "THIRDPARTYNOTICES"]
 

--- a/python/tokenspeed/runtime/configs/load_config.py
+++ b/python/tokenspeed/runtime/configs/load_config.py
@@ -33,6 +33,7 @@ class LoadFormat(str, enum.Enum):
     AUTO = "auto"
     PT = "pt"
     SAFETENSORS = "safetensors"
+    INSTANTTENSOR = "instanttensor"
     NPCACHE = "npcache"
     DUMMY = "dummy"
     SHARDED_STATE = "sharded_state"
@@ -51,6 +52,10 @@ class LoadConfig:
             not available.
         "pt" will load the weights in the pytorch bin format.
         "safetensors" will load the weights in the safetensors format.
+        "instanttensor" will load the safetensors weights on NVIDIA GPUs
+            using InstantTensor, which accelerates loading via distributed
+            loading, pipelined prefetching, and direct I/O (with optional
+            GPUDirect Storage support).
         "npcache" will load the weights in pytorch format and store
             a numpy cache to speed up the loading.
         "dummy" will initialize the weights with random values, which is

--- a/python/tokenspeed/runtime/model_loader/loader.py
+++ b/python/tokenspeed/runtime/model_loader/loader.py
@@ -56,6 +56,7 @@ from tokenspeed.runtime.model_loader.weight_utils import (
     filter_safetensors_files_by_weight_names,
     get_quant_config,
     initialize_dummy_weights,
+    instanttensor_weights_iterator,
     np_cache_weights_iterator,
     pt_weights_iterator,
     safetensors_weights_iterator,
@@ -256,7 +257,7 @@ class DefaultModelLoader(BaseModelLoader):
         # Some quantized models use .pt files for storing the weights.
         if load_format == LoadFormat.AUTO:
             allow_patterns = ["*.safetensors", "*.bin"]
-        elif load_format == LoadFormat.SAFETENSORS:
+        elif load_format in (LoadFormat.SAFETENSORS, LoadFormat.INSTANTTENSOR):
             use_safetensors = True
             allow_patterns = ["*.safetensors"]
         elif load_format == LoadFormat.MISTRAL:
@@ -355,6 +356,8 @@ class DefaultModelLoader(BaseModelLoader):
                 hf_folder,
                 hf_weights_files,
             )
+        elif self.load_config.load_format == LoadFormat.INSTANTTENSOR:
+            weights_iterator = instanttensor_weights_iterator(hf_weights_files)
         elif use_safetensors:
             weights_iterator = safetensors_weights_iterator(
                 hf_weights_files,

--- a/python/tokenspeed/runtime/model_loader/weight_utils.py
+++ b/python/tokenspeed/runtime/model_loader/weight_utils.py
@@ -584,8 +584,7 @@ def safetensors_weights_iterator(
 
 _SUB_BYTE_SAFETENSORS_DTYPES = frozenset({"F4", "F6_E2M3", "F6_E3M2"})
 
-# Real headers are a few hundred KB; the bound just keeps a corrupt length
-# prefix from turning into a multi-gigabyte read.
+# Bounds a corrupt length prefix; real headers are a few hundred KB.
 _MAX_SAFETENSORS_HEADER_BYTES = 128 * 1024 * 1024
 
 
@@ -666,8 +665,6 @@ def _instanttensor_tensors(
 ) -> Generator[tuple[str, torch.Tensor], None, None]:
     process_group = None
     if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
-        # The default (world) group spans every rank in the job, matching the
-        # semantics InstantTensor expects for distributed loading.
         process_group = torch.distributed.group.WORLD
 
     device = torch.cuda.current_device()
@@ -679,14 +676,12 @@ def _instanttensor_tensors(
     with instanttensor.safe_open(
         hf_weights_files, framework="pt", device=device, process_group=process_group
     ) as f:
-        # Since InstantTensor 0.1.9, tensors are cloned internally by default,
-        # so no extra clone is needed here.
+        # InstantTensor 0.1.9 clones internally, so no extra clone here.
         yield from tqdm(
             f.tensors(),
             desc="Loading safetensors using InstantTensor loader",
             disable=not enable_tqdm,
             bar_format=_BAR_FORMAT,
-            position=tqdm._get_free_pos(),
             total=len(f.keys()),
             mininterval=1.0,
         )

--- a/python/tokenspeed/runtime/model_loader/weight_utils.py
+++ b/python/tokenspeed/runtime/model_loader/weight_utils.py
@@ -27,6 +27,7 @@ import hashlib
 import importlib.util
 import json
 import os
+import struct
 import tempfile
 import threading
 import time
@@ -41,6 +42,7 @@ import safetensors.torch
 import torch
 from huggingface_hub import HfFileSystem, hf_hub_download, snapshot_download
 from pydantic import BaseModel, ConfigDict, ValidationInfo, model_validator
+from tokenspeed_kernel.platform import current_platform
 from tqdm.auto import tqdm
 
 from tokenspeed.runtime.configs.load_config import LoadConfig
@@ -578,6 +580,116 @@ def safetensors_weights_iterator(
         yield from result.items()
         if prefetcher is not None:
             prefetcher.advance(file_idx)
+
+
+_SUB_BYTE_SAFETENSORS_DTYPES = frozenset({"F4", "F6_E2M3", "F6_E3M2"})
+
+# Real headers are a few hundred KB; the bound just keeps a corrupt length
+# prefix from turning into a multi-gigabyte read.
+_MAX_SAFETENSORS_HEADER_BYTES = 128 * 1024 * 1024
+
+
+def _find_sub_byte_dtype(hf_weights_files: list[str]) -> str | None:
+    """Return the first sub-byte dtype any shard declares, else ``None``.
+
+    InstantTensor 0.1.9 applies a header's logical element count to a torch
+    dtype whose element is a packed pair, so an ``F4`` tensor declared ``[2048]``
+    over 1024 bytes arrives as shape ``(2048,)`` -- twice its own storage --
+    where safetensors correctly reports ``(1024,)``. Nothing raises, so callers
+    must refuse these checkpoints rather than load them wrong.
+
+    Only each shard's length-prefixed JSON header is read, never tensor data.
+    A header that will not parse raises: this decides whether a checkpoint is
+    safe to load, so it must not wave through the shard it cannot inspect.
+    """
+    for path in hf_weights_files:
+        with open(path, "rb") as f:
+            (header_len,) = struct.unpack("<Q", f.read(8))
+            if header_len > _MAX_SAFETENSORS_HEADER_BYTES:
+                raise ValueError(
+                    f"{path}: safetensors header claims {header_len} bytes"
+                )
+            header = json.loads(f.read(header_len))
+
+        if not isinstance(header, dict):
+            raise ValueError(f"{path}: safetensors header is not a JSON object")
+
+        for name, meta in header.items():
+            if name == "__metadata__" or not isinstance(meta, dict):
+                continue
+            if meta.get("dtype") in _SUB_BYTE_SAFETENSORS_DTYPES:
+                return meta["dtype"]
+    return None
+
+
+def instanttensor_weights_iterator(
+    hf_weights_files: list[str],
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    """Iterate over the weights in the model safetensor files using the
+    InstantTensor library.
+
+    InstantTensor accelerates loading safetensors weights on NVIDIA GPUs
+    through distributed loading, pipelined prefetching, and direct I/O. When
+    the job spans multiple ranks, the world process group is passed to
+    InstantTensor so reads are sharded across ranks.
+
+    Args:
+        hf_weights_files: Local paths to the ``*.safetensors`` shards to load.
+
+    Yields:
+        ``(name, tensor)`` pairs for every tensor in the checkpoint, with the
+        tensors materialized on the current CUDA device.
+    """
+    if not current_platform().is_nvidia:
+        raise ValueError("InstantTensor requires NVIDIA GPUs")
+
+    try:
+        import instanttensor
+    except ImportError as e:
+        raise ImportError(
+            'Please install instanttensor via `pip install "tokenspeed[instanttensor]"`'
+        ) from e
+
+    sub_byte_dtype = _find_sub_byte_dtype(hf_weights_files)
+    if sub_byte_dtype is not None:
+        raise ValueError(
+            f"This checkpoint declares the sub-byte safetensors dtype "
+            f"{sub_byte_dtype!r}, which InstantTensor loads incorrectly. "
+            "Use --load-format auto instead."
+        )
+
+    return _instanttensor_tensors(instanttensor, hf_weights_files)
+
+
+def _instanttensor_tensors(
+    instanttensor, hf_weights_files: list[str]
+) -> Generator[tuple[str, torch.Tensor], None, None]:
+    process_group = None
+    if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+        # The default (world) group spans every rank in the job, matching the
+        # semantics InstantTensor expects for distributed loading.
+        process_group = torch.distributed.group.WORLD
+
+    device = torch.cuda.current_device()
+
+    enable_tqdm = (
+        not torch.distributed.is_initialized() or torch.distributed.get_rank() == 0
+    )
+
+    with instanttensor.safe_open(
+        hf_weights_files, framework="pt", device=device, process_group=process_group
+    ) as f:
+        # Since InstantTensor 0.1.9, tensors are cloned internally by default,
+        # so no extra clone is needed here.
+        yield from tqdm(
+            f.tensors(),
+            desc="Loading safetensors using InstantTensor loader",
+            disable=not enable_tqdm,
+            bar_format=_BAR_FORMAT,
+            position=tqdm._get_free_pos(),
+            total=len(f.keys()),
+            mininterval=1.0,
+        )
 
 
 def pt_weights_iterator(

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -2319,7 +2319,9 @@ class Eagle3DeepseekV2ForCausalLM(DeepseekV3ForCausalLM):
         remapped = []
         for name, loaded_weight in weights:
             if "d2t" in name:
-                self.hot_token_id = loaded_weight + torch.arange(loaded_weight.size(0))
+                self.hot_token_id = loaded_weight + torch.arange(
+                    loaded_weight.size(0), device=loaded_weight.device
+                )
                 continue
             if "t2d" in name:
                 continue

--- a/python/tokenspeed/runtime/models/gpt_oss.py
+++ b/python/tokenspeed/runtime/models/gpt_oss.py
@@ -725,11 +725,7 @@ class GptOssForCausalLM(BaseCausalLM):
         }
 
     def _load_mxfp4_weights(self, weights, weight_name_mapping: dict):
-        # A GPU-direct loader yields tensors already on the device, so buffering
-        # the expert tensors -- 9.5 of gpt-oss-20b's 12.8 GiB -- would hold most
-        # of the checkpoint resident at once and OOM mid-load. Stream those; the
-        # rest is still collected, and is not free (3.3 GiB, half of it the
-        # embedding and lm_head), but it is what the generic pass needs.
+        # Stream experts; buffering them pins most of the checkpoint on the GPU.
         normal_weights = []
 
         def expert_weights():
@@ -786,11 +782,7 @@ class GptOssForCausalLM(BaseCausalLM):
                 )
                 param.data[slices].copy_(narrow_weight[slices])
 
-        # The AMD-Quark per-expert layout (one tensor set per expert) and the
-        # fused layout have disjoint, unambiguous names, so each tensor routes
-        # on its own name -- a probe would have to consume the stream, and
-        # latching the layout off the first tensor would silently drop every
-        # tensor of the other layout.
+        # Route per name: probing would consume the stream and drop a layout.
         per_expert_re = re.compile(r"\.experts\.\d+\.(gate_up_proj|down_proj)\.")
 
         for name, weight in weights:

--- a/python/tokenspeed/runtime/models/gpt_oss.py
+++ b/python/tokenspeed/runtime/models/gpt_oss.py
@@ -725,17 +725,22 @@ class GptOssForCausalLM(BaseCausalLM):
         }
 
     def _load_mxfp4_weights(self, weights, weight_name_mapping: dict):
-
-        mxfp4_weights = []
+        # A GPU-direct loader yields tensors already on the device, so buffering
+        # the expert tensors -- 9.5 of gpt-oss-20b's 12.8 GiB -- would hold most
+        # of the checkpoint resident at once and OOM mid-load. Stream those; the
+        # rest is still collected, and is not free (3.3 GiB, half of it the
+        # embedding and lm_head), but it is what the generic pass needs.
         normal_weights = []
 
-        for name, weight in weights:
-            if ".experts" in name:
-                mxfp4_weights.append((name, weight))
-            else:
-                normal_weights.append((name, weight))
+        def expert_weights():
+            for name, weight in weights:
+                if ".experts" in name:
+                    yield name, weight
+                else:
+                    normal_weights.append((name, weight))
 
-        mxfp4_loaded_params = self._load_mxfp4_experts_weights(mxfp4_weights)
+        # Draining the generator is what fills ``normal_weights``.
+        mxfp4_loaded_params = self._load_mxfp4_experts_weights(expert_weights())
         self._load_normal_weights(
             normal_weights,
             weight_name_mapping=weight_name_mapping,
@@ -781,27 +786,27 @@ class GptOssForCausalLM(BaseCausalLM):
                 )
                 param.data[slices].copy_(narrow_weight[slices])
 
-        # Detect AMD-Quark per-expert checkpoints (e.g.
-        # ``amd/gpt-oss-120b-w-mxfp4-a-fp8``). These store one set of tensors
-        # per expert (``...experts.{e}.gate_up_proj.{weight,...}``) plus a
-        # scalar ``input_scale`` for static FP8 activation quantization.
-        if any(
-            re.search(r"\.experts\.\d+\.(gate_up_proj|down_proj)\.", n)
-            for n, _ in weights
-        ):
-            return self._load_mxfp4_per_expert_weights(
-                weights,
-                params_dict=params_dict,
-                moe_tp_rank_start=moe_tp_rank_start,
-                moe_tp_rank_end=moe_tp_rank_end,
-                moe_ep_rank_start=moe_ep_rank_start,
-                moe_ep_rank_end=moe_ep_rank_end,
-                moe_tp_rank=moe_tp_rank,
-                copy_into_param=_copy_into_param,
-                mxfp4_block=mxfp4_block,
-            )
+        # The AMD-Quark per-expert layout (one tensor set per expert) and the
+        # fused layout have disjoint, unambiguous names, so each tensor routes
+        # on its own name -- a probe would have to consume the stream, and
+        # latching the layout off the first tensor would silently drop every
+        # tensor of the other layout.
+        per_expert_re = re.compile(r"\.experts\.\d+\.(gate_up_proj|down_proj)\.")
 
         for name, weight in weights:
+            if per_expert_re.search(name):
+                loaded_params |= self._load_mxfp4_per_expert_weights(
+                    [(name, weight)],
+                    params_dict=params_dict,
+                    moe_tp_rank_start=moe_tp_rank_start,
+                    moe_tp_rank_end=moe_tp_rank_end,
+                    moe_ep_rank_start=moe_ep_rank_start,
+                    moe_ep_rank_end=moe_ep_rank_end,
+                    moe_tp_rank=moe_tp_rank,
+                    copy_into_param=_copy_into_param,
+                    mxfp4_block=mxfp4_block,
+                )
+                continue
             weight = _WeightCreator.maybe_materialize(weight)
 
             if "gate_up_proj_blocks" in name:

--- a/python/tokenspeed/runtime/models/llama_eagle3.py
+++ b/python/tokenspeed/runtime/models/llama_eagle3.py
@@ -689,7 +689,9 @@ class LlamaForCausalLMEagle3(BaseCausalLM):
                 name = "midlayer." + name[len("layers.0.") :]
 
             if "d2t" in name:
-                self.hot_token_id = loaded_weight + torch.arange(loaded_weight.shape[0])
+                self.hot_token_id = loaded_weight + torch.arange(
+                    loaded_weight.shape[0], device=loaded_weight.device
+                )
                 continue
 
             if "t2d" in name:

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -982,6 +982,7 @@ class ServerArgs:
                 "auto",
                 "pt",
                 "safetensors",
+                "instanttensor",
                 "npcache",
                 "dummy",
                 "extensible",
@@ -992,6 +993,9 @@ class ServerArgs:
             "is not available. "
             '"pt" will load the weights in the pytorch bin format. '
             '"safetensors" will load the weights in the safetensors format. '
+            '"instanttensor" accelerates safetensors loading on NVIDIA GPUs '
+            "via distributed loading, pipelined prefetching, and direct I/O "
+            "(with optional GPUDirect Storage support). "
             '"npcache" will load the weights in pytorch format and store '
             "a numpy cache to speed up the loading. "
             '"dummy" will initialize the weights with random values.',

--- a/test/runtime/test_eagle3_d2t_device.py
+++ b/test/runtime/test_eagle3_d2t_device.py
@@ -1,0 +1,64 @@
+"""Regression test: EAGLE3 ``d2t`` loading follows the weight's device.
+
+The draft vocabulary map is built as ``loaded_weight + torch.arange(n)``.
+``torch.arange`` defaults to CPU, which matched every CPU-staging weight
+loader and so went unnoticed -- until a GPU-direct loader
+(``--load-format instanttensor``) started yielding ``loaded_weight`` already
+on the device, making the addition raise "Expected all tensors to be on the
+same device".
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+import torch
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.models.deepseek_v3 import (
+    DeepseekV3ForCausalLM,
+    Eagle3DeepseekV2ForCausalLM,
+)
+from tokenspeed.runtime.models.llama_eagle3 import LlamaForCausalLMEagle3
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "needs a GPU to place the weight on")
+class TestEagle3D2TDevice(unittest.TestCase):
+    D2T = torch.tensor([5, 7, 9], dtype=torch.long)
+
+    def _assert_hot_token_id(self, model):
+        # loaded_weight + arange(3) == [5, 8, 11]
+        self.assertEqual(model.hot_token_id.device.type, "cuda")
+        self.assertTrue(
+            torch.equal(
+                model.hot_token_id.cpu(), torch.tensor([5, 8, 11], dtype=torch.long)
+            )
+        )
+
+    def test_llama_eagle3_places_hot_token_id_on_the_weight_device(self):
+        model = types.SimpleNamespace(named_parameters=lambda: iter([]))
+        LlamaForCausalLMEagle3.load_weights(model, [("d2t", self.D2T.to("cuda"))])
+        self._assert_hot_token_id(model)
+
+    def test_deepseek_eagle3_places_hot_token_id_on_the_weight_device(self):
+        # Only the ``d2t`` branch is under test. The instance is built without
+        # ``__init__`` so zero-arg ``super()`` still resolves, and the base
+        # class -- which consumes the remaining (here empty) list and needs a
+        # real module tree -- is stubbed out.
+        model = object.__new__(Eagle3DeepseekV2ForCausalLM)
+        with mock.patch.object(DeepseekV3ForCausalLM, "load_weights"):
+            Eagle3DeepseekV2ForCausalLM.load_weights(
+                model, [("d2t", self.D2T.to("cuda"))]
+            )
+        self._assert_hot_token_id(model)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_gpt_oss_mxfp4_streaming.py
+++ b/test/runtime/test_gpt_oss_mxfp4_streaming.py
@@ -26,9 +26,7 @@ from tokenspeed.runtime.models.gpt_oss import GptOssForCausalLM
 
 class TestGptOssMxfp4Streaming(unittest.TestCase):
     def test_load_mxfp4_weights_streams_experts(self):
-        # Expert tensors interleaved with the small non-expert weights, in
-        # checkpoint order. The "weight" stand-in is just the name string,
-        # because the stubbed loaders below never touch tensor data.
+        # The "weight" stand-in is the name; the stubs never touch tensor data.
         items = [
             "model.embed_tokens.weight",
             "model.layers.0.mlp.experts.gate_up_proj_blocks",
@@ -48,15 +46,11 @@ class TestGptOssMxfp4Streaming(unittest.TestCase):
         received = {}
 
         def fake_load_experts(weights):
-            # The dispatcher must hand us a lazy generator, not a materialized
-            # list of every expert tensor.
             received["is_generator"] = isinstance(weights, types.GeneratorType)
             iterator = iter(weights)
             first_expert = next(iterator)
             seen_experts.append(first_expert[0])
-            # Reaching the first expert (item #2) must not have drained the
-            # whole source iterator (5 items) -- proof that loading is
-            # interleaved with iteration, i.e. streamed.
+            # Item 2 of 5: reaching the first expert must not drain the source.
             received["pulled_after_first_expert"] = len(pulled)
             for name, _ in iterator:
                 seen_experts.append(name)
@@ -83,8 +77,6 @@ class TestGptOssMxfp4Streaming(unittest.TestCase):
         self.assertTrue(received["is_generator"])
         self.assertEqual(received["pulled_after_first_expert"], 2)
 
-        # Expert tensors (matched by the ".experts" marker) are routed to the
-        # expert loader, in order.
         self.assertEqual(
             seen_experts,
             [
@@ -93,8 +85,6 @@ class TestGptOssMxfp4Streaming(unittest.TestCase):
             ],
         )
 
-        # Everything else is collected for the generic loader, and the set of
-        # already-loaded expert params is threaded through to it.
         self.assertEqual(
             normal_seen["names"],
             [
@@ -179,8 +169,7 @@ class TestGptOssMxfp4ExpertRouting(unittest.TestCase):
             model, self._per_expert_stream(base)
         )
 
-        # Every per-expert target is reached. Latching the layout off the
-        # leading ``format_marker`` would have produced an empty set.
+        # Latching the layout off the leading ``format_marker`` would be empty.
         self.assertEqual(loaded, set(params))
 
 

--- a/test/runtime/test_gpt_oss_mxfp4_streaming.py
+++ b/test/runtime/test_gpt_oss_mxfp4_streaming.py
@@ -1,0 +1,188 @@
+"""Regression test: GPT-OSS MXFP4 weight loading streams the iterator.
+
+A GPU-direct loader (``--load-format instanttensor``) yields each checkpoint
+tensor already resident on the GPU. ``_load_mxfp4_weights`` must therefore
+consume the weight iterator lazily and copy each (large) MoE expert tensor
+straight into its slot, rather than buffering every expert tensor into a list
+first -- the latter keeps the whole checkpoint on the device at once and OOMs
+mid-load. This test pins that behavior without needing a GPU or real weights.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+import torch
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.models.gpt_oss import GptOssForCausalLM
+
+
+class TestGptOssMxfp4Streaming(unittest.TestCase):
+    def test_load_mxfp4_weights_streams_experts(self):
+        # Expert tensors interleaved with the small non-expert weights, in
+        # checkpoint order. The "weight" stand-in is just the name string,
+        # because the stubbed loaders below never touch tensor data.
+        items = [
+            "model.embed_tokens.weight",
+            "model.layers.0.mlp.experts.gate_up_proj_blocks",
+            "model.layers.0.input_layernorm.weight",
+            "model.layers.0.mlp.experts.down_proj_blocks",
+            "lm_head.weight",
+        ]
+
+        pulled = []
+
+        def source():
+            for name in items:
+                pulled.append(name)
+                yield name, name
+
+        seen_experts = []
+        received = {}
+
+        def fake_load_experts(weights):
+            # The dispatcher must hand us a lazy generator, not a materialized
+            # list of every expert tensor.
+            received["is_generator"] = isinstance(weights, types.GeneratorType)
+            iterator = iter(weights)
+            first_expert = next(iterator)
+            seen_experts.append(first_expert[0])
+            # Reaching the first expert (item #2) must not have drained the
+            # whole source iterator (5 items) -- proof that loading is
+            # interleaved with iteration, i.e. streamed.
+            received["pulled_after_first_expert"] = len(pulled)
+            for name, _ in iterator:
+                seen_experts.append(name)
+            return {"loaded_expert_param"}
+
+        normal_seen = {}
+
+        def fake_load_normal(
+            normal_weights, *, weight_name_mapping, other_loaded_param_names
+        ):
+            normal_seen["names"] = [name for name, _ in normal_weights]
+            normal_seen["other"] = other_loaded_param_names
+
+        fake_self = types.SimpleNamespace(
+            _load_mxfp4_experts_weights=fake_load_experts,
+            _load_normal_weights=fake_load_normal,
+        )
+
+        GptOssForCausalLM._load_mxfp4_weights(
+            fake_self, source(), weight_name_mapping={}
+        )
+
+        # Streamed, not buffered.
+        self.assertTrue(received["is_generator"])
+        self.assertEqual(received["pulled_after_first_expert"], 2)
+
+        # Expert tensors (matched by the ".experts" marker) are routed to the
+        # expert loader, in order.
+        self.assertEqual(
+            seen_experts,
+            [
+                "model.layers.0.mlp.experts.gate_up_proj_blocks",
+                "model.layers.0.mlp.experts.down_proj_blocks",
+            ],
+        )
+
+        # Everything else is collected for the generic loader, and the set of
+        # already-loaded expert params is threaded through to it.
+        self.assertEqual(
+            normal_seen["names"],
+            [
+                "model.embed_tokens.weight",
+                "model.layers.0.input_layernorm.weight",
+                "lm_head.weight",
+            ],
+        )
+        self.assertEqual(normal_seen["other"], {"loaded_expert_param"})
+
+
+class TestGptOssMxfp4ExpertRouting(unittest.TestCase):
+    """Each expert tensor routes on its own name.
+
+    The layout used to be decided by one ``any()`` probe over the whole list.
+    Streaming removed the list, so a probe would consume the stream; latching
+    the decision on the first tensor instead would send every tensor of the
+    other layout down a branch that matches none of its names and drop it with
+    no error.
+    """
+
+    HIDDEN = 64
+    INTERMEDIATE = 32
+    MXFP4_BLOCK = 32
+    NUM_EXPERTS = 2
+
+    def _model(self):
+        base = "model.layers.0.mlp.experts."
+        h, i, n = self.HIDDEN, self.INTERMEDIATE, self.NUM_EXPERTS
+        params = {
+            base + "w13_weight": torch.zeros(n, 2 * i, h // 2, dtype=torch.uint8),
+            base
+            + "w13_weight_scale": torch.zeros(
+                n, 2 * i, h // self.MXFP4_BLOCK, dtype=torch.uint8
+            ),
+            base + "w13_weight_bias": torch.zeros(n, 2 * i, dtype=torch.bfloat16),
+            base + "w2_weight": torch.zeros(n, h, i // 2, dtype=torch.uint8),
+            base
+            + "w2_weight_scale": torch.zeros(
+                n, h, i // self.MXFP4_BLOCK, dtype=torch.uint8
+            ),
+            base + "w2_weight_bias": torch.zeros(n, h, dtype=torch.bfloat16),
+        }
+        moe = types.SimpleNamespace(tp_rank=0, tp_size=1, ep_rank=0, ep_size=1)
+        model = types.SimpleNamespace(
+            named_parameters=lambda: params.items(),
+            mapping=types.SimpleNamespace(moe=moe),
+            config=types.SimpleNamespace(
+                intermediate_size=i, num_local_experts=n, hidden_size=h
+            ),
+        )
+        model._load_mxfp4_per_expert_weights = (
+            lambda *a, **k: GptOssForCausalLM._load_mxfp4_per_expert_weights(
+                model, *a, **k
+            )
+        )
+        return model, params, base
+
+    def _per_expert_stream(self, base):
+        """AMD-Quark tensors, preceded by a name that matches neither layout."""
+        h, i = self.HIDDEN, self.INTERMEDIATE
+        yield base + "format_marker", torch.zeros(1)
+        for e in range(self.NUM_EXPERTS):
+            p = f"{base}{e}."
+            yield p + "gate_up_proj.weight", torch.zeros(
+                2 * i, h // 2, dtype=torch.uint8
+            )
+            yield p + "gate_up_proj.weight_scale", torch.zeros(
+                2 * i, h // self.MXFP4_BLOCK, dtype=torch.uint8
+            )
+            yield p + "gate_up_proj.bias", torch.zeros(2 * i, dtype=torch.bfloat16)
+            yield p + "down_proj.weight", torch.zeros(h, i // 2, dtype=torch.uint8)
+            yield p + "down_proj.weight_scale", torch.zeros(
+                h, i // self.MXFP4_BLOCK, dtype=torch.uint8
+            )
+            yield p + "down_proj.bias", torch.zeros(h, dtype=torch.bfloat16)
+
+    def test_per_expert_layout_loads_when_a_foreign_name_comes_first(self):
+        model, params, base = self._model()
+
+        loaded = GptOssForCausalLM._load_mxfp4_experts_weights(
+            model, self._per_expert_stream(base)
+        )
+
+        # Every per-expert target is reached. Latching the layout off the
+        # leading ``format_marker`` would have produced an empty set.
+        self.assertEqual(loaded, set(params))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_instanttensor_loader.py
+++ b/test/runtime/test_instanttensor_loader.py
@@ -29,8 +29,7 @@ from tokenspeed.runtime.model_loader.weight_utils import (
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
 INSTANTTENSOR_AVAILABLE = find_spec("instanttensor") is not None
-# InstantTensor is NVIDIA-only. torch.cuda.is_available() is also True on ROCm,
-# so guard on the platform vendor to keep the parity test off AMD runners.
+# torch.cuda.is_available() is True on ROCm too, so guard on the vendor.
 IS_NVIDIA = current_platform().is_nvidia
 
 
@@ -51,8 +50,7 @@ class TestInstantTensorConfig(unittest.TestCase):
 
     def test_prepare_weights_treats_instanttensor_as_safetensors(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            # _prepare_weights only globs/filters file paths; it never reads the
-            # tensor data, so an empty placeholder shard is sufficient here.
+            # _prepare_weights only globs paths, never tensor data.
             open(os.path.join(tmpdir, "model.safetensors"), "wb").close()
 
             loader = DefaultModelLoader(LoadConfig(load_format="instanttensor"))
@@ -126,8 +124,7 @@ class TestSubByteDtypeGuard(unittest.TestCase):
     def test_unparsable_header_raises_rather_than_waving_the_shard_through(
         self,
     ) -> None:
-        # Failing open would let the very shard the guard cannot inspect carry
-        # the sub-byte tensors it exists to catch.
+        # Failing open would wave through the shard the guard cannot inspect.
         with tempfile.TemporaryDirectory() as d:
             cases = {
                 "truncated.safetensors": b"\x00",
@@ -157,8 +154,7 @@ class TestInstantTensorRejectsSubByteCheckpoints(unittest.TestCase):
                 f.write(blob)
                 f.write(b"\x11" * 1024)
 
-            # Validating only on the first ``next()`` would defer this until
-            # after the model skeleton is allocated on every rank.
+            # Validating on the first ``next()`` would defer this past alloc.
             with self.assertRaises(ValueError) as caught:
                 instanttensor_weights_iterator([shard])
             self.assertIn("F4", str(caught.exception))

--- a/test/runtime/test_instanttensor_loader.py
+++ b/test/runtime/test_instanttensor_loader.py
@@ -1,0 +1,168 @@
+import argparse
+import glob
+import json
+import os
+import struct
+import sys
+import tempfile
+import unittest
+from importlib.util import find_spec
+
+import torch
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
+
+from tokenspeed_kernel.platform import current_platform
+
+from tokenspeed.runtime.configs.load_config import LoadConfig, LoadFormat
+from tokenspeed.runtime.model_loader.loader import DefaultModelLoader
+from tokenspeed.runtime.model_loader.weight_utils import (
+    _find_sub_byte_dtype,
+    download_weights_from_hf,
+    instanttensor_weights_iterator,
+    safetensors_weights_iterator,
+)
+from tokenspeed.runtime.utils.server_args import ServerArgs
+
+INSTANTTENSOR_AVAILABLE = find_spec("instanttensor") is not None
+# InstantTensor is NVIDIA-only. torch.cuda.is_available() is also True on ROCm,
+# so guard on the platform vendor to keep the parity test off AMD runners.
+IS_NVIDIA = current_platform().is_nvidia
+
+
+class TestInstantTensorConfig(unittest.TestCase):
+    """Config/CLI wiring that needs neither a GPU nor instanttensor."""
+
+    def test_cli_flag_maps_to_load_format(self):
+        parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        args = parser.parse_args(
+            ["--model", "test/model", "--load-format", "instanttensor"]
+        )
+        self.assertEqual(args.load_format, "instanttensor")
+
+    def test_load_config_normalizes_to_enum(self):
+        load_config = LoadConfig(load_format="instanttensor")
+        self.assertEqual(load_config.load_format, LoadFormat.INSTANTTENSOR)
+
+    def test_prepare_weights_treats_instanttensor_as_safetensors(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # _prepare_weights only globs/filters file paths; it never reads the
+            # tensor data, so an empty placeholder shard is sufficient here.
+            open(os.path.join(tmpdir, "model.safetensors"), "wb").close()
+
+            loader = DefaultModelLoader(LoadConfig(load_format="instanttensor"))
+            _, hf_weights_files, use_safetensors = loader._prepare_weights(
+                tmpdir, revision=None, fall_back_to_pt=False
+            )
+
+            self.assertTrue(use_safetensors)
+            self.assertEqual(len(hf_weights_files), 1)
+            self.assertTrue(hf_weights_files[0].endswith("model.safetensors"))
+
+
+@unittest.skipIf(not IS_NVIDIA, "InstantTensor requires NVIDIA GPUs")
+@unittest.skipIf(not INSTANTTENSOR_AVAILABLE, "instanttensor is not installed")
+class TestInstantTensorWeights(unittest.TestCase):
+    """Iterator parity test (requires an NVIDIA GPU and instanttensor)."""
+
+    def test_instanttensor_matches_safetensors(self):
+        model = "openai-community/gpt2"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            download_weights_from_hf(
+                model, cache_dir=tmpdir, allow_patterns=["*.safetensors"]
+            )
+            safetensors_files = glob.glob(f"{tmpdir}/**/*.safetensors", recursive=True)
+            self.assertGreater(len(safetensors_files), 0)
+
+            instanttensor_tensors = {}
+            for name, tensor in instanttensor_weights_iterator(safetensors_files):
+                # Copy immediately in case InstantTensor exposes internal buffers.
+                instanttensor_tensors[name] = tensor.to("cpu")
+
+            reference_tensors = dict(safetensors_weights_iterator(safetensors_files))
+
+            self.assertEqual(len(instanttensor_tensors), len(reference_tensors))
+            for name, got in instanttensor_tensors.items():
+                ref = reference_tensors[name]
+                self.assertEqual(got.dtype, ref.dtype)
+                self.assertEqual(got.shape, ref.shape)
+                self.assertTrue(torch.equal(got, ref))
+
+
+class TestSubByteDtypeGuard(unittest.TestCase):
+    """Sub-byte dtypes must be refused, since InstantTensor misloads them."""
+
+    def _write(self, path: str, dtype: str, shape: list[int], nbytes: int) -> str:
+        header = {"t": {"dtype": dtype, "shape": shape, "data_offsets": [0, nbytes]}}
+        blob = json.dumps(header).encode()
+        blob += b" " * ((8 - len(blob) % 8) % 8)
+        with open(path, "wb") as f:
+            f.write(struct.pack("<Q", len(blob)))
+            f.write(blob)
+            f.write(b"\x11" * nbytes)
+        return path
+
+    def test_packed_fp4_shard_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            shard = self._write(
+                os.path.join(d, "model.safetensors"), "F4", [2048], 1024
+            )
+            self.assertEqual(_find_sub_byte_dtype([shard]), "F4")
+
+    def test_byte_aligned_shard_is_accepted(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            shards = [
+                self._write(os.path.join(d, "a.safetensors"), "BF16", [512], 1024),
+                self._write(os.path.join(d, "b.safetensors"), "F8_E4M3", [1024], 1024),
+                self._write(os.path.join(d, "c.safetensors"), "U8", [1024], 1024),
+            ]
+            self.assertIsNone(_find_sub_byte_dtype(shards))
+
+    def test_unparsable_header_raises_rather_than_waving_the_shard_through(
+        self,
+    ) -> None:
+        # Failing open would let the very shard the guard cannot inspect carry
+        # the sub-byte tensors it exists to catch.
+        with tempfile.TemporaryDirectory() as d:
+            cases = {
+                "truncated.safetensors": b"\x00",
+                "not_an_object.safetensors": struct.pack("<Q", 8) + b"[1,2,3] ",
+                "absurd_header.safetensors": struct.pack("<Q", 2**62),
+            }
+            for filename, blob in cases.items():
+                path = os.path.join(d, filename)
+                with open(path, "wb") as f:
+                    f.write(blob)
+                with self.subTest(filename):
+                    with self.assertRaises((ValueError, struct.error)):
+                        _find_sub_byte_dtype([path])
+
+
+@unittest.skipIf(not IS_NVIDIA, "InstantTensor requires NVIDIA GPUs")
+@unittest.skipIf(not INSTANTTENSOR_AVAILABLE, "instanttensor is not installed")
+class TestInstantTensorRejectsSubByteCheckpoints(unittest.TestCase):
+    def test_iterator_raises_at_call_time_not_at_first_pull(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            shard = os.path.join(d, "model.safetensors")
+            header = {"t": {"dtype": "F4", "shape": [2048], "data_offsets": [0, 1024]}}
+            blob = json.dumps(header).encode()
+            blob += b" " * ((8 - len(blob) % 8) % 8)
+            with open(shard, "wb") as f:
+                f.write(struct.pack("<Q", len(blob)))
+                f.write(blob)
+                f.write(b"\x11" * 1024)
+
+            # Validating only on the first ``next()`` would defer this until
+            # after the model skeleton is allocated on every rank.
+            with self.assertRaises(ValueError) as caught:
+                instanttensor_weights_iterator([shard])
+            self.assertIn("F4", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
(the motivation is to accelerate local dev)

InstantTensor reads safetensors shards directly onto the GPU, sharding the reads across ranks. On MiniMax-M3 over four GPUs it cuts the weight-load phase from 34-43s to a steady 21s.

This re-lands PR #418, which was reverted for CI failures. The revert was correct: the original also switched CI jobs and image builds over to the new format. Only the loader comes back here, reachable solely through an explicit `--load-format instanttensor`; no default and no job changes.

It is an optional extra rather than a core dependency, because the project publishes x86_64 wheels only -- as a core dependency it would break `pip install` on ARM, including this repo's own ARM CI, whether or not the format is ever requested.

Two things the loader's GPU-direct behavior exposes elsewhere:

A model's `load_weights` must consume the iterator lazily. Buffering it is free when tensors stage through host RAM but holds the whole checkpoint on the device here, so gpt-oss's MXFP4 path streams its expert tensors instead of collecting them into a list. That in turn removes the whole-iterator `any()` probe it used to pick an expert layout -- a probe would consume the stream -- so each tensor now routes on its own name, which is unambiguous either way and avoids silently dropping every tensor of the layout that lost the latch.

Sub-byte safetensors dtypes are rejected up front. InstantTensor applies a header's logical element count to a torch dtype whose element is a packed pair, so an `F4` tensor declared [2048] over 1024 bytes arrives at shape (2048,) -- twice its own storage -- and nothing raises. NVFP4 and MXFP4 checkpoints are unaffected: they store packed 4-bit values as byte-aligned `U8`, and load bit-identically to the safetensors loader (verified over 321 tensors of MiniMax-M3-NVFP4).

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
