### PR TITLE
review(k3): detach router operands, reject unusable out buffers

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
@@ -61,12 +61,13 @@ def cute_dsl_ll_bf16_router(
     Args:
         hidden_states: ``[M, K]`` contiguous BF16 activation.
         weight: ``[N, K]`` contiguous BF16 router weight.
-        out: Optional ``[M, N]`` FP32 destination; allocated when omitted.
+        out: Optional contiguous ``[M, N]`` FP32 destination on the operand
+            device; allocated when omitted.
 
     Returns:
         ``[M, N]`` FP32 router logits, ``out`` when it was given.
     """
-    return ll_bf16_router(hidden_states, weight, out)
+    return ll_bf16_router(hidden_states.detach(), weight.detach(), out)
 
 
 def ll_bf16_router_supported(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/__init__.py
@@ -190,7 +190,8 @@ class LLBf16Router:
         Args:
             a: ``[M, K]`` contiguous BF16 activation.
             b: ``[N, K]`` contiguous BF16 weight.
-            out: Optional ``[M, N]`` FP32 destination; allocated when omitted.
+            out: Optional contiguous ``[M, N]`` FP32 destination on ``a``'s
+                device; allocated when omitted.
             block_size: Dot-product threads per output column; the measured
                 pick for ``M`` when omitted. Ignored by split-K.
 
@@ -205,8 +206,15 @@ class LLBf16Router:
             )
         if out is None:
             out = torch.empty(m, n, dtype=torch.float32, device=a.device)
-        elif out.shape != (m, n) or out.dtype is not torch.float32:
-            raise ValueError(f"out must be a [{m}, {n}] float32 tensor")
+        elif (
+            out.shape != (m, n)
+            or out.dtype is not torch.float32
+            or not out.is_contiguous()
+            or out.device != a.device
+        ):
+            raise ValueError(
+                f"out must be a contiguous [{m}, {n}] float32 tensor on {a.device}"
+            )
 
         device = a.device
         stream = self._stream(device)

--- a/tokenspeed-kernel/test/ops/gemm/test_ll_bf16_router.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_ll_bf16_router.py
@@ -27,7 +27,11 @@ from tokenspeed_kernel.ops.gemm.kimi3 import (
     KIMI3_ROUTER_SIZE,
     kimi3_router_projection,
 )
-from tokenspeed_kernel.ops.gemm.ll_bf16 import MAX_M, ll_bf16_router_supported
+from tokenspeed_kernel.ops.gemm.ll_bf16 import (
+    MAX_M,
+    cute_dsl_ll_bf16_router,
+    ll_bf16_router_supported,
+)
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.thirdparty.cute_dsl.ll_bf16 import ll_bf16_router
 
@@ -89,3 +93,31 @@ def test_declines_non_contiguous_and_odd_k() -> None:
         KIMI3_ROUTER_SIZE, KIMI3_HIDDEN_SIZE + 1, device="cuda", dtype=torch.bfloat16
     )
     assert not ll_bf16_router_supported(odd, odd_w, 1)
+
+
+def test_rejects_an_unusable_out_buffer() -> None:
+    """A wrongly laid out ``out`` must raise, not be written through blindly."""
+    a, b = _inputs(1)
+    strided = torch.empty(1, KIMI3_ROUTER_SIZE * 2, device="cuda")[:, ::2]
+    assert not strided.is_contiguous()
+    with pytest.raises(ValueError):
+        ll_bf16_router(a, b, strided)
+    half = torch.empty(1, KIMI3_ROUTER_SIZE, device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError):
+        ll_bf16_router(a, b, half)
+    if torch.cuda.device_count() > 1:
+        other = torch.empty(1, KIMI3_ROUTER_SIZE, device="cuda:1", dtype=torch.float32)
+        with pytest.raises(ValueError):
+            ll_bf16_router(a, b, other)
+
+
+@pytest.mark.parametrize("m", [1, 8])
+def test_serves_parameters_that_require_grad(m: int) -> None:
+    """The real gate holds an ``nn.Parameter``; DLPack rejects those undetached."""
+    a, b = _inputs(m, seed=5)
+    weight = torch.nn.Parameter(b.clone())
+    assert weight.requires_grad
+    got = cute_dsl_ll_bf16_router(a.requires_grad_(), weight)
+    torch.testing.assert_close(
+        got, kimi3_router_projection(a.detach(), b, solution="ll_bf16")
+    )


### PR DESCRIPTION
Follow-up to #1179, which merged while the last two review comments were still open.

- **Detach the operands.** `KimiLinearMoEGate` holds its weight as an `nn.Parameter` with `requires_grad` set, and the compiled CuTe callable crosses the TVM-FFI/DLPack boundary, which refuses tensors that require gradients. The registry entry now detaches both operands, matching the skinny and TGV wrappers.
- **Reject unusable `out` buffers.** The driver accepted any correctly shaped FP32 `out`, then handed its pointer to a kernel that assumes a dense buffer on the operand device. It now also requires `out.is_contiguous()` and `out.device == a.device`.

## Tests

`test_ll_bf16_router.py` — 14 passed on GB300 (sm103), including two new cases:

- `test_serves_parameters_that_require_grad[1,8]` feeds a real `nn.Parameter`, the shape that would otherwise raise `BufferError: Can't export tensors that require gradient`.
- `test_rejects_an_unusable_out_buffer` covers strided, wrong-dtype, and wrong-device destinations.