### PR TITLE
perf(k3): fuse the multi-token MoE front

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -291,6 +291,7 @@ class MoELayer(torch.nn.Module):
         num_global_tokens: int,
         max_num_tokens_per_gpu: int,
         do_finalize: bool = True,
+        prepared_input: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
         low_latency: bool | None = None,
         overlap_fn: Callable[[], None] | None = None,
     ):
@@ -303,6 +304,8 @@ class MoELayer(torch.nn.Module):
             num_global_tokens: Token count summed over the attention DP ranks.
             max_num_tokens_per_gpu: Largest per-GPU token count this forward.
             do_finalize: Whether the kernel must produce the finalized output.
+            prepared_input: Optional packed route, quantized activation, and
+                scale tensors prepared for a backend that accepts this ABI.
             low_latency: For all-to-all EP plans, whether to take the
                 latency-optimized dispatch/combine legs. Must be identical on
                 every rank of the EP group; see
@@ -334,6 +337,7 @@ class MoELayer(torch.nn.Module):
                 topk_output.router_logits,
                 topk_weights=topk_output.topk_weights,
                 topk_ids=topk_output.topk_ids,
+                prepared_input=prepared_input,
                 num_tokens_global=num_global_tokens,
                 max_num_tokens_per_gpu=max_num_tokens_per_gpu,
                 do_finalize=do_finalize,

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -66,6 +66,7 @@ from tokenspeed_kernel.ops.activation.triton import (
     attnres_partial_dual,
     rmsnorm_gated_sigmoid,
     sigmoid_mul,
+    situ_and_mul,
 )
 from tokenspeed_kernel.ops.attention import mla_normalize_project_query
 from tokenspeed_kernel.ops.attn_res import attn_res_fwd, attn_res_fwd_available
@@ -82,6 +83,7 @@ from tokenspeed_kernel.ops.gemm.triton_gemv import (
     decode_gemv,
 )
 from tokenspeed_kernel.ops.moe import (
+    kimi3_route_pack_quant_mxfp8,
     latent_moe_decode_pipeline_available,
     latent_moe_input_projections,
 )
@@ -89,7 +91,7 @@ from tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxfp4 import (
     situ_moe_unavailable_reason,
 )
 from tokenspeed_kernel.ops.tuning import load_packaged_flashinfer_tuning_cache
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.platform import ArchVersion, current_platform
 from torch import nn
 
 from tokenspeed.runtime.configs.kimi_k3_config import KimiK3Config, KimiLinearConfig
@@ -121,7 +123,12 @@ from tokenspeed.runtime.layers.moe.latent import (
 )
 from tokenspeed.runtime.layers.moe.loader import build_moe_checkpoint_loader
 from tokenspeed.runtime.layers.moe.schema import ExpertCheckpointSchema
-from tokenspeed.runtime.layers.moe.topk import TopK, TopKOutput, TopKOutputFormat
+from tokenspeed.runtime.layers.moe.topk import (
+    StandardTopKOutput,
+    TopK,
+    TopKOutput,
+    TopKOutputFormat,
+)
 from tokenspeed.runtime.layers.moe.utils import RoutingMethodType, get_moe_backend
 from tokenspeed.runtime.layers.quantization.base_config import QuantizationConfig
 from tokenspeed.runtime.layers.quantization.modelopt_mixed import (
@@ -1675,6 +1682,60 @@ class KimiLinearMoE(nn.Module):
         )
         return router_logits, routed_input, shared_output
 
+    def _fused_front_projection(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+        """Project multi-token router, routed, and shared inputs in one GEMM.
+
+        The three returned views retain the wide FP32 row stride. The route
+        preparation and shared SiTU kernels consume them without copies.
+        """
+        platform = current_platform()
+        packed = self.packed_input_projection_weight
+        if (
+            platform.arch_version != ArchVersion(10, 0)
+            or not get_is_capture_mode()
+            or hidden_states.shape[0] <= 1
+            or not self.execution_plan.use_trtllm
+            or packed is None
+            or hidden_states.dtype != torch.bfloat16
+        ):
+            return None
+
+        front = torch.mm(hidden_states, packed.t(), out_dtype=torch.float32)
+        router_end = self.num_experts
+        routed_end = router_end + self.routed_hidden
+        return (
+            front[:, :router_end],
+            front[:, router_end:routed_end],
+            front[:, routed_end:],
+        )
+
+    def _shared_from_fused_front(
+        self,
+        gate_up: torch.Tensor,
+        *,
+        down_out: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Finish the shared-expert branch from its fused-front view."""
+        shared = self.shared_experts
+        activated = torch.empty(
+            (gate_up.shape[0], gate_up.shape[1] // 2),
+            dtype=torch.bfloat16,
+            device=gate_up.device,
+        )
+        situ_and_mul(
+            gate_up,
+            out=activated,
+            beta=shared.act_fn.beta,
+            linear_beta=shared.act_fn.linear_beta,
+        )
+        return kimi3_shared_down_projection(
+            activated,
+            shared.down_proj.weight,
+            out=down_out,
+        )
+
     def _routed_experts(
         self,
         routed_in: torch.Tensor,
@@ -1682,7 +1743,8 @@ class KimiLinearMoE(nn.Module):
         num_global_tokens: int,
         max_num_tokens_per_gpu: int,
         do_finalize: bool = True,
-    ) -> torch.Tensor:
+        prepared_input: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Run the precomputed-TopK SiTU MoE (TRT-LLM cubin or Hopper Marlin)."""
         plan = self.execution_plan
         if not plan.use_trtllm and not plan.use_marlin:
@@ -1696,6 +1758,7 @@ class KimiLinearMoE(nn.Module):
             num_global_tokens=num_global_tokens,
             max_num_tokens_per_gpu=max_num_tokens_per_gpu,
             do_finalize=do_finalize,
+            prepared_input=prepared_input,
         )
         # The kernel returns this rank's pre-reduce partial; the selected
         # tail tier owns the combining reduction.
@@ -1835,10 +1898,13 @@ class KimiLinearMoE(nn.Module):
         if num_tokens == 0:
             return prefix_sum
 
-        # Router runs uncontended on main (3us; on aux it starves to 14us
-        # under concurrent GEMMs). Topk is a single small CTA, so it overlaps
-        # down_proj from the aux stream, followed by the shared chain.
-        router_logits = self.gate(hidden_states)
+        fused_front = self._fused_front_projection(hidden_states)
+        if fused_front is None:
+            # Router runs uncontended on main. Top-k then overlaps routed-down
+            # on the auxiliary stream, followed by the shared chain.
+            router_logits = self.gate(hidden_states)
+        else:
+            router_logits, front_routed_input, front_shared_gate_up = fused_front
         plan = self.comm.plan(num_tokens, hidden_states)
         if plan.lane is not None:
             self.experts._situ_output_buffer = plan.lane[:, : self.routed_hidden]
@@ -1846,26 +1912,59 @@ class KimiLinearMoE(nn.Module):
             self.experts._situ_output_buffer = None
         with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
             with fork.branch():
-                topk_output = self.topk(hidden_states, router_logits)
-                if self._topk_ready is not None and fork._active:
-                    self._topk_ready.record(torch.cuda.current_stream())
-                shared_partial = self.shared_experts(
-                    hidden_states,
-                    down_out=(
-                        plan.lane[:, self.routed_hidden :]
-                        if plan.lane is not None
-                        else None
-                    ),
+                shared_out = (
+                    plan.lane[:, self.routed_hidden :]
+                    if plan.lane is not None
+                    else None
                 )
-            routed_in = decode_gemv(hidden_states, self.routed_expert_down_proj.weight)
-            if self._topk_ready is not None and fork._active:
-                self._topk_ready.wait(torch.cuda.current_stream())
+                if fused_front is None:
+                    topk_output = self.topk(hidden_states, router_logits)
+                    if self._topk_ready is not None and fork._active:
+                        self._topk_ready.record(torch.cuda.current_stream())
+                    shared_partial = self.shared_experts(
+                        hidden_states,
+                        down_out=shared_out,
+                    )
+                else:
+                    shared_partial = self._shared_from_fused_front(
+                        front_shared_gate_up,
+                        down_out=shared_out,
+                    )
+
+            prepared_input = None
+            if fused_front is None:
+                routed_in = decode_gemv(
+                    hidden_states, self.routed_expert_down_proj.weight
+                )
+                if self._topk_ready is not None and fork._active:
+                    self._topk_ready.wait(torch.cuda.current_stream())
+            else:
+                topk_weights, topk_ids, packed_topk, routed_in, routed_scales = (
+                    kimi3_route_pack_quant_mxfp8(
+                        router_logits,
+                        self.gate.e_score_correction_bias,
+                        front_routed_input,
+                        routed_scaling_factor=float(self.routed_scaling_factor),
+                        renormalize=bool(self.config.moe_renormalize),
+                        enable_pdl=True,
+                    )
+                )
+                topk_output = StandardTopKOutput(
+                    topk_weights,
+                    topk_ids,
+                    router_logits,
+                )
+                prepared_input = (packed_topk, routed_in, routed_scales)
+                # The backend dispatch key remains BF16 even though the
+                # prepared tensors replace this placeholder before execution.
+                routed_in = hidden_states.new_empty((num_tokens, self.routed_hidden))
             routed_partial = self._routed_experts(
                 routed_in,
                 topk_output,
                 num_global_tokens,
                 max_num_tokens_per_gpu,
                 do_finalize=not plan.defer_finalize,
+                prepared_input=prepared_input,
             )
             if plan.routed_in_fork:
                 # No fused collective to hide behind: reduce and project here

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
@@ -418,17 +418,20 @@ def situ_and_mul(
     SiTU computes ``beta * tanh(gate / beta) * sigmoid(gate) * up``.
     When ``linear_beta`` is provided, it first soft-clips the up branch as
     ``linear_beta * tanh(up / linear_beta)``. The nonlinear math is evaluated
-    in FP32 and the result is stored in the input/output dtype.
+    in FP32. By default the result uses the input dtype; an explicit BF16
+    ``out`` is also accepted for an FP32 input so a strided fused-GEMM view can
+    feed a BF16 projection without a materialization kernel.
 
     Args:
         x: Tensor shaped ``[..., 2 * D]`` with a contiguous final dimension.
-        out: Optional output tensor shaped ``[..., D]``.
+        out: Optional output tensor shaped ``[..., D]``. Its dtype must match
+            ``x``, except an FP32 ``x`` may write a BF16 ``out``.
         beta: Positive gate soft-clipping scale.
         linear_beta: Optional positive up-branch soft-clipping scale.
         enable_pdl: Reserved for API compatibility; ignored on this kernel.
 
     Returns:
-        Tensor shaped ``[..., D]`` in the same dtype and device as ``x``.
+        Tensor shaped ``[..., D]`` on the same device as ``x``.
     """
     del enable_pdl
     if x.shape[-1] % 2 != 0:
@@ -446,8 +449,11 @@ def situ_and_mul(
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
     elif tuple(out.shape) != output_shape:
         raise ValueError(f"out shape must be {output_shape}, got {tuple(out.shape)}")
-    if out.dtype != x.dtype or out.device != x.device:
-        raise ValueError("out must have the same dtype and device as x")
+    mixed_fp32_to_bf16 = x.dtype == torch.float32 and out.dtype == torch.bfloat16
+    if (out.dtype != x.dtype and not mixed_fp32_to_bf16) or out.device != x.device:
+        raise ValueError(
+            "out must share x's device and dtype, except FP32 x may write BF16"
+        )
     if out.stride(-1) != 1:
         raise ValueError("out must have stride(-1) == 1")
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "latent_moe_decode_pipeline_available",
     "latent_moe_expert_shared",
     "latent_moe_input_projections",
+    "kimi3_route_pack_quant_mxfp8",
     "moe_apply",
     "moe_plan",
     "moe_process_weights",
@@ -43,6 +44,9 @@ __all__ = [
     "moe_softmax_topk",
 ]
 
+from tokenspeed_kernel.ops.moe.kimi3_front import (  # noqa: E402
+    kimi3_route_pack_quant_mxfp8,
+)
 from tokenspeed_kernel.ops.moe.latent_decode import (  # noqa: E402
     latent_moe_decode_pipeline_available,
     latent_moe_expert_shared,
@@ -322,6 +326,7 @@ def moe_apply(
     # top-k routing results
     topk_weights: torch.Tensor | None = None,
     topk_ids: torch.Tensor | None = None,
+    prepared_input: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     # token length
     num_tokens_global: int | None = None,
     max_num_tokens_per_gpu: int | None = None,
@@ -343,6 +348,8 @@ def moe_apply(
             [tokens, top_k]. Required when plan support_routing is false.
         topk_ids: Optional precomputed expert ids with shape [tokens, top_k].
             Required when plan support_routing is false.
+        prepared_input: Optional backend-specific ``(packed_topk, quantized_x,
+            x_scales)`` tuple. Only kernels that declare this ABI consume it.
         num_tokens_global: Optional global token count for distributed MoE.
         max_num_tokens_per_gpu: Optional per-GPU token capacity hint.
         do_finalize: Whether the kernel must produce the finalized output.
@@ -373,6 +380,9 @@ def moe_apply(
         if _uses_all_to_all_ep(plan.get("a2a_backend"))
         else {}
     )
+    prepared_kwargs = (
+        {"prepared_input": prepared_input} if prepared_input is not None else {}
+    )
     return kernel(
         plan=plan,
         x=x,
@@ -380,6 +390,7 @@ def moe_apply(
         router_logits=router_logits,
         topk_weights=topk_weights,
         topk_ids=topk_ids,
+        **prepared_kwargs,
         num_tokens_global=num_tokens_global,
         max_num_tokens_per_gpu=max_num_tokens_per_gpu,
         do_finalize=do_finalize,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxfp4.py
@@ -137,6 +137,8 @@ if platform.is_nvidia:
         _SITU_ACTIVATION_TYPE = None
         _situ_import_error = exc
 
+    from tokenspeed_kernel.thirdparty.cuda.moe import moe_pack_topk_quant_mxfp8
+
     def _get_device_permute_indices(
         x: torch.Tensor,
         epilogue_tile_m: int,
@@ -433,14 +435,14 @@ if platform.is_nvidia:
 
     def _call_mxfp4_situ_routed_moe(
         w: torch.nn.Module,
-        topk_weights: torch.Tensor,
+        topk_weights: torch.Tensor | None,
         topk_ids: torch.Tensor,
         x: torch.Tensor,
-        output: torch.Tensor,
+        output: torch.Tensor | None,
         enable_pdl: bool,
         hidden_states_scale: torch.Tensor | None = None,
         do_finalize: bool = True,
-    ) -> torch.Tensor:
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         local_experts = getattr(w, "num_local_experts", w.w13_weight.shape[0])
         if local_experts != w.w13_weight.shape[0]:
             raise RuntimeError(
@@ -455,13 +457,15 @@ if platform.is_nvidia:
                 f"{local_expert_offset + local_experts}) for {num_experts} experts"
             )
         topk = (
-            topk_ids.to(torch.int32).contiguous(),
-            topk_weights.to(torch.bfloat16).contiguous(),
+            topk_ids
+            if topk_weights is None
+            else (
+                topk_ids.to(torch.int32).contiguous(),
+                topk_weights.to(torch.bfloat16).contiguous(),
+            )
         )
-        # The unpacked ``(ids, weights)`` tuple is flashinfer's precomputed-topk
-        # format; expert IDs stay global and the kernel filters to the local
-        # range. routing_method_type=1 (Renormalize) matches K3's
-        # pre-normalized topk weights, which the kernel consumes as-is.
+        # Packed input skips FlashInfer's unpacked-route preparation. Expert
+        # IDs remain global and the kernel filters to the local range.
         result = _fi_fp4_routed_moe(
             topk_ids=topk,
             routing_bias=None,
@@ -638,6 +642,7 @@ if platform.is_nvidia:
         max_num_tokens_per_gpu: int | None = None,
         do_finalize: bool = True,
         enable_pdl: bool = False,
+        prepared_input: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     ):
         if topk_weights is None or topk_ids is None:
             raise ValueError("precomputed_topk plan requires topk_weights and topk_ids")
@@ -660,12 +665,46 @@ if platform.is_nvidia:
                 value=0.0,
             )
 
-        # cute-dsl beats the cuda backend at every size under CUDA-graph
-        # replay (1.5x at decode M, +6-16% at prefill); its higher eager
-        # launch overhead is amortized by graph capture.
-        x, x_scale = mxfp8_quantize(
-            x, False, alignment=hidden_padded, backend="cute-dsl"
-        )
+        packed_topk = None
+        if prepared_input is not None:
+            packed_topk, prepared_x, x_scale = prepared_input
+            expected_route = (x.shape[0], 16)
+            expected_x = (x.shape[0], hidden_padded)
+            if (
+                hidden_padded != 3584
+                or packed_topk.shape != expected_route
+                or packed_topk.dtype != torch.int32
+                or packed_topk.device != x.device
+                or not packed_topk.is_contiguous()
+                or prepared_x.shape != expected_x
+                or prepared_x.dtype != torch.float8_e4m3fn
+                or prepared_x.device != x.device
+                or not prepared_x.is_contiguous()
+                or x_scale.numel() != x.shape[0] * (hidden_padded // 32)
+                or x_scale.dtype != torch.uint8
+                or x_scale.device != x.device
+                or not x_scale.is_contiguous()
+            ):
+                raise ValueError("invalid prepared Kimi-K3 MXFP8 MoE input")
+            x = prepared_x
+        elif (
+            hidden_padded == 3584
+            and 0 < x.shape[0] <= 64
+            and topk_ids.shape == (x.shape[0], 16)
+            and topk_ids.dtype == torch.int32
+            and topk_ids.is_contiguous()
+            and topk_weights.shape == (x.shape[0], 16)
+            and topk_weights.dtype == torch.bfloat16
+            and topk_weights.is_contiguous()
+        ):
+            packed_topk, x, x_scale = moe_pack_topk_quant_mxfp8(
+                x, topk_ids, topk_weights
+            )
+        else:
+            # Retain the general quantizer for non-K3 shapes.
+            x, x_scale = mxfp8_quantize(
+                x, False, alignment=hidden_padded, backend="cute-dsl"
+            )
         hidden_states_scale = x_scale.view(torch.float8_e4m3fn).reshape(x.shape[0], -1)
 
         # Deferred finalize returns the raw triple, so it needs no
@@ -690,8 +729,8 @@ if platform.is_nvidia:
         # fallback. Serving never enters a tuning context.
         result = _call_mxfp4_situ_routed_moe(
             w,
-            topk_weights,
-            topk_ids,
+            None if packed_topk is not None else topk_weights,
+            packed_topk if packed_topk is not None else topk_ids,
             x,
             output,
             enable_pdl,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/kimi3_front.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/kimi3_front.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Kimi-K3 fused-front preparation kernels."""
+
+import torch
+from tokenspeed_kernel.thirdparty.cuda import moe_route_pack_quant_mxfp8
+
+
+def kimi3_route_pack_quant_mxfp8(
+    router_logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    routed_input: torch.Tensor,
+    *,
+    routed_scaling_factor: float,
+    renormalize: bool,
+    enable_pdl: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Route and quantize strided views from Kimi-K3's FP32 fused front.
+
+    Args:
+        router_logits: Inner-contiguous FP32 logits shaped ``[M, 896]``.
+        correction_bias: Contiguous FP32 selection bias shaped ``[896]``.
+        routed_input: Inner-contiguous FP32/BF16 activation shaped
+            ``[M, 3584]``.
+        routed_scaling_factor: Scale applied after optional normalization.
+        renormalize: Normalize the selected sigmoid weights when true.
+        enable_pdl: Allow programmatic dependent launch from the front GEMM.
+
+    Returns:
+        BF16 route weights, INT32 route ids, packed TRT-LLM routes, MXFP8
+        activations, and flattened UE8M0 scales.
+    """
+    return moe_route_pack_quant_mxfp8(
+        router_logits,
+        correction_bias,
+        routed_input,
+        routed_scaling_factor=routed_scaling_factor,
+        renormalize=renormalize,
+        enable_pdl=enable_pdl,
+    )
+
+
+__all__ = ["kimi3_route_pack_quant_mxfp8"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/__init__.py
@@ -39,7 +39,11 @@ from tokenspeed_kernel.thirdparty.cuda.marlin_moe import (
     moe_align_block_size,
     moe_wna16_marlin_gemm,
 )
-from tokenspeed_kernel.thirdparty.cuda.moe import moe_finalize_fuse_shared
+from tokenspeed_kernel.thirdparty.cuda.moe import (
+    moe_finalize_fuse_shared,
+    moe_pack_topk_quant_mxfp8,
+    moe_route_pack_quant_mxfp8,
+)
 from tokenspeed_kernel.thirdparty.cuda.rmsnorm import rmsnorm_fused_parallel
 from tokenspeed_kernel.thirdparty.cuda.rope import apply_rope_with_cos_sin_cache_inplace
 from tokenspeed_kernel.thirdparty.cuda.routing import (
@@ -65,6 +69,8 @@ __all__ = [
     "marlin_make_workspace",
     "moe_align_block_size",
     "moe_finalize_fuse_shared",
+    "moe_pack_topk_quant_mxfp8",
+    "moe_route_pack_quant_mxfp8",
     "moe_wna16_marlin_gemm",
     "rmsnorm_fused_parallel",
     "routing_flash",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/moe_finalize_fuse_shared.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/moe_finalize_fuse_shared.cu
@@ -57,6 +57,10 @@
  */
 
 #include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#include <type_traits>
 
 #include <cutlass/array.h>
 #include <cutlass/numeric_conversion.h>
@@ -342,6 +346,409 @@ void dispatchFinalize(int numTokens, int hiddenDim, int hiddenDimPadded, int top
   }
 }
 
+// ---------------------------------------------------------------------------
+// Kimi-K3 prepared MoE front: pack precomputed top-k + MXFP8 quant
+// ---------------------------------------------------------------------------
+//
+// FlashInfer needs MXFP8 quantization of routed activations and packed
+// (expert id, bf16 weight) pairs. One CTA per token performs both: the first
+// 16 lanes pack routes while all 224 lanes quantize one 32-value group per
+// lane pair.
+
+constexpr int K3_PREP_HIDDEN = 3584;
+constexpr int K3_PREP_GROUP = 32;
+constexpr int K3_PREP_GROUPS = K3_PREP_HIDDEN / K3_PREP_GROUP;
+constexpr int K3_PREP_TOPK = 16;
+constexpr int K3_PREP_THREADS = K3_PREP_GROUPS * 2;
+constexpr float K3_FP8_MAX = 448.0f;
+
+constexpr int K3_ROUTE_EXPERTS = 896;
+constexpr int K3_ROUTE_VEC = 4;
+constexpr int K3_ROUTE_THREADS = K3_ROUTE_EXPERTS / K3_ROUTE_VEC;
+constexpr int K3_ROUTE_WARPS = (K3_ROUTE_THREADS + 31) / 32;
+constexpr int K3_ROUTE_RADIX_BITS = 8;
+constexpr int K3_ROUTE_RADIX_SIZE = 1 << K3_ROUTE_RADIX_BITS;
+constexpr int K3_ROUTE_RADIX_ROUNDS = 32 / K3_ROUTE_RADIX_BITS;
+
+struct alignas(16) K3RouteMatch {
+  uint32_t bin;
+  uint32_t aboveCount;
+  uint32_t equalCount;
+};
+
+struct K3RouteSmem {
+  uint32_t warpSum[3][K3_ROUTE_WARPS];
+  K3RouteMatch match[K3_ROUTE_RADIX_ROUNDS];
+  uint32_t histogram[K3_ROUTE_RADIX_SIZE];
+  int32_t winnerId[K3_PREP_TOPK];
+  uint32_t winnerKey[K3_PREP_TOPK];
+  float winnerWeight[K3_PREP_TOPK];
+};
+
+__device__ __forceinline__ uint32_t k3WarpInclusiveSum(uint32_t value) {
+#pragma unroll
+  for (int offset = 1; offset < 32; offset <<= 1) {
+    uint32_t const peer = __shfl_up_sync(0xffffffffu, value, offset);
+    if ((threadIdx.x & 31) >= offset)
+      value += peer;
+  }
+  return value;
+}
+
+__device__ __forceinline__ uint32_t
+k3BlockExclusiveSum(uint32_t value, uint32_t *__restrict__ warpSum) {
+  int const lane = int(threadIdx.x) & 31;
+  int const warp = int(threadIdx.x) >> 5;
+  uint32_t const inclusive = k3WarpInclusiveSum(value);
+  if (lane == 31 || int(threadIdx.x) == K3_ROUTE_THREADS - 1) {
+    warpSum[warp] = inclusive;
+  }
+  __syncthreads();
+  uint32_t base = 0;
+#pragma unroll
+  for (int i = 0; i < K3_ROUTE_WARPS; ++i) {
+    if (i < warp)
+      base += warpSum[i];
+  }
+  return base + inclusive - value;
+}
+
+__device__ __forceinline__ float k3Sigmoid(float x) {
+  return __fdividef(1.0f, 1.0f + __expf(-x));
+}
+
+__device__ __forceinline__ uint32_t k3BiasedToKey(float value) {
+  // Match the Triton packed-key router: canonicalize signed zero and order
+  // every finite FP32 value monotonically as an unsigned integer.
+  if (value == 0.0f)
+    value = 0.0f;
+  uint32_t const bits = __float_as_uint(value);
+  return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+}
+
+__device__ __forceinline__ void
+k3RouteRow(float const *__restrict__ logits, int64_t logitsRowStride,
+           float const *__restrict__ bias,
+           __nv_bfloat16 *__restrict__ topkWeights, int64_t weightsRowStride,
+           int32_t *__restrict__ topkIds, int64_t idsRowStride,
+           int32_t *__restrict__ packedTopk, int64_t packedRowStride,
+           float routedScalingFactor, bool renormalize, K3RouteSmem &smem) {
+  int const row = int(blockIdx.x);
+  int const tid = int(threadIdx.x);
+  int const lane = tid & 31;
+  int const warp = tid >> 5;
+  int const firstExpert = tid * K3_ROUTE_VEC;
+
+  uint32_t keys[K3_ROUTE_VEC];
+  float weights[K3_ROUTE_VEC];
+  auto const *rowLogits = logits + int64_t(row) * logitsRowStride;
+#pragma unroll
+  for (int i = 0; i < K3_ROUTE_VEC; ++i) {
+    int const expert = firstExpert + i;
+    float const weight = k3Sigmoid(rowLogits[expert]);
+    float selected = weight + bias[expert];
+    if (isnan(selected))
+      selected = -1.0e30f;
+    weights[i] = weight;
+    keys[i] = k3BiasedToKey(selected);
+  }
+
+  bool active[K3_ROUTE_VEC] = {true, true, true, true};
+  uint32_t totalActive = K3_ROUTE_EXPERTS;
+  uint32_t quota = K3_PREP_TOPK;
+  uint32_t threshold = 0;
+  uint32_t examinedMask = 0;
+  bool takeAllEquals = false;
+
+  if (tid < K3_ROUTE_RADIX_SIZE / 2) {
+    smem.histogram[2 * tid] = 0;
+    smem.histogram[2 * tid + 1] = 0;
+  }
+#pragma unroll
+  for (int round = 0; round < K3_ROUTE_RADIX_ROUNDS; ++round) {
+    __syncthreads();
+    int const shift = 24 - round * K3_ROUTE_RADIX_BITS;
+    uint32_t bins[K3_ROUTE_VEC];
+#pragma unroll
+    for (int i = 0; i < K3_ROUTE_VEC; ++i) {
+      bins[i] = (keys[i] >> shift) & 0xffu;
+      if (active[i])
+        atomicAdd(&smem.histogram[bins[i]], 1u);
+    }
+    __syncthreads();
+
+    uint32_t pairCount = 0;
+    if (tid < K3_ROUTE_RADIX_SIZE / 2) {
+      pairCount = smem.histogram[2 * tid] + smem.histogram[2 * tid + 1];
+    }
+    uint32_t const pairInclusive = k3WarpInclusiveSum(pairCount);
+    if (lane == 31 && warp < 4)
+      smem.warpSum[0][warp] = pairInclusive;
+    __syncthreads();
+
+    if (tid < K3_ROUTE_RADIX_SIZE / 2) {
+      uint32_t prefix = pairInclusive;
+#pragma unroll
+      for (int i = 0; i < 4; ++i) {
+        if (i < warp)
+          prefix += smem.warpSum[0][i];
+      }
+      uint32_t const right = smem.histogram[2 * tid + 1];
+      uint32_t const left = smem.histogram[2 * tid];
+      uint32_t const aboveRight = totalActive - prefix;
+      uint32_t const aboveLeft = aboveRight + right;
+      if (aboveRight < quota && aboveRight + right >= quota) {
+        smem.match[round] = {static_cast<uint32_t>(2 * tid + 1), aboveRight,
+                             right};
+      } else if (aboveLeft < quota && aboveLeft + left >= quota) {
+        smem.match[round] = {static_cast<uint32_t>(2 * tid), aboveLeft, left};
+      }
+    }
+    __syncthreads();
+
+    K3RouteMatch const split = smem.match[round];
+    threshold |= split.bin << shift;
+    examinedMask |= 0xffu << shift;
+#pragma unroll
+    for (int i = 0; i < K3_ROUTE_VEC; ++i) {
+      active[i] = active[i] && bins[i] == split.bin;
+    }
+    totalActive = split.equalCount;
+    quota -= split.aboveCount;
+    if (quota == totalActive) {
+      takeAllEquals = true;
+      break;
+    }
+    if (round + 1 < K3_ROUTE_RADIX_ROUNDS && tid < K3_ROUTE_RADIX_SIZE / 2) {
+      smem.histogram[2 * tid] = 0;
+      smem.histogram[2 * tid + 1] = 0;
+    }
+  }
+
+  bool selected[K3_ROUTE_VEC];
+  if (takeAllEquals) {
+#pragma unroll
+    for (int i = 0; i < K3_ROUTE_VEC; ++i) {
+      selected[i] = active[i] || (keys[i] & examinedMask) > threshold;
+    }
+  } else {
+    uint32_t activeCount = 0;
+#pragma unroll
+    for (int i = 0; i < K3_ROUTE_VEC; ++i)
+      activeCount += active[i];
+    uint32_t rank = k3BlockExclusiveSum(activeCount, smem.warpSum[1]);
+#pragma unroll
+    for (int i = 0; i < K3_ROUTE_VEC; ++i) {
+      bool const equalWinner = active[i] && rank < quota;
+      if (active[i])
+        ++rank;
+      selected[i] = equalWinner || (keys[i] & examinedMask) > threshold;
+    }
+  }
+
+  uint32_t selectedCount = 0;
+#pragma unroll
+  for (int i = 0; i < K3_ROUTE_VEC; ++i)
+    selectedCount += selected[i];
+  uint32_t slot = k3BlockExclusiveSum(selectedCount, smem.warpSum[2]);
+#pragma unroll
+  for (int i = 0; i < K3_ROUTE_VEC; ++i) {
+    if (selected[i] && slot < K3_PREP_TOPK) {
+      smem.winnerId[slot] = firstExpert + i;
+      smem.winnerKey[slot] = keys[i];
+      smem.winnerWeight[slot] = weights[i];
+      ++slot;
+    }
+  }
+  __syncthreads();
+
+  if (tid < K3_PREP_TOPK) {
+    // Match TokenSpeed's existing Triton top-k order: selection score
+    // descending, expert id ascending for ties.
+    uint32_t const key = smem.winnerKey[tid];
+    int32_t const id = smem.winnerId[tid];
+    int rank = 0;
+#pragma unroll
+    for (int i = 0; i < K3_PREP_TOPK; ++i) {
+      rank += smem.winnerKey[i] > key ||
+              (smem.winnerKey[i] == key && smem.winnerId[i] < id);
+    }
+    float denominator = 0.0f;
+#pragma unroll
+    for (int i = 0; i < K3_PREP_TOPK; ++i) {
+      denominator += smem.winnerWeight[i];
+    }
+    float weight = smem.winnerWeight[tid];
+    if (renormalize)
+      weight /= denominator > 0.0f ? denominator : 1.0f;
+    weight *= routedScalingFactor;
+    __nv_bfloat16 const weightBf16 = __float2bfloat16_rn(weight);
+    topkWeights[int64_t(row) * weightsRowStride + rank] = weightBf16;
+    topkIds[int64_t(row) * idsRowStride + rank] = id;
+    uint32_t const bits = __bfloat16_as_ushort(weightBf16);
+    packedTopk[int64_t(row) * packedRowStride + rank] =
+        static_cast<int32_t>((static_cast<uint32_t>(id) << 16) | bits);
+  }
+}
+
+__device__ __forceinline__ int k3CastToUe8m0(float x) {
+  uint32_t const bits = __float_as_uint(x);
+  int exponent = int((bits >> 23) & 0xffu);
+  exponent += (bits & 0x7fffffu) != 0;
+  return exponent;
+}
+
+__device__ __forceinline__ float k3InvUe8m0Scale(int exponent) {
+  return __uint_as_float(uint32_t(254 - exponent) << 23);
+}
+
+template <typename InputT>
+__device__ __forceinline__ float k3LoadQuantValue(InputT const *input,
+                                                  int offset) {
+  if constexpr (std::is_same_v<InputT, float>) {
+    return input[offset];
+  } else {
+    return __bfloat162float(input[offset]);
+  }
+}
+
+template <typename InputT>
+__device__ __forceinline__ void
+k3QuantMxfp8Row(InputT const *__restrict__ x, int64_t xRowStride,
+                uint8_t *__restrict__ xQuant, int64_t quantRowStride,
+                uint8_t *__restrict__ xScales, int row) {
+  int const tid = int(threadIdx.x);
+  int const group = tid >> 1;
+  int const pairLane = tid & 1;
+  int const col = group * K3_PREP_GROUP + pairLane * 16;
+  auto const *input = x + int64_t(row) * xRowStride + col;
+
+  float values[16];
+  float localAbsMax = 0.0f;
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    float const value = k3LoadQuantValue(input, i);
+    values[i] = value;
+    localAbsMax = fmaxf(localAbsMax, fabsf(value));
+  }
+  float const peerAbsMax = __shfl_xor_sync(0xffffffffu, localAbsMax, 1);
+  float const absMax = fmaxf(fmaxf(localAbsMax, peerAbsMax), 1.0e-10f);
+  int const scaleExponent = k3CastToUe8m0(absMax / K3_FP8_MAX);
+  float const inverseScale = k3InvUe8m0Scale(scaleExponent);
+  // The packed BF16 path matches FlashInfer/CuTe's BF16 multiply. The FP32
+  // path deliberately retains FP32 multiplication, matching SGLang's
+  // strided FP32 fused-front consumer.
+  float const multiplier =
+      std::is_same_v<InputT, float>
+          ? inverseScale
+          : __bfloat162float(__float2bfloat16_rn(inverseScale));
+
+  uint4 quantized;
+  auto *quantBytes = reinterpret_cast<uint8_t *>(&quantized);
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    float scaled = values[i] * multiplier;
+    if constexpr (!std::is_same_v<InputT, float>) {
+      scaled = __bfloat162float(__float2bfloat16_rn(scaled));
+    }
+    scaled = fminf(scaled, K3_FP8_MAX);
+    quantBytes[i] = static_cast<uint8_t>(
+        __nv_cvt_float_to_fp8(scaled, __NV_SATFINITE, __NV_E4M3));
+  }
+  auto *output = xQuant + int64_t(row) * quantRowStride + col;
+  *reinterpret_cast<uint4 *>(output) = quantized;
+  if (pairLane == 0) {
+    xScales[row * K3_PREP_GROUPS + group] = static_cast<uint8_t>(scaleExponent);
+  }
+}
+
+template <typename InputT, bool EnablePDL>
+__global__ __launch_bounds__(K3_ROUTE_THREADS) void k3RoutePackQuantMxfp8Kernel(
+    float const *__restrict__ logits, int64_t logitsRowStride,
+    float const *__restrict__ bias, InputT const *__restrict__ x,
+    int64_t xRowStride, __nv_bfloat16 *__restrict__ topkWeights,
+    int64_t weightsRowStride, int32_t *__restrict__ topkIds,
+    int64_t idsRowStride, int32_t *__restrict__ packedTopk,
+    int64_t packedRowStride, uint8_t *__restrict__ xQuant,
+    int64_t quantRowStride, uint8_t *__restrict__ xScales,
+    float routedScalingFactor, bool renormalize, int numTokens) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if constexpr (EnablePDL)
+    cudaGridDependencySynchronize();
+#endif
+  if (int(blockIdx.x) < numTokens) {
+    __shared__ K3RouteSmem routeSmem;
+    k3RouteRow(logits, logitsRowStride, bias, topkWeights, weightsRowStride,
+               topkIds, idsRowStride, packedTopk, packedRowStride,
+               routedScalingFactor, renormalize, routeSmem);
+  } else {
+    k3QuantMxfp8Row(x, xRowStride, xQuant, quantRowStride, xScales,
+                    int(blockIdx.x) - numTokens);
+  }
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  if constexpr (EnablePDL)
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+__global__ __launch_bounds__(K3_PREP_THREADS) void k3PackTopkQuantMxfp8Kernel(
+    __nv_bfloat16 const *__restrict__ x, int64_t xRowStride,
+    int32_t const *__restrict__ topkIds, int64_t idsRowStride,
+    uint16_t const *__restrict__ topkWeightBits, int64_t weightsRowStride,
+    int32_t *__restrict__ packedTopk, int64_t packedRowStride,
+    uint8_t *__restrict__ xQuant, int64_t quantRowStride,
+    uint8_t *__restrict__ xScales) {
+  int const row = int(blockIdx.x);
+  int const tid = int(threadIdx.x);
+
+  if (tid < K3_PREP_TOPK) {
+    uint32_t const id =
+        static_cast<uint32_t>(topkIds[row * idsRowStride + tid]);
+    uint32_t const weight = topkWeightBits[row * weightsRowStride + tid];
+    packedTopk[row * packedRowStride + tid] =
+        static_cast<int32_t>((id << 16) | weight);
+  }
+
+  int const group = tid >> 1;
+  int const pairLane = tid & 1;
+  int const col = group * K3_PREP_GROUP + pairLane * 16;
+  auto const *input = x + int64_t(row) * xRowStride + col;
+
+  float values[16];
+  float localAbsMax = 0.0f;
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    float const value = __bfloat162float(input[i]);
+    values[i] = value;
+    localAbsMax = fmaxf(localAbsMax, fabsf(value));
+  }
+  float const peerAbsMax = __shfl_xor_sync(0xffffffffu, localAbsMax, 1);
+  float const absMax = fmaxf(fmaxf(localAbsMax, peerAbsMax), 1.0e-10f);
+  int const scaleExponent = k3CastToUe8m0(absMax / K3_FP8_MAX);
+  float const inverseScale = k3InvUe8m0Scale(scaleExponent);
+  // The production FlashInfer/CuTe quantizer rounds the power-of-two
+  // multiplier and the multiply itself in BF16 before the FP8 conversion.
+  float const inverseScaleBf16 =
+      __bfloat162float(__float2bfloat16_rn(inverseScale));
+
+  uint4 quantized;
+  auto *quantBytes = reinterpret_cast<uint8_t *>(&quantized);
+#pragma unroll
+  for (int i = 0; i < 16; ++i) {
+    float scaled =
+        __bfloat162float(__float2bfloat16_rn(values[i] * inverseScaleBf16));
+    // fminf sanitizes NaN/+inf to +448; -inf is saturated by the FP8 cast.
+    scaled = fminf(scaled, K3_FP8_MAX);
+    quantBytes[i] = static_cast<uint8_t>(
+        __nv_cvt_float_to_fp8(scaled, __NV_SATFINITE, __NV_E4M3));
+  }
+  auto *output = xQuant + int64_t(row) * quantRowStride + col;
+  *reinterpret_cast<uint4 *>(output) = quantized;
+  if (pairLane == 0) {
+    xScales[row * K3_PREP_GROUPS + group] = static_cast<uint8_t>(scaleExponent);
+  }
+}
+
 }  // namespace tokenspeed
 
 // ---------------------------------------------------------------------------
@@ -430,3 +837,175 @@ void moe_finalize_fuse_shared(TensorView out, TensorView gemm2_out,
 }
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_finalize_fuse_shared, moe_finalize_fuse_shared);
+
+void moe_pack_topk_quant_mxfp8(TensorView packed_topk, TensorView x_quant,
+                               TensorView x_scales, TensorView x,
+                               TensorView topk_ids, TensorView topk_weights) {
+  TVM_FFI_ICHECK_EQ(x.ndim(), 2) << "x must be [numTokens, 3584]";
+  TVM_FFI_ICHECK_EQ(x.size(1), tokenspeed::K3_PREP_HIDDEN);
+  TVM_FFI_ICHECK_EQ(x.dtype(), dl_bfloat16);
+  int const numTokens = int(x.size(0));
+  TVM_FFI_ICHECK_GT(numTokens, 0);
+  TVM_FFI_ICHECK_LE(numTokens, 64)
+      << "prepared K3 MoE front is limited to decode batches <= 64";
+
+  TVM_FFI_ICHECK_EQ(topk_ids.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(topk_ids.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(topk_ids.size(1), tokenspeed::K3_PREP_TOPK);
+  TVM_FFI_ICHECK_EQ(topk_ids.dtype(), dl_int32);
+  TVM_FFI_ICHECK_EQ(topk_weights.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(topk_weights.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(topk_weights.size(1), tokenspeed::K3_PREP_TOPK);
+  TVM_FFI_ICHECK_EQ(topk_weights.dtype(), dl_bfloat16);
+
+  TVM_FFI_ICHECK_EQ(packed_topk.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(packed_topk.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(packed_topk.size(1), tokenspeed::K3_PREP_TOPK);
+  TVM_FFI_ICHECK_EQ(packed_topk.dtype(), dl_int32);
+  TVM_FFI_ICHECK_EQ(x_quant.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(x_quant.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(x_quant.size(1), tokenspeed::K3_PREP_HIDDEN);
+  TVM_FFI_ICHECK_EQ(x_quant.dtype(), dl_float8_e4m3fn);
+  TVM_FFI_ICHECK_EQ(x_scales.numel(), numTokens * tokenspeed::K3_PREP_GROUPS);
+  TVM_FFI_ICHECK_EQ(x_scales.dtype(), dl_uint8);
+
+  TVM_FFI_ICHECK_EQ(x.stride(1), 1);
+  TVM_FFI_ICHECK_EQ(topk_ids.stride(1), 1);
+  TVM_FFI_ICHECK_EQ(topk_weights.stride(1), 1);
+  TVM_FFI_ICHECK_EQ(packed_topk.stride(1), 1);
+  TVM_FFI_ICHECK_EQ(x_quant.stride(1), 1);
+
+  cudaSetDevice(x.device().device_id);
+  cudaStream_t const stream = get_stream(x.device());
+  tokenspeed::k3PackTopkQuantMxfp8Kernel<<<
+      numTokens, tokenspeed::K3_PREP_THREADS, 0, stream>>>(
+      static_cast<__nv_bfloat16 const *>(x.data_ptr()), x.stride(0),
+      static_cast<int32_t const *>(topk_ids.data_ptr()), topk_ids.stride(0),
+      static_cast<uint16_t const *>(topk_weights.data_ptr()),
+      topk_weights.stride(0), static_cast<int32_t *>(packed_topk.data_ptr()),
+      packed_topk.stride(0), static_cast<uint8_t *>(x_quant.data_ptr()),
+      x_quant.stride(0), static_cast<uint8_t *>(x_scales.data_ptr()));
+  cudaError_t const err = cudaGetLastError();
+  TVM_FFI_ICHECK(err == cudaSuccess)
+      << "moe_pack_topk_quant_mxfp8 launch failed: " << cudaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_pack_topk_quant_mxfp8,
+                              moe_pack_topk_quant_mxfp8);
+
+void moe_route_pack_quant_mxfp8(TensorView topk_weights, TensorView topk_ids,
+                                TensorView packed_topk, TensorView x_quant,
+                                TensorView x_scales, TensorView router_logits,
+                                TensorView correction_bias, TensorView x,
+                                double routed_scaling_factor, bool renormalize,
+                                bool enable_pdl) {
+  TVM_FFI_ICHECK_EQ(router_logits.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(router_logits.size(1), tokenspeed::K3_ROUTE_EXPERTS);
+  TVM_FFI_ICHECK_EQ(router_logits.dtype(), dl_float32);
+  int const numTokens = int(router_logits.size(0));
+  TVM_FFI_ICHECK_GT(numTokens, 0);
+  TVM_FFI_ICHECK_LE(numTokens, 64);
+  TVM_FFI_ICHECK_EQ(router_logits.stride(1), 1);
+
+  TVM_FFI_ICHECK_EQ(correction_bias.ndim(), 1);
+  TVM_FFI_ICHECK_EQ(correction_bias.size(0), tokenspeed::K3_ROUTE_EXPERTS);
+  TVM_FFI_ICHECK_EQ(correction_bias.dtype(), dl_float32);
+
+  TVM_FFI_ICHECK_EQ(x.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(x.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(x.size(1), tokenspeed::K3_PREP_HIDDEN);
+  TVM_FFI_ICHECK(x.dtype() == dl_float32 || x.dtype() == dl_bfloat16)
+      << "x must be FP32 or BF16";
+  TVM_FFI_ICHECK_EQ(x.stride(1), 1);
+
+  TVM_FFI_ICHECK_EQ(topk_weights.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(topk_weights.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(topk_weights.size(1), tokenspeed::K3_PREP_TOPK);
+  TVM_FFI_ICHECK_EQ(topk_weights.dtype(), dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(topk_weights.stride(1), 1);
+  TVM_FFI_ICHECK_EQ(topk_ids.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(topk_ids.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(topk_ids.size(1), tokenspeed::K3_PREP_TOPK);
+  TVM_FFI_ICHECK_EQ(topk_ids.dtype(), dl_int32);
+  TVM_FFI_ICHECK_EQ(topk_ids.stride(1), 1);
+  TVM_FFI_ICHECK_EQ(packed_topk.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(packed_topk.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(packed_topk.size(1), tokenspeed::K3_PREP_TOPK);
+  TVM_FFI_ICHECK_EQ(packed_topk.dtype(), dl_int32);
+  TVM_FFI_ICHECK_EQ(packed_topk.stride(1), 1);
+
+  TVM_FFI_ICHECK_EQ(x_quant.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(x_quant.size(0), numTokens);
+  TVM_FFI_ICHECK_EQ(x_quant.size(1), tokenspeed::K3_PREP_HIDDEN);
+  TVM_FFI_ICHECK_EQ(x_quant.dtype(), dl_float8_e4m3fn);
+  TVM_FFI_ICHECK_EQ(x_quant.stride(1), 1);
+  TVM_FFI_ICHECK_EQ(x_scales.numel(), numTokens * tokenspeed::K3_PREP_GROUPS);
+  TVM_FFI_ICHECK_EQ(x_scales.dtype(), dl_uint8);
+
+  cudaSetDevice(router_logits.device().device_id);
+  cudaStream_t const stream = get_stream(router_logits.device());
+  dim3 const grid(2 * numTokens);
+  dim3 const block(tokenspeed::K3_ROUTE_THREADS);
+  auto const *logitsPtr = static_cast<float const *>(router_logits.data_ptr());
+  auto const *biasPtr = static_cast<float const *>(correction_bias.data_ptr());
+  auto *weightsPtr = static_cast<__nv_bfloat16 *>(topk_weights.data_ptr());
+  auto *idsPtr = static_cast<int32_t *>(topk_ids.data_ptr());
+  auto *packedPtr = static_cast<int32_t *>(packed_topk.data_ptr());
+  auto *quantPtr = static_cast<uint8_t *>(x_quant.data_ptr());
+  auto *scalesPtr = static_cast<uint8_t *>(x_scales.data_ptr());
+  cudaLaunchAttribute attrs[1];
+  attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attrs[0].val.programmaticStreamSerializationAllowed = 1;
+  cudaLaunchConfig_t config = {};
+  config.gridDim = grid;
+  config.blockDim = block;
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  config.attrs = attrs;
+  config.numAttrs = enable_pdl ? 1 : 0;
+  if (x.dtype() == dl_float32) {
+    if (enable_pdl) {
+      cudaLaunchKernelEx(
+          &config, tokenspeed::k3RoutePackQuantMxfp8Kernel<float, true>,
+          logitsPtr, router_logits.stride(0), biasPtr,
+          static_cast<float const *>(x.data_ptr()), x.stride(0), weightsPtr,
+          topk_weights.stride(0), idsPtr, topk_ids.stride(0), packedPtr,
+          packed_topk.stride(0), quantPtr, x_quant.stride(0), scalesPtr,
+          float(routed_scaling_factor), renormalize, numTokens);
+    } else {
+      cudaLaunchKernelEx(
+          &config, tokenspeed::k3RoutePackQuantMxfp8Kernel<float, false>,
+          logitsPtr, router_logits.stride(0), biasPtr,
+          static_cast<float const *>(x.data_ptr()), x.stride(0), weightsPtr,
+          topk_weights.stride(0), idsPtr, topk_ids.stride(0), packedPtr,
+          packed_topk.stride(0), quantPtr, x_quant.stride(0), scalesPtr,
+          float(routed_scaling_factor), renormalize, numTokens);
+    }
+  } else {
+    if (enable_pdl) {
+      cudaLaunchKernelEx(
+          &config, tokenspeed::k3RoutePackQuantMxfp8Kernel<__nv_bfloat16, true>,
+          logitsPtr, router_logits.stride(0), biasPtr,
+          static_cast<__nv_bfloat16 const *>(x.data_ptr()), x.stride(0),
+          weightsPtr, topk_weights.stride(0), idsPtr, topk_ids.stride(0),
+          packedPtr, packed_topk.stride(0), quantPtr, x_quant.stride(0),
+          scalesPtr, float(routed_scaling_factor), renormalize, numTokens);
+    } else {
+      cudaLaunchKernelEx(
+          &config,
+          tokenspeed::k3RoutePackQuantMxfp8Kernel<__nv_bfloat16, false>,
+          logitsPtr, router_logits.stride(0), biasPtr,
+          static_cast<__nv_bfloat16 const *>(x.data_ptr()), x.stride(0),
+          weightsPtr, topk_weights.stride(0), idsPtr, topk_ids.stride(0),
+          packedPtr, packed_topk.stride(0), quantPtr, x_quant.stride(0),
+          scalesPtr, float(routed_scaling_factor), renormalize, numTokens);
+    }
+  }
+  cudaError_t const err = cudaGetLastError();
+  TVM_FFI_ICHECK(err == cudaSuccess)
+      << "moe_route_pack_quant_mxfp8 launch failed: "
+      << cudaGetErrorString(err);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(moe_route_pack_quant_mxfp8,
+                              moe_route_pack_quant_mxfp8);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/moe.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/moe.py
@@ -144,3 +144,144 @@ def moe_finalize_fuse_shared(
         bool(enable_pdl),
     )
     return out
+
+
+def moe_pack_topk_quant_mxfp8(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Prepare the small Kimi-K3 TRT-LLM MoE front in one CUDA launch.
+
+    Packs precomputed ``(expert_id, bf16 weight)`` pairs and quantizes the
+    3584-wide routed activations to MXFP8/UE8M0.  This preserves the model's
+    router-vs-routed-down stream overlap: the fusion runs only after those two
+    independent branches join.
+
+    Returns ``(packed_topk, hidden_states_fp8, scales_uint8)``.  The scale
+    tensor is flattened, matching FlashInfer's ``mxfp8_quantize`` result; the
+    caller may view it as ``[tokens, hidden // 32]``.
+    """
+    if (
+        hidden_states.dim() != 2
+        or hidden_states.shape[1] != 3584
+        or hidden_states.dtype != torch.bfloat16
+        or not hidden_states.is_cuda
+        or not 0 < hidden_states.shape[0] <= 64
+    ):
+        raise ValueError("prepared Kimi-K3 MoE input requires CUDA BF16 [1..64, 3584]")
+    expected_route_shape = (hidden_states.shape[0], 16)
+    if (
+        topk_ids.shape != expected_route_shape
+        or topk_ids.dtype != torch.int32
+        or topk_ids.device != hidden_states.device
+        or not topk_ids.is_contiguous()
+    ):
+        raise ValueError("topk_ids must be contiguous colocated INT32 [tokens, 16]")
+    if (
+        topk_weights.shape != expected_route_shape
+        or topk_weights.dtype != torch.bfloat16
+        or topk_weights.device != hidden_states.device
+        or not topk_weights.is_contiguous()
+    ):
+        raise ValueError("topk_weights must be contiguous colocated BF16 [tokens, 16]")
+
+    packed_topk = torch.empty_like(topk_ids)
+    hidden_states_quant = torch.empty_like(hidden_states, dtype=torch.float8_e4m3fn)
+    scales = torch.empty(
+        hidden_states.shape[0] * (hidden_states.shape[1] // 32),
+        dtype=torch.uint8,
+        device=hidden_states.device,
+    )
+    mod = _load_moe_finalize_fuse_shared_module()
+    mod.moe_pack_topk_quant_mxfp8(
+        packed_topk,
+        hidden_states_quant,
+        scales,
+        hidden_states,
+        topk_ids,
+        topk_weights,
+    )
+    return packed_topk, hidden_states_quant, scales
+
+
+def moe_route_pack_quant_mxfp8(
+    router_logits: torch.Tensor,
+    correction_bias: torch.Tensor,
+    routed_input: torch.Tensor,
+    *,
+    routed_scaling_factor: float,
+    renormalize: bool,
+    enable_pdl: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Route and prepare Kimi-K3's small TRT-LLM MoE input in one launch.
+
+    One routing CTA and one MXFP8-quantization CTA run per token. The router
+    consumes a potentially strided FP32 ``[M, 896]`` view, while the quantizer
+    consumes a potentially strided FP32 or BF16 ``[M, 3584]`` view. This lets
+    both slices come directly from a wider fused projection without a copy.
+
+    Args:
+        router_logits: FP32 router logits shaped ``[M, 896]``.
+        correction_bias: FP32 expert-selection bias shaped ``[896]``.
+        routed_input: FP32 or BF16 routed activation shaped ``[M, 3584]``.
+        routed_scaling_factor: Scale applied to normalized route weights.
+        renormalize: Whether to normalize the selected sigmoid weights.
+        enable_pdl: Allow the launch to overlap scheduling with its predecessor.
+
+    Returns:
+        ``(weights_bf16, ids_int32, packed_topk, input_fp8, scales_uint8)``.
+    """
+    if (
+        router_logits.dim() != 2
+        or router_logits.shape[1] != 896
+        or router_logits.dtype != torch.float32
+        or not router_logits.is_cuda
+        or not 0 < router_logits.shape[0] <= 64
+        or router_logits.stride(1) != 1
+    ):
+        raise ValueError("router_logits must be CUDA FP32 [1..64, 896]")
+    tokens = router_logits.shape[0]
+    if (
+        correction_bias.shape != (896,)
+        or correction_bias.dtype != torch.float32
+        or correction_bias.device != router_logits.device
+        or not correction_bias.is_contiguous()
+    ):
+        raise ValueError("correction_bias must be contiguous colocated FP32 [896]")
+    if (
+        routed_input.shape != (tokens, 3584)
+        or routed_input.dtype not in (torch.float32, torch.bfloat16)
+        or routed_input.device != router_logits.device
+        or routed_input.stride(1) != 1
+    ):
+        raise ValueError(
+            "routed_input must be inner-contiguous colocated FP32/BF16 [tokens, 3584]"
+        )
+
+    topk_ids = torch.empty((tokens, 16), dtype=torch.int32, device=router_logits.device)
+    topk_weights = torch.empty(
+        (tokens, 16), dtype=torch.bfloat16, device=router_logits.device
+    )
+    packed_topk = torch.empty_like(topk_ids)
+    routed_quant = torch.empty(
+        (tokens, 3584), dtype=torch.float8_e4m3fn, device=router_logits.device
+    )
+    scales = torch.empty(
+        tokens * (3584 // 32), dtype=torch.uint8, device=router_logits.device
+    )
+    mod = _load_moe_finalize_fuse_shared_module()
+    mod.moe_route_pack_quant_mxfp8(
+        topk_weights,
+        topk_ids,
+        packed_topk,
+        routed_quant,
+        scales,
+        router_logits,
+        correction_bias,
+        routed_input,
+        float(routed_scaling_factor),
+        bool(renormalize),
+        bool(enable_pdl),
+    )
+    return topk_weights, topk_ids, packed_topk, routed_quant, scales

--- a/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_flashinfer_trtllm.py
+++ b/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_flashinfer_trtllm.py
@@ -81,6 +81,99 @@ class _MoEWeights(torch.nn.Module):
 
 
 @requires_flashinfer_situ
+@pytest.mark.parametrize("num_tokens", [1, 16])
+def test_k3_prepared_front_matches_flashinfer_quant_and_pack(num_tokens: int) -> None:
+    """The fused preparation preserves FlashInfer's byte-level input ABI."""
+    from flashinfer import mxfp8_quantize
+    from tokenspeed_kernel.thirdparty.cuda.moe import moe_pack_topk_quant_mxfp8
+
+    hidden = 3584
+    topk = 16
+    generator = torch.Generator().manual_seed(20260818 + num_tokens)
+    x = torch.randn(
+        num_tokens, hidden, generator=generator, dtype=torch.bfloat16
+    ).cuda()
+    ids = torch.stack(
+        [torch.randperm(896, generator=generator)[:topk] for _ in range(num_tokens)]
+    ).to(device="cuda", dtype=torch.int32)
+    weights = (
+        torch.rand(num_tokens, topk, generator=generator)
+        .softmax(dim=-1)
+        .to(device="cuda", dtype=torch.bfloat16)
+    )
+
+    packed, actual_q, actual_s = moe_pack_topk_quant_mxfp8(x, ids, weights)
+    expected_q, expected_s = mxfp8_quantize(
+        x, False, alignment=hidden, backend="cute-dsl"
+    )
+    expected_packed = (ids << 16) | weights.view(torch.uint16).to(torch.int32)
+
+    assert torch.equal(packed, expected_packed)
+    assert torch.equal(
+        actual_q.view(torch.uint8).flatten(), expected_q.view(torch.uint8).flatten()
+    )
+    assert torch.equal(actual_s, expected_s.view(torch.uint8))
+
+
+@requires_flashinfer_situ
+@pytest.mark.parametrize(
+    ("num_tokens", "enable_pdl"),
+    [(1, False), (2, True), (4, True), (8, True), (12, True), (16, True)],
+)
+def test_k3_route_pack_quant_accepts_strided_front_views(
+    num_tokens: int,
+    enable_pdl: bool,
+) -> None:
+    from tokenspeed_kernel.ops.moe import kimi3_route_pack_quant_mxfp8
+
+    generator = torch.Generator().manual_seed(20260819 + num_tokens)
+    front = torch.randn(
+        num_tokens, 6016, generator=generator, dtype=torch.float32
+    ).cuda()
+    router_logits = front[:, :896]
+    routed_input = front[:, 896 : 896 + 3584]
+    bias = torch.randn(896, generator=generator, dtype=torch.float32).cuda()
+    scaling = 2.5
+
+    weights, ids, packed, actual_q, actual_s = kimi3_route_pack_quant_mxfp8(
+        router_logits,
+        bias,
+        routed_input,
+        routed_scaling_factor=scaling,
+        renormalize=True,
+        enable_pdl=enable_pdl,
+    )
+    scores = router_logits.sigmoid()
+    expected_ids = torch.topk(scores + bias, 16, dim=-1).indices.to(torch.int32)
+    expected_weights = scores.gather(1, expected_ids.long())
+    expected_weights = (
+        expected_weights / expected_weights.sum(dim=-1, keepdim=True) * scaling
+    ).to(torch.bfloat16)
+    expected_packed = (ids << 16) | weights.view(torch.uint16).to(torch.int32)
+
+    assert torch.equal(ids, expected_ids)
+    assert torch.equal(weights, expected_weights)
+    assert torch.equal(packed, expected_packed)
+
+    groups = routed_input.reshape(num_tokens, -1, 32)
+    raw_scale = groups.abs().amax(dim=-1).clamp_min(1.0e-10) / 448.0
+    scale_bits = raw_scale.view(torch.int32)
+    expected_s = (((scale_bits >> 23) & 0xFF) + ((scale_bits & 0x7FFFFF) != 0)).to(
+        torch.uint8
+    )
+    multiplier = torch.ldexp(
+        torch.ones_like(raw_scale), 127 - expected_s.to(torch.int32)
+    )
+    expected_q = (
+        (groups * multiplier[..., None]).clamp(max=448.0).to(torch.float8_e4m3fn)
+    )
+    assert torch.equal(
+        actual_q.view(torch.uint8).flatten(), expected_q.view(torch.uint8).flatten()
+    )
+    assert torch.equal(actual_s, expected_s.flatten())
+
+
+@requires_flashinfer_situ
 def test_flashinfer_situ_routed_moe_matches_portable_reference() -> None:
     from tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxfp4 import (
         flashinfer_trtllm_mxfp4_situ_moe_weights,

--- a/tokenspeed-kernel/test/ops/test_activation.py
+++ b/tokenspeed-kernel/test/ops/test_activation.py
@@ -199,6 +199,25 @@ def test_situ_and_mul_writes_provided_output(device: str) -> None:
     assert same.data_ptr() == out.data_ptr()
 
 
+def test_situ_and_mul_strided_fp32_front_writes_bf16(device: str) -> None:
+    front = torch.randn(16, 6016, device=device, dtype=torch.float32)
+    x = front[:, -1536:]
+    assert x.stride() == (6016, 1)
+    out = torch.empty(16, 768, device=device, dtype=torch.bfloat16)
+    gate, up = x.chunk(2, dim=-1)
+    expected = (
+        4.0
+        * torch.tanh(gate / 4.0)
+        * torch.sigmoid(gate)
+        * (25.0 * torch.tanh(up / 25.0))
+    ).bfloat16()
+
+    same = situ_and_mul(x, out, beta=4.0, linear_beta=25.0)
+
+    assert same.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(out, expected, rtol=1e-2, atol=1e-2)
+
+
 def test_situ_and_mul_writes_noncontiguous_output(device: str) -> None:
     x = torch.randn(2, 3, 64, device=device, dtype=torch.bfloat16)
     gate, up = x.float().chunk(2, dim=-1)


### PR DESCRIPTION
## Summary

- fuse the K3 router, routed-down, and shared gate/up projections for captured multi-token decode batches on SM100
- consume the fused FP32 strided views directly in route/top-k/MXFP8 preparation and allow the shared SiTU path to write BF16 without an extra materialization kernel
- keep the existing singleton GEMV path for `M == 1`; use the fused front for captured `M >= 2` batches

## Dispatch A/B

Three paired serving repetitions per CUDA graph bucket, 256 input / 256 output tokens, TP8/EP8 on 8x B200:

| M | Output throughput | TPOT |
|---:|---:|---:|
| 1 | -0.62% | -0.72% |
| 2 | +2.80% | +3.04% |
| 4 | +5.05% | +5.02% |
| 8 | +2.44% | +2.72% |
| 12 | +5.79% | +3.63% |
| 16 | +0.21% | +0.10% |

Positive values are improvements. The all-M candidate regressed at `M == 1` in all three TPOT repetitions, so the final dispatch retains GEMV only for that singleton case. The old exact-`M == 16` allowlist was otherwise too restrictive.

## Testing

- `pre-commit run --files` on all changed Python files
- complete activation and focused FlashInfer TRT-LLM SiTU MoE tests: 100 passed
- CUDA graph capture and warmup generation at `M = 1, 2, 4, 8, 12, 16`
- 36 serving benchmark cases, zero failed requests
