### PR TITLE
Remove CachePoolSpec.layer_group_ids; derive state groups from the plan

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -323,7 +323,7 @@ class MambaForwardMetadata:
     # it, so immutability rules out stale-aliasing.
     cu_extend_seq_lens_cpu: tuple[int, ...] | None = None
     # Per-state-group metadata is gathered once per group and batch;
-    # layers select their entry via ``pool.group_id_for_layer(layer_id)``.
+    # layers select their entry via ``pool.state_group_by_layer[layer_id]``.
     state_in_blocks_by_group: dict[str, torch.Tensor] | None = None
     state_out_blocks_by_group: dict[str, torch.Tensor] | None = None
 
@@ -387,11 +387,11 @@ class MambaAttnBackend(AttentionBackend):
             raise RuntimeError(
                 "MambaAttnBackend requires at least one state-family cache group"
             )
-        if not callable(getattr(kv_pool, "group_id_for_layer", None)) or not callable(
+        if getattr(kv_pool, "state_group_by_layer", None) is None or not callable(
             getattr(kv_pool, "get_component", None)
         ):
             raise RuntimeError(
-                "MambaAttnBackend requires group_id_for_layer() and get_component()"
+                "MambaAttnBackend requires state_group_by_layer and get_component()"
             )
         self._state_group_ids = state_group_ids
         self.state_paging_active = True
@@ -441,18 +441,18 @@ class MambaAttnBackend(AttentionBackend):
 
     def _state_layer_ids(self) -> list[int]:
         """Recurrent layer ids backed by the unified cache pool."""
-        state_groups = set(self._state_group_ids)
-        return sorted(
-            layer_id
-            for layer_id, group_id in self.kv_pool._group_ids_by_layer.items()
-            if group_id in state_groups
-        )
+        return sorted(self.kv_pool.state_group_by_layer)
 
     def _state_groups(self) -> tuple[str, ...]:
         return self._state_group_ids
 
     def _state_group_for(self, layer_id: int) -> str:
-        return self.kv_pool.group_id_for_layer(layer_id)
+        try:
+            return self.kv_pool.state_group_by_layer[layer_id]
+        except KeyError as exc:
+            raise RuntimeError(
+                f"layer {layer_id} has no state-family cache group"
+            ) from exc
 
     def _state_components(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
         return (
@@ -821,7 +821,7 @@ class MambaAttnBackend(AttentionBackend):
 
         The dual-index gather runs ONCE per state group per batch — never per
         layer. State layers select their group's entry via
-        ``pool.group_id_for_layer(layer_id)`` at forward time.
+        ``pool.state_group_by_layer[layer_id]`` at forward time.
 
         validate: explicit True/False wins; None (the hot-path default)
         validates only under TOKENSPEED_CACHE_DEBUG=1 (the checks host-sync).

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, ClassVar
 
 import torch
@@ -54,6 +55,53 @@ def _layer_plane(
     if not 0 <= local_layer < num_layers:
         return None
     return local_layer, match.group(2)
+
+
+def derive_state_groups_by_layer(
+    arena: CacheArena,
+    *,
+    first_layer: int,
+    num_layers: int,
+    state_layer_ids: Iterable[int],
+) -> dict[int, str]:
+    """Map each recurrent layer to the state-family group holding its fields.
+
+    The memory plan is the single record of which group a layer's fields were
+    declared in, so the mapping is read back from the planned fields rather
+    than carried as a parallel per-layer tuple.
+
+    Args:
+        arena: The cache arena whose plan and group specs to read.
+        first_layer: This view's first layer in the merged plan.
+        num_layers: Number of layers in this view's window.
+        state_layer_ids: View-local ids of the recurrent (state) layers.
+
+    Returns:
+        View-local layer id -> state-family group id, one entry per state
+        layer whose fields the plan declares inside this view's window.
+
+    Raises:
+        ValueError: a state layer's fields span more than one state group.
+    """
+    state_groups = {
+        spec.group_id for spec in arena.cache_group_specs if spec.family == "state"
+    }
+    wanted = set(state_layer_ids)
+    mapping: dict[int, str] = {}
+    for field in arena.plan.fields:
+        located = _layer_plane(field.field_id, first_layer, num_layers)
+        if located is None:
+            continue
+        layer_id, _ = located
+        if layer_id not in wanted or field.group_id not in state_groups:
+            continue
+        existing = mapping.setdefault(layer_id, field.group_id)
+        if existing != field.group_id:
+            raise ValueError(
+                f"layer {layer_id} has state fields in more than one cache "
+                f"group: {existing!r} and {field.group_id!r}"
+            )
+    return mapping
 
 
 class CachePool(ABC):

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
@@ -108,7 +108,6 @@ def create_cache_pool(
             layer_num=num_layers,
             rank=rank,
             index_head_dim=config.index_head_dim,
-            layer_group_ids=spec.layer_group_ids,
             field_layer_offset=field_layer_offset,
         )
     if isinstance(config, MSAConfig):
@@ -127,7 +126,6 @@ def create_cache_pool(
             index_dtype=config.dtype,
             indexed_layer_ids=config.sparse_layer_ids,
             layer_types=spec.layer_types,
-            layer_group_ids=spec.layer_group_ids,
             field_layer_offset=field_layer_offset,
         )
     if isinstance(config, MHAConfig):
@@ -142,7 +140,6 @@ def create_cache_pool(
             layer_types=spec.layer_types,
             layer_kv_head_counts=spec.layer_kv_head_counts,
             kv_alloc_head_count=config.num_kv_heads,
-            layer_group_ids=spec.layer_group_ids,
             field_layer_offset=field_layer_offset,
         )
     if isinstance(config, MLAConfig):
@@ -160,7 +157,6 @@ def create_cache_pool(
                 qk_rope_head_dim=config.qk_rope_head_dim,
                 layer_num=num_layers,
                 rank=rank,
-                layer_group_ids=spec.layer_group_ids,
                 field_layer_offset=field_layer_offset,
             )
 
@@ -183,7 +179,6 @@ def create_cache_pool(
             layer_num=num_layers,
             rank=rank,
             layer_types=spec.layer_types,
-            layer_group_ids=spec.layer_group_ids,
             field_layer_offset=field_layer_offset,
         )
     raise TypeError(f"cache setup does not support config type {type(config).__name__}")

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
@@ -22,10 +22,14 @@
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import ClassVar
 
 import torch
 
+from tokenspeed.runtime.layers.attention.kv_cache.base import (
+    derive_state_groups_by_layer,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.mla import MLATokenToKVPool
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     STATE_LAYER_TYPES,
@@ -43,26 +47,17 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
     def __init__(
         self,
         *,
-        layer_group_ids: tuple[str, ...],
         layer_types: tuple[str, ...],
         **kwargs,
     ):
         self._layer_types = tuple(layer_types)
-        group_ids = tuple(layer_group_ids)
-        self._group_ids_by_layer = dict(enumerate(group_ids))
         self._state_buffers_by_layer: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
         self.requires_page_zeroing = True
 
-        layer_num = kwargs["layer_num"]
-        if len(self._layer_types) != layer_num:
+        if len(self._layer_types) != kwargs["layer_num"]:
             raise ValueError("cache layer types must cover every model layer")
-        if len(group_ids) != layer_num:
-            raise ValueError("cache group ids must cover every model layer")
 
-        super().__init__(
-            layer_group_ids=group_ids,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
     # A KDA layer has conv/recurrent planes planned and an MLA layer has a
     # latent plane; the plan's field list decides per layer. Latent-page
@@ -93,11 +88,19 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
     def state_slabs(self) -> list[tuple[torch.Tensor, torch.Tensor]]:
         return list(self._state_buffers_by_layer.values())
 
-    def group_id_for_layer(self, layer_id: int) -> str:
-        try:
-            return self._group_ids_by_layer[layer_id]
-        except KeyError as exc:
-            raise ValueError(f"layer {layer_id} has no cache group") from exc
+    @cached_property
+    def state_group_by_layer(self) -> dict[int, str]:
+        """View-local state layer id -> its state-family cache group id."""
+        return derive_state_groups_by_layer(
+            self.arena,
+            first_layer=self._field_layer_offset,
+            num_layers=self.layer_num,
+            state_layer_ids=(
+                layer_id
+                for layer_id, label in enumerate(self._layer_types)
+                if label in STATE_LAYER_TYPES
+            ),
+        )
 
     def get_component(self, layer_id: int, component_name: str) -> torch.Tensor:
         """Return one KDA state plane. Latent KV is read via ``kv_buffer``."""

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
@@ -22,10 +22,14 @@
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import ClassVar
 
 import torch
 
+from tokenspeed.runtime.layers.attention.kv_cache.base import (
+    derive_state_groups_by_layer,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.mha import (
     MHATokenToKVPool,
     MHATokenToKVPoolMXFP8,
@@ -38,14 +42,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
 class HybridMHATokenToKVPool(MHATokenToKVPool):
     """MHA compute interface whose history and state share one buffer."""
 
-    def __init__(
-        self,
-        *,
-        layer_group_ids: tuple[str, ...],
-        **kwargs,
-    ):
-        group_ids = tuple(layer_group_ids)
-        self._group_ids_by_layer = dict(enumerate(group_ids))
+    def __init__(self, **kwargs):
         layer_types = tuple(kwargs.get("layer_types", ()))
         self._state_layer_ids = tuple(
             layer_id
@@ -55,13 +52,10 @@ class HybridMHATokenToKVPool(MHATokenToKVPool):
         self._state_buffers_by_layer: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
         self.requires_page_zeroing = True
 
-        if len(group_ids) != kwargs["layer_num"]:
-            raise ValueError("cache group ids must cover every model layer")
+        if len(layer_types) != kwargs["layer_num"]:
+            raise ValueError("cache layer types must cover every model layer")
 
-        super().__init__(
-            layer_group_ids=group_ids,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
     # A state layer has no k/v field planned and an attention layer has no
     # conv/ssm, so the plan's field list decides which planes a layer has.
@@ -90,11 +84,15 @@ class HybridMHATokenToKVPool(MHATokenToKVPool):
             self._state_buffers_by_layer[layer_id] for layer_id in self._state_layer_ids
         ]
 
-    def group_id_for_layer(self, layer_id: int) -> str:
-        try:
-            return self._group_ids_by_layer[layer_id]
-        except KeyError as exc:
-            raise ValueError(f"layer {layer_id} has no cache group") from exc
+    @cached_property
+    def state_group_by_layer(self) -> dict[int, str]:
+        """View-local state layer id -> its state-family cache group id."""
+        return derive_state_groups_by_layer(
+            self.arena,
+            first_layer=self._field_layer_offset,
+            num_layers=self.layer_num,
+            state_layer_ids=self._state_layer_ids,
+        )
 
     def get_state_buffers(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:
         if layer_id not in self._state_layer_ids:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mha.py
@@ -55,7 +55,6 @@ class MHATokenToKVPool(CachePool):
         rank: int,
         *,
         layer_types: tuple[str, ...] = (),
-        layer_group_ids: tuple[str, ...] = (),
         layer_kv_head_counts: tuple[int, ...] | None = None,
         kv_alloc_head_count: int | None = None,
         field_layer_offset: int = 0,
@@ -87,17 +86,6 @@ class MHATokenToKVPool(CachePool):
             int(kv_alloc_head_count) if kv_alloc_head_count else None
         )
         self._layer_types = tuple(layer_types or ())
-        # Physical group id per layer, from the cache recipe
-        # (CachePoolSpec.layer_group_ids) — the single source the scheduler
-        # groups are published from.
-        self.layer_cache_group_ids = tuple(layer_group_ids)
-        if len(self.layer_cache_group_ids) != layer_num:
-            raise ValueError(
-                f"layer_group_ids has {len(self.layer_cache_group_ids)} "
-                f"entries but the pool has {layer_num} layers; the cache "
-                "recipe must supply one group id per layer "
-                "(CachePoolSpec.layer_group_ids)"
-            )
         self._bind_layer_planes()
 
         k_size, v_size = self.get_kv_size_bytes()

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
@@ -62,7 +62,6 @@ class MLATokenToKVPool(CachePool):
         layer_num: int,
         rank: int,
         *,
-        layer_group_ids: tuple[str, ...] = (),
         field_layer_offset: int = 0,
     ):
         super().__init__(
@@ -78,17 +77,6 @@ class MLATokenToKVPool(CachePool):
         self.qk_rope_head_dim = qk_rope_head_dim
         self.layer_num = layer_num
         self.kv_cache_dim = kv_lora_rank + qk_rope_head_dim
-        # Physical group id per layer, from the cache recipe
-        # (CachePoolSpec.layer_group_ids) — the single source the scheduler
-        # groups are published from.
-        self.layer_cache_group_ids = tuple(layer_group_ids)
-        if len(self.layer_cache_group_ids) != layer_num:
-            raise ValueError(
-                f"layer_group_ids has {len(self.layer_cache_group_ids)} "
-                f"entries but the pool has {layer_num} layers; the cache "
-                "recipe must supply one group id per layer "
-                "(CachePoolSpec.layer_group_ids)"
-            )
         self._bind_layer_planes()
 
     # Quantized MLA splits one logical cache into three planes, so its

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
@@ -29,7 +29,6 @@ class MSATokenToKVPool(MHATokenToKVPool):
         index_dtype: torch.dtype,
         indexed_layer_ids: frozenset[int],
         layer_types: tuple[str, ...] = (),
-        layer_group_ids: tuple[str, ...] = (),
         field_layer_offset: int = 0,
     ) -> None:
         self.index_head_dim = index_head_dim
@@ -43,7 +42,6 @@ class MSATokenToKVPool(MHATokenToKVPool):
             layer_num=layer_num,
             rank=rank,
             layer_types=layer_types,
-            layer_group_ids=layer_group_ids,
             field_layer_offset=field_layer_offset,
         )
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
@@ -36,6 +36,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     pack,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
+    FULL_ATTENTION,
     CacheGroupSpec,
     compute_cache_group_page_counts,
     group,
@@ -114,8 +115,8 @@ class CacheRecipe(ABC):
             spec=CachePoolSpec(
                 family=self.family,
                 memory_plan=layout.bind(num_lcm_blocks),
-                layer_types=self.layer_types,
-                layer_group_ids=self.group_ids,
+                layer_types=self.layer_types
+                or (FULL_ATTENTION,) * (self.num_target_layers + self.num_draft_layers),
                 # The same declarations the layout was packed from, so plan and
                 # specs cannot name different groups.
                 cache_group_specs=tuple(spec for spec, _ in groups),
@@ -133,8 +134,8 @@ class CacheRecipe(ABC):
     #
     # Subclasses mark every seam they fill with @override, so a renamed or
     # mistyped seam fails type checking instead of silently falling back to
-    # the default below. The two abstract seams are the exception: ABC
-    # already refuses to instantiate a subclass that misses them.
+    # the default below. The abstract seam is the exception: ABC already
+    # refuses to instantiate a subclass that misses it.
     # ------------------------------------------------------------------
 
     @property
@@ -143,9 +144,18 @@ class CacheRecipe(ABC):
         """Per-layer cache-group label, target layers then draft layers."""
 
     @property
-    @abstractmethod
     def group_ids(self) -> tuple[str, ...]:
-        """Per-layer cache group id, target layers then draft layers."""
+        """Per-layer cache group id, target layers then draft layers.
+
+        Only the default per-layer :meth:`groups` walk consumes this seam:
+        it is the storage policy "layer i's fields go to group_ids[i]".
+        Families that override :meth:`groups` wholesale express that policy
+        directly in their field declarations and need not implement it.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} uses the default per-layer groups() walk "
+            "but does not define group_ids"
+        )
 
     @property
     def num_target_layers(self) -> int:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/deepseek_v4.py
@@ -220,18 +220,6 @@ class DeepseekV4Recipe(CacheRecipe):
         """The compression ratio per layer -- V4's own layer vocabulary."""
         return tuple(str(ratio) for ratio in self._cache_layout.layer_ratio)
 
-    @cached_property
-    def group_ids(self) -> tuple[str, ...]:
-        """The group a layer's own attention reads: SWA, or its chain."""
-        return tuple(
-            (
-                v4_compressed_kv_spec(ratio).group_id
-                if ratio > 1
-                else v4_swa_kv_spec(self.model_config.hf_config).group_id
-            )
-            for ratio in self._cache_layout.layer_ratio
-        )
-
     # ---- geometry ----
 
     @property

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
@@ -68,7 +68,6 @@ class CachePoolSpec:
     family: CacheModelFamily
     memory_plan: CacheMemoryPlan
     layer_types: tuple[str, ...]
-    layer_group_ids: tuple[str, ...]
     # Scheduler group specs, declared next to the fields the plan was packed
     # from (CacheRecipe.groups), so the plan and the specs name one group set.
     cache_group_specs: tuple[CacheGroupSpec, ...]
@@ -90,7 +89,7 @@ class CachePoolSpec:
         metadata is sliced. The arena publishes the contract once, from the
         merged spec, so no view can republish or diverge from it.
         """
-        total_layers = len(self.layer_group_ids)
+        total_layers = len(self.layer_types)
         if first_layer < 0 or num_layers < 0:
             raise ValueError("cache layer view bounds must be non-negative")
         last_layer = first_layer + num_layers
@@ -99,8 +98,6 @@ class CachePoolSpec:
                 f"cache layer view [{first_layer}, {last_layer}) exceeds "
                 f"the merged {total_layers}-layer spec"
             )
-        if self.layer_types and len(self.layer_types) != total_layers:
-            raise ValueError("cache layer types must be empty or cover every layer")
         if self.layer_kv_head_counts is not None and (
             len(self.layer_kv_head_counts) != total_layers
         ):
@@ -112,10 +109,7 @@ class CachePoolSpec:
         return replace(
             self,
             family=family or self.family,
-            layer_types=(
-                self.layer_types[first_layer:last_layer] if self.layer_types else ()
-            ),
-            layer_group_ids=self.layer_group_ids[first_layer:last_layer],
+            layer_types=self.layer_types[first_layer:last_layer],
             layer_kv_head_counts=(
                 self.layer_kv_head_counts[first_layer:last_layer]
                 if self.layer_kv_head_counts is not None
@@ -149,7 +143,7 @@ class CacheSetup:
 
     @property
     def num_target_layers(self) -> int:
-        return len(self.spec.layer_group_ids) - self.num_draft_layers
+        return len(self.spec.layer_types) - self.num_draft_layers
 
 
 # family -> how to build its recipe. Every family runs the one pipeline in

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
@@ -25,6 +25,10 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes import plan
 Retention = Literal["full_history", "sliding_window"]
 Family = Literal["history", "state"]
 TransferPolicy = Literal["full_suffix", "latest_snapshot"]
+# How a caller spells sliding windows: one window broadcast to every sliding
+# layer (today's HF scalar), one entry per layer (multi-window models, with
+# None at full-history positions), or None for a model with no sliding layers.
+SlidingWindowTokens = int | Sequence[int | None] | None
 
 
 @dataclass(frozen=True)
@@ -350,10 +354,53 @@ def _retention_for_label(label: str) -> Retention | None:
     return None
 
 
+def _is_window_int(value: object) -> bool:
+    """True for a real int; a bool is never a window, however int-like it is."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _windows_per_layer(
+    sliding_window_tokens: SlidingWindowTokens, num_layers: int
+) -> tuple[list[int | None], bool]:
+    """Normalize either window spelling to one entry per layer.
+
+    Args:
+        sliding_window_tokens: A scalar window to broadcast, one entry per
+            layer, or None.
+        num_layers: How many layers the windows must cover.
+
+    Returns:
+        ``(windows, broadcast)`` -- the per-layer windows, and whether they
+        came from a scalar. Callers need that second half: a broadcast scalar
+        reaches full-history layers too, which must then ignore it, while a
+        window written at a full-history position in a sequence is a
+        mislabeled layer.
+
+    Raises:
+        ValueError: Not a window spelling, or a sequence of the wrong length.
+    """
+    if sliding_window_tokens is None or _is_window_int(sliding_window_tokens):
+        return [sliding_window_tokens] * num_layers, True
+    if isinstance(sliding_window_tokens, str) or not isinstance(
+        sliding_window_tokens, Sequence
+    ):
+        raise ValueError(  # noqa: TRY004 - preserve the existing API contract
+            "sliding_window_tokens must be None, an int, or a sequence of "
+            f"int/None, got {sliding_window_tokens!r}"
+        )
+    windows = list(sliding_window_tokens)
+    if len(windows) != num_layers:
+        raise ValueError(
+            f"sliding_window_tokens has {len(windows)} entries but "
+            f"layer_types has {num_layers}"
+        )
+    return windows, False
+
+
 def hybrid_slab_group_size(
     layer_types: Sequence[str] | None,
     *,
-    sliding_window_tokens: int | Sequence[int | None] | None = None,
+    sliding_window_tokens: SlidingWindowTokens = None,
 ) -> int | None:
     """Slab count for the hybrid slab KV layout (the i-th layer of EACH
     group shares slab i), or None when the model cannot share slabs.
@@ -385,57 +432,30 @@ def hybrid_slab_group_size(
         counts[label] = counts.get(label, 0) + 1
     if len(counts) < 2:
         return None
-    if sliding_window_tokens is not None and not isinstance(sliding_window_tokens, int):
-        if not isinstance(sliding_window_tokens, Sequence) or len(
-            sliding_window_tokens
-        ) != len(layer_types):
-            return None
-        distinct = {
-            w
-            for label, w in zip(layer_types, sliding_window_tokens)
-            if _retention_for_label(label) == "sliding_window"
-            and isinstance(w, int)
-            and not isinstance(w, bool)
-            and w > 0
-        }
-        if len(distinct) > 1:
-            return None
-    return max(counts.values())
+    windows = sliding_window_tokens
+    if windows is None or isinstance(windows, int):
+        # One window for every sliding layer: pairing per raw label holds.
+        return max(counts.values())
+    if not isinstance(windows, Sequence) or len(windows) != len(layer_types):
+        return None
+    distinct = {
+        window
+        for label, window in zip(layer_types, windows)
+        if _retention_for_label(label) == "sliding_window"
+        and _is_window_int(window)
+        and window > 0
+    }
+    return None if len(distinct) > 1 else max(counts.values())
 
 
 def _layer_retention_windows(
     layer_types: Sequence[str],
-    sliding_window_tokens: int | Sequence[int | None] | None,
+    sliding_window_tokens: SlidingWindowTokens,
 ) -> list[tuple[Retention, int | None]]:
     """Validate the per-layer labels/windows and return (retention, window)
     per layer. A scalar window broadcasts to sliding layers; a sequence
     lines up 1:1 (full-history positions must be None)."""
-    if isinstance(sliding_window_tokens, str):
-        raise ValueError(  # noqa: TRY004 - preserve the existing API contract
-            "sliding_window_tokens must be None, an int, or a "
-            f"sequence of int/None, got {sliding_window_tokens!r}"
-        )
-    if sliding_window_tokens is None or isinstance(sliding_window_tokens, int):
-        if isinstance(sliding_window_tokens, bool):
-            raise ValueError(
-                "sliding_window_tokens must be None, an int, or "
-                f"a sequence of int/None, got {sliding_window_tokens!r}"
-            )
-        windows: list[int | None] = [sliding_window_tokens] * len(layer_types)
-        scalar = True
-    elif not isinstance(sliding_window_tokens, Sequence):
-        raise ValueError(
-            "sliding_window_tokens must be None, an int, or a "
-            f"sequence of int/None, got {sliding_window_tokens!r}"
-        )
-    else:
-        windows = list(sliding_window_tokens)
-        scalar = False
-        if len(windows) != len(layer_types):
-            raise ValueError(
-                f"sliding_window_tokens has {len(windows)} "
-                f"entries but layer_types has {len(layer_types)}"
-            )
+    windows, broadcast = _windows_per_layer(sliding_window_tokens, len(layer_types))
     rows: list[tuple[Retention, int | None]] = []
     for i, (label, raw) in enumerate(zip(layer_types, windows)):
         retention = _retention_for_label(label)
@@ -445,32 +465,34 @@ def _layer_retention_windows(
                 f"expected one of {sorted(_LAYER_TYPE_RETENTION)} or a "
                 f"sliding sub-group label '{_SLIDING_SUBGROUP_PREFIX}<k>'"
             )
-        if raw is not None and (isinstance(raw, bool) or not isinstance(raw, int)):
+        if raw is not None and not _is_window_int(raw):
             raise ValueError(
-                f"layer {i} ({label!r}) window must be None or " f"an int, got {raw!r}"
+                f"layer {i} ({label!r}) window must be None or an int, got {raw!r}"
             )
-        window = raw
         if retention == "sliding_window":
-            if window is None or window <= 0:
+            if raw is None or raw <= 0:
                 raise ValueError(
                     f"layer {i} ({label!r}) is sliding but its "
                     f"window is not a positive int (got {raw!r})"
                 )
-        else:
-            if not scalar and window is not None and window > 0:
-                raise ValueError(
-                    f"layer {i} ({label!r}) is full-history but "
-                    f"carries sliding window {window}; mislabeled layer_type?"
-                )
-            window = None
-        rows.append((retention, window))
+            rows.append((retention, raw))
+            continue
+        # A broadcast scalar reaches full-history layers too and they ignore
+        # it; a window written at this position by hand means the label is
+        # wrong. Either way the group carries no window.
+        if not broadcast and raw is not None and raw > 0:
+            raise ValueError(
+                f"layer {i} ({label!r}) is full-history but "
+                f"carries sliding window {raw}; mislabeled layer_type?"
+            )
+        rows.append((retention, None))
     return rows
 
 
 def layer_group_ids(
     *,
     layer_types: Sequence[str],
-    sliding_window_tokens: int | Sequence[int | None] | None,
+    sliding_window_tokens: SlidingWindowTokens,
 ) -> list[str]:
     """Per-layer cache group id — the single derivation the recipes
     and multi-window models assign ``PagedAttention(group_id=...)`` from
@@ -517,7 +539,7 @@ def group(
     *,
     layer_types: Sequence[str],
     group_ids: Sequence[str],
-    sliding_window_tokens: int | Sequence[int | None] | None,
+    sliding_window_tokens: SlidingWindowTokens,
     prefix_granularity: int,
     fields_for_layer,
     page_sizes: Mapping[str, int] | None = None,
@@ -709,6 +731,7 @@ __all__ = [
     "LINEAR_ATTENTION",
     "CacheGroupSpec",
     "Retention",
+    "SlidingWindowTokens",
     "STATE_LAYER_TYPES",
     "apply_pd_transfer_policies",
     "group",

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
@@ -599,8 +599,7 @@ def group(
         raise ValueError(
             "group requires per-layer group_ids; the "
             "cache recipe is their single source: derive them with "
-            "layer_group_ids(...) and carry them via "
-            "CachePoolSpec.layer_group_ids"
+            "layer_group_ids(...)"
         )
     resolved_layer_types = tuple(layer_types) or (FULL_ATTENTION,) * len(
         resolved_group_ids

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -559,7 +559,7 @@ def _create_target_components(
         cache_spec,
         config,
         arena,
-        num_layers=len(cache_spec.layer_group_ids),
+        num_layers=len(cache_spec.layer_types),
         rank=rank,
     )
     if is_hybrid_linear:
@@ -907,7 +907,7 @@ def create_attn_components(
         spec.memory_plan.prefix_granularity,
         spec.memory_plan.num_lcm_blocks,
         spec.token_capacity,
-        len(spec.layer_group_ids),
+        len(spec.layer_types),
         cache_setup.num_draft_layers,
         {
             group.group_id: group.cache_blocks_per_lcm_block

--- a/test/runtime/conftest.py
+++ b/test/runtime/conftest.py
@@ -148,7 +148,6 @@ def make_kimi_pool(device, usable_pages: int = 6, *, with_mla_dims: bool = True)
         layer_num=text_config.num_hidden_layers,
         rank=0,
         layer_types=layer_types,
-        layer_group_ids=group_ids,
         cache_group_specs=_kimi_group_specs(group_ids, layer_types, plan),
     )
     return pool
@@ -162,21 +161,21 @@ def kimi_pool():
 def layer_for_group(pool, group_id: str) -> int:
     return next(
         layer_id
-        for layer_id, candidate in pool._group_ids_by_layer.items()
+        for layer_id, candidate in sorted(pool.state_group_by_layer.items())
         if candidate == group_id
     )
 
 
 def mla_layer_id(pool) -> int:
-    return layer_for_group(pool, "full_attention")
+    return next(
+        layer_id
+        for layer_id in range(pool.layer_num)
+        if layer_id not in pool.state_group_by_layer
+    )
 
 
 def kda_layer_id(pool) -> int:
-    return next(
-        layer_id
-        for layer_id, group_id in pool._group_ids_by_layer.items()
-        if group_id != "full_attention"
-    )
+    return min(pool.state_group_by_layer)
 
 
 def cache_metadata_for(contract, tables, device, *, filler_page: int = 1):

--- a/test/runtime/distributed/test_mla_dsa_pd_contract.py
+++ b/test/runtime/distributed/test_mla_dsa_pd_contract.py
@@ -138,7 +138,6 @@ def _make_mla_pool(pd_enabled: bool):
         rank=0,
         cache_group_specs=specs,
         token_capacity=_NUM_LCM_BLOCKS * _P,
-        layer_group_ids=("full_attention",) * _NUM_LAYERS,
     )
     return pool
 
@@ -163,7 +162,6 @@ def _make_dsa_pool(pd_enabled: bool):
         index_head_dim=128,
         cache_group_specs=specs,
         token_capacity=_NUM_LCM_BLOCKS * _P,
-        layer_group_ids=("full_attention",) * _NUM_LAYERS,
     )
     return pool
 

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -222,7 +222,6 @@ def test_attention_configs_do_not_own_cache_setup() -> None:
         "ssm_dtype",
         "recurrent_dtype",
         "lcm_memory_plan",
-        "layer_cache_group_ids",
         "token_capacity",
     }
 
@@ -291,10 +290,12 @@ def test_qwen_recipe_preserves_backend_kernel_page_size() -> None:
     assert attn_config.kernel_page_size == 64
     assert setup.spec.memory_plan.prefix_granularity == 128
     assert setup.num_draft_layers == 0
-    assert setup.spec.layer_group_ids == (
-        f"{LINEAR_ATTENTION}_0",
-        FULL_ATTENTION,
-    )
+    # The plan's field declarations are the single record of layer -> group.
+    plan_groups = {
+        field.field_id: field.group_id for field in setup.spec.memory_plan.fields
+    }
+    assert plan_groups["layer.0.conv"] == f"{LINEAR_ATTENTION}_0"
+    assert plan_groups["layer.1.k"] == FULL_ATTENTION
     # The plan is the single source of field dtypes; no side channel.
     plan_dtypes = {
         field.field_id: field.dtype for field in setup.spec.memory_plan.fields
@@ -682,14 +683,10 @@ def test_hybrid_draft_only_sliding_group_packs_by_ratio() -> None:
     # own packing, and its spec joins the ONE published spec set.
     assert setup.num_draft_layers == 2
     plan = setup.spec.memory_plan
+    assert plan.field("layer.0.kv").group_id == "full_attention"
     assert plan.field("layer.1.kv").group_id == "full_attention"
     assert plan.field("layer.2.kv").group_id == "draft_swa"
     assert plan.group("draft_swa").cache_blocks_per_lcm_block >= 1
-    assert setup.spec.layer_group_ids == (
-        "full_attention",
-        "full_attention",
-        "draft_swa",
-    )
     published = {spec.group_id for spec in setup.spec.cache_group_specs}
     assert published == {"full_attention", "draft_swa"}
 

--- a/test/runtime/test_gdn_state_paging.py
+++ b/test/runtime/test_gdn_state_paging.py
@@ -47,12 +47,9 @@ class _ContractPool:
         )
         self.arena = SimpleNamespace(runtime_contract=contract)
         self._components = components
-        self._group_ids_by_layer = {
+        self.state_group_by_layer = {
             layer_id: group_id for layer_id, (group_id, _, _) in components.items()
         }
-
-    def group_id_for_layer(self, layer_id):
-        return self._group_ids_by_layer[layer_id]
 
     def get_component(self, layer_id, name):
         _, conv_state, recurrent_state = self._components[layer_id]

--- a/test/runtime/test_group_specs_from_layer_types.py
+++ b/test/runtime/test_group_specs_from_layer_types.py
@@ -403,6 +403,41 @@ class MultiWindowGroupSpecsTest(unittest.TestCase):
         self.assertEqual(len(specs), 2)
 
 
+class BroadcastWindowAsymmetryTest(unittest.TestCase):
+    """The one asymmetry between the two window spellings.
+
+    A scalar reaches every layer, so non-sliding layers must ignore it; the
+    same value written at that position in a sequence is a mislabeled layer
+    (see ``test_full_layer_with_positive_window_in_sequence_raises``).
+    """
+
+    def test_broadcast_scalar_leaves_full_group_windowless(self):
+        by_id = {
+            spec.group_id: spec
+            for spec in _specs(
+                layer_types=["full_attention", "sliding_attention"],
+                sliding_window_tokens=128,
+                prefix_granularity=16,
+            )
+        }
+        self.assertIsNone(by_id["full_attention"].sliding_window_tokens)
+        self.assertEqual(by_id["sliding_attention"].sliding_window_tokens, 128)
+
+    def test_broadcast_scalar_leaves_state_group_windowless(self):
+        by_id = {
+            spec.group_id: spec
+            for spec in _specs(
+                layer_types=["linear_attention", "sliding_attention"],
+                sliding_window_tokens=128,
+                prefix_granularity=16,
+            )
+        }
+        state = by_id["linear_attention"]
+        self.assertEqual(state.family, "state")
+        self.assertEqual(state.retention, "full_history")
+        self.assertIsNone(state.sliding_window_tokens)
+
+
 class CacheGroupSpecShapeTest(unittest.TestCase):
     """A spec declares exactly one geometry shape: row geometry (paged KV)
     or checkpoint_granularity (snapshot state)."""

--- a/test/runtime/test_inkling_activation_parity.py
+++ b/test/runtime/test_inkling_activation_parity.py
@@ -219,7 +219,6 @@ class _Harness:
             head_dim=text.head_dim,
             layer_num=text.num_hidden_layers,
             rank=0,
-            layer_group_ids=("full_attention",) * text.num_hidden_layers,
         )
         conv_pool = InklingConvStatePool(
             num_layers=text.num_hidden_layers,

--- a/test/runtime/test_kimi_k3_cache_pool.py
+++ b/test/runtime/test_kimi_k3_cache_pool.py
@@ -50,7 +50,6 @@ def test_kimi_k3_pool_binds_mla_and_kda_to_one_lcm_backing() -> None:
         layer_num=text_config.num_hidden_layers,
         rank=0,
         layer_types=layer_types,
-        layer_group_ids=group_ids,
     )
 
     assert pool.num_lcm_blocks == num_lcm_blocks
@@ -107,7 +106,6 @@ def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
         family="kimi_k3",
         memory_plan=plan,
         layer_types=recipe.layer_types,
-        layer_group_ids=recipe.group_ids,
         cache_group_specs=tuple(spec for spec, _ in groups),
         token_capacity=128,
     )

--- a/test/runtime/test_kimi_k3_kda.py
+++ b/test/runtime/test_kimi_k3_kda.py
@@ -6,7 +6,7 @@ Coverage:
   ``state_out_blocks_by_group``
   mappings keyed by state group id, dual-index computed ONCE per group per
   batch, with a proof the three groups' indices are independent and selected
-  per layer via ``pool.group_id_for_layer``;
+  per layer via ``pool.state_group_by_layer``;
 - structural binding of the two KDA components (``conv_state`` /
   ``recurrent_state``) from the LCM pool's no-copy component views;
 - eager prefill and decode over dual state page indices compared against a
@@ -153,8 +153,9 @@ class _StubContractPool:
             for layer_id in self._groups
         }
 
-    def group_id_for_layer(self, layer_id: int) -> str:
-        return self._groups[layer_id]
+    @property
+    def state_group_by_layer(self) -> dict[int, str]:
+        return self._groups
 
     def get_component(self, layer_id: int, name: str) -> torch.Tensor:
         return self._components[layer_id][name]

--- a/test/runtime/test_kimi_k3_kda_eager_commit.py
+++ b/test/runtime/test_kimi_k3_kda_eager_commit.py
@@ -141,7 +141,7 @@ class _Harness:
 
 def _assert_committed_pages_equal(left, right, pages):
     for layer_id in left.layer_ids:
-        group_id = left.pool.group_id_for_layer(layer_id)
+        group_id = left.pool.state_group_by_layer[layer_id]
         for page in pages[group_id]:
             torch.testing.assert_close(
                 left.pool.get_component(layer_id, "conv_state")[page],
@@ -393,7 +393,7 @@ def test_no_store_fused_verify_matches_decomposed_outputs():
 
     # Negative control: perturbing the decomposed base state must break the oracle.
     layer_id = decomposed.layer_ids[0]
-    group_id = decomposed.pool.group_id_for_layer(layer_id)
+    group_id = decomposed.pool.state_group_by_layer[layer_id]
     recurrent = decomposed.pool.get_component(layer_id, "recurrent_state")
     recurrent[torch.tensor(pages[group_id], device=DEV)] += 1
     wrong = decomposed.forward(inputs, len(rpis))[0]

--- a/test/runtime/test_mha_pool_spec_decode_groups.py
+++ b/test/runtime/test_mha_pool_spec_decode_groups.py
@@ -62,13 +62,10 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
             layer_types=kwargs.get("layer_types", ()),
             sliding_window_tokens=kwargs.get("sliding_window_tokens"),
         )
-        kwargs.setdefault(
-            "layer_group_ids",
-            make_layer_group_ids(
-                layer_num=kwargs["layer_num"],
-                layer_types=kwargs.get("layer_types", ()),
-                sliding_window_tokens=kwargs.get("sliding_window_tokens"),
-            ),
+        group_ids = make_layer_group_ids(
+            layer_num=kwargs["layer_num"],
+            layer_types=kwargs.get("layer_types", ()),
+            sliding_window_tokens=kwargs.get("sliding_window_tokens"),
         )
         from cache_pool_test_utils import specs_for_layers
 
@@ -76,7 +73,7 @@ class MHAPoolGroupPublicationTest(unittest.TestCase):
             "cache_group_specs",
             specs_for_layers(
                 layer_types=kwargs.get("layer_types", ()),
-                group_ids=kwargs["layer_group_ids"],
+                group_ids=group_ids,
                 sliding_window_tokens=kwargs.get("sliding_window_tokens"),
                 prefix_granularity=kwargs["prefix_granularity"],
             ),

--- a/test/runtime/test_mxfp8_kv_pool.py
+++ b/test/runtime/test_mxfp8_kv_pool.py
@@ -64,7 +64,6 @@ def _make_pool(page_size: int, size: int = 512):
         head_dim=HEAD_DIM,
         layer_num=LAYERS,
         rank=0,
-        layer_group_ids=("full_attention",) * LAYERS,
     )
 
 
@@ -190,7 +189,6 @@ def _make_shared_pool(size: int = 512):
         layer_num=len(SHARED_LAYER_TYPES),
         rank=0,
         layer_types=SHARED_LAYER_TYPES,
-        layer_group_ids=SHARED_LAYER_TYPES,
         layer_kv_head_counts=SHARED_KV_HEADS,
     )
 

--- a/test/runtime/test_unified_kv_slab_pool.py
+++ b/test/runtime/test_unified_kv_slab_pool.py
@@ -181,7 +181,6 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
 
     def _pool(self, **overrides):
         from cache_pool_test_utils import (
-            make_layer_group_ids,
             make_mha_memory_plan,
             make_pool,
         )
@@ -209,14 +208,6 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
             dtype=kwargs["dtype"],
             layer_types=kwargs.get("layer_types", ()),
             sliding_window_tokens=kwargs.get("sliding_window_tokens"),
-        )
-        kwargs.setdefault(
-            "layer_group_ids",
-            make_layer_group_ids(
-                layer_num=kwargs["layer_num"],
-                layer_types=kwargs.get("layer_types", ()),
-                sliding_window_tokens=kwargs.get("sliding_window_tokens"),
-            ),
         )
         kwargs.pop("sliding_window_tokens", None)
         # The arena owns the allocation; ``size`` and the plan geometry are
@@ -333,7 +324,6 @@ class MHAPoolSlabLayoutTest(unittest.TestCase):
             pd_disaggregation_enabled=True,
         )
         pool = self._pool(
-            layer_group_ids=group_ids,
             cache_group_specs=specs,
         )
 
@@ -439,7 +429,6 @@ class MLAPoolAllocationHookTest(unittest.TestCase):
             qk_rope_head_dim=2,
             layer_num=1,
             rank=0,
-            layer_group_ids=("full_attention",),
             cache_group_specs=_specs_for_layers(
                 layer_types=(),
                 group_ids=("full_attention",),
@@ -571,7 +560,6 @@ class CachePoolFieldBindingTest(unittest.TestCase):
             layer_num=2,
             rank=0,
             layer_types=("linear_attention", "full_attention"),
-            layer_group_ids=("linear_attention_0", "full_attention"),
             cache_group_specs=_specs_for_layers(
                 layer_types=("linear_attention", "full_attention"),
                 group_ids=("linear_attention_0", "full_attention"),
@@ -601,7 +589,6 @@ class CachePoolFieldBindingTest(unittest.TestCase):
             layer_num=2,
             rank=0,
             layer_types=("linear_attention", "full_attention"),
-            layer_group_ids=("linear_attention", "full_attention"),
         )
         return pool
 
@@ -631,7 +618,7 @@ class CachePoolFieldBindingTest(unittest.TestCase):
             pool.arena.runtime_contract.group_page_counts,
             {"linear_attention_0": 3, "full_attention": 2},
         )
-        self.assertEqual(pool.group_id_for_layer(0), "linear_attention_0")
+        self.assertEqual(pool.state_group_by_layer[0], "linear_attention_0")
         conv, ssm = pool.get_state_buffers(0)
         self.assertIs(pool.get_component(0, "conv_state"), conv)
         self.assertIs(pool.get_component(0, "recurrent_state"), ssm)
@@ -651,6 +638,74 @@ class CachePoolFieldBindingTest(unittest.TestCase):
         self.assertTrue(all(buffer is not None for buffer in pool.v_buffer))
         self.assertFalse(hasattr(pool, "lcm_pool"))
         self.assertFalse(hasattr(pool, "state_slabs"))
+
+
+class DeriveStateGroupsByLayerTest(unittest.TestCase):
+    """The plan's field declarations are the single layer -> group record."""
+
+    def setUp(self):
+        try:
+            from tokenspeed.runtime.layers.attention.kv_cache.base import (
+                derive_state_groups_by_layer,
+            )
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs torch + tokenspeed_kernel: {exc}")
+        self.derive = derive_state_groups_by_layer
+
+    @staticmethod
+    def _arena(fields, families):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            plan=SimpleNamespace(
+                fields=tuple(
+                    SimpleNamespace(field_id=field_id, group_id=group_id)
+                    for field_id, group_id in fields
+                )
+            ),
+            cache_group_specs=tuple(
+                SimpleNamespace(group_id=group_id, family=family)
+                for group_id, family in families.items()
+            ),
+        )
+
+    def test_reads_state_groups_back_from_planned_fields(self):
+        arena = self._arena(
+            fields=(
+                ("layer.0.conv", "linear_attention_0"),
+                ("layer.0.ssm", "linear_attention_0"),
+                ("layer.1.k", "full_attention"),
+                ("layer.1.v", "full_attention"),
+            ),
+            families={"linear_attention_0": "state", "full_attention": "history"},
+        )
+        mapping = self.derive(arena, first_layer=0, num_layers=2, state_layer_ids=(0,))
+        self.assertEqual(mapping, {0: "linear_attention_0"})
+
+    def test_draft_view_window_offsets_layer_ids(self):
+        arena = self._arena(
+            fields=(
+                ("layer.0.k", "full_attention"),
+                ("layer.1.conv", "linear_attention_0"),
+            ),
+            families={"linear_attention_0": "state", "full_attention": "history"},
+        )
+        mapping = self.derive(arena, first_layer=1, num_layers=1, state_layer_ids=(0,))
+        self.assertEqual(mapping, {0: "linear_attention_0"})
+
+    def test_rejects_a_layer_spanning_two_state_groups(self):
+        arena = self._arena(
+            fields=(
+                ("layer.0.conv", "linear_attention_0"),
+                ("layer.0.ssm", "linear_attention_1"),
+            ),
+            families={
+                "linear_attention_0": "state",
+                "linear_attention_1": "state",
+            },
+        )
+        with self.assertRaisesRegex(ValueError, "more than one cache group"):
+            self.derive(arena, first_layer=0, num_layers=1, state_layer_ids=(0,))
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_v4_sliding_window_groups_smoke.py
+++ b/test/runtime/test_v4_sliding_window_groups_smoke.py
@@ -60,7 +60,6 @@ class _CapacityProbe(CacheRecipe):
 
     family = "deepseek_v4"
     layer_types = ()
-    group_ids = ()
 
     def __init__(self, specs, limits) -> None:
         self._specs = tuple(specs)


### PR DESCRIPTION
## Summary

`CachePoolSpec.layer_group_ids` (the per-layer cache-group-id tuple) was a second, parallel encoding of a fact the memory plan already records authoritatively: every planned field names both its layer (`layer.<id>.<component>`) and its group. DeepSeek V4 showed the tuple's semantics drift — a layer's fields span several groups, its attention reads two of them, and the backend routes reads itself — so the tuple could only ever label a nominal "primary" group. This PR deletes the whole parallel pipeline and reads layer→group back from the plan where it is actually needed.

- **New derivation**: `derive_state_groups_by_layer` (`kv_cache/base.py`) walks the plan's field declarations, gated to `STATE_LAYER_TYPES` layers, asserting exactly one state group per layer. Hybrid pools expose it as a cached `state_group_by_layer` mapping.
- **Backend contract**: `MambaAttnBackend` consumes the public `state_group_by_layer` + `get_component` instead of reaching into the private `_group_ids_by_layer` dict; `group_id_for_layer` is gone.
- **Dead plumbing removed**: mha/mla's write-only `layer_cache_group_ids` attribute, the msa/dsa pass-throughs, and all five factory hand-offs.
- **Spec field deleted**: `CachePoolSpec.layer_group_ids` is removed. `layer_types` is now published at full length (`FULL_ATTENTION` fallback) and layer counting / PD layer-view slicing read it.
- **Recipe seam demoted**: `group_ids` drops from abstractmethod to a default that raises — it is the storage-policy input of the default per-layer `groups()` walk, and families overriding `groups()` wholesale (deepseek_v4) need not implement it. The V4 recipe's dead `group_ids` property is removed.

Causality boundary this PR establishes: **before the plan** (inside a recipe) per-layer group ids remain a legitimate storage-policy input to the default walk; **after the plan** (pools, backends, scheduler, tests) everything derives from the plan/contract — no parallel tuple to drift.

## Testing

- New unit tests for `derive_state_groups_by_layer` (state-group readback, draft-view window offsets, rejection of a layer spanning two state groups).
- `test/runtime` full sweep on H20 (excluding `distributed/` and server-launching e2e): all failures reproduce identically on the clean tree (pre-existing: sm_90a MLA prefill unsupported in the installed `tokenspeed_mla` wheel, `test_port_args`, `test_mamba_mtp_state_reset`, etc.).
- `pre-commit run --all-files` clean; CI ruff select set clean on `python/tokenspeed/runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)