### PR TITLE
ci: add GB300 two-node AIME26 gates for K3-NVFP4 and K3-NVFP4+DSpark

### DIFF
--- a/.github/workflows/slurm-dispatch.yml
+++ b/.github/workflows/slurm-dispatch.yml
@@ -36,6 +36,8 @@ on:
           - test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-ocr-bench.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp16-four-node-evalscope-aime26-slurm.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+          - test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+          - test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
           - test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-evalscope-ocr-bench.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-evalscope-ocr-bench.yaml

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -242,8 +242,15 @@ test/ci/run_slurm.sh \
 
 GB300 server containers mount `TS_CI_LOCAL_MODEL_ROOT` read-only at `/models`.
 It defaults to `/scratch/$USER-models`, the node-local RAID path. The Kimi-K3
-GB300 task uses its pinned snapshot below that mount so weight loading does not
-read the shared Hugging Face cache.
+GB300 tasks use pinned snapshots below that mount so weight loading does not
+read the shared Hugging Face cache. Synchronize these directories to every
+eligible GB300 node before enabling the tasks:
+
+```text
+moonshotai--Kimi-K3/9f62e4e9fffbd0a83ddd60e1c209d828994b3569
+nvidia--Kimi-K3-NVFP4/f8c5234a0a880bcc6cbf779a315e7ee2f405b812
+lightseekorg--kimi-k3-dspark/dbd305f7d6c2df88d62b101c82db6d36fa761a57
+```
 
 The `Slurm Dispatch` workflow exposes a `cluster` input. `gb200` keeps the
 existing `slurm-dispatch` coordinator and runner defaults. `gb300` is an
@@ -272,9 +279,11 @@ cannot filter the multi-node matrix here. During this workflow's
 bootstrap only, leave the switch unset; after dispatcher support reaches
 `main`, set it to `true` and re-run the merge commit's workflow.
 
-The two-node Kimi K3 task declares `slurm-gb300-4gpu`, `slurm.nodes: 2`, and
+The two-node Kimi K3 tasks declare `slurm-gb300-4gpu`, `slurm.nodes: 2`, and
 `slurm.gpus_per_node: 4`. The runner label describes GPUs per node, while the
-Slurm topology fields describe the allocation.
+Slurm topology fields describe the allocation. The NVFP4 DSpark task pairs the
+pinned `nvidia/Kimi-K3-NVFP4` target with `lightseekorg/kimi-k3-dspark` and
+preserves the draft checkpoint's required `attn_res` auxiliary stream.
 
 GB200 examples:
 

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -249,7 +249,7 @@ eligible GB300 node before enabling the tasks:
 ```text
 moonshotai--Kimi-K3/9f62e4e9fffbd0a83ddd60e1c209d828994b3569
 nvidia--Kimi-K3-NVFP4/f8c5234a0a880bcc6cbf779a315e7ee2f405b812
-lightseekorg--kimi-k3-dspark/dbd305f7d6c2df88d62b101c82db6d36fa761a57
+Inferact--Kimi-K3-DSpark/cf6b8244620e7ea4b0651d214f28e89eac75bed6
 ```
 
 The `Slurm Dispatch` workflow exposes a `cluster` input. `gb200` keeps the
@@ -282,7 +282,7 @@ bootstrap only, leave the switch unset; after dispatcher support reaches
 The two-node Kimi K3 tasks declare `slurm-gb300-4gpu`, `slurm.nodes: 2`, and
 `slurm.gpus_per_node: 4`. The runner label describes GPUs per node, while the
 Slurm topology fields describe the allocation. The NVFP4 DSpark task pairs the
-pinned `nvidia/Kimi-K3-NVFP4` target with `lightseekorg/kimi-k3-dspark` and
+pinned `nvidia/Kimi-K3-NVFP4` target with `Inferact/Kimi-K3-DSpark` and
 preserves the draft checkpoint's required `attn_res` auxiliary stream.
 
 GB200 examples:

--- a/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -19,15 +19,16 @@ slurm:
   gpus_per_node: 4
 env:
   CI: "true"
+  TOKENSPEED_DFLASH_AUX_STREAM: attn_res
 install:
   - bash test/ci_system/install_deps.sh
   - python3 -m pip install flash-linear-attention
 server:
   command: >-
-    ts serve nvidia/Kimi-K3-NVFP4
+    ts serve /models/nvidia--Kimi-K3-NVFP4/f8c5234a0a880bcc6cbf779a315e7ee2f405b812
     --served-model-name kimi-k3
     --speculative-algorithm DSPARK
-    --speculative-draft-model-path Inferact/Kimi-K3-DSpark
+    --speculative-draft-model-path /models/lightseekorg--kimi-k3-dspark/dbd305f7d6c2df88d62b101c82db6d36fa761a57
     --speculative-num-draft-tokens 8
     --drafter-attention-backend mla
     --trust-remote-code

--- a/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -1,0 +1,70 @@
+api_version: ci.tokenspeed.io/v1
+# NVFP4 target + DSpark speculative decoding, on the same two-node shape as
+# the speculator-free NVFP4 gate. Speculative flags follow the proven AMD
+# DSpark gate (kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml):
+# --disable-prefill-graph because prefill graphs add ~40 capture buckets on
+# top of the decode ones the speculator rides on, and the draft weights plus
+# its BF16 cache (kept BF16 automatically when the target KV is FP8) need the
+# headroom — hence also the lower 0.92 memory fraction.
+name: eval-kimi-k3-nvfp4-dspark-tp8-two-node-aime26-gb300-slurm
+type: eval
+workflow_stage: model-test
+triggers:
+  - per-commit
+runner:
+  labels:
+    - slurm-b300-4gpu
+slurm:
+  nodes: 2
+  gpus_per_node: 4
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps.sh
+  - python3 -m pip install flash-linear-attention
+server:
+  command: >-
+    ts serve nvidia/Kimi-K3-NVFP4
+    --served-model-name kimi-k3
+    --speculative-algorithm DSPARK
+    --speculative-draft-model-path Inferact/Kimi-K3-DSpark
+    --speculative-num-draft-tokens 8
+    --drafter-attention-backend mla
+    --trust-remote-code
+    --max-model-len 65536
+    --kv-cache-dtype fp8
+    --tensor-parallel-size 8
+    --mm-encoder-tp-mode data
+    --moe-backend flashinfer_trtllm
+    --gpu-memory-utilization 0.92
+    --max-num-seqs 16
+    --disable-prefill-graph
+    --disable-kvstore
+    --host 0.0.0.0
+    --port 8000
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 7200
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets aime26
+    --dataset-hub huggingface
+    --dataset-args '{"aime26":{"dataset_id":"math-ai/aime26"}}'
+    --eval-batch-size 16
+    --stream
+    --generation-config '{"do_sample":true,"temperature":1.0,"max_tokens":32768,"extra_body":{"reasoning_effort":"high"}}'
+report:
+  github_step_summary: true
+# Same bar as the speculator-free NVFP4 gate: DSpark preserves the target's
+# distribution rather than its exact tokens, so the score is the correctness
+# check that matters (see the AMD DSpark gate's same-machine control for the
+# accuracy/TPOT evidence).
+score_threshold: 0.90

--- a/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -28,7 +28,7 @@ server:
     ts serve /models/nvidia--Kimi-K3-NVFP4/f8c5234a0a880bcc6cbf779a315e7ee2f405b812
     --served-model-name kimi-k3
     --speculative-algorithm DSPARK
-    --speculative-draft-model-path /models/lightseekorg--kimi-k3-dspark/dbd305f7d6c2df88d62b101c82db6d36fa761a57
+    --speculative-draft-model-path /models/Inferact--Kimi-K3-DSpark/cf6b8244620e7ea4b0651d214f28e89eac75bed6
     --speculative-num-draft-tokens 8
     --drafter-attention-backend mla
     --trust-remote-code

--- a/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -13,7 +13,7 @@ triggers:
   - per-commit
 runner:
   labels:
-    - slurm-b300-4gpu
+    - slurm-gb300-4gpu
 slurm:
   nodes: 2
   gpus_per_node: 4

--- a/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -11,7 +11,7 @@ triggers:
   - per-commit
 runner:
   labels:
-    - slurm-b300-4gpu
+    - slurm-gb300-4gpu
 slurm:
   nodes: 2
   gpus_per_node: 4

--- a/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -1,9 +1,9 @@
 api_version: ci.tokenspeed.io/v1
 # NVFP4 sibling of the mxfp4 two-node gate: identical serve shape, but the
 # ModelOpt MIXED_PRECISION checkpoint (NVFP4 SiTU experts + FP8_PB_WO
-# attention kept FP8-resident). A cold runner's first boot downloads and
-# autotunes the trtllm-gen NVFP4 cubins (~15 min), covered by the 7200s
-# readiness timeout.
+# attention kept FP8-resident). The pinned checkpoint is loaded from the
+# node-local RAID mounted at /models; the 7200s readiness timeout also covers
+# first-boot trtllm-gen NVFP4 cubin autotuning (~15 min).
 name: eval-kimi-k3-nvfp4-tp8-two-node-aime26-gb300-slurm
 type: eval
 workflow_stage: model-test
@@ -22,7 +22,7 @@ install:
   - python3 -m pip install flash-linear-attention
 server:
   command: >-
-    ts serve nvidia/Kimi-K3-NVFP4
+    ts serve /models/nvidia--Kimi-K3-NVFP4/f8c5234a0a880bcc6cbf779a315e7ee2f405b812
     --served-model-name kimi-k3
     --trust-remote-code
     --max-model-len 65536

--- a/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -1,0 +1,62 @@
+api_version: ci.tokenspeed.io/v1
+# NVFP4 sibling of the mxfp4 two-node gate: identical serve shape, but the
+# ModelOpt MIXED_PRECISION checkpoint (NVFP4 SiTU experts + FP8_PB_WO
+# attention kept FP8-resident). A cold runner's first boot downloads and
+# autotunes the trtllm-gen NVFP4 cubins (~15 min), covered by the 7200s
+# readiness timeout.
+name: eval-kimi-k3-nvfp4-tp8-two-node-aime26-gb300-slurm
+type: eval
+workflow_stage: model-test
+triggers:
+  - per-commit
+runner:
+  labels:
+    - slurm-b300-4gpu
+slurm:
+  nodes: 2
+  gpus_per_node: 4
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps.sh
+  - python3 -m pip install flash-linear-attention
+server:
+  command: >-
+    ts serve nvidia/Kimi-K3-NVFP4
+    --served-model-name kimi-k3
+    --trust-remote-code
+    --max-model-len 65536
+    --kv-cache-dtype fp8
+    --tensor-parallel-size 8
+    --mm-encoder-tp-mode data
+    --moe-backend flashinfer_trtllm
+    --gpu-memory-utilization 0.94
+    --max-num-seqs 16
+    --disable-kvstore
+    --host 0.0.0.0
+    --port 8000
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 7200
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets aime26
+    --dataset-hub huggingface
+    --dataset-args '{"aime26":{"dataset_id":"math-ai/aime26"}}'
+    --eval-batch-size 16
+    --stream
+    --generation-config '{"do_sample":true,"temperature":1.0,"max_tokens":32768,"extra_body":{"reasoning_effort":"high"}}'
+report:
+  github_step_summary: true
+# Same bar as the mxfp4 sibling gate. NVFP4 measured 0.9333-0.9667 on the
+# 65536-token evalscope protocol (tp16, PR #1128); the mxfp4 sibling records
+# 0.9333 on this exact 32768-token CI protocol.
+score_threshold: 0.90

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -327,8 +327,7 @@ def test_kimi_k3_nvfp4_gb300_uses_pinned_local_models():
         "/models/nvidia--Kimi-K3-NVFP4/" "f8c5234a0a880bcc6cbf779a315e7ee2f405b812"
     )
     draft_path = (
-        "/models/lightseekorg--kimi-k3-dspark/"
-        "dbd305f7d6c2df88d62b101c82db6d36fa761a57"
+        "/models/Inferact--Kimi-K3-DSpark/" "cf6b8244620e7ea4b0651d214f28e89eac75bed6"
     )
     plain = load_yaml(
         REPO_ROOT / "test/ci/eval/"

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -297,13 +297,17 @@ def test_slurm_dispatch_rejects_ambiguous_gb300_runner(tmp_path):
     assert "exactly one declared [slurm-]gb300-* runner" in result.stderr
 
 
-def test_only_dedicated_task_declares_gb300():
+def test_only_dedicated_tasks_declare_gb300():
     configs = []
     for path in (REPO_ROOT / "test/ci").rglob("*.yaml"):
         if any("gb300-" in label for label in load_yaml(path)["runner"]["labels"]):
             configs.append(path.name)
 
-    assert configs == ["kimi-k3-mxfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml"]
+    assert sorted(configs) == [
+        "kimi-k3-mxfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml",
+        "kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml",
+        "kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml",
+    ]
 
 
 def test_kimi_k3_gb300_is_two_node_per_commit_tp8():
@@ -316,6 +320,29 @@ def test_kimi_k3_gb300_is_two_node_per_commit_tp8():
     assert task["runner"]["labels"] == ["slurm-gb300-4gpu"]
     assert task["slurm"] == {"nodes": 2, "gpus_per_node": 4}
     assert "--tensor-parallel-size 8" in task["server"]["command"]
+
+
+def test_kimi_k3_nvfp4_gb300_uses_pinned_local_models():
+    target_path = (
+        "/models/nvidia--Kimi-K3-NVFP4/" "f8c5234a0a880bcc6cbf779a315e7ee2f405b812"
+    )
+    draft_path = (
+        "/models/lightseekorg--kimi-k3-dspark/"
+        "dbd305f7d6c2df88d62b101c82db6d36fa761a57"
+    )
+    plain = load_yaml(
+        REPO_ROOT / "test/ci/eval/"
+        "kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml"
+    )
+    dspark = load_yaml(
+        REPO_ROOT / "test/ci/eval/"
+        "kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml"
+    )
+
+    assert target_path in plain["server"]["command"]
+    assert target_path in dspark["server"]["command"]
+    assert draft_path in dspark["server"]["command"]
+    assert dspark["env"]["TOKENSPEED_DFLASH_AUX_STREAM"] == "attn_res"
 
 
 def test_gb300_slurm_per_commit_workflow_is_isolated_and_automatic():
@@ -376,7 +403,7 @@ def test_gb300_slurm_per_commit_workflow_is_isolated_and_automatic():
     assert "gb300-slurm-per-commit" in cancel_groups
 
 
-def test_gb300_slurm_per_commit_matrix_selects_kimi_k3(monkeypatch):
+def test_gb300_slurm_per_commit_matrix_selects_kimi_k3_tasks(monkeypatch):
     monkeypatch.delenv("TOKENSPEED_CI_EXCLUDED_RUNNER_LABELS", raising=False)
 
     matrix = build_matrix(
@@ -400,7 +427,31 @@ def test_gb300_slurm_per_commit_matrix_selects_kimi_k3(monkeypatch):
             "priority": "normal",
             "optional": False,
             "workflow_stage": "model-test",
-        }
+        },
+        {
+            "name": "eval-kimi-k3-nvfp4-dspark-tp8-two-node-aime26-gb300-slurm",
+            "type": "eval",
+            "config": (
+                "test/ci/eval/"
+                "kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml"
+            ),
+            "runner": "slurm-gb300-4gpu",
+            "priority": "normal",
+            "optional": False,
+            "workflow_stage": "model-test",
+        },
+        {
+            "name": "eval-kimi-k3-nvfp4-tp8-two-node-aime26-gb300-slurm",
+            "type": "eval",
+            "config": (
+                "test/ci/eval/"
+                "kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml"
+            ),
+            "runner": "slurm-gb300-4gpu",
+            "priority": "normal",
+            "optional": False,
+            "workflow_stage": "model-test",
+        },
     ]
 
 


### PR DESCRIPTION
## Summary

Two per-commit GB300 two-node AIME26 gates, siblings of
`kimi-k3-mxfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml`:

- **`eval-kimi-k3-nvfp4-tp8-two-node-aime26-gb300-slurm`** — serves
  `nvidia/Kimi-K3-NVFP4` (ModelOpt MIXED_PRECISION: NVFP4 SiTU experts +
  FP8-resident FP8_PB_WO attention, #1128) with serve arguments otherwise
  identical to the mxfp4 gate.
- **`eval-kimi-k3-nvfp4-dspark-tp8-two-node-aime26-gb300-slurm`** — the same
  NVFP4 target with DSpark speculative decoding; speculative flags follow the
  proven AMD DSpark gate (`--disable-prefill-graph`, memory fraction 0.92 for
  the draft weights and its BF16 draft cache).

Both keep the mxfp4 gate's `score_threshold: 0.90` and its exact 32768-token
evalscope protocol, so scores stay comparable across the three siblings.

## Local validation (GB200 tp16 four-node, exact CI eval protocol)

| shape | AIME26 | notes |
|---|---|---|
| plain NVFP4 | 0.9333 (28/30) | TPOT 17.5 ms |
| NVFP4 + DSpark | 0.9333 (28/30) | draft loaded, avg accept ~1.7 on AIME traffic |

- The one chronic miss in both runs is a problem whose reasoning exceeds the
  32768-token budget (empty final answer); the second miss wanders between
  runs (temperature 1.0 sampling noise). No DSpark-specific anomaly.
- Memory data point: on 186GB GB200 the DSpark form OOMed at 0.92 during
  draft warmup and needed 0.88. The yaml keeps 0.92 for B300, whose
  (1-0.92) slack is ~23GB absolute vs GB200's ~15GB; if the first B300 run
  OOMs anyway, drop it to 0.90.
- `--speculative-num-draft-tokens 8` is inherited from the AMD gate; accept
  length ~1.7 on AIME suggests a smaller window may suit B300 better — left
  as a follow-up knob, not a gate concern (the gate checks correctness).

## Notes for reviewers

- Both yamls validate through `pipeline.py scan` and land in the GB300
  per-commit matrix next to the existing mxfp4 entry; `pre-commit` clean.
- First run on a cold runner downloads the NVFP4 checkpoint and autotunes
  the trtllm-gen NVFP4 cubins (~15 min), covered by the 7200s readiness
  timeout — the very first attempt may still be slow.
- Capacity note: this triples the per-commit K3 load on the GB300 Slurm pool
  (three 2-node evals per commit). Happy to demote either new gate to a
  `slurm`-trigger if that is too much.

🤖 Generated with [Claude Code](https://claude.com/claude-code)