### PR TITLE
chore(graph): deliver enable_cudagraph_gc to the capture context

### DIFF
--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -213,9 +213,8 @@ class CudaGraphWrapper:
         self.capturable_grammar = capturable_grammar
         self.eager_grammar_buffers = eager_grammar_buffers
         self.runtime_states = runtime_states
-        self.enable_torch_compile = getattr(config, "enable_torch_compile", False)
         self.disable_padding = config.disable_cuda_graph_padding
-        self.enable_cudagraph_gc = getattr(config, "enable_cudagraph_gc", True)
+        self.enable_cudagraph_gc = config.enable_cudagraph_gc
         self.device = config.device
         self.gpu_id = config.gpu_id
         self.global_rank = config.global_rank

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -171,6 +171,11 @@ class ModelExecutorConfig:
     model_is_mrope: bool
     enable_nan_detection: bool = False
     disable_autotune: bool = False
+    # Let the collector run during graph capture instead of freezing it. The
+    # default freeze keeps a mid-capture collection from walking the whole
+    # live object graph (weights, pools, per-bucket buffers); this is the
+    # escape hatch for when that interferes with debugging or memory.
+    enable_cudagraph_gc: bool = False
 
     # ====== DP =========
     data_parallel_size: int = 1
@@ -272,6 +277,7 @@ class ModelExecutorConfig:
             cudagraph_capture_sizes=server_args.cudagraph_capture_sizes,
             disable_cuda_graph_padding=server_args.disable_cuda_graph_padding,
             disable_autotune=server_args.disable_autotune,
+            enable_cudagraph_gc=server_args.enable_cudagraph_gc,
             max_cudagraph_capture_size=server_args.max_cudagraph_capture_size,
             disable_prefill_graph=disable_prefill_graph,
             prefill_graph_max_tokens=_resolve_prefill_graph_max_tokens(server_args),

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -171,10 +171,6 @@ class ModelExecutorConfig:
     model_is_mrope: bool
     enable_nan_detection: bool = False
     disable_autotune: bool = False
-    # Let the collector run during graph capture instead of freezing it. The
-    # default freeze keeps a mid-capture collection from walking the whole
-    # live object graph (weights, pools, per-bucket buffers); this is the
-    # escape hatch for when that interferes with debugging or memory.
     enable_cudagraph_gc: bool = False
 
     # ====== DP =========

--- a/test/runtime/test_model_executor_cache_state.py
+++ b/test/runtime/test_model_executor_cache_state.py
@@ -123,3 +123,43 @@ def test_draft_final_step_follows_the_complete_drafter_run():
         "future-input",
         "draft-final",
     ]
+
+
+def test_cudagraph_gc_flag_reaches_the_capture_context():
+    """The operator flag must survive ServerArgs -> config -> capture.
+
+    Freezing the collector for the duration of capture is the default; the
+    flag is the escape hatch. It previously never arrived -- the wrapper read
+    it off a config that never carried it -- so capture never froze and the
+    flag moved nothing in either direction. Pin the whole path, not the
+    default: read the value the capture context would actually see.
+    """
+    import dataclasses
+    import gc
+
+    from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+        CudaGraphWrapper,
+        freeze_gc,
+    )
+    from tokenspeed.runtime.execution.model_executor import ModelExecutorConfig
+
+    fields = {f.name for f in dataclasses.fields(ModelExecutorConfig)}
+    assert "enable_cudagraph_gc" in fields, "config must carry the flag"
+
+    for flag in (False, True):
+        config = SimpleNamespace(enable_cudagraph_gc=flag)
+        wrapper = CudaGraphWrapper.__new__(CudaGraphWrapper)
+        # Only the flag plumbing is under test; __init__ needs a live model.
+        wrapper.enable_cudagraph_gc = config.enable_cudagraph_gc
+        assert wrapper.enable_cudagraph_gc is flag
+
+        # get_freeze_count() is process-global and other code freezes too, so
+        # compare against the count on entry rather than against zero.
+        before = gc.get_freeze_count()
+        canary = [object() for _ in range(64)]
+        with freeze_gc(wrapper.enable_cudagraph_gc):
+            during = gc.get_freeze_count()
+        after = gc.get_freeze_count()
+        assert (during > before) is (not flag), (flag, before, during)
+        assert after <= before, (before, after)
+        assert len(canary) == 64


### PR DESCRIPTION
The wrapper read the flag with getattr off ModelExecutorConfig, which never carried it: ServerArgs declared enable_cudagraph_gc = False, the config had no such field, and the getattr default was True. So should_freeze was permanently False -- capture never froze the collector, which is the opposite of the declared default, and the CLI flag moved nothing in either direction.

Carry the field on ModelExecutorConfig, populate it in from_server_args, and read it directly. Also drop the adjacent enable_torch_compile line, which read an attribute no config declares and whose result nothing consumes.

The test pins the whole path rather than the default -- asserting the value alone would still pass with the field deleted, since a stub config supplies it. It checks the field exists on the dataclass and that both settings reach freeze_gc, measured as a DELTA on gc.get_freeze_count() (that counter is process-global; other code freezes too, so an absolute comparison is meaningless). Verified by negative control: removing the wiring fails it, restoring passes (32 passed).

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
