### PR TITLE
[WIP] perf(k3): extend packed top-k to decode batches

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
@@ -94,16 +94,16 @@ def moe_sigmoid_bias_topk(
     platform = Platform.get()
     if (
         solution is None
-        and (platform.is_cdna4 or platform.is_nvidia)
-        and router_logits.shape == (1, 896)
+        and (platform.is_nvidia or (platform.is_cdna4 and tokens == 1))
+        and experts == 896
         and router_logits.dtype == torch.float32
         and correction_bias.dtype == torch.float32
+        and router_logits.is_cuda
+        and router_logits.is_contiguous()
+        and correction_bias.is_contiguous()
         and topk == 16
     ):
-        # The packed-key single-CTA kernel wins on both vendors for the K3
-        # decode shape: one bitonic top-16 instead of the grouped multi-pass
-        # (NVIDIA B300: 3.7us vs 7.0us for the minimax path, bit-identical
-        # selection and weights).
+        # CDNA4 retains M=1; NVIDIA runs one packed-key CTA per token.
         topk_weights, topk_ids = kimi3_sigmoid_bias_topk(
             router_logits,
             correction_bias,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
@@ -32,6 +32,10 @@ def _kimi3_sigmoid_bias_topk_kernel(
     num_experts: tl.constexpr = 896
     padded_experts: tl.constexpr = 1024
     topk: tl.constexpr = 16
+    row = tl.program_id(0)
+    logits += row * num_experts
+    topk_ids += row * topk
+    topk_weights += row * topk
     expert = tl.arange(0, padded_experts)
     valid = expert < num_experts
 
@@ -94,10 +98,10 @@ def kimi3_sigmoid_bias_topk(
     weights_dtype: torch.dtype = torch.float32,
     enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Route one Kimi K3 decode token to its top 16 of 896 experts.
+    """Route Kimi K3 decode tokens to their top 16 of 896 experts.
 
     Args:
-        router_logits: Contiguous FP32 logits shaped ``[1, 896]``.
+        router_logits: Contiguous FP32 logits shaped ``[tokens, 896]``.
         correction_bias: Contiguous FP32 selection bias shaped ``[896]``.
         routed_scaling_factor: Scale applied to selected route weights.
         normalize_topk_weights: Normalize selected sigmoid scores when true.
@@ -112,16 +116,21 @@ def kimi3_sigmoid_bias_topk(
             that writes ``router_logits`` is chained on the same stream/graph.
 
     Returns:
-        ``(topk_weights, topk_ids)`` shaped ``[1, 16]`` with ``weights_dtype``
-        weights and INT32 ids (physical ids when a dispatch map is given).
+        ``(topk_weights, topk_ids)`` shaped ``[tokens, 16]`` with
+        ``weights_dtype`` weights and INT32 ids (physical ids when a dispatch
+        map is given).
     """
+    if router_logits.ndim != 2:
+        raise ValueError("Kimi K3 top-k requires GPU FP32 logits shaped [tokens, 896]")
+    tokens, experts = router_logits.shape
     if (
-        router_logits.shape != (1, 896)
+        tokens <= 0
+        or experts != 896
         or router_logits.dtype != torch.float32
         or not router_logits.is_cuda
         or not router_logits.is_contiguous()
     ):
-        raise ValueError("Kimi K3 top-k requires contiguous GPU FP32 logits [1, 896]")
+        raise ValueError("Kimi K3 top-k requires contiguous GPU FP32 [tokens, 896]")
     if (
         correction_bias.shape != (896,)
         or correction_bias.dtype != torch.float32
@@ -141,12 +150,12 @@ def kimi3_sigmoid_bias_topk(
         )
 
     topk_ids = torch.empty(
-        (1, 16),
+        (tokens, 16),
         dtype=torch.int32,
         device=router_logits.device,
     )
     topk_weights = torch.empty(
-        (1, 16),
+        (tokens, 16),
         dtype=weights_dtype,
         device=router_logits.device,
     )
@@ -155,7 +164,7 @@ def kimi3_sigmoid_bias_topk(
     pdl_kwargs = (
         {"launch_pdl": True} if enable_pdl and current_platform().is_nvidia else {}
     )
-    _kimi3_sigmoid_bias_topk_kernel[(1,)](
+    _kimi3_sigmoid_bias_topk_kernel[(tokens,)](
         router_logits,
         correction_bias,
         topk_ids,

--- a/tokenspeed-kernel/test/ops/moe/test_sigmoid_bias_topk_nvidia.py
+++ b/tokenspeed-kernel/test/ops/moe/test_sigmoid_bias_topk_nvidia.py
@@ -82,12 +82,11 @@ def test_entry_point_selects_fused_kernel():
 
 @pytest.mark.parametrize("normalize", [False, True])
 @pytest.mark.parametrize("scale", [1.0, 2.5])
-def test_decode_shape_uses_lean_kernel_and_is_exact(normalize, scale):
-    """The K3 decode shape (1, 896) topk=16 takes the packed-key single-CTA
-    kernel on NVIDIA: exact expert set and weights vs torch, and CUDA-graph
-    capturable (the decode path replays it inside the step graph)."""
+@pytest.mark.parametrize("tokens", [1, 2, 16, 128])
+def test_kimi3_shape_uses_packed_key_kernel(tokens, normalize, scale):
+    """The packed-key row kernel is exact and CUDA-graph capturable."""
     torch.manual_seed(7)
-    logits = (torch.randn(1, 896, device="cuda") * 0.2).float()
+    logits = (torch.randn(tokens, 896, device="cuda") * 0.2).float()
     bias = (torch.randn(896, device="cuda") * 0.01).float()
     scores = logits.sigmoid()
     expected_ids = torch.topk(
@@ -111,20 +110,26 @@ def test_decode_shape_uses_lean_kernel_and_is_exact(normalize, scale):
     torch.cuda.synchronize()
 
     assert weights.dtype == torch.float32 and ids.dtype == torch.int32
-    assert set(ids[0].tolist()) == set(expected_ids[0].tolist())
-    expected_by_id = dict(
-        zip(expected_ids[0].tolist(), expected_weights[0].tolist(), strict=True)
-    )
-    for expert_id, weight in zip(ids[0].tolist(), weights[0].tolist(), strict=True):
-        assert weight == pytest.approx(expected_by_id[expert_id], abs=1e-5)
+    for row in range(tokens):
+        assert set(ids[row].tolist()) == set(expected_ids[row].tolist())
+        expected_by_id = dict(
+            zip(
+                expected_ids[row].tolist(),
+                expected_weights[row].tolist(),
+                strict=True,
+            )
+        )
+        for expert_id, weight in zip(
+            ids[row].tolist(), weights[row].tolist(), strict=True
+        ):
+            assert weight == pytest.approx(expected_by_id[expert_id], abs=1e-5)
 
 
 @pytest.mark.parametrize("tokens", [1, 2])
 @pytest.mark.parametrize("map_dtype", [torch.int32, torch.int64])
 def test_static_dispatch_map_and_weights_dtype(tokens, map_dtype):
     """The optional logical->physical map must translate the selected ids on
-    both the lean decode kernel (tokens=1) and the registry fallback
-    (tokens=2), and bf16 weight output must match the fp32 path."""
+    the lean decode kernel, and bf16 weight output must match the fp32 path."""
     torch.manual_seed(11)
     logits = torch.randn(tokens, 896, dtype=torch.float32, device="cuda")
     bias = torch.randn(896, dtype=torch.float32, device="cuda")


### PR DESCRIPTION
## Summary

- extend the packed K3 sigmoid top-k path from single-token decode to small multi-token batches
- use row strides so one kernel launch handles each decode row
- keep the existing platform and shape fallbacks

## Testing

- `pre-commit run --all-files`
- `pytest -q tokenspeed-kernel/test/ops/moe/test_sigmoid_bias_topk_nvidia.py`: 37 passed