### PR TITLE
fix(attention): prevent Triton address overflow

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gated_delta_rule.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gated_delta_rule.py
@@ -198,7 +198,7 @@ def _fused_gdn_decode_update_kernel(
     mask_h = mask_k[:, None] & mask_v[None, :]
 
     b_h = tl.zeros([BK, BV], dtype=tl.float32)
-    idx = tl.load(h0_indices + i_n)
+    idx = tl.load(h0_indices + i_n).to(tl.int64)
     if idx >= 0:
         # K-last [.., HV, V, K]: row v (stride K), col k (stride 1) -- the
         # opposite of this kernel's own [BK, BV] (K-row, V-col) tile layout,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mla_decode.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mla_decode.py
@@ -100,7 +100,7 @@ def _mla_decode_kernel(
             page_table + cur_batch * page_table_stride_b + page_indices,
             mask=mask_n,
             other=0,
-        )
+        ).to(tl.int64)
         cache_base = (
             physical_pages * stride_kv_page
             + page_offsets * stride_kv_token


### PR DESCRIPTION
## Summary
- promote MLA physical page IDs to int64 before multiplying by the KV page stride
- promote GDN state row IDs to int64 before computing recurrent-state pool offsets
- prevent large KV and recurrent-state pools from wrapping signed 32-bit Triton address calculations