### PR TITLE
perf(kda): fold the gated RMSNorm into the NVIDIA megafuse decode

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda_dispatch.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda_dispatch.py
@@ -32,7 +32,7 @@ _DENSE_HALF_SIGNATURES = format_signatures(
     priority=Priority.SPECIALIZED,
     traits={
         "paged_state": frozenset({True}),
-        "fused_output_norm": frozenset({False}),
+        "fused_output_norm": frozenset({False, True}),
     },
     tags={"nvidia", "paged_cache", "cuda_graph", "fusion"},
 )
@@ -58,7 +58,6 @@ def triton_nvidia_kda_fused_paged_decode(
     norm_eps: float | None = None,
 ) -> torch.Tensor:
     """Adapt dev's NVIDIA conv/GEMV/recurrent megafusion."""
-    del output_gate, norm_weight, norm_eps
     from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
         fused_recurrent_kda_megafuse,
     )
@@ -79,6 +78,9 @@ def triton_nvidia_kda_fused_paged_decode(
         head_dim=head_dim,
         cu_seqlens=cu_seqlens,
         lower_bound=lower_bound,
+        output_gate=output_gate,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
     ).view(1, -1, num_heads, head_dim)
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -11,6 +11,10 @@ change is state I/O: instead of gather -> kernel -> scatter round-trips through
 ``at::index_elementwise``, the kernel reads ``h0_pool[read_idx]`` and writes
 ``h0_pool[write_idx]`` directly. ``write_idx < 0`` (graph padding) skips the
 store; read and write indices may differ (flat-KV page-boundary crossing).
+
+``fused_recurrent_kda_megafuse`` additionally accepts a tokenspeed-only gated
+RMSNorm epilogue (``output_gate``/``norm_weight``/``norm_eps``); with it unset
+the kernel is unchanged.
 """
 
 from __future__ import annotations
@@ -496,6 +500,7 @@ def fused_recurrent_kda_mtp(
         "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
         "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
         "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+        "FUSE_OUTPUT_NORM": lambda args: args["gate"] is not None,
     }
 )
 @triton.jit(do_not_specialize=["N", "T"])
@@ -509,6 +514,9 @@ def fused_recurrent_kda_megafuse_fwd_kernel(
     A_log,
     dt_bias,
     o,
+    gate,  # tokenspeed extension: [T, HV*V] raw output-gate logits, or None
+    norm_w,  # tokenspeed extension: [V] gated-RMSNorm weight, or None
+    norm_eps,
     h_pool,
     read_indices,
     write_indices,
@@ -517,6 +525,7 @@ def fused_recurrent_kda_megafuse_fwd_kernel(
     stride_raw_tok: tl.constexpr,
     stride_fa_tok: tl.constexpr,
     stride_beta_tok: tl.constexpr,
+    stride_gate_tok: tl.constexpr,
     scale: tl.constexpr,
     N: tl.int64,
     T: tl.int64,
@@ -533,6 +542,7 @@ def fused_recurrent_kda_megafuse_fwd_kernel(
     IS_VARLEN: tl.constexpr,
     HAS_DT_BIAS: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
+    FUSE_OUTPUT_NORM: tl.constexpr,
 ):
     pid = tl.program_id(0)
     NV = tl.cdiv(V, BV)
@@ -675,6 +685,14 @@ def fused_recurrent_kda_megafuse_fwd_kernel(
     b_v *= b_beta
     b_h += b_k[:, None] * b_v[None, :]
     b_o = tl.sum(b_h * b_q[:, None], 0)
+    # tokenspeed extension: NV == 1, so b_o is the whole row the norm would reload.
+    if FUSE_OUTPUT_NORM:
+        b_rsig = tl.math.rsqrt(tl.sum(b_o * b_o) / V + norm_eps)
+        b_nw = tl.load(norm_w + o_v, mask=mask_v, other=0.0).to(tl.float32)
+        b_gate = tl.load(
+            gate + bos * stride_gate_tok + i_hv * V + o_v, mask=mask_v, other=0.0
+        ).to(tl.float32)
+        b_o = b_o * b_rsig * b_nw * tl.sigmoid(b_gate)
     tl.store(
         o + (bos * HV + i_hv) * V + o_v,
         b_o.to(o.dtype.element_ty),
@@ -1005,6 +1023,9 @@ def fused_recurrent_kda_megafuse(
     scale: float | None = None,
     cu_seqlens: torch.Tensor | None = None,
     lower_bound: float | None = None,
+    output_gate: torch.Tensor | None = None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
 ) -> torch.Tensor:
     """Single-step KDA decode with conv1d(+silu) and the f_b gate GEMV fused in.
 
@@ -1016,9 +1037,17 @@ def fused_recurrent_kda_megafuse(
         beta: ``[T, HV]`` raw logits (sigmoid in-kernel).
         h_pool / read_indices / write_indices: as in the pool kernel.
         num_heads/head_dim: per-rank head geometry (P = num_heads*head_dim).
+        output_gate: optional ``[T, HV*V]`` (or ``[T, HV, V]``) raw gate logits;
+            a row-strided slice of a wider packed projection is accepted.
+            Supplying it, with ``norm_weight`` and ``norm_eps``, folds the gated
+            RMSNorm epilogue ``rmsnorm(o)*norm_weight*sigmoid(gate)`` into this
+            kernel instead of running it as a second pass.
+        norm_weight: ``[V]`` RMSNorm weight; required with ``output_gate``.
+        norm_eps: RMSNorm epsilon; required with ``output_gate``.
 
     Returns:
-        o: ``[T, HV, V]`` attention output (bf16).
+        o: ``[T, HV, V]`` attention output (bf16), normalized and gated when
+        ``output_gate`` is given.
     """
     T = qkv_raw.shape[0]
     HV = num_heads
@@ -1028,6 +1057,24 @@ def fused_recurrent_kda_megafuse(
     if scale is None:
         scale = K**-0.5
     assert qkv_raw.stride(-1) == 1 and conv_w.is_contiguous() and w_fb.is_contiguous()
+    if (output_gate is None) != (norm_weight is None):
+        raise ValueError("output_gate and norm_weight must be given together")
+    if output_gate is not None:
+        if norm_eps is None:
+            raise ValueError("norm_eps is required with output_gate")
+        if output_gate.stride(-1) != 1 or output_gate.numel() != T * HV * V:
+            raise ValueError(
+                f"output_gate must be row-contiguous over {T * HV * V} elements, "
+                f"got shape {tuple(output_gate.shape)} stride "
+                f"{tuple(output_gate.stride())}"
+            )
+        if output_gate.dim() == 3 and output_gate.stride(1) != V:
+            raise ValueError("output_gate heads must be V-strided")
+        if norm_weight.numel() != V:
+            raise ValueError(f"norm_weight must be [{V}], got {norm_weight.shape}")
+        stride_gate_tok = output_gate.stride(0)
+    else:
+        stride_gate_tok = 0
     N = T if cu_seqlens is None else len(cu_seqlens) - 1
     out = torch.empty(T, HV, V, dtype=qkv_raw.dtype, device=qkv_raw.device)
     # One program per (request, head): NV == 1 leaves the q/k taps unshared.
@@ -1043,6 +1090,10 @@ def fused_recurrent_kda_megafuse(
         A_log=A_log,
         dt_bias=dt_bias,
         o=out,
+        gate=output_gate,
+        norm_w=norm_weight,
+        norm_eps=0.0 if norm_eps is None else norm_eps,
+        stride_gate_tok=stride_gate_tok,
         h_pool=h_pool,
         read_indices=read_indices,
         write_indices=write_indices,

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -17,6 +17,10 @@ from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.registry import KernelRegistry
 from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 
+# K3 serving values: gate lower bound from the config, RMSNorm eps from the model.
+LOWER_BOUND = -5.0
+NORM_EPS = 1e-6
+
 
 def test_k3_safe_gate_reference_matches_sigmoid_contract() -> None:
     """Distinguish K3's safe sigmoid gate from a clamped softplus gate."""
@@ -243,6 +247,8 @@ def test_kda_paged_decode_graph_padding_and_page_stride() -> None:
 )
 def test_kda_fused_paged_decode_matches_reference(batch: int, active: int) -> None:
     """The K3 megafusion preserves state paging and its fused norm epilogue."""
+    # NVIDIA is covered by test_kda_megafuse_fused_norm_matches_separate_norm: the
+    # 2e-4 state tolerance below is tuned to the gfx950 kernel's accumulation.
     if not (current_platform().is_cdna4 or current_platform().is_cdna5):
         pytest.skip("gfx950/gfx1250 KDA fusion test")
 
@@ -384,10 +390,15 @@ def test_kda_fused_paged_decode_matches_reference(batch: int, active: int) -> No
 
 def test_kda_fused_decode_override_preserves_external_output_norm(monkeypatch) -> None:
     """A core-only override must not claim that it applied output normalization."""
-    kernel_name = "triton_nvidia_kda_fused_paged_decode"
+    assert KernelRegistry.get().get_by_name(
+        "triton_nvidia_kda_fused_paged_decode"
+    ).traits["fused_output_norm"] == frozenset({False, True})
+
+    # The verify kernel is registered without the trait at all.
+    kernel_name = "triton_nvidia_kda_fused_paged_verify"
     spec = KernelRegistry.get().get_by_name(kernel_name)
     assert spec is not None
-    assert spec.traits["fused_output_norm"] == frozenset({False})
+    assert "fused_output_norm" not in spec.traits
 
     captured_kwargs = {}
 
@@ -477,3 +488,138 @@ def test_kda_paged_decode_does_not_select_nvidia_kernel_on_amd() -> None:
             _attention_format_signature(q=q, k=k, v=v),
             traits={"indexed_state": True, "single_token": False},
         )
+
+
+def _megafuse_inputs(batch: int, seed: int = 17):
+    """Build K3-shaped megafuse decode inputs (TP8 rank: 12 heads, K=V=128)."""
+    torch.manual_seed(seed)
+    heads, head_dim = 12, 128
+    pages = 2 * batch
+    width = heads * head_dim
+    used = 4 * width + head_dim + heads
+    packed = torch.randn(
+        batch, (used + 15) // 16 * 16, device="cuda", dtype=torch.bfloat16
+    )
+    return {
+        "heads": heads,
+        "head_dim": head_dim,
+        "mixed_qkv": packed[:, : 3 * width],
+        "output_gate": packed[:, 3 * width : 4 * width],
+        "f_a_out": packed[:, 4 * width : 4 * width + head_dim],
+        "beta_logits": packed[:, 4 * width + head_dim : used],
+        "conv_weights": 0.1
+        * torch.randn(3 * width, 4, device="cuda", dtype=torch.bfloat16),
+        "conv_states": 0.1
+        * torch.randn(pages, 3 * width, 3, device="cuda", dtype=torch.bfloat16),
+        "f_b_weight": 0.1
+        * torch.randn(width, head_dim, device="cuda", dtype=torch.bfloat16),
+        "a_log": torch.randn(heads, device="cuda", dtype=torch.float32),
+        "dt_bias": torch.randn(width, device="cuda", dtype=torch.float32),
+        "norm_weight": torch.randn(head_dim, device="cuda", dtype=torch.bfloat16),
+        "state_pool": 0.01
+        * torch.randn(
+            pages, heads, head_dim, head_dim, device="cuda", dtype=torch.float32
+        ),
+        "read_indices": torch.arange(batch, device="cuda", dtype=torch.int32),
+        "write_indices": torch.arange(
+            batch, 2 * batch, device="cuda", dtype=torch.int32
+        ),
+        "cu_seqlens": torch.arange(batch + 1, device="cuda", dtype=torch.int32),
+    }
+
+
+def _run_megafuse(inp, *, fused: bool):
+    """One megafuse decode, with the norm epilogue fused in or applied after."""
+    from tokenspeed_kernel.ops.activation.triton import rmsnorm_gated_sigmoid
+    from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
+        fused_recurrent_kda_megafuse,
+    )
+
+    heads, head_dim = inp["heads"], inp["head_dim"]
+    # Serving passes a row-strided slice of the packed projection, not a copy.
+    gate = inp["output_gate"]
+    out = fused_recurrent_kda_megafuse(
+        inp["mixed_qkv"],
+        inp["conv_weights"],
+        inp["conv_states"],
+        inp["f_a_out"],
+        inp["f_b_weight"],
+        inp["beta_logits"],
+        inp["a_log"],
+        inp["dt_bias"],
+        h_pool=inp["state_pool"],
+        read_indices=inp["read_indices"],
+        write_indices=inp["write_indices"],
+        num_heads=heads,
+        head_dim=head_dim,
+        cu_seqlens=inp["cu_seqlens"],
+        lower_bound=LOWER_BOUND,
+        output_gate=gate if fused else None,
+        norm_weight=inp["norm_weight"] if fused else None,
+        norm_eps=NORM_EPS if fused else None,
+    )
+    if fused:
+        return out
+    return rmsnorm_gated_sigmoid(
+        out.reshape(-1, heads * head_dim).contiguous(),
+        gate.contiguous(),
+        inp["norm_weight"],
+        NORM_EPS,
+        heads,
+        head_dim,
+    ).view_as(out)
+
+
+@pytest.mark.parametrize("batch", [1, 4])
+def test_kda_megafuse_fused_norm_matches_separate_norm(batch: int) -> None:
+    """The fused epilogue reproduces megafuse followed by rmsnorm_gated_sigmoid."""
+    if not current_platform().is_nvidia:
+        pytest.skip("NVIDIA triton KDA megafusion test")
+
+    inp = _megafuse_inputs(batch)
+    conv0, state0 = inp["conv_states"].clone(), inp["state_pool"].clone()
+
+    expected = _run_megafuse(inp, fused=False)
+    conv_ref, state_ref = inp["conv_states"].clone(), inp["state_pool"].clone()
+
+    inp["conv_states"].copy_(conv0)
+    inp["state_pool"].copy_(state0)
+    fused = _run_megafuse(inp, fused=True)
+
+    torch.testing.assert_close(fused.float(), expected.float(), atol=0.5, rtol=2e-2)
+    # The epilogue must not disturb the state it writes back.
+    torch.testing.assert_close(inp["conv_states"], conv_ref)
+    torch.testing.assert_close(inp["state_pool"], state_ref)
+
+
+def test_kda_megafuse_fused_norm_is_cuda_graph_safe() -> None:
+    """The fused epilogue captures and replays inside a CUDA graph."""
+    if not current_platform().is_nvidia:
+        pytest.skip("NVIDIA triton KDA megafusion test")
+
+    inp = _megafuse_inputs(1)
+    conv0, state0 = inp["conv_states"].clone(), inp["state_pool"].clone()
+
+    # Warm eagerly: the JIT must not compile inside the capture.
+    eager = _run_megafuse(inp, fused=True)
+    inp["conv_states"].copy_(conv0)
+    inp["state_pool"].copy_(state0)
+
+    graph = torch.cuda.CUDAGraph()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        _run_megafuse(inp, fused=True)
+    torch.cuda.current_stream().wait_stream(stream)
+    inp["conv_states"].copy_(conv0)
+    inp["state_pool"].copy_(state0)
+
+    with torch.cuda.graph(graph):
+        captured = _run_megafuse(inp, fused=True)
+
+    inp["conv_states"].copy_(conv0)
+    inp["state_pool"].copy_(state0)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(captured.float(), eager.float(), atol=0.5, rtol=2e-2)


### PR DESCRIPTION
At K3 TP8 bs=1 decode every one of the 69 KDA layers ran the megafuse scan and then _rmsnorm_gated_kernel, which re-read the scan's output from HBM to normalize and gate it: 69/step at 1.90 us, 131 us/step in a 833 us/step KDA core. The launcher pins NV == 1, so each program already owns the whole V row in registers when the scan ends; normalizing there costs two narrow loads and no extra reduction.

The AMD gfx950 Gluon decode has advertised fused_output_norm since it landed, and the selection path, the KdaFusedDecodeResult flag, and the model-side skip were all built for it. Only the NVIDIA Triton kernel never claimed the trait.

The gate arrives as a row-strided slice of the packed projection, not a contiguous tensor, so the epilogue indexes it through a token stride like qkv_raw, f_a, and beta rather than assuming a packed [T, HV*V] layout.

Cold-L2 CUDA-graph microbenchmark, 16 cycled state copies: 9.09 -> 7.30 us per layer-call at bs=1 and 15.75 -> 10.51 at bs=4. State and conv writes are bit-identical with the epilogue on or off; the output differs from the composed pair by at most one bf16 ulp, because the fused path keeps the core output in fp32 instead of round-tripping it through bf16.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
