### PR TITLE
refactor(kda): disallow None host extend lengths — raise instead of silent fallback

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
@@ -49,34 +49,6 @@ if TYPE_CHECKING:
 KDA_PREFILL_BACKENDS = ("auto", "fla", "flashkda", "cutedsl_kda")
 
 
-def _cu_seqlens_cpu_hint(
-    extend_seq_lens_cpu: torch.Tensor | None, expected_len: int
-) -> tuple[int, ...] | None:
-    """Host prefix sum of the scheduler's extend lengths, or ``None``.
-
-    The tuple must equal the contents of ``query_start_loc`` — a wrong hint
-    silently corrupts the CuteDSL host chunk plan — so any absence or length
-    misalignment returns ``None`` (the wrapper then falls back to its own
-    boundary read).
-
-    Args:
-        extend_seq_lens_cpu: CPU per-sequence extend lengths, or ``None``.
-        expected_len: ``query_start_loc.numel()`` of the batch.
-
-    Returns:
-        ``(0, lens[0], lens[0]+lens[1], ...)`` when it has exactly
-        ``expected_len`` entries; ``None`` otherwise.
-    """
-    if extend_seq_lens_cpu is None:
-        return None
-    bounds = [0]
-    for n in extend_seq_lens_cpu.tolist():
-        bounds.append(bounds[-1] + int(n))
-    if len(bounds) != expected_len:
-        return None
-    return tuple(bounds)
-
-
 def _slice_kda_prefill_inputs(
     num_real_tokens: int,
     query: torch.Tensor,
@@ -400,7 +372,7 @@ class KdaAttnBackend(MambaAttnBackend):
         seq_len: int,
         num_real_tokens: int,
         lower_bound: float | None,
-        extend_seq_lens_cpu: torch.Tensor | None = None,
+        cu_seqlens_cpu: tuple[int, ...] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Run only the real-token prefix through the KDA prefill kernel.
 
@@ -409,14 +381,15 @@ class KdaAttnBackend(MambaAttnBackend):
         unwritten and feed padding into its final full-tile loads. The graph
         handoff clears and restores the bucket tail afterward.
 
-        ``extend_seq_lens_cpu`` is the scheduler's host-side per-sequence
-        extend lengths; its prefix sum equals the contents of
-        ``query_start_loc``. Forwarding it as ``cu_seqlens_cpu`` lets the
-        CuteDSL wrapper plan on the host without a stream-synchronizing D2H
-        read of the boundaries — otherwise that read recurs on every KDA
-        layer of every prefill chunk (the wrapper's identity memo cannot hit
-        across layers because the op casts ``cu_seqlens`` to a fresh int64
-        tensor per call).
+        ``cu_seqlens_cpu`` is the metadata-built host copy of
+        ``query_start_loc``'s contents (``init_forward_metadata`` constructs
+        and validates it once per extend batch, mirroring MHA's
+        ``cu_extend_seq_lens_cpu``). Forwarding it lets the CuteDSL wrapper
+        plan on the host without a stream-synchronizing D2H read of the
+        boundaries — otherwise that read recurs on every KDA layer of every
+        prefill chunk (the wrapper's identity memo cannot hit across layers
+        because the op casts ``cu_seqlens`` to a fresh int64 tensor per
+        call).
         """
         head_k_dim = query.shape[3]
         num_value_heads = value.shape[2]
@@ -431,9 +404,12 @@ class KdaAttnBackend(MambaAttnBackend):
             num_real_tokens, query, key, value, g_kda, beta_kda
         )
 
-        cu_seqlens_cpu = _cu_seqlens_cpu_hint(
-            extend_seq_lens_cpu, query_start_loc.numel()
-        )
+        if cu_seqlens_cpu is None:
+            raise RuntimeError(
+                "KDA prefill scan requires the metadata-built cu_seqlens_cpu "
+                "hint; init_forward_metadata constructs it for every extend "
+                "batch"
+            )
 
         kda_result = kda_paged_prefill(
             query,

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -270,12 +270,58 @@ def _prepare_gdn_decode_state_path(
     return initial_state_indices, output_state_indices, solution
 
 
+def _build_cu_extend_seq_lens_cpu(
+    extend_seq_lens_cpu: torch.Tensor | None, expected_len: int
+) -> tuple[int, ...]:
+    """Host prefix sum of the scheduler's extend lengths.
+
+    The tuple must equal the contents of ``query_start_loc`` — a wrong hint
+    silently corrupts the CuteDSL host chunk plan. Both are built together
+    here in ``init_forward_metadata`` (mirroring MHA's
+    ``cu_extend_seq_lens_cpu``), so absence or length misalignment can only
+    mean a caller broke that contract: fail loudly instead of silently
+    degrading to the wrapper's boundary re-read.
+
+    Args:
+        extend_seq_lens_cpu: CPU per-sequence extend lengths.
+        expected_len: ``query_start_loc.numel()`` of the batch.
+
+    Returns:
+        ``(0, lens[0], lens[0]+lens[1], ...)`` with ``expected_len`` entries.
+
+    Raises:
+        RuntimeError: the lengths are absent or disagree with
+            ``query_start_loc`` on the sequence count.
+    """
+    if extend_seq_lens_cpu is None:
+        raise RuntimeError(
+            "extend metadata requires the scheduler's host extend lengths; "
+            "the executor provides them for every extend batch"
+        )
+    bounds = [0]
+    for n in extend_seq_lens_cpu.tolist():
+        bounds.append(bounds[-1] + int(n))
+    if len(bounds) != expected_len:
+        raise RuntimeError(
+            "host extend lengths disagree with query_start_loc on the "
+            f"sequence count: {len(bounds)} boundaries vs {expected_len} "
+            "entries"
+        )
+    return tuple(bounds)
+
+
 @dataclass
 class MambaForwardMetadata:
     query_start_loc: torch.Tensor | None
     mamba_output_indices: torch.Tensor | None = None
     extend_prefix_lens: torch.Tensor | None = None
     extend_seq_lens_cpu: torch.Tensor | None = None
+    # Host prefix sum of extend_seq_lens_cpu, equal to query_start_loc's
+    # contents; built once per extend batch (mirroring MHA's field of the
+    # same name) and reused by every layer's prefill scan. A tuple, unlike
+    # MHA's list: it crosses into the CuteDSL wheel, which seeds a memo from
+    # it, so immutability rules out stale-aliasing.
+    cu_extend_seq_lens_cpu: tuple[int, ...] | None = None
     # Per-state-group metadata is gathered once per group and batch;
     # layers select their entry via ``pool.group_id_for_layer(layer_id)``.
     state_in_blocks_by_group: dict[str, torch.Tensor] | None = None
@@ -840,6 +886,7 @@ class MambaAttnBackend(AttentionBackend):
         if not 0 <= num_extends <= bs:
             raise ValueError("num_extends must be between 0 and bs")
         mamba_output_indices = None
+        cu_extend_seq_lens_cpu: tuple[int, ...] | None = None
         extend_seq_lens_cpu = kwargs.get("extend_seq_lens_cpu")
         if extend_seq_lens_cpu is not None:
             extend_seq_lens_cpu = extend_seq_lens_cpu[:num_extends]
@@ -861,10 +908,16 @@ class MambaAttnBackend(AttentionBackend):
                 )
                 set_total_chunks_hint_uniform(bs, tokens_per_req, query_start_loc)
             else:
+                if extend_seq_lens_cpu is None:
+                    raise RuntimeError(
+                        "extend metadata requires the scheduler's host extend "
+                        "lengths; the executor provides them for every extend "
+                        "batch"
+                    )
                 extend_start_loc = kwargs.get("extend_start_loc")
                 extend_seq_lens = kwargs.get("extend_seq_lens")
                 if forward_mode.is_mixed():
-                    if extend_seq_lens is None or extend_seq_lens_cpu is None:
+                    if extend_seq_lens is None:
                         raise RuntimeError(
                             "mixed GDN metadata requires extend sequence lengths"
                         )
@@ -895,10 +948,6 @@ class MambaAttnBackend(AttentionBackend):
                     )
                     query_start_loc[:bs] = extend_start_loc
                     query_start_loc[bs] = extend_start_loc[-1] + extend_seq_lens[-1]
-                    if extend_seq_lens_cpu is None:
-                        extend_seq_lens_cpu = extend_seq_lens[:bs].to(
-                            device="cpu", dtype=torch.int32
-                        )
                 else:
                     extend_prefix_lens = kwargs.get("extend_prefix_lens")
                     if extend_prefix_lens is not None:
@@ -912,9 +961,10 @@ class MambaAttnBackend(AttentionBackend):
                         bs + 1, dtype=torch.int32, device=self.device
                     )
                     torch.cumsum(extend_lens, dim=0, out=query_start_loc[1:])
-                    if extend_seq_lens_cpu is None:
-                        extend_seq_lens_cpu = extend_lens.to(device="cpu")
                 set_total_chunks_hint(extend_seq_lens_cpu, query_start_loc)
+                cu_extend_seq_lens_cpu = _build_cu_extend_seq_lens_cpu(
+                    extend_seq_lens_cpu, query_start_loc.numel()
+                )
         else:
             raise ValueError(f"Invalid forward mode: {forward_mode=}")
 
@@ -958,6 +1008,7 @@ class MambaAttnBackend(AttentionBackend):
             mamba_output_indices=mamba_output_indices,
             extend_prefix_lens=kwargs.get("extend_prefix_lens"),
             extend_seq_lens_cpu=extend_seq_lens_cpu,
+            cu_extend_seq_lens_cpu=cu_extend_seq_lens_cpu,
             state_in_blocks_by_group=state_in_blocks_by_group,
             state_out_blocks_by_group=state_out_blocks_by_group,
         )
@@ -1802,7 +1853,7 @@ class MambaAttnBackend(AttentionBackend):
                 seq_len=seq_len,
                 num_real_tokens=num_real_tokens,
                 lower_bound=gate_lower_bound,
-                extend_seq_lens_cpu=extend_seq_lens_cpu,
+                cu_seqlens_cpu=self.forward_metadata.cu_extend_seq_lens_cpu,
             )
             last_recurrent_state = last_recurrent_state.to(ssm_states.dtype, copy=False)
             # Extend indices never carry pad(-1), so this write is unguarded.
@@ -1990,7 +2041,7 @@ class MambaAttnBackend(AttentionBackend):
         seq_len: int,
         num_real_tokens: int,
         lower_bound: float | None,
-        extend_seq_lens_cpu: torch.Tensor | None = None,
+        cu_seqlens_cpu: tuple[int, ...] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Chunked scan of an extend/prefill batch, from the gathered state.
 
@@ -2018,10 +2069,11 @@ class MambaAttnBackend(AttentionBackend):
             seq_len: Padded token extent of the batch.
             num_real_tokens: Token extent excluding the graph padding tail.
             lower_bound: KDA decay clamp.
-            extend_seq_lens_cpu: Host-side per-sequence extend lengths whose
-                prefix sum equals ``query_start_loc``. The KDA override
-                forwards it so the CuteDSL wrapper can plan without a D2H
-                read; the GDN scan plans on device and ignores it.
+            cu_seqlens_cpu: Metadata-built host copy of ``query_start_loc``'s
+                contents (see ``MambaForwardMetadata.cu_extend_seq_lens_cpu``). The
+                KDA override forwards it so the CuteDSL wrapper can plan
+                without a D2H read; the GDN scan plans on device and ignores
+                it.
 
         Returns:
             ``(core_attn_out, last_recurrent_state)``.

--- a/test/runtime/test_cu_extend_seq_lens_cpu_metadata.py
+++ b/test/runtime/test_cu_extend_seq_lens_cpu_metadata.py
@@ -18,39 +18,56 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Runtime-side ``cu_seqlens_cpu`` hint construction for the KDA backend.
+"""Metadata-side ``cu_extend_seq_lens_cpu`` construction for linear attention.
 
-The hint tuple must equal the contents of ``query_start_loc`` (a wrong hint
-silently corrupts the CuteDSL host chunk plan), so the builder returns
-``None`` on any absence or length misalignment rather than guessing.
+The tuple must equal the contents of ``query_start_loc`` (a wrong hint
+silently corrupts the CuteDSL host chunk plan). Both are built together by
+``init_forward_metadata`` once per extend batch — mirroring MHA's
+``cu_extend_seq_lens_cpu`` — so the builder raises on absence or length
+misalignment instead of silently degrading to the wrapper's boundary
+re-read.
 """
 
 from __future__ import annotations
 
-import torch
+import os
+import sys
 
-from tokenspeed.runtime.layers.attention.backends.hybrid_kda import (
-    _cu_seqlens_cpu_hint,
+_TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _TEST_DIR)
+sys.path.insert(0, os.path.dirname(_TEST_DIR))
+
+import pytest
+import torch
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
+
+from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
+    _build_cu_extend_seq_lens_cpu,
 )
 
 
 def test_prefix_sum_matches_query_start_loc_contents() -> None:
     lens = torch.tensor([3, 5, 2], dtype=torch.int32)
-    assert _cu_seqlens_cpu_hint(lens, expected_len=4) == (0, 3, 8, 10)
+    assert _build_cu_extend_seq_lens_cpu(lens, expected_len=4) == (0, 3, 8, 10)
 
 
-def test_absent_lens_yield_none() -> None:
-    assert _cu_seqlens_cpu_hint(None, expected_len=4) is None
+def test_absent_lens_raise() -> None:
+    with pytest.raises(RuntimeError, match="host extend lengths"):
+        _build_cu_extend_seq_lens_cpu(None, expected_len=4)
 
 
-def test_length_misalignment_yields_none() -> None:
+def test_length_misalignment_raises() -> None:
     lens = torch.tensor([3, 5], dtype=torch.int32)
     # query_start_loc has 4 entries but only 2 lens -> 3 bounds: mismatch.
-    assert _cu_seqlens_cpu_hint(lens, expected_len=4) is None
+    with pytest.raises(RuntimeError, match="disagree with query_start_loc"):
+        _build_cu_extend_seq_lens_cpu(lens, expected_len=4)
     # And the over-long case.
-    assert _cu_seqlens_cpu_hint(lens, expected_len=2) is None
+    with pytest.raises(RuntimeError, match="disagree with query_start_loc"):
+        _build_cu_extend_seq_lens_cpu(lens, expected_len=2)
 
 
 def test_single_sequence() -> None:
     lens = torch.tensor([129104], dtype=torch.int32)
-    assert _cu_seqlens_cpu_hint(lens, expected_len=2) == (0, 129104)
+    assert _build_cu_extend_seq_lens_cpu(lens, expected_len=2) == (0, 129104)

--- a/test/runtime/test_gdn_state_paging.py
+++ b/test/runtime/test_gdn_state_paging.py
@@ -226,6 +226,8 @@ class CacheContractMetadataTest(unittest.TestCase):
         # before = 8 -> page slot 1 (row 2); after = 9 -> page slot 2 (row 3).
         self.assertEqual(md.state_in_blocks_by_group["linear_attention"].tolist(), [2])
         self.assertEqual(md.state_out_blocks_by_group["linear_attention"].tolist(), [3])
+        # Decode builds no host boundary tuple; only extend batches carry one.
+        self.assertIsNone(md.cu_extend_seq_lens_cpu)
 
     def test_extend_metadata(self):
         torch = self.torch
@@ -236,6 +238,7 @@ class CacheContractMetadataTest(unittest.TestCase):
             seq_lens=torch.tensor([8], dtype=torch.int32),
             forward_mode=self.ForwardMode.EXTEND,
             extend_prefix_lens=torch.zeros(1, dtype=torch.int32),
+            extend_seq_lens_cpu=torch.tensor([8], dtype=torch.int32),
             cache_metadata=_CacheMetadata(
                 {"linear_attention": torch.tensor([[1, 2]], dtype=torch.int32)}
             ),
@@ -243,6 +246,48 @@ class CacheContractMetadataTest(unittest.TestCase):
         md = backend.forward_metadata
         self.assertEqual(md.state_in_blocks_by_group["linear_attention"].tolist(), [0])
         self.assertEqual(md.state_out_blocks_by_group["linear_attention"].tolist(), [2])
+        # The metadata builds the host boundary tuple once, next to
+        # query_start_loc, and keeps the raw lengths for the conv kernel.
+        self.assertEqual(md.cu_extend_seq_lens_cpu, (0, 8))
+        self.assertEqual(md.extend_seq_lens_cpu.tolist(), [8])
+        self.assertEqual(md.query_start_loc.tolist(), [0, 8])
+
+    def test_extend_metadata_requires_host_lens(self):
+        torch = self.torch
+        backend = self.backend
+        with self.assertRaisesRegex(RuntimeError, "host extend lengths"):
+            backend.init_forward_metadata(
+                bs=1,
+                req_pool_indices=torch.tensor([0], dtype=torch.int32),
+                seq_lens=torch.tensor([8], dtype=torch.int32),
+                forward_mode=self.ForwardMode.EXTEND,
+                extend_prefix_lens=torch.zeros(1, dtype=torch.int32),
+                cache_metadata=_CacheMetadata(
+                    {"linear_attention": torch.tensor([[1, 2]], dtype=torch.int32)}
+                ),
+            )
+
+    def test_mixed_metadata_pads_decode_rows(self):
+        torch = self.torch
+        backend = self.backend
+        backend.init_forward_metadata(
+            bs=2,
+            num_extends=1,
+            req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+            seq_lens=torch.tensor([8, 9], dtype=torch.int32),
+            forward_mode=self.ForwardMode.MIXED,
+            extend_seq_lens=torch.tensor([5, 1], dtype=torch.int32),
+            extend_seq_lens_cpu=torch.tensor([5], dtype=torch.int32),
+            cache_metadata=_CacheMetadata(
+                {"linear_attention": torch.tensor([[1, 2], [3, 4]], dtype=torch.int32)}
+            ),
+        )
+        md = backend.forward_metadata
+        # One extend row (5 tokens) plus one decode row padded to
+        # spec_num_tokens (= 1): boundaries and the raw cat agree.
+        self.assertEqual(md.cu_extend_seq_lens_cpu, (0, 5, 6))
+        self.assertEqual(md.extend_seq_lens_cpu.tolist(), [5, 1])
+        self.assertEqual(md.query_start_loc.tolist(), [0, 5, 6])
 
     def test_capture_replay_metadata(self):
         torch = self.torch
@@ -559,6 +604,7 @@ class GDNStatePagingGPUTest(unittest.TestCase):
             seq_lens=torch.tensor([self.PREFILL], dtype=torch.int32, device="cuda"),
             forward_mode=ForwardMode.EXTEND,
             extend_prefix_lens=torch.zeros(1, dtype=torch.int32, device="cuda"),
+            extend_seq_lens_cpu=torch.tensor([self.PREFILL], dtype=torch.int32),
             cache_metadata=_CacheMetadata(
                 {
                     "linear_attention": torch.tensor(

--- a/test/runtime/test_kimi_k3_kda.py
+++ b/test/runtime/test_kimi_k3_kda.py
@@ -413,6 +413,14 @@ class _KDAHarness:
             kwargs["extend_prefix_lens"] = torch.tensor(
                 extend_prefix_lens, dtype=torch.int32, device=self.device
             )
+        if mode.is_extend_or_mixed():
+            # The executor guarantees host extend lengths for every extend
+            # batch; model that contract here.
+            prefix = extend_prefix_lens or [0] * bs
+            kwargs["extend_seq_lens_cpu"] = torch.tensor(
+                [int(s) - int(p) for s, p in zip(seq_lens, prefix)],
+                dtype=torch.int32,
+            )
         self.backend.init_forward_metadata(
             bs=bs,
             req_pool_indices=torch.arange(bs, dtype=torch.int32, device=self.device),


### PR DESCRIPTION
## What this changes

**`None` is no longer an accepted value for the scheduler's host extend lengths on the linear-attention prefill path — absence now raises at once instead of silently degrading.**

Two silent-`None` behaviors are removed:

1. `init_forward_metadata` no longer synthesizes missing host lengths through a hidden D2H copy — an EXTEND/MIXED batch without `extend_seq_lens_cpu` raises `RuntimeError` at metadata build time;
2. the prefill scan no longer converts an absent or length-mismatched host table into a silent fallback (a stream-synchronizing boundary read inside the CuteDSL wheel, per KDA layer per prefill chunk) — it raises instead.

## Why None must be an error

The executor supplies the host lengths for **every** extend batch (`input_buffers.extend_seq_lens_cpu` is unconditionally allocated and refilled per step). A full call-surface audit — eager extend, chunked prefill, mixed batches, prefill-graph capture/replay, PD-disaggregation extend, all four KDA kernel backends; decode/verify/draft/idle never reach the scan — found no legitimate producer of `None`. So a `None` here can only mean a broken caller, and the old fallbacks converted that bug into either a hidden per-batch D2H sync or an unbounded per-layer slowdown that no test or log would ever surface.

KDA was also the family outlier — every other backend already treats the host lengths as mandatory:

| backend | on absent host lens |
|---|---|
| MHA | `assert extend_seq_lens_cpu is not None` (mha.py:251) |
| MSA | same asserts (msa.py:221, :249) |
| MLA | implicit hard requirement (`[:num_extends]` slice — `TypeError` on `None`) |
| **KDA (before)** | silent D2H synthesis + silent per-layer fallback |
| **KDA (after)** | `RuntimeError` with a self-explanatory message, `-O`-safe |

## Implementation

- The boundary tuple **`cu_extend_seq_lens_cpu`** (MHA's field name) is built **once per extend batch** in `init_forward_metadata`, right next to `query_start_loc`, validated against its entry count, and stored in `MambaForwardMetadata` — replacing the per-layer rebuild in `_prefill_scan` (69 layers x chunks per Kimi-K3 request);
- `_prefill_scan` receives the finished tuple under the kernel-facing name `cu_seqlens_cpu` (mirroring `mha_prefill(cu_seqlens_cpu=metadata.cu_extend_seq_lens_cpu)`) and raises if it is missing;
- the field is a tuple where MHA uses a list: it crosses into the CuteDSL wheel, which seeds a memo from its contents, so immutability rules out stale aliasing;
- the kernel facade and the wheel keep their None-tolerant signature — that layer serves other backends and direct callers, and its D2H path remains the correctness backstop. The prohibition lives where the invariant lives: the runtime.

Blast radius: the raise applies to the shared `MambaAttnBackend`, i.e. GDN (Qwen3.5 family) too — justified because GDN itself consumes the raw lengths (conv kernel `seq_lens_cpu`, padding-tail scrub, chunk estimate); previously a missing table was silently patched by the same hidden D2H.

## Tests

- Metadata wiring asserted end to end (new): EXTEND boundary contents, MIXED decode-row padding (`(0, 5, 6)` for one 5-token extend + one padded decode row), decode leaving the field unset, and **the raise on absent lengths**.
- Builder unit tests flipped from None-assertions to raise-assertions; test file renamed to `test_cu_extend_seq_lens_cpu_metadata.py` and CI-registered (it wasn't before).
- The KDA and GDN test harnesses now pass the host lengths explicitly, modeling the executor contract — including the fla-gated KDA extend tests, exercised for real (GPU + flash-linear-attention): 2/2 pass.
- Full affected set: 72 passed, 1 skipped (AMD-only).

Notes for reviewers: `forward_extend` still honors the pre-existing per-call `extend_seq_lens_cpu` kwargs override for the conv path (no production caller uses it); the builder keeps a defensive absence check that duplicates the init-site raise for direct callers.

Follow-up to #1120 (which introduced the host hint on the KDA path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
