### PR TITLE
perf(k3): extend latent-tail fusion to M64 with split collectives

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1844,6 +1844,7 @@ class KimiLinearMoE(nn.Module):
             self.experts._situ_output_buffer = plan.lane[:, : self.routed_hidden]
         else:
             self.experts._situ_output_buffer = None
+        prepared_shared_shard = None
         with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
             with fork.branch():
                 topk_output = self.topk(hidden_states, router_logits)
@@ -1857,6 +1858,10 @@ class KimiLinearMoE(nn.Module):
                         else None
                     ),
                 )
+                if plan.split_shared_rs and fork._active:
+                    prepared_shared_shard = self.comm.reduce_scatter_shared(
+                        shared_partial
+                    )
             routed_in, _ = self.routed_expert_down_proj(hidden_states)
             if self._topk_ready is not None and fork._active:
                 self._topk_ready.wait(torch.cuda.current_stream())
@@ -1880,6 +1885,7 @@ class KimiLinearMoE(nn.Module):
             prefix_sum,
             num_tokens,
             hidden_size,
+            prepared_shared_shard,
         )
         # Cross-DP-EP: the tail ran on the gathered token set; every DP rank
         # keeps only its slice (a no-op view when no gather happened).

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -59,13 +59,17 @@ from tokenspeed_kernel.ops.moe.latent_tail import (
     KimiK3LatentTailOp,
     latent_tail_supported,
 )
+from tokenspeed_kernel.platform import ArchVersion, current_platform
 
 from tokenspeed.runtime.distributed.comm_ops import (
     all_reduce,
     prepare_all_reduce_fusion,
     prepare_all_reduce_lane,
 )
-from tokenspeed.runtime.execution.cuda_graph_wrapper import get_is_cuda_graph_phase
+from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+    get_is_capture_mode,
+    get_is_cuda_graph_phase,
+)
 from tokenspeed.runtime.execution.workspace import workspace_pool
 from tokenspeed.runtime.layers.layernorm import RMSNorm, _get_process_group
 from tokenspeed.runtime.layers.moe.latent import kimi3_join_reduce_moe
@@ -475,12 +479,15 @@ class TailPlan:
             ``lane[:, :routed_hidden]`` and the shared experts into the rest.
         routed_in_fork: Whether the routed partial must be reduced and
             projected inside the fork (SEPARATE_REDUCE overlap).
+        split_shared_rs: Start the shared ReduceScatter on the auxiliary
+            stream before the routed collective is ready.
     """
 
     tier: "K3MoETailTier"
     defer_finalize: bool = False
     lane: torch.Tensor | None = None
     routed_in_fork: bool = False
+    split_shared_rs: bool = False
 
 
 def _tail_finalize_top_k(
@@ -544,6 +551,7 @@ class K3MoeTailComm:
         # Derived from the projection itself (built with a shard group iff
         # _shard_k3_up_projection held), so comm and module cannot disagree.
         self._shard_up_projection = up_proj.shard_group is not None
+        self._split_shared_rs = current_platform().arch_version == ArchVersion(10, 0)
         self.latent_tail = None
         if self.state.latent_tail_ok:
             # Deferred-finalize arming (rank-uniform). The gate is the
@@ -577,11 +585,14 @@ class K3MoeTailComm:
                 # mailbox must remain private.
                 scratch_allocator=workspace_pool(_device).allocate,
                 finalize_top_k=tail_finalize_top_k,
+                split_collective=self._split_shared_rs,
             )
             logger.info(
-                "multicast latent tail engaged (%s, deferred_finalize=%s)",
+                "multicast latent tail engaged "
+                "(%s, deferred_finalize=%s, split_shared_rs=%s)",
                 prefix,
                 tail_finalize_top_k is not None,
+                self.latent_tail.supports_split_collective,
             )
 
     # ------------------------------------------------------------------
@@ -616,6 +627,12 @@ class K3MoeTailComm:
                     and self.latent_tail is not None
                     and self.latent_tail.supports_deferred_finalize
                 ),
+                split_shared_rs=(
+                    num_tokens > 8
+                    and get_is_capture_mode()
+                    and self.latent_tail is not None
+                    and self.latent_tail.supports_split_collective
+                ),
             )
         # Shard mode splits the joined reduction, so it cannot use the packed lane.
         lane = allreduce_fusion_lane(
@@ -639,6 +656,15 @@ class K3MoeTailComm:
         if self.mapping.moe.tp_ep_size > 1:
             return all_reduce(shared_partial, self.mapping.moe.tp_ep_group)
         return shared_partial
+
+    def reduce_scatter_shared(self, shared_partial: torch.Tensor) -> torch.Tensor:
+        """Launch the split shared ReduceScatter on the current stream."""
+        if self.latent_tail is None:
+            raise RuntimeError("split shared ReduceScatter requires the latent tail")
+        return self.latent_tail.reduce_scatter_shared(
+            shared_partial,
+            self.routed_norm.weight,
+        )
 
     def reduce_project_routed(self, routed_out: torch.Tensor) -> torch.Tensor:
         """Reduce, norm and up-project the routed partial (SEPARATE_REDUCE).
@@ -669,6 +695,7 @@ class K3MoeTailComm:
         prefix_sum: torch.Tensor,
         num_tokens: int,
         hidden_size: int,
+        prepared_shared_shard: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Dispatch the selected tier over the partials.
 
@@ -688,8 +715,14 @@ class K3MoeTailComm:
                     shared_partial,
                     prefix_sum,
                     num_tokens,
+                    prepared_shared_shard,
                 )
-            return self._tail_fusion(routed_out, shared_partial, prefix_sum)
+            return self._tail_fusion(
+                routed_out,
+                shared_partial,
+                prefix_sum,
+                prepared_shared_shard,
+            )
         if tier is K3MoETailTier.MULTIMEM_AR:
             return self._tail_multimem_ar(
                 routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
@@ -712,6 +745,7 @@ class K3MoeTailComm:
         routed_out: torch.Tensor,
         shared_partial: torch.Tensor,
         prefix_sum: torch.Tensor,
+        prepared_shared_shard: torch.Tensor | None,
     ) -> torch.Tensor:
         return self.latent_tail(
             routed_out,
@@ -719,6 +753,7 @@ class K3MoeTailComm:
             self.routed_norm.weight,
             self.up_proj.weight,
             prefix=prefix_sum,
+            prepared_shared_shard=prepared_shared_shard,
         )
 
     def _tail_fusion_deferred(
@@ -729,6 +764,7 @@ class K3MoeTailComm:
         shared_partial: torch.Tensor,
         prefix_sum: torch.Tensor,
         num_tokens: int,
+        prepared_shared_shard: torch.Tensor | None,
     ) -> torch.Tensor:
         """TAIL_FUSION over the deferred-finalize triple (finalize in-kernel)."""
         return self.latent_tail.call_deferred(
@@ -740,6 +776,7 @@ class K3MoeTailComm:
             self.up_proj.weight,
             num_tokens=num_tokens,
             prefix=prefix_sum,
+            prepared_shared_shard=prepared_shared_shard,
         )
 
     def _tail_multimem_ar(

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -59,7 +59,7 @@ from tokenspeed_kernel.ops.moe.latent_tail import (
     KimiK3LatentTailOp,
     latent_tail_supported,
 )
-from tokenspeed_kernel.platform import ArchVersion, current_platform
+from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.distributed.comm_ops import (
     all_reduce,
@@ -551,7 +551,6 @@ class K3MoeTailComm:
         # Derived from the projection itself (built with a shard group iff
         # _shard_k3_up_projection held), so comm and module cannot disagree.
         self._shard_up_projection = up_proj.shard_group is not None
-        self._split_shared_rs = current_platform().arch_version == ArchVersion(10, 0)
         self.latent_tail = None
         if self.state.latent_tail_ok:
             # Deferred-finalize arming (rank-uniform). The gate is the
@@ -585,7 +584,7 @@ class K3MoeTailComm:
                 # mailbox must remain private.
                 scratch_allocator=workspace_pool(_device).allocate,
                 finalize_top_k=tail_finalize_top_k,
-                split_collective=self._split_shared_rs,
+                split_collective=current_platform().is_blackwell,
             )
             logger.info(
                 "multicast latent tail engaged "
@@ -628,10 +627,10 @@ class K3MoeTailComm:
                     and self.latent_tail.supports_deferred_finalize
                 ),
                 split_shared_rs=(
-                    num_tokens > 8
-                    and get_is_capture_mode()
-                    and self.latent_tail is not None
+                    self.latent_tail is not None
                     and self.latent_tail.supports_split_collective
+                    and num_tokens >= self.latent_tail.split_collective_min_tokens
+                    and get_is_capture_mode()
                 ),
             )
         # Shard mode splits the joined reduction, so it cannot use the packed lane.
@@ -745,7 +744,7 @@ class K3MoeTailComm:
         routed_out: torch.Tensor,
         shared_partial: torch.Tensor,
         prefix_sum: torch.Tensor,
-        prepared_shared_shard: torch.Tensor | None,
+        prepared_shared_shard: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return self.latent_tail(
             routed_out,
@@ -764,7 +763,7 @@ class K3MoeTailComm:
         shared_partial: torch.Tensor,
         prefix_sum: torch.Tensor,
         num_tokens: int,
-        prepared_shared_shard: torch.Tensor | None,
+        prepared_shared_shard: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """TAIL_FUSION over the deferred-finalize triple (finalize in-kernel)."""
         return self.latent_tail.call_deferred(

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -362,12 +362,14 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
     from tokenspeed.runtime.models import kimi_k3_comm as mod
 
     monkeypatch.setattr(mod, "get_is_cuda_graph_phase", lambda: True)
+    monkeypatch.setattr(mod, "get_is_capture_mode", lambda: True)
 
     def build(*, supports_deferred, fused_ar):
         comm = object.__new__(mod.K3MoeTailComm)
         comm.latent_tail = SimpleNamespace(
             max_num_tokens=16,
             supports_deferred_finalize=supports_deferred,
+            supports_split_collective=True,
         )
         comm.execution_plan = SimpleNamespace(fused_moe_ar=fused_ar)
         comm.state = SimpleNamespace(multimem_ar_ok=False)
@@ -378,12 +380,19 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
     plan = build(supports_deferred=True, fused_ar=True).plan(1, None)
     assert plan.tier is mod.K3MoETailTier.TAIL_FUSION
     assert plan.defer_finalize
+    assert not plan.split_shared_rs
     assert plan.lane is None and not plan.routed_in_fork
 
     # A tail op without the deferred variant must keep the materialized mode.
     plan = build(supports_deferred=False, fused_ar=True).plan(16, None)
     assert plan.tier is mod.K3MoETailTier.TAIL_FUSION
     assert not plan.defer_finalize
+    assert plan.split_shared_rs
+
+    # Split at the measured second-wave boundary, not at one exact graph size.
+    comm = build(supports_deferred=True, fused_ar=True)
+    assert not comm.plan(8, None).split_shared_rs
+    assert comm.plan(9, None).split_shared_rs
 
     # Without the fused-AR (trtllm) plan the experts kernel cannot defer.
     plan = build(supports_deferred=True, fused_ar=False).plan(1, None)

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -324,7 +324,7 @@ def test_selector_boundaries():
         select_k3_moe_tail_tier,
     )
 
-    def pick(num_tokens, *, graph_phase=True, fused_max=16, fused_ar=True, mm=True):
+    def pick(num_tokens, *, graph_phase=True, fused_max=64, fused_ar=True, mm=True):
         return select_k3_moe_tail_tier(
             num_tokens=num_tokens,
             graph_phase=graph_phase,
@@ -334,9 +334,9 @@ def test_selector_boundaries():
         )
 
     assert pick(1) is K3MoETailTier.TAIL_FUSION
-    assert pick(16) is K3MoETailTier.TAIL_FUSION
+    assert pick(64) is K3MoETailTier.TAIL_FUSION
     # One past capacity must leave the fused tail rather than truncate.
-    assert pick(17) is not K3MoETailTier.TAIL_FUSION
+    assert pick(65) is not K3MoETailTier.TAIL_FUSION
     # Outside the graph phase the fused tail is unreachable at any size.
     assert pick(1, graph_phase=False) is not K3MoETailTier.TAIL_FUSION
     # No fused tail compiled: capacity is 0 and the join tier takes decode.
@@ -349,7 +349,7 @@ def test_selector_boundaries():
     # The fused tail owns its own multicast collective, so it outranks the
     # flag rather than being gated by it; every other size falls to portable.
     assert pick(1, fused_ar=False) is K3MoETailTier.TAIL_FUSION
-    for n in (17, 64, 256, 100_000):
+    for n in (65, 256, 100_000):
         assert pick(n, fused_ar=False) is K3MoETailTier.SEPARATE_REDUCE
 
 
@@ -367,7 +367,7 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
     def build(*, supports_deferred, fused_ar):
         comm = object.__new__(mod.K3MoeTailComm)
         comm.latent_tail = SimpleNamespace(
-            max_num_tokens=16,
+            max_num_tokens=64,
             supports_deferred_finalize=supports_deferred,
             supports_split_collective=True,
         )
@@ -384,7 +384,7 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
     assert plan.lane is None and not plan.routed_in_fork
 
     # A tail op without the deferred variant must keep the materialized mode.
-    plan = build(supports_deferred=False, fused_ar=True).plan(16, None)
+    plan = build(supports_deferred=False, fused_ar=True).plan(64, None)
     assert plan.tier is mod.K3MoETailTier.TAIL_FUSION
     assert not plan.defer_finalize
     assert plan.split_shared_rs

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -370,6 +370,7 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
             max_num_tokens=64,
             supports_deferred_finalize=supports_deferred,
             supports_split_collective=True,
+            split_collective_min_tokens=9,
         )
         comm.execution_plan = SimpleNamespace(fused_moe_ar=fused_ar)
         comm.state = SimpleNamespace(multimem_ar_ok=False)
@@ -389,7 +390,7 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
     assert not plan.defer_finalize
     assert plan.split_shared_rs
 
-    # Split at the measured second-wave boundary, not at one exact graph size.
+    # Split once token work enters a second collective-CTA wave.
     comm = build(supports_deferred=True, fused_ar=True)
     assert not comm.plan(8, None).split_shared_rs
     assert comm.plan(9, None).split_shared_rs
@@ -484,6 +485,7 @@ def test_fused_tail_deferred_finalize_matches_reference(m):
         layer_index=0,
         model_scope="test-deferred",
         finalize_top_k=TOP_K,
+        split_collective=True,
     )
     assert tail.supports_deferred_finalize
     comm = _build_comm(dev, latent_tail=tail)
@@ -502,6 +504,21 @@ def test_fused_tail_deferred_finalize_matches_reference(m):
     scale = out_materialized.float().abs().max().item()
     diff = (out.float() - out_materialized.float()).abs().max().item()
     assert diff / max(scale, 1e-6) < 0.02
+
+    if m >= tail.split_collective_min_tokens:
+        prepared = tail.reduce_scatter_shared(shared, comm.routed_norm.weight)
+        out_split = comm._tail_fusion_deferred(
+            gemm2,
+            weights,
+            idx,
+            shared,
+            prefix,
+            m,
+            prepared,
+        )
+        torch.cuda.synchronize()
+        split_diff = (out.float() - out_split.float()).abs().max().item()
+        assert split_diff / max(scale, 1e-6) < 0.02
 
 
 @collective

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
@@ -54,7 +54,7 @@ _ScratchAllocator = Callable[..., list[torch.Tensor]]
 
 logger = logging.getLogger(__name__)
 
-_MAX_NUM_TOKENS = 16
+_MAX_NUM_TOKENS = 64
 _SKINNY_MAX_NUM_TOKENS = 5
 _MMA_TILER_MN = (64, 32)
 _GEMM_CLUSTER_MN = (1, 8)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
@@ -507,7 +507,24 @@ class KimiK3LatentTailOp:
         shared_partial: torch.Tensor,
         rms_weight: torch.Tensor,
     ) -> torch.Tensor:
-        """Run the shared ReduceScatter into stable split-mode staging."""
+        """Run the shared ReduceScatter into stable split-mode staging.
+
+        Args:
+            shared_partial: This rank's contiguous CUDA BF16 shared-expert
+                partial ``[M, hidden_size]``, where
+                ``1 <= M <= max_num_tokens``.
+            rms_weight: Contiguous CUDA BF16 latent RMSNorm weight
+                ``[latent_size]`` required by the collective signature.
+
+        Returns:
+            The rank-local BF16 shard view
+            ``[max_num_tokens, hidden_size / tp_size]`` with stride
+            ``(hidden_size, 1)``. Only the first ``M`` rows contain this
+            launch's output. The view aliases the pooled split staging and is
+            valid until the next shared ReduceScatter using the same pool
+            slot. A consumer on another stream must wait for this launch's
+            stream before reading it.
+        """
         if not self.supports_split_collective:
             raise RuntimeError("shared-only ReduceScatter is not initialized")
         m = shared_partial.shape[0]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
@@ -158,6 +158,7 @@ class _SymmetricPoolSlot:
 
     collective: CollectiveKernel
     up_projection: AdaptiveUpProjectionKernel
+    split_shared_output: torch.Tensor | None
     scratch_allocator_key: object
 
 
@@ -211,7 +212,7 @@ class KimiK3LatentTailOp:
                 the standalone finalize kernel and its ``[M, latent]``
                 intermediate. The standard mode stays available.
             split_collective: Precompile independent shared-ReduceScatter and
-                routed-AllReduce roles for multistream M16 execution.
+                routed-AllReduce roles for multistream execution.
         """
         contract = _Contract(
             group_name=group.group_name,
@@ -298,6 +299,15 @@ class KimiK3LatentTailOp:
                         cluster_shape_mn=_GEMM_CLUSTER_MN,
                         b_prime_stages=_B_PRIME_STAGES,
                     ),
+                    split_shared_output=(
+                        torch.empty(
+                            (_MAX_NUM_TOKENS, contract.hidden_size),
+                            dtype=torch.bfloat16,
+                            device=contract.device,
+                        )
+                        if contract.split_collective
+                        else None
+                    ),
                     scratch_allocator_key=allocator_key,
                 )
                 type(self)._symmetric_pools[pool_key] = slot
@@ -308,15 +318,7 @@ class KimiK3LatentTailOp:
                 )
             self._collective = slot.collective
             self._up_projection = slot.up_projection
-            self._split_shared_output = (
-                torch.empty(
-                    (_MAX_NUM_TOKENS, contract.hidden_size),
-                    dtype=torch.bfloat16,
-                    device=contract.device,
-                )
-                if contract.split_collective
-                else None
-            )
+            self._split_shared_output = slot.split_shared_output
             self._lamport_copy = LamportCopyKernel(
                 hidden_dim=contract.hidden_size,
                 max_m=_MAX_NUM_TOKENS,
@@ -336,6 +338,11 @@ class KimiK3LatentTailOp:
     @property
     def supports_split_collective(self) -> bool:
         return self.contract.split_collective
+
+    @property
+    def split_collective_min_tokens(self) -> int:
+        """First M whose token work spans more than one collective CTA wave."""
+        return _COLLECTIVE_TOKEN_CTAS + 1
 
     def __call__(
         self,
@@ -381,7 +388,7 @@ class KimiK3LatentTailOp:
             self._validate_prepared_shared_shard(prepared_shared_shard)
             latent, _ = self._collective(
                 routed_partial,
-                self._collective._shared_output[:m],
+                self._collective.shared_output[:m],
                 rms_weight,
                 include_reduce_scatter=False,
                 include_routed=True,
@@ -424,6 +431,8 @@ class KimiK3LatentTailOp:
             num_tokens: Token count M for this step.
             prefix: Optional residual stream ``[M, 7168]``, as in
                 :meth:`__call__`.
+            prepared_shared_shard: Shared ReduceScatter output produced by
+                :meth:`reduce_scatter_shared` on an auxiliary stream.
 
         Returns:
             ``[M, 7168]`` post-communication hidden, as in :meth:`__call__`.
@@ -484,7 +493,7 @@ class KimiK3LatentTailOp:
             gemm2_output,
             expert_weights,
             expanded_idx_to_permuted_idx,
-            (self._collective._shared_output[:m] if split_shared else shared_partial),
+            (self._collective.shared_output[:m] if split_shared else shared_partial),
             rms_weight,
             num_tokens=m,
             include_reduce_scatter=not split_shared,
@@ -503,7 +512,7 @@ class KimiK3LatentTailOp:
             raise RuntimeError("shared-only ReduceScatter is not initialized")
         m = shared_partial.shape[0]
         _, shared_shard = self._collective(
-            self._collective._latent_output[:m],
+            self._collective.latent_output[:m],
             shared_partial,
             rms_weight,
             include_reduce_scatter=True,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_tail.py
@@ -149,6 +149,7 @@ class _Contract:
     # inlines the MoE finalize); part of the pool identity because it selects
     # which kernel variants the pooled slot compiles.
     finalize_top_k: int | None = None
+    split_collective: bool = False
 
 
 @dataclass
@@ -169,7 +170,7 @@ class KimiK3LatentTailOp:
     """
 
     _symmetric_pools: dict[
-        tuple[str, int, torch.device, int, int, float, int | None, str, int],
+        tuple[str, int, torch.device, int, int, float, int | None, bool, str, int],
         _SymmetricPoolSlot,
     ] = {}
 
@@ -186,6 +187,7 @@ class KimiK3LatentTailOp:
         model_scope: str,
         scratch_allocator: _ScratchAllocator | None = None,
         finalize_top_k: int | None = None,
+        split_collective: bool = False,
     ) -> "KimiK3LatentTailOp":
         """Construct this caller's tail op with a statically bound pool slot.
 
@@ -208,6 +210,8 @@ class KimiK3LatentTailOp:
                 weights, expanded->permuted index)`` triple directly, skipping
                 the standalone finalize kernel and its ``[M, latent]``
                 intermediate. The standard mode stays available.
+            split_collective: Precompile independent shared-ReduceScatter and
+                routed-AllReduce roles for multistream M16 execution.
         """
         contract = _Contract(
             group_name=group.group_name,
@@ -217,6 +221,7 @@ class KimiK3LatentTailOp:
             latent_size=latent_size,
             rms_eps=float(rms_eps),
             finalize_top_k=finalize_top_k,
+            split_collective=split_collective,
         )
         return cls(
             contract,
@@ -251,11 +256,17 @@ class KimiK3LatentTailOp:
             contract.latent_size,
             contract.rms_eps,
             contract.finalize_top_k,
+            contract.split_collective,
             model_scope,
             slot_index,
         )
 
-        allocator_key = _allocator_identity(scratch_allocator)
+        # Split output lives across two streams, so it cannot borrow storage
+        # from the moving workspace pool.
+        effective_scratch_allocator = (
+            None if contract.split_collective else scratch_allocator
+        )
+        allocator_key = _allocator_identity(effective_scratch_allocator)
         with torch.accelerator.device_index(contract.device.index):
             slot = type(self)._symmetric_pools.get(pool_key)
             if slot is None:
@@ -271,8 +282,9 @@ class KimiK3LatentTailOp:
                         max_token_ctas=_COLLECTIVE_TOKEN_CTAS,
                         rms_eps=contract.rms_eps,
                         fp32_internal=True,
-                        scratch_allocator=scratch_allocator,
+                        scratch_allocator=effective_scratch_allocator,
                         finalize_top_k=contract.finalize_top_k,
+                        precompile_split=contract.split_collective,
                     ),
                     up_projection=AdaptiveUpProjectionKernel(
                         group=group,
@@ -296,6 +308,15 @@ class KimiK3LatentTailOp:
                 )
             self._collective = slot.collective
             self._up_projection = slot.up_projection
+            self._split_shared_output = (
+                torch.empty(
+                    (_MAX_NUM_TOKENS, contract.hidden_size),
+                    dtype=torch.bfloat16,
+                    device=contract.device,
+                )
+                if contract.split_collective
+                else None
+            )
             self._lamport_copy = LamportCopyKernel(
                 hidden_dim=contract.hidden_size,
                 max_m=_MAX_NUM_TOKENS,
@@ -312,6 +333,10 @@ class KimiK3LatentTailOp:
         """Whether :meth:`call_deferred` may consume the deferred triple."""
         return self.contract.finalize_top_k is not None
 
+    @property
+    def supports_split_collective(self) -> bool:
+        return self.contract.split_collective
+
     def __call__(
         self,
         routed_partial: torch.Tensor,
@@ -319,6 +344,7 @@ class KimiK3LatentTailOp:
         rms_weight: torch.Tensor,
         up_weight: torch.Tensor,
         prefix: torch.Tensor | None = None,
+        prepared_shared_shard: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Fused tail for one decode step.
 
@@ -335,6 +361,8 @@ class KimiK3LatentTailOp:
             prefix: Optional residual stream ``[M, 7168]``; when given the
                 lamport gather fuses ``+ prefix`` (same rounding as an eager
                 add) and the caller's accumulate disappears.
+            prepared_shared_shard: Shared ReduceScatter output produced by
+                :meth:`reduce_scatter_shared` on an auxiliary stream.
 
         Returns:
             ``[M, 7168]`` post-communication hidden (up-projection + shared,
@@ -343,11 +371,22 @@ class KimiK3LatentTailOp:
         # Same-slot calls are stream-ordered, preserving Lamport buffer rotation.
         m = routed_partial.shape[0]
         self._assert_capture_compiled(m)
-        latent, shared_shard = self._collective(
-            routed_partial,
-            shared_partial,
-            rms_weight,
-        )
+        if prepared_shared_shard is None:
+            latent, shared_shard = self._collective(
+                routed_partial,
+                shared_partial,
+                rms_weight,
+            )
+        else:
+            self._validate_prepared_shared_shard(prepared_shared_shard)
+            latent, _ = self._collective(
+                routed_partial,
+                self._collective._shared_output[:m],
+                rms_weight,
+                include_reduce_scatter=False,
+                include_routed=True,
+            )
+            shared_shard = prepared_shared_shard
         return self._project_and_gather(latent, shared_shard, m, up_weight, prefix)
 
     def call_deferred(
@@ -361,6 +400,7 @@ class KimiK3LatentTailOp:
         *,
         num_tokens: int,
         prefix: torch.Tensor | None = None,
+        prepared_shared_shard: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Fused tail consuming the MoE kernel's deferred-finalize triple.
 
@@ -437,15 +477,57 @@ class KimiK3LatentTailOp:
                 dtype=torch.bfloat16,
                 device=gemm2_output.device,
             )
+        split_shared = prepared_shared_shard is not None
+        if split_shared:
+            self._validate_prepared_shared_shard(prepared_shared_shard)
         latent, shared_shard = self._collective.call_deferred(
             gemm2_output,
             expert_weights,
             expanded_idx_to_permuted_idx,
-            shared_partial,
+            (self._collective._shared_output[:m] if split_shared else shared_partial),
             rms_weight,
             num_tokens=m,
+            include_reduce_scatter=not split_shared,
         )
+        if split_shared:
+            shared_shard = prepared_shared_shard
         return self._project_and_gather(latent, shared_shard, m, up_weight, prefix)
+
+    def reduce_scatter_shared(
+        self,
+        shared_partial: torch.Tensor,
+        rms_weight: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run the shared ReduceScatter into stable split-mode staging."""
+        if not self.supports_split_collective:
+            raise RuntimeError("shared-only ReduceScatter is not initialized")
+        m = shared_partial.shape[0]
+        _, shared_shard = self._collective(
+            self._collective._latent_output[:m],
+            shared_partial,
+            rms_weight,
+            include_reduce_scatter=True,
+            include_routed=False,
+            shared_output_override=self._split_shared_output,
+        )
+        return shared_shard
+
+    def _validate_prepared_shared_shard(self, shared_shard: torch.Tensor) -> None:
+        expected = (
+            _MAX_NUM_TOKENS,
+            self.contract.hidden_size // self.contract.tp_size,
+        )
+        if (
+            not self.supports_split_collective
+            or shared_shard.shape != expected
+            or shared_shard.dtype != torch.bfloat16
+            or shared_shard.device != self.contract.device
+            or shared_shard.stride() != (self.contract.hidden_size, 1)
+        ):
+            raise ValueError(
+                "prepared shared shard must be the split collective's "
+                f"BF16 {list(expected)} output view"
+            )
 
     def _assert_capture_compiled(self, m: int) -> None:
         # JIT compilation launches kernels; under capture they would be

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
@@ -1021,10 +1021,6 @@ class CollectiveKernel:
             self._latent_output, self._shared_output = scratch_allocator(
                 *self._scratch_specs
             )
-        shard_start = rank * self.shard_dim
-        shard_end = shard_start + self.shard_dim
-        self._shared_shard = self._shared_output[:, shard_start:shard_end]
-
         self._shared_workspace = symm_mem.empty(
             (NUM_LAMPORT_BUFFERS, max_m, tp_size, self.shard_dim),
             dtype=torch.bfloat16,
@@ -1145,7 +1141,6 @@ class CollectiveKernel:
         num_tokens: int,
         *,
         include_reduce_scatter: bool = True,
-        shared_output_override: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Fused collective over the MoE kernel's deferred-finalize triple.
 
@@ -1224,7 +1219,7 @@ class CollectiveKernel:
             finalize_top_k=self.finalize_top_k,
             include_reduce_scatter=include_reduce_scatter,
             include_routed=True,
-            shared_output_override=shared_output_override,
+            shared_output_override=None,
         )
 
     def _dispatch(
@@ -1247,10 +1242,6 @@ class CollectiveKernel:
             self._latent_output, self._shared_output = self._scratch_allocator(
                 *self._scratch_specs
             )
-            shard_start = self.rank * self.shard_dim
-            self._shared_shard = self._shared_output[
-                :, shard_start : shard_start + self.shard_dim
-            ]
 
         shared_output = (
             self._shared_output

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/latent_moe_tail/allreduce_rmsnorm_reduce_scatter_early_exit.py
@@ -946,6 +946,7 @@ class CollectiveKernel:
         fp32_internal: bool,
         scratch_allocator=None,
         finalize_top_k: int | None = None,
+        precompile_split: bool = False,
     ) -> None:
         validate_shape(
             tp_size=tp_size,
@@ -963,6 +964,7 @@ class CollectiveKernel:
         self.max_token_ctas = max_token_ctas
         self.rms_eps = float(rms_eps)
         self.fp32_internal = fp32_internal
+        self.precompile_split = precompile_split
         # When set, ``call_deferred`` additionally accepts the MoE kernel's
         # deferred-finalize triple; the standard materialized-input mode
         # stays available on the same instance.
@@ -1051,11 +1053,19 @@ class CollectiveKernel:
         dist.barrier(group=group, device_ids=[device.index])
         for owner in range(tp_size):
             if rank == owner:
-                # Compile the standard variant always and the deferred-input
-                # variant when armed; both must exist before graph capture.
-                for variant_top_k in (
-                    (None,) if finalize_top_k is None else (None, finalize_top_k)
-                ):
+                variants = [(True, True, None)]
+                if finalize_top_k is not None:
+                    variants.append((True, True, finalize_top_k))
+                if precompile_split:
+                    variants.extend(
+                        [
+                            (True, False, None),
+                            (False, True, None),
+                        ]
+                    )
+                    if finalize_top_k is not None:
+                        variants.append((False, True, finalize_top_k))
+                for include_reduce_scatter, include_routed, variant_top_k in variants:
                     compile_kernel(
                         rank=rank,
                         tp_size=tp_size,
@@ -1073,6 +1083,8 @@ class CollectiveKernel:
                         shared_peer_ptrs=self._shared_peer_ptrs,
                         rms_eps=self.rms_eps,
                         fp32_internal=fp32_internal,
+                        include_reduce_scatter=include_reduce_scatter,
+                        include_routed=include_routed,
                         finalize_top_k=variant_top_k,
                     )
             dist.barrier(group=group, device_ids=[device.index])
@@ -1082,7 +1094,15 @@ class CollectiveKernel:
         latent_source: torch.Tensor,
         shared_source: torch.Tensor,
         gamma: torch.Tensor,
+        *,
+        include_reduce_scatter: bool = True,
+        include_routed: bool = True,
+        shared_output_override: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if not include_reduce_scatter and not include_routed:
+            raise ValueError("at least one collective role must be enabled")
+        if include_reduce_scatter != include_routed and not self.precompile_split:
+            raise RuntimeError("split collective roles require precompile_split=True")
         if latent_source.ndim != 2 or shared_source.ndim != 2:
             raise ValueError("latent_source and shared_source must be rank-2")
         m = latent_source.shape[0]
@@ -1110,6 +1130,9 @@ class CollectiveKernel:
             finalize_weights=self._finalize_dummy_weights,
             finalize_idx=self._finalize_dummy_idx,
             finalize_top_k=None,
+            include_reduce_scatter=include_reduce_scatter,
+            include_routed=include_routed,
+            shared_output_override=shared_output_override,
         )
 
     def call_deferred(
@@ -1120,6 +1143,9 @@ class CollectiveKernel:
         shared_source: torch.Tensor,
         gamma: torch.Tensor,
         num_tokens: int,
+        *,
+        include_reduce_scatter: bool = True,
+        shared_output_override: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Fused collective over the MoE kernel's deferred-finalize triple.
 
@@ -1144,6 +1170,8 @@ class CollectiveKernel:
                 "CollectiveKernel was constructed without finalize_top_k; "
                 "the deferred-finalize variant is not compiled"
             )
+        if not include_reduce_scatter and not self.precompile_split:
+            raise RuntimeError("split collective roles require precompile_split=True")
         m = int(num_tokens)
         if not 1 <= m <= self.max_m:
             raise ValueError(f"runtime M={m} must be in [1, {self.max_m}]")
@@ -1194,6 +1222,9 @@ class CollectiveKernel:
             finalize_weights=expert_weights,
             finalize_idx=expanded_idx_to_permuted_idx,
             finalize_top_k=self.finalize_top_k,
+            include_reduce_scatter=include_reduce_scatter,
+            include_routed=True,
+            shared_output_override=shared_output_override,
         )
 
     def _dispatch(
@@ -1206,6 +1237,9 @@ class CollectiveKernel:
         finalize_weights: torch.Tensor,
         finalize_idx: torch.Tensor,
         finalize_top_k: int | None,
+        include_reduce_scatter: bool,
+        include_routed: bool,
+        shared_output_override: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         device = self._routed_workspace.device
         if self._scratch_allocator is not None:
@@ -1218,6 +1252,24 @@ class CollectiveKernel:
                 :, shard_start : shard_start + self.shard_dim
             ]
 
+        shared_output = (
+            self._shared_output
+            if shared_output_override is None
+            else shared_output_override
+        )
+        if (
+            shared_output.shape != (self.max_m, self.hidden_dim)
+            or shared_output.dtype != torch.bfloat16
+            or shared_output.device != device
+            or not shared_output.is_contiguous()
+        ):
+            raise ValueError(
+                "shared_output_override must be contiguous CUDA BF16 "
+                f"[{self.max_m}, {self.hidden_dim}]"
+            )
+        shard_start = self.rank * self.shard_dim
+        shared_shard = shared_output[:, shard_start : shard_start + self.shard_dim]
+
         with torch.accelerator.device_index(device.index):
             launch(
                 latent_source,
@@ -1227,7 +1279,7 @@ class CollectiveKernel:
                 self._routed_flags,
                 self._routed_multicast_ptr,
                 shared_source,
-                self._shared_output,
+                shared_output,
                 self._shared_workspace,
                 self._shared_flags,
                 self._shared_peer_ptrs,
@@ -1242,11 +1294,13 @@ class CollectiveKernel:
                 max_m=self.max_m,
                 max_token_ctas=self.max_token_ctas,
                 fp32_internal=self.fp32_internal,
+                include_reduce_scatter=include_reduce_scatter,
+                include_routed=include_routed,
                 finalize_top_k=finalize_top_k,
             )
         return (
             self._latent_output[:m],
-            self._shared_shard,
+            shared_shard,
         )
 
     @property

--- a/tokenspeed-kernel/test/ops/moe/test_latent_tail_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_tail_contract.py
@@ -57,6 +57,32 @@ def test_initialize_constructs_a_fresh_op(monkeypatch: pytest.MonkeyPatch) -> No
     assert len(constructed) == 2
 
 
+def test_initialize_propagates_split_collective_contract(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contracts = []
+
+    def fake_init(self, contract, *args, **kwargs) -> None:
+        contracts.append(contract)
+
+    monkeypatch.setattr(KimiK3LatentTailOp, "__init__", fake_init)
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.moe.latent_tail.dist.get_world_size", lambda group: 8
+    )
+    KimiK3LatentTailOp.initialize(
+        group=SimpleNamespace(group_name="test-group"),
+        hidden_size=7168,
+        latent_size=3584,
+        rms_eps=1e-6,
+        device=torch.device("cuda", 0),
+        layer_index=1,
+        model_scope="model.layers",
+        split_collective=True,
+    )
+
+    assert contracts[0].split_collective is True
+
+
 def test_slot_binding_is_rank_identical_for_same_layer() -> None:
     rank_zero_slot = _tail_pool_slot(31, 2)
     rank_one_slot = _tail_pool_slot(31, 2)

--- a/tokenspeed-kernel/test/ops/moe/test_latent_tail_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_tail_contract.py
@@ -57,32 +57,6 @@ def test_initialize_constructs_a_fresh_op(monkeypatch: pytest.MonkeyPatch) -> No
     assert len(constructed) == 2
 
 
-def test_initialize_propagates_split_collective_contract(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    contracts = []
-
-    def fake_init(self, contract, *args, **kwargs) -> None:
-        contracts.append(contract)
-
-    monkeypatch.setattr(KimiK3LatentTailOp, "__init__", fake_init)
-    monkeypatch.setattr(
-        "tokenspeed_kernel.ops.moe.latent_tail.dist.get_world_size", lambda group: 8
-    )
-    KimiK3LatentTailOp.initialize(
-        group=SimpleNamespace(group_name="test-group"),
-        hidden_size=7168,
-        latent_size=3584,
-        rms_eps=1e-6,
-        device=torch.device("cuda", 0),
-        layer_index=1,
-        model_scope="model.layers",
-        split_collective=True,
-    )
-
-    assert contracts[0].split_collective is True
-
-
 def test_slot_binding_is_rank_identical_for_same_layer() -> None:
     rank_zero_slot = _tail_pool_slot(31, 2)
     rank_one_slot = _tail_pool_slot(31, 2)

--- a/tokenspeed-kernel/test/ops/moe/test_latent_tail_distributed.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_tail_distributed.py
@@ -148,6 +148,67 @@ def test_latent_tail_graph_replay():
         assert err < 0.05 * max(scale, 1.0), f"seed={seed}: err {err}"
 
 
+def test_latent_tail_split_collective_multistream_graph_replay():
+    """Prepared shared shards remain exact and fresh across graph replays."""
+    from tokenspeed_kernel.ops.moe.latent_tail import KimiK3LatentTailOp
+
+    rank, dev = _setup()
+    _require_latent_tail()
+    control = KimiK3LatentTailOp.initialize(
+        group=dist.group.WORLD,
+        hidden_size=H,
+        latent_size=L,
+        rms_eps=EPS,
+        device=dev,
+        layer_index=0,
+        model_scope="test-split-control",
+    )
+    split = KimiK3LatentTailOp.initialize(
+        group=dist.group.WORLD,
+        hidden_size=H,
+        latent_size=L,
+        rms_eps=EPS,
+        device=dev,
+        layer_index=0,
+        model_scope="test-split-candidate",
+        split_collective=True,
+    )
+    routed, shared, rms_w, up_w = _inputs(rank, dev, 16, seed=400)
+    auxiliary = torch.cuda.Stream(device=dev)
+
+    def split_call():
+        main = torch.cuda.current_stream(dev)
+        auxiliary.wait_stream(main)
+        with torch.cuda.stream(auxiliary):
+            prepared = split.reduce_scatter_shared(shared, rms_w)
+        main.wait_stream(auxiliary)
+        return split(
+            routed,
+            shared,
+            rms_w,
+            up_w,
+            prepared_shared_shard=prepared,
+        )
+
+    for _ in range(3):
+        split_call()
+    torch.cuda.synchronize()
+    dist.barrier()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = split_call()
+
+    for seed in range(500, 508):
+        torch.manual_seed(seed + rank)
+        routed.copy_(torch.randn_like(routed) * 0.1)
+        shared.copy_(torch.randn_like(shared) * 0.1)
+        graph.replay()
+        torch.cuda.synchronize()
+        expected = control(routed, shared, rms_w, up_w)
+        torch.cuda.synchronize()
+        assert torch.equal(actual, expected), f"split collective differs at seed={seed}"
+
+
 @pytest.mark.parametrize("m", [1, 4, 6, 8, 16])
 def test_latent_tail_fused_prefix_matches_eager(m):
     from tokenspeed_kernel.ops.moe.latent_tail import KimiK3LatentTailOp

--- a/tokenspeed-kernel/test/ops/moe/test_latent_tail_distributed.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_tail_distributed.py
@@ -89,7 +89,7 @@ def _inputs(rank, dev, m, seed):
     return routed, shared, rms_w, up_w
 
 
-@pytest.mark.parametrize("m", [1, 4, 5, 6, 16])
+@pytest.mark.parametrize("m", [1, 4, 5, 6, 16, 64])
 def test_latent_tail_matches_reference(m):
     from tokenspeed_kernel.ops.moe.latent_tail import KimiK3LatentTailOp
 
@@ -148,8 +148,9 @@ def test_latent_tail_graph_replay():
         assert err < 0.05 * max(scale, 1.0), f"seed={seed}: err {err}"
 
 
-def test_latent_tail_split_collective_multistream_graph_replay():
-    """Prepared shared shards remain exact and fresh across graph replays."""
+@pytest.mark.parametrize("m", [9, 64])
+def test_latent_tail_split_collective_multistream_graph_replay(m):
+    """Prepared shared shards remain accurate and fresh across graph replays."""
     from tokenspeed_kernel.ops.moe.latent_tail import KimiK3LatentTailOp
 
     rank, dev = _setup()
@@ -173,7 +174,7 @@ def test_latent_tail_split_collective_multistream_graph_replay():
         model_scope="test-split-candidate",
         split_collective=True,
     )
-    routed, shared, rms_w, up_w = _inputs(rank, dev, 16, seed=400)
+    routed, shared, rms_w, up_w = _inputs(rank, dev, m, seed=400 + m)
     auxiliary = torch.cuda.Stream(device=dev)
 
     def split_call():
@@ -206,7 +207,9 @@ def test_latent_tail_split_collective_multistream_graph_replay():
         torch.cuda.synchronize()
         expected = control(routed, shared, rms_w, up_w)
         torch.cuda.synchronize()
-        assert torch.equal(actual, expected), f"split collective differs at seed={seed}"
+        scale = expected.float().abs().max().item()
+        err = (actual.float() - expected.float()).abs().max().item()
+        assert err < 0.02 * max(scale, 1.0), f"seed={seed}: err {err}"
 
 
 @pytest.mark.parametrize("m", [1, 4, 6, 8, 16])


### PR DESCRIPTION

## Summary

This PR extends the Kimi-K3 multicast latent-tail path from 16 to 64 decode tokens and adds a split-collective schedule for the larger graph buckets.

For captured Blackwell decode graphs, the resulting policy is:

| Token count | Strategy |
|---:|---|
| M1--M8 | Combined TailFusion |
| M9--M64 | Split TailFusion |
| M65+ | Existing fallback selector (FusedLane, Multimem, or portable separate reductions as applicable) |

The split schedule launches the shared-expert ReduceScatter on the auxiliary stream as soon as the shared branch is ready. The routed expert branch continues on the main stream, and the final latent tail consumes the prepared shared shard after performing only the routed AllReduce/RMSNorm work.

There is no new server argument. The choice follows the compiled TailFusion capacity, the Blackwell capability check, CUDA-graph capture state, and the collective's CTA geometry.

## Motivation

The original TailFusion kernel performs the routed AllReduce/RMSNorm and shared ReduceScatter together after both expert branches finish. The split schedule moves shared ReduceScatter forward so it overlaps the routed expert branch:

```text
Combined TailFusion:
  shared:  [shared experts] -------------------------┐
  routed:  [routed experts] -------------------------┤
  tail:                                              [routed AR + shared RS] -> [up projection] -> [gather]

Split TailFusion:
  shared:  [shared experts] -> [shared RS] -----------┐
  routed:  [routed experts] --------------------┐     │
  tail:                                         [routed AR] -> [up projection + shared shard] -> [gather]
                           <----- overlap ----->
```

The collective uses eight token CTAs. M1--M8 therefore stays on the existing combined path, while M9 is the first size that requires a second wave and can benefit from launching the shared ReduceScatter early. This makes the split threshold `_COLLECTIVE_TOKEN_CTAS + 1` instead of an independently tuned runtime knob.

The TailFusion capacity is raised to M64 because both the full-layer benchmark and full-model Agentic benchmark show a useful range beyond the old M16 boundary. M64 is also a deliberate evidence and memory boundary: larger M values do not have full-model Agentic validation and would require larger persistent cross-stream staging. M65+ therefore keeps the existing fallback tiers unchanged.

Split roles are precompiled only on Blackwell. This covers both B200 and B300 without a device-specific server option; non-graph execution and unsupported configurations retain the existing behavior.

## Implementation

- Precompile independent shared-ReduceScatter and routed-AllReduce roles and launch shared ReduceScatter from the shared-expert fork.
- Keep the prepared shared shard in stable pooled storage for CUDA-graph replay.
- Use combined TailFusion for M1--M8, split TailFusion for M9--M64, and the existing fallback selector above M64.

## Validation

### Full Kimi-K3 MoE layer latency

This measures an actual `KimiLinearMoE.forward`, including routing, routed/shared experts, and the communication tail, on 8x B300 in both EP8 and TP8 modes.

| Parallelism | M | FusedLane (ms) | Combined TailFusion (ms) | Split TailFusion (ms) | Split vs FusedLane | Split vs combined |
|---|---:|---:|---:|---:|---:|---:|
| EP8 | 9  | 0.133232 | 0.126960 | 0.124088 | **-6.86%** | **-2.26%** |
| EP8 | 16 | 0.166064 | 0.159728 | 0.154776 | **-6.80%** | **-3.10%** |
| EP8 | 24 | 0.195784 | 0.193744 | 0.185464 | **-5.27%** | **-4.27%** |
| EP8 | 32 | 0.235872 | 0.239656 | 0.228480 | **-3.13%** | **-4.66%** |
| EP8 | 48 | 0.269288 | 0.283680 | 0.259528 | **-3.62%** | **-8.51%** |
| EP8 | 64 | 0.312008 | 0.339984 | 0.305656 | **-2.04%** | **-10.10%** |
| EP8 | 80 | 0.342648 | 0.387992 | 0.336384 | **-1.83%** | **-13.30%** |
| EP8 | 96 | 0.360144 | 0.422376 | 0.368656 | +2.36% | **-12.72%** |
| TP8 | 9  | 0.141376 | 0.141472 | 0.135160 | **-4.40%** | **-4.46%** |
| TP8 | 16 | 0.170280 | 0.171904 | 0.163904 | **-3.74%** | **-4.65%** |
| TP8 | 24 | 0.210976 | 0.222864 | 0.203352 | **-3.61%** | **-8.76%** |
| TP8 | 32 | 0.245792 | 0.266488 | 0.240808 | **-2.03%** | **-9.64%** |
| TP8 | 48 | 0.284656 | 0.331384 | 0.278720 | **-2.09%** | **-15.89%** |
| TP8 | 64 | 0.321648 | 0.397280 | 0.321536 | **-0.03%** | **-19.07%** |
| TP8 | 80 | 0.352400 | 0.454160 | 0.356360 | +1.12% | **-21.53%** |
| TP8 | 96 | 0.377624 | 0.504880 | 0.390264 | +3.35% | **-22.70%** |

M1--M8 stays on the combined path because the collective still fits in one token-CTA wave. Through M64, Split TailFusion is faster in EP8 and no slower in TP8. At M80, TP8 has already crossed back to FusedLane, and by M96 FusedLane is faster in both modes. M64 is therefore the conservative common graph boundary aligned with the full-model Agentic measurements below.

### Agentic E2E at larger concurrency

The full-model comparison ran the EvalScope SWE-Smith multi-turn workload on 8x B300. Under the existing selector, the full-batch path is combined TailFusion at C16 and FusedLane above C16; with this PR it is split TailFusion from C16 through C64.

| Concurrency | Before full-batch path | This PR full-batch path | Before (output tok/s) | This PR (output tok/s) | Change |
|---:|---|---|---:|---:|---:|
| C16 | Combined TailFusion | Split TailFusion | 401.97 | 411.92 | **+2.47%** |
| C24 | FusedLane | Split TailFusion | 414.82 | 432.18 | **+4.19%** |
| C32 | FusedLane | Split TailFusion | 446.87 | 472.66 | **+5.77%** |
| C48 | FusedLane | Split TailFusion | 415.99 | 438.65 | **+5.45%** |
| C64 | FusedLane | Split TailFusion | 404.57 | 421.31 | **+4.14%** |
