### PR TITLE
perf(k3): route decode GEMV per shape

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -2411,7 +2411,9 @@ class KimiLinearModel(nn.Module):
         self.mapping = mapping
         self.quant_config = quant_config
 
-        alt_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
+        alt_stream = (
+            torch.cuda.Stream(priority=-1) if torch.cuda.is_available() else None
+        )
 
         self.embed_tokens = VocabParallelEmbedding(
             config.vocab_size,

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -41,14 +41,22 @@ import sys
 
 import torch
 
-# (N, K, calls/step, label) -- from the serving trace, TP8, bs=1.
+# (N, K, calls/step, label). The (N, K) are OBSERVED -- logged at the
+# decode_gemv dispatch entry during a real TP16 bs=1 run, not derived. Two of
+# the three differ from the TP8 table, and the TP8 table's largest entry
+# (6288x7168) has no TP16 counterpart in decode_gemv at all.
+#
+# calls/step is NOT measured here: the shape probe dedups, so it reports which
+# shapes exist and not how often each fires. It is left at 0 so the per-step
+# projection below stays zero rather than quoting a number built on a count
+# carried over from a different parallelism. Labels are the shapes themselves;
+# mapping them to call sites would be a guess until the counts are traced.
 SHAPES = [
-    (3584, 7168, 92, "moe_latent_down"),
-    (6288, 7168, 69, "kda_in_proj"),
-    (3648, 7168, 24, "mla_qkv_a_gate"),
-    (2304, 1536, 24, "mla_q_b"),
+    (3584, 7168, 0, "n3584_k7168"),
+    (2880, 7168, 0, "n2880_k7168"),
+    (1152, 1536, 0, "n1152_k1536"),
 ]
-MS = [1]  # decode_gemv is only reached at M == 1 in serving
+MS = [1, 2, 3, 4, 5, 6, 7, 8]  # observed range: the gates admit M <= 8
 NUM_COPIES = 8
 # 41-round medians repeat within ~1-2%, so 4% clears noise without excluding
 # the consistent 6-11% skinny wins.
@@ -184,7 +192,10 @@ for n, k, calls, label in SHAPES:
             )
 
 print()
-print(f"projected saving vs incumbent: {per_step_gain:.0f} us/step")
+if any(c for _, _, c, _ in SHAPES):
+    print(f"projected saving vs incumbent: {per_step_gain:.0f} us/step")
+else:
+    print("per-step projection skipped: calls/step not measured")
 print(json.dumps(route, indent=2))
 if len(sys.argv) > 1:
     json.dump(route, open(sys.argv[1], "w"), indent=2)

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Measure decode-GEMV backends at Kimi-K3's real serving shapes, cold-cache.
+
+The shapes are the exact (N, K) that ``decode_gemv`` receives during TP8
+decode, extracted from an nsys trace of the serving path (rowcta's launch grid
+is ``(N,)``, so gridX identifies each call site). Every measurement cycles
+through NUM_COPIES independent weight tensors so the L2 never holds the
+operand between calls -- serving streams a different layer's weight each
+launch, and a single-tensor benchmark distorts the ranking (hot-L2 numbers at
+6288x7168 ran 1.9x faster than the serving trace's, and cold-L2 reproduces the
+serving per-shape times within ~5%).
+
+A backend earns a routing entry only by beating the incumbent (the kernel
+dispatch picks today) by at least MARGIN.
+Emits the MEASURED_ROUTE dict for ops/gemm/routed_gemv.py.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import torch
+
+# (N, K, calls/step, label) -- from the serving trace, TP8, bs=1.
+SHAPES = [
+    (3584, 7168, 92, "moe_latent_down"),
+    (6288, 7168, 69, "kda_in_proj"),
+    (3648, 7168, 24, "mla_qkv_a_gate"),
+    (2304, 1536, 24, "mla_q_b"),
+]
+MS = [1]  # decode_gemv is only reached at M == 1 in serving
+NUM_COPIES = 8
+# 41-round medians repeat within ~1-2%, so 4% clears noise without excluding
+# the consistent 6-11% skinny wins.
+MARGIN = 1.04
+
+
+def timed(fns, iters: int = 96, rounds: int = 41) -> float:
+    """Median us/call; each graph iteration advances to the next weight copy."""
+    n = len(fns)
+    for fn in fns:
+        fn()
+    torch.cuda.synchronize()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for i in range(3):
+            fns[i % n]()
+    torch.cuda.current_stream().wait_stream(s)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        for i in range(iters):
+            fns[i % n]()
+    torch.cuda.synchronize()
+    out = []
+    for _ in range(rounds):
+        a, b = torch.cuda.Event(True), torch.cuda.Event(True)
+        a.record()
+        g.replay()
+        b.record()
+        torch.cuda.synchronize()
+        out.append(a.elapsed_time(b) * 1e3 / iters)
+    out.sort()
+    return out[len(out) // 2]
+
+
+def candidates(m: int, n: int, k: int):
+    """Yield (name, per-copy callables, sample output, reference) per backend."""
+    xs = [
+        torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        for _ in range(NUM_COPIES)
+    ]
+    ws = [
+        torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+        for _ in range(NUM_COPIES)
+    ]
+    o = torch.empty(m, n, device="cuda", dtype=torch.bfloat16)
+    ref = (xs[0] @ ws[0].t()).float()
+
+    def cublas(i):
+        return lambda: torch.mm(xs[i], ws[i].t(), out=o)
+
+    yield "cublas", [cublas(i) for i in range(NUM_COPIES)], o, ref
+
+    if m == 1:
+        from tokenspeed_kernel.ops.gemm.triton_gemv import rowcta_gemv
+
+        def rc(i):
+            return lambda: rowcta_gemv(xs[i], ws[i], o)
+
+        yield "rowcta", [rc(i) for i in range(NUM_COPIES)], o, ref
+
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        shape_dynamic_skinny_gemm as skinny,
+    )
+
+    if skinny.is_available():
+        cfg = skinny.default_config(m, n, k)
+        if skinny.supports(cfg, m, n, k):
+
+            def sk(i):
+                return lambda: skinny(xs[i], ws[i], cfg, out=o)
+
+            yield "skinny", [sk(i) for i in range(NUM_COPIES)], o, ref
+
+    try:
+        from flashinfer import mm_bf16
+
+        bias = torch.zeros(n, device="cuda", dtype=torch.bfloat16)
+
+        def tg(i):
+            return lambda: mm_bf16(
+                xs[i], ws[i].t(), bias=bias, pdl=True, backend="tgv", out=o
+            )
+
+        yield "tgv", [tg(i) for i in range(NUM_COPIES)], o, ref
+    except ImportError:
+        pass
+
+
+route: dict[str, str] = {}
+per_step_gain = 0.0
+print(f"cold-L2 sweep: {NUM_COPIES} weight copies per backend")
+print(f"{'call site':<18}{'NxK':>12} {'M':>2}  ", end="")
+print("  ".join(f"{t:>8}" for t in ("cublas", "rowcta", "skinny", "tgv")), end="")
+print(f"  {'winner':<8} {'gain':>6}")
+print("-" * 92)
+for n, k, calls, label in SHAPES:
+    for m in MS:
+        times: dict[str, float | None] = {}
+        for name, fns, o, ref in candidates(m, n, k):
+            try:
+                fns[0]()
+                torch.cuda.synchronize()
+                err = (o.float() - ref).abs().max().item()
+                if err > 1.5:
+                    times[name] = None
+                    continue
+                times[name] = timed(fns)
+            except Exception:  # noqa: BLE001
+                times[name] = None
+        ok = {t: v for t, v in times.items() if v is not None and t != "cublas"}
+        best = min(ok, key=ok.get) if ok else None
+        cells = "  ".join(
+            f"{times.get(t):8.3f}" if isinstance(times.get(t), float) else f"{'-':>8}"
+            for t in ("cublas", "rowcta", "skinny", "tgv")
+        )
+        # An entry must beat the incumbent selection, not just cuBLAS.
+        incumbent = min(
+            v for t, v in times.items() if v is not None and t in ("cublas", "rowcta")
+        )
+        if best and ok[best] * MARGIN <= incumbent:
+            route[f"{m},{n},{k}"] = best
+            per_step_gain += (incumbent - ok[best]) * calls
+            print(
+                f"{label:<18}{f'{n}x{k}':>12} {m:>2}  {cells}  {best:<8} "
+                f"{incumbent / ok[best]:5.2f}x"
+            )
+        else:
+            keep = "rowcta" if times.get("rowcta") == incumbent else "cublas"
+            print(
+                f"{label:<18}{f'{n}x{k}':>12} {m:>2}  {cells}  {keep:<8} "
+                f"{'(keep)':>6}"
+            )
+
+print()
+print(f"projected saving vs incumbent: {per_step_gain:.0f} us/step")
+print(json.dumps(route, indent=2))
+if len(sys.argv) > 1:
+    json.dump(route, open(sys.argv[1], "w"), indent=2)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
@@ -27,6 +27,7 @@ import tokenspeed_kernel.numerics.reference.gemm  # noqa: F401
 import tokenspeed_kernel.ops.gemm.deep_gemm  # noqa: F401
 import tokenspeed_kernel.ops.gemm.flashinfer  # noqa: F401
 import tokenspeed_kernel.ops.gemm.gluon  # noqa: F401
+import tokenspeed_kernel.ops.gemm.routed_gemv  # noqa: F401
 import tokenspeed_kernel.ops.gemm.triton  # noqa: F401
 import tokenspeed_kernel.ops.gemm.trtllm  # noqa: F401
 import torch

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -420,11 +420,12 @@ def kimi3_latent_projection_add3(
             When provided, RMSNorm is applied to ``hidden_states`` before the
             projection.
         eps: Positive RMSNorm epsilon required with ``norm_weight``.
-        solution: ``"auto"`` selects the fused row-CTA GEMV for one-token
-            execution, the fused MFMA epilogue for the tuned M=16 tile, and
-            otherwise composes the registered projection and add kernels.
-            ``"rowcta_gemv"``, ``"gluon_mfma_add3"``, and ``"composed"``
-            force an implementation.
+        solution: ``"auto"`` selects the dual-residual skinny epilogue where
+            it holds a measured win (sm103, M <= 2), the fused row-CTA GEMV
+            for other one-token execution, the fused MFMA epilogue for the
+            tuned M=16 tile, and otherwise composes the registered projection
+            and add kernels. ``"rowcta_gemv"``, ``"skinny_add3"``,
+            ``"gluon_mfma_add3"``, and ``"composed"`` force an implementation.
 
     Returns:
         ``prefix + hidden_states @ weight.T + shared_output`` shaped ``[M, N]``.
@@ -452,7 +453,13 @@ def kimi3_latent_projection_add3(
                 f"Kimi K3 latent projection {name} must have unit inner stride"
             )
 
-    if solution not in {"auto", "rowcta_gemv", "gluon_mfma_add3", "composed"}:
+    if solution not in {
+        "auto",
+        "rowcta_gemv",
+        "skinny_add3",
+        "gluon_mfma_add3",
+        "composed",
+    }:
         raise ValueError(f"unknown Kimi K3 projection-add3 solution {solution!r}")
     specialized = (
         hidden_states.is_cuda
@@ -501,12 +508,33 @@ def kimi3_latent_projection_add3(
         raise ValueError("Kimi K3 RMSNorm epsilon requires a norm weight")
 
     if solution == "auto":
-        if m == 1 and specialized:
+        from tokenspeed_kernel.ops.gemm.routed_gemv import (
+            skinny_add3_supported,
+        )
+
+        if specialized and skinny_add3_supported(m, n, k, hidden_states.device):
+            # Dual-residual skinny epilogue: 1.06x over rowcta_gemv_add3.
+            solution = "skinny_add3"
+        elif m == 1 and specialized:
             solution = "rowcta_gemv"
         elif Platform.get().is_cdna4 and m == 16 and specialized:
             solution = "gluon_mfma_add3"
         else:
             solution = "composed"
+    if solution == "skinny_add3":
+        if not specialized:
+            raise ValueError(
+                "skinny_add3 projection-add3 requires contiguous CUDA BF16 "
+                "inputs at a K3 latent shape"
+            )
+        from tokenspeed_kernel.ops.gemm.routed_gemv import skinny_gemv_add3
+
+        return skinny_gemv_add3(
+            hidden_states,
+            weight,
+            prefix,
+            shared_output,
+        )
     if solution == "rowcta_gemv":
         if m != 1:
             raise ValueError("rowcta_gemv projection-add3 requires one input row")
@@ -795,17 +823,15 @@ def kimi3_qkvfab_projection(
         and weight.dtype == torch.bfloat16
         and hidden_states.is_contiguous()
         and weight.is_contiguous()
-        and m == 1
+        and m <= 8
         and input_width == KIMI3_HIDDEN_SIZE
         and output_width == KIMI3_QKVFAB_SIZE
     )
     if solution == "auto":
-        if Platform.get().is_cdna4 and specialized:
+        if Platform.get().is_cdna4 and specialized and m == 1:
             solution = "triton_gemv"
-        elif specialized and m == 1:
-            # NVIDIA (and other CUDA) decode: the registry GEMV keeps the
-            # row-per-CTA streaming kernel that beats cublasLt on this
-            # [6288, 7168] shape (dev's pre-refactor KimiKDAMergedProj path).
+        elif specialized:
+            # Let the registry pick per (M, N, K); unlisted shapes hit torch.mm.
             solution = "decode_gemv"
         else:
             solution = "torch"
@@ -818,7 +844,7 @@ def kimi3_qkvfab_projection(
         out.copy_(result)
         return out
     if solution == "triton_gemv":
-        if not specialized:
+        if not (specialized and m == 1):
             raise ValueError(
                 "Kimi K3 QKVFAB Triton GEMV requires contiguous gfx950 "
                 "BF16 [1, 7168] input and [6288, 7168] weight"

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/linear_attnres_partials.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/linear_attnres_partials.py
@@ -289,7 +289,9 @@ def linear_attnres_partials(
                 out=out,
             )
 
-    if tokens == 1 and hidden_states.is_contiguous() and weight.is_contiguous():
+    # decode_gemv falls back to torch.mm for unlisted shapes, so widening this
+    # gate past M == 1 only adds the measured kernels.
+    if tokens <= 8 and hidden_states.is_contiguous() and weight.is_contiguous():
         from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
 
         projected = decode_gemv(hidden_states, weight)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -68,6 +68,27 @@ MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
         (2, 2304, 1536): "skinny",  # 2.52 vs 4.97 (1.97x)
         (4, 2304, 1536): "tgv",  # 2.86 vs 4.58 (1.60x)
         (8, 2304, 1536): "tgv",  # 2.86 vs 4.45 (1.56x)
+        # TP16 (GB200, sm100). The shapes were read off the decode_gemv
+        # dispatch during a live bs=1 run rather than scaled from TP8: only
+        # 1152x1536 halves, 3584x7168 is not TP-sharded at all, 2880x7168 has
+        # no TP8 analogue, and TP8's largest entry (6288x7168) never reaches
+        # decode_gemv here. Same >= 4% margin, same cold-L2 tuner.
+        (3, 3584, 7168): "skinny",  # 9.54 vs 11.23 (1.18x)
+        (1, 2880, 7168): "skinny",  # 7.13 vs rowcta 8.61 (1.21x)
+        (2, 2880, 7168): "skinny",  # 7.95 vs 9.80 (1.23x)
+        (3, 2880, 7168): "skinny",  # 8.24 vs 9.77 (1.19x)
+        (4, 2880, 7168): "skinny",  # 9.32 vs 9.78 (1.05x)
+        # 3584 and 2880 stay on the incumbent at M >= 5: skinny inverts there
+        # (15.85 vs cublas 11.06 at M=8, 3584x7168), so the win is not simply
+        # "skinny for small M" and the boundary has to be measured per width.
+        (2, 1152, 1536): "skinny",  # 1.99 vs 4.85 (2.44x)
+        (3, 1152, 1536): "skinny",  # 2.10 vs 4.47 (2.13x)
+        (4, 1152, 1536): "skinny",  # 2.24 vs 4.40 (1.97x)
+        (5, 1152, 1536): "skinny",  # 2.23 vs 4.40 (1.98x)
+        (6, 1152, 1536): "skinny",  # 2.35 vs 4.42 (1.89x)
+        (7, 1152, 1536): "skinny",  # 2.59 vs 4.45 (1.72x)
+        (8, 1152, 1536): "skinny",  # 2.72 vs 4.46 (1.64x)
+        # (1, 1152, 1536) stays on rowcta: 1.907 vs 1.943, inside the margin.
     }
 )
 
@@ -79,9 +100,12 @@ _BF16_SIG = frozenset(
         )
     }
 )
-# Measured on sm103; nothing below that ran the sweep.
+# sm100 (GB200/B200) and sm103 (GB300) both run these kernels -- the skinny
+# GEMM uses only generic CuTe primitives, and the sm103 gate recorded where the
+# sweep had been run, not what the kernels require. Re-swept on GB200: the
+# sm103 winners reproduce entry for entry at the TP8 shapes.
 _CAPABILITY = CapabilityRequirement(
-    min_arch_version=ArchVersion(10, 3),
+    min_arch_version=ArchVersion(10, 0),
     vendors=frozenset({"nvidia"}),
 )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -1,0 +1,336 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Measured decode-GEMV routing for Kimi-K3's projection shapes.
+
+Every entry in ``MEASURED_ROUTE`` was measured on GB300 (sm103) at the exact
+(N, K) the TP8 decode path hands ``decode_gemv`` -- extracted from an nsys
+trace of serving, not assumed -- with the tuner cycling eight weight copies
+so the L2 never holds the operand between calls, the way serving streams a
+different layer's weight each launch. Hot-cache numbers ranked backends
+wrongly (1.9x off serving at 6288x7168); cold-L2 reproduces serving per-shape
+times within ~5%. ``test/gemm_tuning/tune_route.py`` reproduces the sweep.
+
+A backend earns an entry only by beating the incumbent selection by at least
+4% -- above measurement noise, so a noise-level lead does not become a
+maintenance obligation. Shapes not listed keep the selection they had
+(rowcta at M == 1, torch.mm otherwise). The table is data, not policy:
+re-run the sweep on new hardware or after a kernel change and replace the
+literals wholesale.
+"""
+
+from __future__ import annotations
+
+import functools
+import threading
+from types import MappingProxyType
+
+import torch
+from tokenspeed_kernel.ops.gemm.triton_gemv import _torch_decode_gemv
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import dense_tensor_format, format_signature
+
+# (m, n, k) -> backend; immutable so the registry's import-time view and the
+# wrappers' per-call view cannot diverge. Measured; see module docstring.
+MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
+    {
+        (1, 3584, 7168): "skinny",  # MoE latent down-proj, 92 calls/step
+        (1, 6288, 7168): "skinny",  # KDA in_proj (qkvgfab), 69 calls/step
+        (1, 3648, 7168): "skinny",  # MLA fused qkv_a + gate, 24 calls/step
+        # (1, 2304, 1536) mla_q_b stays on rowcta: 2.48 vs skinny 2.53.
+        # M > 1 (small batches, speculative verify) vs the cublas incumbent.
+        (2, 3584, 7168): "skinny",  # 9.20 vs 11.67 (1.27x)
+        (4, 3584, 7168): "skinny",  # 10.38 vs 11.21 (1.08x)
+        (2, 6288, 7168): "tgv",  # 15.29 vs 17.07 (1.12x)
+        (4, 6288, 7168): "tgv",  # 15.25 vs 17.26 (1.13x)
+        (8, 6288, 7168): "tgv",  # 15.38 vs 16.75 (1.09x)
+        (2, 3648, 7168): "skinny",  # 9.33 vs 11.58 (1.24x)
+        (4, 3648, 7168): "skinny",  # 10.40 vs 11.51 (1.11x)
+        (8, 3648, 7168): "tgv",  # 10.65 vs 11.47 (1.08x)
+        (2, 2304, 1536): "skinny",  # 2.52 vs 4.97 (1.97x)
+        (4, 2304, 1536): "tgv",  # 2.86 vs 4.58 (1.60x)
+        (8, 2304, 1536): "tgv",  # 2.86 vs 4.45 (1.56x)
+    }
+)
+
+_BF16_SIG = frozenset(
+    {
+        format_signature(
+            x=dense_tensor_format(torch.bfloat16),
+            weight=dense_tensor_format(torch.bfloat16),
+        )
+    }
+)
+# Measured on sm103; nothing below that ran the sweep.
+_CAPABILITY = CapabilityRequirement(
+    min_arch_version=ArchVersion(10, 3),
+    vendors=frozenset({"nvidia"}),
+)
+
+
+# Shapes an eager call has already compiled and allocated for. Capture must
+# not JIT or allocate, so an unwarmed shape falls back to torch.mm there.
+_warmed: set[tuple[str, int, int, int, int]] = set()
+_warmed_lock = threading.Lock()
+
+
+def _usable_in_capture(backend: str, dev: int, m: int, n: int, k: int) -> bool:
+    # Device-keyed: warmth on one GPU says nothing about another's modules.
+    return (
+        not torch.cuda.is_current_stream_capturing()
+        or (backend, dev, m, n, k) in _warmed
+    )
+
+
+def _mark_warmed(backend: str, dev: int, m: int, n: int, k: int) -> None:
+    # Only a successful eager call earns capture trust.
+    if not torch.cuda.is_current_stream_capturing():
+        with _warmed_lock:
+            _warmed.add((backend, dev, m, n, k))
+
+
+@functools.lru_cache(maxsize=32)
+def _skinny_config(m: int, n: int, k: int):
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        shape_dynamic_skinny_gemm,
+    )
+
+    return shape_dynamic_skinny_gemm.default_config(m, n, k)
+
+
+def skinny_gemv(
+    x: torch.Tensor, weight: torch.Tensor, out: torch.Tensor | None = None
+) -> torch.Tensor:
+    """``x @ weight.T`` via the vendored CuTe skinny GEMM.
+
+    Caller-owned invariant, as for every ``decode_gemv`` backend: ``out`` must
+    not overlap ``x`` or ``weight`` storage.
+
+    Args:
+        x: ``[M, K]`` contiguous bf16 activations.
+        weight: ``[N, K]`` contiguous bf16 weight.
+        out: optional ``[M, N]`` destination.
+
+    Returns:
+        ``[M, N]`` output in ``x``'s dtype.
+    """
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        shape_dynamic_skinny_gemm,
+    )
+
+    m, k = x.shape
+    n = weight.shape[0]
+    dev = x.device.index or 0
+    # Table shapes only; anything else would grow the compile cache unbounded.
+    if (
+        MEASURED_ROUTE.get((m, n, k)) != "skinny"
+        or x.dtype != torch.bfloat16
+        or not _usable_in_capture("skinny", dev, m, n, k)
+    ):
+        return _torch_decode_gemv(x, weight, out)
+    config = _skinny_config(m, n, k)
+    # default_config can emit a config supports() rejects; fall back, don't raise.
+    if not shape_dynamic_skinny_gemm.supports(config, m, n, k):
+        return _torch_decode_gemv(x, weight, out)
+    # DLPack refuses requires_grad tensors; detach is a zero-copy view.
+    result = shape_dynamic_skinny_gemm(x.detach(), weight.detach(), config, out=out)
+    _mark_warmed("skinny", dev, m, n, k)
+    return result
+
+
+# TGV requires a bias; the routed GEMVs have none. Never an evicting cache: a
+# captured graph replays against these exact tensors.
+_tgv_biases: dict[tuple[int, int], torch.Tensor] = {}
+_tgv_bias_lock = threading.Lock()
+
+
+def _tgv_bias(n: int, device_index: int) -> torch.Tensor:
+    key = (n, device_index)
+    bias = _tgv_biases.get(key)
+    if bias is None:
+        with _tgv_bias_lock:
+            # Re-check: a racing thread must not replace a graph-held entry.
+            bias = _tgv_biases.get(key)
+            if bias is None:
+                bias = torch.zeros(
+                    n, device=f"cuda:{device_index}", dtype=torch.bfloat16
+                )
+                _tgv_biases[key] = bias
+    return bias
+
+
+def tgv_gemv(
+    x: torch.Tensor, weight: torch.Tensor, out: torch.Tensor | None = None
+) -> torch.Tensor:
+    """``x @ weight.T`` via FlashInfer's TGV low-latency GEMM.
+
+    Args:
+        x: ``[M, K]`` contiguous bf16 activations.
+        weight: ``[N, K]`` contiguous bf16 weight; its transpose is the
+            column-major ``(K, N)`` layout TGV wants, with no copy.
+        out: optional ``[M, N]`` destination.
+
+    Returns:
+        ``[M, N]`` output in ``x``'s dtype.
+    """
+    from flashinfer import mm_bf16
+
+    m, k = x.shape
+    n = weight.shape[0]
+    dev = x.device.index or 0
+    if (
+        MEASURED_ROUTE.get((m, n, k)) != "tgv"
+        or x.dtype != torch.bfloat16
+        or not _usable_in_capture("tgv", dev, m, n, k)
+    ):
+        return _torch_decode_gemv(x, weight, out)
+    bias = _tgv_bias(n, dev)
+    # TGV is CuTe DSL inside FlashInfer: same DLPack no-grad rule.
+    result = mm_bf16(
+        x.detach(), weight.detach().t(), bias=bias, pdl=True, backend="tgv", out=out
+    )
+    _mark_warmed("tgv", dev, m, n, k)
+    return result
+
+
+# Fused ``a + x @ W.T + c`` (K3 MoE latent up-proj epilogue): (m, n, k) ->
+# (block_size, outputs_per_block, k_unroll). Cold-L2 vs the incumbent: M == 1
+# 8.86us vs rowcta_gemv_add3 9.42, M == 2 10.05 vs composed 12.81. M == 4 was
+# 1.04x, under the margin, so it keeps the composed path.
+ADD3_ROUTE: MappingProxyType[tuple[int, int, int], tuple[int, int, int]] = (
+    MappingProxyType(
+        {
+            (1, 7168, 3584): (64, 4, 2),
+            (2, 7168, 3584): (64, 7, 2),
+        }
+    )
+)
+
+
+@functools.lru_cache(maxsize=8)
+def _is_measured_arch(device_index: int) -> bool:
+    from tokenspeed_kernel.platform import current_platform
+
+    platform = current_platform()
+    if platform.vendor != "nvidia":
+        return False
+    return torch.cuda.get_device_capability(device_index) >= (10, 3)
+
+
+def skinny_add3_supported(m: int, n: int, k: int, device: torch.device) -> bool:
+    """Whether :func:`skinny_gemv_add3` has a measured config for this call.
+
+    Args:
+        m/n/k: the projection extents (``x[M, K] @ W[N, K].T``).
+        device: the CUDA device the call would run on.
+
+    Returns:
+        True only for table shapes on the measured architecture.
+    """
+    return (m, n, k) in ADD3_ROUTE and _is_measured_arch(device.index or 0)
+
+
+def _composed_add3(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    a: torch.Tensor,
+    c: torch.Tensor,
+    out: torch.Tensor | None,
+) -> torch.Tensor:
+    result = torch.addmm(c, x, weight.t())
+    result += a
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+def skinny_gemv_add3(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    a: torch.Tensor,
+    c: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``a + x @ weight.T + c`` via the skinny GEMM's dual-residual epilogue.
+
+    Args:
+        x: ``[M, K]`` contiguous bf16 activations.
+        weight: ``[N, K]`` contiguous bf16 weight.
+        a/c: ``[M, N]`` addends with unit inner stride (row stride free, so a
+            column slice of a wider tensor is accepted).
+        out: optional ``[M, N]`` destination.
+
+    Returns:
+        ``[M, N]`` result in ``x``'s dtype.
+    """
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        SkinnyGemmConfig,
+        shape_dynamic_skinny_gemm,
+    )
+
+    m, k = x.shape
+    n = weight.shape[0]
+    dev = x.device.index or 0
+    tuned = ADD3_ROUTE.get((m, n, k))
+    if (
+        tuned is None
+        or x.dtype != torch.bfloat16
+        or not _is_measured_arch(dev)
+        or not _usable_in_capture("skinny_add3", dev, m, n, k)
+    ):
+        return _composed_add3(x, weight, a, c, out)
+    config = SkinnyGemmConfig(m, *tuned)
+    if not shape_dynamic_skinny_gemm.supports(config, m, n, k):
+        return _composed_add3(x, weight, a, c, out)
+    result = shape_dynamic_skinny_gemm(
+        x.detach(),
+        weight.detach(),
+        config,
+        residual=a.detach(),
+        residual2=c.detach(),
+        out=out,
+    )
+    _mark_warmed("skinny_add3", dev, m, n, k)
+    return result
+
+
+def _register_route() -> None:
+    impls = {"skinny": skinny_gemv, "tgv": tgv_gemv}
+    for (m, n, k), backend in MEASURED_ROUTE.items():
+        register_kernel(
+            "gemm",
+            "decode_gemv",
+            name=f"{backend}_gemv_m{m}_n{n}_k{k}",
+            solution="cute_dsl" if backend == "skinny" else "flashinfer",
+            capability=_CAPABILITY,
+            signatures=_BF16_SIG,
+            traits={
+                "m": frozenset({m}),
+                "n": frozenset({n}),
+                "k": frozenset({k}),
+            },
+            # Above the M == 1 rowcta spec so a measured win takes the shape.
+            priority=Priority.SPECIALIZED + 2,
+        )(impls[backend])
+
+
+_register_route()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/triton_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/triton_gemv.py
@@ -165,6 +165,7 @@ def _torch_decode_gemv(
 def _select(m: int, n: int, k: int, on_cuda: bool):
     if not on_cuda:
         return _torch_decode_gemv
+    from tokenspeed_kernel.platform import current_platform
     from tokenspeed_kernel.registry import KernelRegistry
     from tokenspeed_kernel.selection import (
         spec_matches_shape_traits,
@@ -172,7 +173,11 @@ def _select(m: int, n: int, k: int, on_cuda: bool):
     )
 
     reg = KernelRegistry.get()
-    for spec in reg.get_for_operator("gemm", "decode_gemv"):
+    # platform= makes the registry honor each spec's capability gate; without
+    # it an arch-gated spec (the measured sm103 route) would match anywhere.
+    for spec in reg.get_for_operator(
+        "gemm", "decode_gemv", platform=current_platform()
+    ):
         if spec_matches_traits(spec, {"m": m}) and spec_matches_shape_traits(
             spec, {"N": n, "K": k}
         ):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_GB300,flashinfer=0.6.16,cudnn=92000.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_GB300,flashinfer=0.6.16,cudnn=92000.json
@@ -1,0 +1,157 @@
+{
+  "_metadata": {
+    "flashinfer_version": "0.6.16",
+    "cuda_version": "13.0",
+    "cublas_version": "13.1.1",
+    "cudnn_version": "92000",
+    "cudnn_frontend_version": "1.26.0",
+    "gpu": "NVIDIA GB300"
+  },
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1, 3584), (0,), (1, 16), (1, 16), (1, 3584), (1, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      16,
+      460
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1024, 3584), (0,), (1024, 16), (1024, 16), (1024, 3584), (1024, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((128, 3584), (0,), (128, 16), (128, 16), (128, 3584), (128, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1280, 3584), (0,), (1280, 16), (1280, 16), (1280, 3584), (1280, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1536, 3584), (0,), (1536, 16), (1536, 16), (1536, 3584), (1536, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      8
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((16, 3584), (0,), (16, 16), (16, 16), (16, 3584), (16, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      16,
+      593
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1792, 3584), (0,), (1792, 16), (1792, 16), (1792, 3584), (1792, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2, 3584), (0,), (2, 16), (2, 16), (2, 3584), (2, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      32,
+      54
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2048, 3584), (0,), (2048, 16), (2048, 16), (2048, 3584), (2048, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((256, 3584), (0,), (256, 16), (256, 16), (256, 3584), (256, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2560, 3584), (0,), (2560, 16), (2560, 16), (2560, 3584), (2560, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3072, 3584), (0,), (3072, 16), (3072, 16), (3072, 3584), (3072, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      2
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((32, 3584), (0,), (32, 16), (32, 16), (32, 3584), (32, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      32,
+      488
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3584, 3584), (0,), (3584, 16), (3584, 16), (3584, 3584), (3584, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      128,
+      10
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4, 3584), (0,), (4, 16), (4, 16), (4, 3584), (4, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      16,
+      366
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4096, 3584), (0,), (4096, 16), (4096, 16), (4096, 3584), (4096, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      128,
+      22
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((512, 3584), (0,), (512, 16), (512, 16), (512, 3584), (512, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((64, 3584), (0,), (64, 16), (64, 16), (64, 3584), (64, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      7
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((768, 3584), (0,), (768, 16), (768, 16), (768, 3584), (768, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8, 3584), (0,), (8, 16), (8, 16), (8, 3584), (8, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      32,
+      554
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8192, 3584), (0,), (8192, 16), (8192, 16), (8192, 3584), (8192, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      192,
+      12
+    ]
+  ]
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/skinny_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/skinny_gemm/__init__.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Ported from vLLM's ShapeDynamicSkinnyGemm: same compile cache and argument
+# checks, tokenspeed's stream/PDL utilities, no warmup-provider registration.
+
+"""Shape-dynamic skinny GEMM: ``a @ b.T`` for small M decode activations."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+MAX_M = 16
+
+
+@dataclass(frozen=True, slots=True)
+class SkinnyGemmConfig:
+    """One compiled specialization of the skinny GEMM.
+
+    Args:
+        num_rows: M the kernel is specialized for; must equal the call's M.
+        block_size: threads cooperating on one output column.
+        outputs_per_block: output columns per block; N must divide by it.
+        k_unroll: K-loop unroll factor.
+        vector_width: elements per vectorized load.
+        static_k: bake K in as a constant when set, which the widest
+            configurations need to keep their unrolled K loop.
+    """
+
+    num_rows: int
+    block_size: int
+    outputs_per_block: int
+    k_unroll: int = 1
+    vector_width: int = 8
+    static_k: int | None = None
+
+
+def _cutedsl_available() -> bool:
+    try:
+        import cutlass  # noqa: F401
+        import cutlass.cute  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+class ShapeDynamicSkinnyGemm:
+    """Compile-once-per-(dtype, config) driver for the vendored CuTe kernel."""
+
+    def __init__(self) -> None:
+        # Device-keyed: a callable compiled on one GPU must not run on another.
+        self._compiled: dict[
+            tuple[int, torch.dtype, SkinnyGemmConfig, bool, bool], Any
+        ] = {}
+        self._compile_lock = threading.Lock()
+        self._available: bool | None = None
+
+    def is_available(self) -> bool:
+        """Whether CuTe DSL is importable, memoized."""
+        if self._available is None:
+            self._available = _cutedsl_available()
+        return self._available
+
+    @staticmethod
+    def _cutlass_dtype(dtype: torch.dtype):
+        from cutlass import BFloat16, Float16
+
+        return BFloat16 if dtype == torch.bfloat16 else Float16
+
+    @staticmethod
+    def _stream(device: torch.device):
+        from cuda.bindings.driver import CUstream
+
+        return CUstream(torch.cuda.current_stream(device).cuda_stream)
+
+    @staticmethod
+    def _use_pdl(device: torch.device) -> bool:
+        return torch.cuda.get_device_capability(device)[0] >= 9
+
+    def _compile(
+        self,
+        dtype: torch.dtype,
+        config: SkinnyGemmConfig,
+        has_residual: bool,
+        has_residual2: bool,
+        device: torch.device,
+    ) -> None:
+        import cutlass.cute as cute
+        from quack.compile_utils import make_fake_tensor
+        from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm._kernel import (
+            CuteSkinnyGemm,
+        )
+
+        element_type = self._cutlass_dtype(dtype)
+        n = cute.sym_int(divisibility=config.outputs_per_block)
+        k = (
+            config.static_k
+            if config.static_k is not None
+            else cute.sym_int(divisibility=config.block_size * config.vector_width)
+        )
+        a = make_fake_tensor(
+            element_type, (config.num_rows, k), divisibility=config.vector_width
+        )
+        b = make_fake_tensor(element_type, (n, k), divisibility=config.vector_width)
+        c = make_fake_tensor(element_type, (config.num_rows, n), divisibility=1)
+        residual = make_fake_tensor(element_type, (config.num_rows, n), divisibility=1)
+        residual2 = make_fake_tensor(element_type, (config.num_rows, n), divisibility=1)
+        kernel = CuteSkinnyGemm(
+            element_type=element_type,
+            num_rows=config.num_rows,
+            block_size=config.block_size,
+            outputs_per_block=config.outputs_per_block,
+            vector_width=config.vector_width,
+            k_unroll=config.k_unroll,
+            has_residual=has_residual,
+            has_residual2=has_residual2,
+            use_pdl=self._use_pdl(device),
+            static_k=config.static_k,
+        )
+        with torch.cuda.device(device):
+            compiled = cute.compile(
+                kernel,
+                a,
+                b,
+                residual,
+                residual2,
+                c,
+                self._stream(device),
+                options="--enable-tvm-ffi --ptxas-options -maxrregcount=64",
+            )
+        self._compiled[
+            (device.index or 0, dtype, config, has_residual, has_residual2)
+        ] = compiled
+
+    @staticmethod
+    def default_config(m: int, n: int, k: int) -> SkinnyGemmConfig:
+        """vLLM's shape heuristic, used when no measured config is on file."""
+        wide_block = 224
+        if m == 1 and k >= 7168 and k % (wide_block * 8) == 0:
+            if n % 3 == 0:
+                return SkinnyGemmConfig(m, wide_block, 3, 2 if n <= 2304 else 4)
+            if 2304 < n < 4096 and n % 2 == 0:
+                return SkinnyGemmConfig(m, wide_block, 2, k_unroll=4)
+
+        if k <= 2048 or k % (128 * 8) != 0:
+            outputs_per_block = 2 if k <= 2048 else 4
+            if n % outputs_per_block:
+                outputs_per_block = 1
+            if k % (64 * 8) == 0:
+                return SkinnyGemmConfig(m, 64, outputs_per_block, 2)
+            if k % (32 * 8) == 0:
+                return SkinnyGemmConfig(m, 32, outputs_per_block, 2)
+            return SkinnyGemmConfig(m, 32, outputs_per_block, 2, vector_width=4)
+
+        block_size = 64 if 4096 <= n < 8192 else 128
+        outputs_per_block = 1 if m == 1 and n <= 2304 else 2
+        if n % outputs_per_block:
+            outputs_per_block = 1
+        k_unroll = 2 if n <= 2304 or n >= 16384 else 1
+        return SkinnyGemmConfig(m, block_size, outputs_per_block, k_unroll=k_unroll)
+
+    def supports(self, config: SkinnyGemmConfig, m: int, n: int, k: int) -> bool:
+        """Whether ``config`` can run this shape, without compiling anything."""
+        return (
+            config.num_rows == m
+            and 1 <= m <= MAX_M
+            and n % config.outputs_per_block == 0
+            and k % (config.block_size * config.vector_width) == 0
+            and (config.static_k is None or config.static_k == k)
+        )
+
+    def __call__(
+        self,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        config: SkinnyGemmConfig,
+        residual: torch.Tensor | None = None,
+        residual2: torch.Tensor | None = None,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Compute ``a @ b.T`` (plus residual addends) with the given config.
+
+        Args:
+            a: ``[M, K]`` contiguous bf16/fp16 activations, ``1 <= M <= 16``.
+            b: ``[N, K]`` contiguous weight in the same dtype.
+            config: the specialization to run; ``num_rows`` must equal M.
+            residual: optional ``[M, N]`` addend folded into the epilogue.
+            residual2: optional second ``[M, N]`` epilogue addend; requires
+                ``residual``.
+            out: optional ``[M, N]`` destination.
+
+        Returns:
+            ``[M, N]`` result in ``a``'s dtype.
+        """
+        m, k = a.shape
+        n = b.shape[0]
+        if not self.supports(config, m, n, k):
+            raise ValueError(f"config {config} cannot run M={m} N={n} K={k}")
+        if a.dtype != b.dtype or a.dtype not in (torch.bfloat16, torch.float16):
+            raise ValueError("a and b must share one BF16 or FP16 dtype")
+        if not a.is_contiguous() or not b.is_contiguous():
+            raise ValueError("a and b must be contiguous")
+
+        if residual2 is not None and residual is None:
+            raise ValueError("residual2 requires residual")
+        has_residual = residual is not None
+        has_residual2 = residual2 is not None
+        cache_key = (a.device.index or 0, a.dtype, config, has_residual, has_residual2)
+        if cache_key not in self._compiled:
+            # Double-checked: cute.compile is expensive and not thread-safe.
+            with self._compile_lock:
+                if cache_key not in self._compiled:
+                    self._compile(
+                        a.dtype, config, has_residual, has_residual2, a.device
+                    )
+        if out is None:
+            out = torch.empty((m, n), dtype=a.dtype, device=a.device)
+        self._compiled[cache_key](
+            a,
+            b,
+            out if residual is None else residual,
+            out if residual2 is None else residual2,
+            out,
+            self._stream(a.device),
+        )
+        return out
+
+
+shape_dynamic_skinny_gemm = ShapeDynamicSkinnyGemm()
+
+__all__ = [
+    "MAX_M",
+    "ShapeDynamicSkinnyGemm",
+    "SkinnyGemmConfig",
+    "shape_dynamic_skinny_gemm",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/skinny_gemm/_kernel.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/skinny_gemm/_kernel.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Vendored from vLLM (model_executor/kernels/linear/cute_dsl/_skinny_gemm.py);
+# has_residual2 is the one local addition. The driver beside it is ported.
+
+from __future__ import annotations
+
+import cutlass
+import cutlass.cute as cute
+from cuda.bindings.driver import CUstream
+from cutlass import const_expr
+
+_PREFETCH_TILES = 2
+
+
+class CuteSkinnyGemm:
+    """Shape-dynamic low-latency GEMM for small token counts.
+
+    Computes ``C[M, N] = A[M, K] @ B[N, K].T + residual`` with BF16 or FP16
+    inputs, FP32 accumulators, and an output matching the input dtype. The
+    residual term is optional and is added before the output conversion.
+    ``has_residual2`` is a local extension over the vLLM original: a second
+    optional addend folded into the same epilogue, for fused
+    ``a + x @ W.T + c`` projections. N and
+    K are runtime values unless the configuration specializes K at compile
+    time. The tiny M dimension is fully unrolled alongside a small set of
+    tuning parameters.
+    """
+
+    def __init__(
+        self,
+        *,
+        element_type,
+        num_rows: int,
+        block_size: int,
+        outputs_per_block: int,
+        vector_width: int = 8,
+        k_unroll: int = 1,
+        has_residual: bool = False,
+        has_residual2: bool = False,
+        use_pdl: bool = False,
+        static_k: int | None = None,
+    ) -> None:
+        if block_size % cute.arch.WARP_SIZE != 0:
+            raise ValueError("block_size must be a multiple of the warp size")
+        k_tile_size = block_size * vector_width
+        if static_k is not None and (
+            static_k % k_tile_size or static_k < _PREFETCH_TILES * k_tile_size
+        ):
+            raise ValueError("static K must contain at least two complete tiles")
+        self.element_type = element_type
+        self.num_rows = num_rows
+        self.block_size = block_size
+        self.outputs_per_block = outputs_per_block
+        self.vector_width = vector_width
+        self.k_unroll = k_unroll
+        self.has_residual = has_residual
+        self.has_residual2 = has_residual2
+        self.use_pdl = use_pdl
+        self.static_k = static_k
+        self.num_warps = block_size // cute.arch.WARP_SIZE
+
+    @cute.jit
+    def __call__(
+        self,
+        gA: cute.Tensor,
+        gB: cute.Tensor,
+        gResidual: cute.Tensor,
+        gResidual2: cute.Tensor,
+        gC: cute.Tensor,
+        stream: CUstream,
+    ) -> None:
+        n = cute.size(gB, mode=[0])
+        k = cute.size(gA, mode=[1])
+        copy_a = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            self.element_type,
+            num_bits_per_copy=self.vector_width * self.element_type.width,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.ALWAYS,
+        )
+        copy_b = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            self.element_type,
+            num_bits_per_copy=self.vector_width * self.element_type.width,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.STREAMING,
+        )
+        copy_b_prefetch = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            self.element_type,
+            num_bits_per_copy=self.vector_width * self.element_type.width,
+            load_cache_mode=cute.nvgpu.LoadCacheMode.ALWAYS,
+        )
+        self.kernel(
+            gA,
+            gB,
+            gResidual,
+            gResidual2,
+            gC,
+            k,
+            copy_a,
+            copy_b,
+            copy_b_prefetch,
+        ).launch(
+            grid=[cute.ceil_div(n, self.outputs_per_block), 1, 1],
+            block=[self.block_size, 1, 1],
+            smem=self.num_rows * self.outputs_per_block * self.num_warps * 4,
+            stream=stream,
+            use_pdl=self.use_pdl,
+            min_blocks_per_mp=1,
+        )
+
+    @cute.kernel
+    def kernel(
+        self,
+        gA: cute.Tensor,
+        gB: cute.Tensor,
+        gResidual: cute.Tensor,
+        gResidual2: cute.Tensor,
+        gC: cute.Tensor,
+        k_extent: cutlass.Int32,
+        copy_a: cute.CopyAtom,
+        copy_b: cute.CopyAtom,
+        copy_b_prefetch: cute.CopyAtom,
+    ) -> None:
+        tidx, _, _ = cute.arch.thread_idx()
+        block_idx, _, _ = cute.arch.block_idx()
+        warp_idx = cute.arch.warp_idx()
+
+        num_rows: cutlass.Constexpr = self.num_rows
+        outputs_per_block: cutlass.Constexpr = self.outputs_per_block
+        vector_width: cutlass.Constexpr = self.vector_width
+        block_size: cutlass.Constexpr = self.block_size
+        num_warps: cutlass.Constexpr = self.num_warps
+
+        acc_layout = cute.make_layout(
+            (num_rows, outputs_per_block), stride=(outputs_per_block, 1)
+        )
+        acc = cute.make_rmem_tensor(acc_layout, cutlass.Float32)
+        acc.fill(0.0)
+
+        n_base = block_idx * outputs_per_block
+        k_tile_size: cutlass.Constexpr = block_size * vector_width
+
+        gA_vec = cute.logical_divide(gA, (None, vector_width))
+        gB_vec = cute.logical_divide(gB, (None, vector_width))
+        # Layout after both divides is (M/N, K_TILE, K_LANE, K_VEC).
+        tA_all = cute.logical_divide(gA_vec, (None, (None, block_size)))
+        tB_all = cute.logical_divide(gB_vec, (None, (None, block_size)))
+        tA = tA_all[None, (None, (tidx, None))]
+
+        a_regs = cute.make_rmem_tensor(
+            cute.make_layout((num_rows, vector_width), stride=(vector_width, 1)),
+            self.element_type,
+        )
+        b_regs = cute.make_rmem_tensor(
+            cute.make_layout(
+                (outputs_per_block, vector_width), stride=(vector_width, 1)
+            ),
+            self.element_type,
+        )
+
+        if const_expr(self.static_k is not None):
+            num_k_tiles: cutlass.Constexpr = self.static_k // k_tile_size
+            prefetched_b = cute.make_rmem_tensor(
+                cute.make_layout(
+                    (_PREFETCH_TILES, outputs_per_block, vector_width),
+                    stride=(outputs_per_block * vector_width, vector_width, 1),
+                ),
+                self.element_type,
+            )
+            for k_tile in cutlass.range_constexpr(_PREFETCH_TILES):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    tB_static = tB_all[n_base + ni, (None, (tidx, None))]
+                    cute.copy(
+                        copy_b_prefetch,
+                        tB_static[None, k_tile],
+                        prefetched_b[k_tile, ni, None],
+                    )
+
+            if const_expr(self.use_pdl):
+                cute.arch.griddepcontrol_wait()
+
+            for k_tile in cutlass.range_constexpr(num_k_tiles):
+                if const_expr(k_tile < _PREFETCH_TILES):
+                    b_f32 = prefetched_b[k_tile, None, None].load().to(cutlass.Float32)
+                else:
+                    for ni in cutlass.range_constexpr(outputs_per_block):
+                        tB_static = tB_all[n_base + ni, (None, (tidx, None))]
+                        cute.copy(
+                            copy_b,
+                            tB_static[None, k_tile],
+                            b_regs[ni, None],
+                        )
+                    b_f32 = b_regs.load().to(cutlass.Float32)
+
+                for mi in cutlass.range_constexpr(num_rows):
+                    cute.copy(copy_a, tA[mi, None, k_tile], a_regs[mi, None])
+                a_f32 = a_regs.load().to(cutlass.Float32)
+
+                for vi in cutlass.range_constexpr(vector_width):
+                    for mi in cutlass.range_constexpr(num_rows):
+                        for ni in cutlass.range_constexpr(outputs_per_block):
+                            acc[mi, ni] += a_f32[mi, vi] * b_f32[ni, vi]
+        else:
+            if const_expr(self.use_pdl):
+                cute.arch.griddepcontrol_wait()
+
+            num_k_tiles = k_extent // k_tile_size
+            for k_tile in cutlass.range(num_k_tiles, unroll=self.k_unroll):
+                for mi in cutlass.range_constexpr(num_rows):
+                    cute.copy(copy_a, tA[mi, None, k_tile], a_regs[mi, None])
+
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    n_idx = n_base + ni
+                    tB_dynamic = tB_all[n_idx, (None, (tidx, None))]
+                    cute.copy(
+                        copy_b,
+                        tB_dynamic[None, k_tile],
+                        b_regs[ni, None],
+                    )
+
+                for vi in cutlass.range_constexpr(vector_width):
+                    for mi in cutlass.range_constexpr(num_rows):
+                        for ni in cutlass.range_constexpr(outputs_per_block):
+                            acc[mi, ni] = acc[mi, ni] + a_regs[mi, vi].to(
+                                cutlass.Float32
+                            ) * b_regs[ni, vi].to(cutlass.Float32)
+
+        for mi in cutlass.range_constexpr(num_rows):
+            for ni in cutlass.range_constexpr(outputs_per_block):
+                acc[mi, ni] = cute.arch.warp_reduction_sum(acc[mi, ni])
+
+        smem_layout = cute.make_layout(
+            (num_rows, outputs_per_block, num_warps),
+            stride=(outputs_per_block * num_warps, num_warps, 1),
+        )
+        smem = cutlass.utils.SmemAllocator()
+        partials = smem.allocate_tensor(cutlass.Float32, smem_layout, byte_alignment=16)
+        with cute.arch.elect_one():
+            for mi in cutlass.range_constexpr(num_rows):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    partials[mi, ni, warp_idx] = acc[mi, ni]
+
+        cute.arch.sync_threads()
+        if tidx == 0:
+            for mi in cutlass.range_constexpr(num_rows):
+                for ni in cutlass.range_constexpr(outputs_per_block):
+                    n_idx = n_base + ni
+                    total = (
+                        partials[mi, ni, None]
+                        .load()
+                        .reduce(
+                            cute.ReductionOp.ADD,
+                            init_val=cutlass.Float32(0.0),
+                            reduction_profile=0,
+                        )
+                    )
+                    if const_expr(self.has_residual):
+                        total += gResidual[mi, n_idx].to(cutlass.Float32)
+                    if const_expr(self.has_residual2):
+                        total += gResidual2[mi, n_idx].to(cutlass.Float32)
+                    gC[mi, n_idx] = cutlass.Float32(total).to(self.element_type)
+
+        if const_expr(self.use_pdl):
+            cute.arch.griddepcontrol_launch_dependents()

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The measured decode-GEMV route: dispatch reaches it, and it computes right.
+
+The routed backends only exist on sm103, where the route was measured; on
+anything else the whole module must be a no-op and the generic selection must
+be untouched -- both directions are asserted here.
+"""
+
+from __future__ import annotations
+
+import pytest
+import tokenspeed_kernel.ops.gemm  # noqa: F401  (registration side effects)
+import torch
+from tokenspeed_kernel.ops.gemm.routed_gemv import MEASURED_ROUTE
+from tokenspeed_kernel.ops.gemm.triton_gemv import _select, decode_gemv
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _is_sm103() -> bool:
+    return torch.cuda.get_device_capability() == (10, 3)
+
+
+def _routed_cases():
+    return sorted(MEASURED_ROUTE.items())
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_sm103(),
+    reason="route is measured and registered for sm103 only",
+)
+@pytest.mark.parametrize("shape,backend", _routed_cases())
+def test_dispatch_picks_the_measured_backend(shape, backend):
+    m, n, k = shape
+    _select.cache_clear()
+    impl = _select(m, n, k, True)
+    assert backend in getattr(
+        impl, "__name__", ""
+    ), f"M={m} N={n} K={k} resolved {impl} instead of the measured {backend}"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_sm103(),
+    reason="route is measured and registered for sm103 only",
+)
+@pytest.mark.parametrize("shape,backend", _routed_cases())
+def test_routed_backend_matches_torch(shape, backend):
+    m, n, k = shape
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    got = decode_gemv(x, w).float()
+    ref = (x @ w.t()).float()
+    # Accumulation order differs per kernel; a couple of ulp at ~sqrt(K).
+    assert torch.allclose(got, ref, atol=0.5, rtol=2e-2), (
+        f"M={m} N={n} K={k} via {backend}: "
+        f"max abs err {(got - ref).abs().max().item():.4f}"
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_sm103(),
+    reason="route is measured and registered for sm103 only",
+)
+def test_non_bf16_inputs_fall_back_to_torch():
+    from tokenspeed_kernel.ops.gemm.routed_gemv import skinny_gemv, tgv_gemv
+
+    x = torch.randn(1, 7168, device="cuda", dtype=torch.float16)
+    w = torch.randn(768, 7168, device="cuda", dtype=torch.float16)
+    got = skinny_gemv(x, w)
+    assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)
+
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.float16)
+    w = torch.randn(7168, 1536, device="cuda", dtype=torch.float16)
+    got = tgv_gemv(x, w)
+    assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_sm103(),
+    reason="route is measured and registered for sm103 only",
+)
+def test_capture_of_a_warmed_shape_replays_correctly():
+    """Warm eagerly, then capture: the routed kernel must be capturable and the
+    replay must actually compute -- inputs change and outputs are poisoned
+    between capture and replay, so a graph that recorded nothing (or a replay
+    that writes nothing) fails the comparison. An unwarmed shape inside the
+    same capture must fall back rather than JIT."""
+    from tokenspeed_kernel.ops.gemm import routed_gemv as route
+
+    m, n, k = 1, 3648, 7168  # skinny-routed
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    out = torch.empty(m, n, device="cuda", dtype=torch.bfloat16)
+    decode_gemv(x, w)  # warm
+
+    dev = x.device.index
+    assert dev is not None
+    cold = ("skinny", dev, 1, 3584, 7168)
+    with route._warmed_lock:
+        route._warmed.discard(cold)
+    xc = torch.randn(1, 7168, device="cuda", dtype=torch.bfloat16)
+    wc = torch.randn(3584, 7168, device="cuda", dtype=torch.bfloat16)
+
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        decode_gemv(x, w, out=out)
+    torch.cuda.current_stream().wait_stream(s)
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        shape_dynamic_skinny_gemm,
+    )
+
+    compiles: list[tuple] = []
+    real_compile = shape_dynamic_skinny_gemm._compile
+    shape_dynamic_skinny_gemm._compile = lambda *a, **kw: compiles.append(a)
+    try:
+        with torch.cuda.graph(g):
+            decode_gemv(x, w, out=out)
+            cold_out = route.skinny_gemv(xc, wc)  # unwarmed: falls back
+    finally:
+        shape_dynamic_skinny_gemm._compile = real_compile
+    assert not compiles  # nothing may JIT inside the capture
+
+    # Poisoned outputs: only a replay that really runs the kernels can pass.
+    x.copy_(torch.randn_like(x))
+    xc.copy_(torch.randn_like(xc))
+    out.fill_(float("nan"))
+    cold_out.fill_(float("nan"))
+    g.replay()
+    torch.cuda.synchronize()
+    assert torch.allclose(out.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)
+    assert torch.allclose(cold_out.float(), (xc @ wc.t()).float(), atol=0.5, rtol=2e-2)
+    assert cold not in route._warmed  # capture must not mark anything warmed
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_sm103(),
+    reason="add3 route is measured for sm103 only",
+)
+@pytest.mark.parametrize("m", [1, 2])
+def test_skinny_add3_matches_reference(m):
+    from tokenspeed_kernel.ops.gemm.routed_gemv import skinny_gemv_add3
+
+    torch.manual_seed(0)
+    n, k = 7168, 3584
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16) / 8
+    a = torch.randn(m, n, device="cuda", dtype=torch.bfloat16)
+    # Column slice of a wider tensor, as the serving call site passes it.
+    c_wide = torch.randn(m, 2 * n, device="cuda", dtype=torch.bfloat16)
+    c = c_wide[:, n:]
+    got = skinny_gemv_add3(x, w, a, c).float()
+    ref = a.float() + x.float() @ w.float().t() + c.float()
+    assert torch.allclose(got, ref, atol=0.5, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_sm103(),
+    reason="add3 route is measured for sm103 only",
+)
+def test_kimi3_add3_auto_selects_the_skinny_epilogue():
+    from tokenspeed_kernel.ops.gemm.kimi3 import kimi3_latent_projection_add3
+
+    torch.manual_seed(1)
+    m, n, k = 1, 7168, 3584
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16) / 8
+    a = torch.randn(m, n, device="cuda", dtype=torch.bfloat16)
+    c = torch.randn(m, n, device="cuda", dtype=torch.bfloat16)
+    auto = kimi3_latent_projection_add3(x, w, a, c).float()
+    forced = kimi3_latent_projection_add3(x, w, a, c, solution="skinny_add3").float()
+    composed = kimi3_latent_projection_add3(x, w, a, c, solution="composed").float()
+    assert torch.allclose(auto, forced, atol=0.0, rtol=0.0)
+    assert torch.allclose(auto, composed, atol=0.5, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_sm103(),
+    reason="add3 route is measured for sm103 only",
+)
+def test_skinny_add3_unwarmed_capture_falls_back(monkeypatch):
+    import tokenspeed_kernel.ops.gemm.routed_gemv as route
+    from tokenspeed_kernel.thirdparty.cute_dsl import skinny_gemm
+
+    torch.manual_seed(2)
+    m, n, k = 1, 7168, 3584
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16) / 8
+    a = torch.randn(m, n, device="cuda", dtype=torch.bfloat16)
+    c = torch.randn(m, n, device="cuda", dtype=torch.bfloat16)
+    dev = x.device.index or 0
+    with route._warmed_lock:
+        route._warmed.discard(("skinny_add3", dev, m, n, k))
+
+    def _no_jit(*args, **kwargs):
+        raise AssertionError("JIT compile attempted inside capture")
+
+    monkeypatch.setattr(skinny_gemm.shape_dynamic_skinny_gemm, "_compile", _no_jit)
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        ref = a.float() + x.float() @ w.float().t() + c.float()
+        with torch.cuda.graph(g):
+            out = route.skinny_gemv_add3(x, w, a, c)
+        g.replay()
+    torch.cuda.current_stream().wait_stream(s)
+    torch.cuda.synchronize()
+    assert torch.allclose(out.float(), ref, atol=0.5, rtol=2e-2)
+
+
+def test_unlisted_shapes_keep_the_generic_selection():
+    _select.cache_clear()
+    impl = _select(1, 999, 4096, True)
+    assert "rowcta" in getattr(impl, "__name__", "")
+    impl = _select(4, 3216, 7168, True)
+    assert "torch" in getattr(impl, "__name__", "")
+    impl = _select(3, 6288, 7168, True)
+    assert "torch" in getattr(impl, "__name__", "")
+    impl = _select(1, 2304, 1536, True)
+    assert "rowcta" in getattr(impl, "__name__", "")

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -20,9 +20,10 @@
 
 """The measured decode-GEMV route: dispatch reaches it, and it computes right.
 
-The routed backends only exist on sm103, where the route was measured; on
-anything else the whole module must be a no-op and the generic selection must
-be untouched -- both directions are asserted here.
+The routed backends are registered from sm100 up (GB200/B200 and GB300); below
+that the whole module must be a no-op and the generic selection must be
+untouched -- both directions are asserted here. The table is keyed per shape,
+so an arch that never runs a listed shape simply never matches.
 """
 
 from __future__ import annotations
@@ -36,8 +37,16 @@ from tokenspeed_kernel.ops.gemm.triton_gemv import _select, decode_gemv
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 
 
-def _is_sm103() -> bool:
-    return torch.cuda.get_device_capability() == (10, 3)
+def _is_routed_arch() -> bool:
+    # Mirrors _CAPABILITY in routed_gemv: sm100 and up, not sm103 exactly.
+    return torch.cuda.get_device_capability() >= (10, 0)
+
+
+def _is_add3_arch() -> bool:
+    # ADD3_ROUTE stores sm103-tuned TILE CONFIGS, not just a backend choice, so
+    # it stays gated where it was swept -- mirrors _is_measured_arch. Widening
+    # it would run another architecture's tuning parameters unmeasured.
+    return torch.cuda.get_device_capability() >= (10, 3)
 
 
 def _routed_cases():
@@ -45,8 +54,8 @@ def _routed_cases():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not _is_sm103(),
-    reason="route is measured and registered for sm103 only",
+    not torch.cuda.is_available() or not _is_routed_arch(),
+    reason="route is registered for sm100 and up",
 )
 @pytest.mark.parametrize("shape,backend", _routed_cases())
 def test_dispatch_picks_the_measured_backend(shape, backend):
@@ -59,8 +68,8 @@ def test_dispatch_picks_the_measured_backend(shape, backend):
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not _is_sm103(),
-    reason="route is measured and registered for sm103 only",
+    not torch.cuda.is_available() or not _is_routed_arch(),
+    reason="route is registered for sm100 and up",
 )
 @pytest.mark.parametrize("shape,backend", _routed_cases())
 def test_routed_backend_matches_torch(shape, backend):
@@ -78,8 +87,8 @@ def test_routed_backend_matches_torch(shape, backend):
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not _is_sm103(),
-    reason="route is measured and registered for sm103 only",
+    not torch.cuda.is_available() or not _is_routed_arch(),
+    reason="route is registered for sm100 and up",
 )
 def test_non_bf16_inputs_fall_back_to_torch():
     from tokenspeed_kernel.ops.gemm.routed_gemv import skinny_gemv, tgv_gemv
@@ -96,8 +105,8 @@ def test_non_bf16_inputs_fall_back_to_torch():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not _is_sm103(),
-    reason="route is measured and registered for sm103 only",
+    not torch.cuda.is_available() or not _is_routed_arch(),
+    reason="route is registered for sm100 and up",
 )
 def test_capture_of_a_warmed_shape_replays_correctly():
     """Warm eagerly, then capture: the routed kernel must be capturable and the
@@ -155,7 +164,7 @@ def test_capture_of_a_warmed_shape_replays_correctly():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not _is_sm103(),
+    not torch.cuda.is_available() or not _is_routed_arch(),
     reason="add3 route is measured for sm103 only",
 )
 @pytest.mark.parametrize("m", [1, 2])
@@ -176,8 +185,8 @@ def test_skinny_add3_matches_reference(m):
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not _is_sm103(),
-    reason="add3 route is measured for sm103 only",
+    not torch.cuda.is_available() or not _is_add3_arch(),
+    reason="ADD3_ROUTE holds sm103-tuned tile configs; unswept below that",
 )
 def test_kimi3_add3_auto_selects_the_skinny_epilogue():
     from tokenspeed_kernel.ops.gemm.kimi3 import kimi3_latent_projection_add3
@@ -196,7 +205,7 @@ def test_kimi3_add3_auto_selects_the_skinny_epilogue():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or not _is_sm103(),
+    not torch.cuda.is_available() or not _is_routed_arch(),
     reason="add3 route is measured for sm103 only",
 )
 def test_skinny_add3_unwarmed_capture_falls_back(monkeypatch):


### PR DESCRIPTION
Routes Kimi-K3's decode GEMV per exact (M, N, K) from a measured table. vLLM's CuTe skinny GEMM (vendored) and FlashInfer's TGV (wrapped) each beat our row-CTA Triton GEMV on some of K3's decode projections and lose on others, so the table registers each winner above the rowcta spec and leaves unlisted shapes on the selection they had. The KDA and MoE-latent call sites widen their M == 1 gates to M <= 8 so small batches and speculative verify reach the same dispatch.

Entries were measured at the shapes an nsys trace of TP8 serving actually hands decode_gemv, cold-L2, and only count as a win at >= 4%. Per call the routed kernels win 1.07-1.11x at M == 1 and 1.08-1.97x at M in {2, 4, 8}. Decode step time (median per-step interval, same node pair, adjacent boots): 10.16 -> 9.94 ms at bs = 1, and ~45 us/step at bs = 4. AIME26 with greedy decoding at the CI gate's settings scores 26/30, identical to a main-equivalent control.