### PR TITLE
perf(k3): route a whole verify window through the packed top-k

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/sigmoid_topk.py
@@ -47,6 +47,7 @@ if invoke_sigmoid_bias_topk_route_prefill_gluon is not None:
         topk: int,
         routed_scaling_factor: float,
         normalize_topk_weights: bool,
+        weights_dtype: torch.dtype = torch.float32,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         route = (
             invoke_sigmoid_bias_topk_route_gluon
@@ -60,7 +61,8 @@ if invoke_sigmoid_bias_topk_route_prefill_gluon is not None:
             routed_scaling_factor=routed_scaling_factor,
             normalize_topk_weights=normalize_topk_weights,
         )
-        return topk_weights, topk_ids
+        # The gluon route has no output-dtype argument to store through.
+        return topk_weights.to(weights_dtype), topk_ids
 
 else:
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
@@ -163,9 +163,8 @@ def moe_sigmoid_bias_topk(
                 routed_scaling_factor=routed_scaling_factor,
                 normalize_topk_weights=normalize_topk_weights,
                 logical_to_physical_map=logical_to_physical_map,
+                weights_dtype=weights_dtype,
             )
-            if topk_weights.dtype != weights_dtype:
-                topk_weights = topk_weights.to(weights_dtype)
             return topk_weights, topk_ids
 
     kernel = select_kernel(
@@ -181,11 +180,10 @@ def moe_sigmoid_bias_topk(
         topk=topk,
         routed_scaling_factor=routed_scaling_factor,
         normalize_topk_weights=normalize_topk_weights,
+        weights_dtype=weights_dtype,
     )
     if logical_to_physical_map is not None:
         topk_ids = logical_to_physical_map[topk_ids.long()].to(torch.int32)
-    if topk_weights.dtype != weights_dtype:
-        topk_weights = topk_weights.to(weights_dtype)
     return topk_weights, topk_ids
 
 
@@ -208,6 +206,7 @@ def triton_minimax_sigmoid_bias_topk(
     topk: int,
     routed_scaling_factor: float,
     normalize_topk_weights: bool,
+    weights_dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Fused single-kernel routing via the minimax biased-topk Triton kernel.
 
@@ -218,6 +217,7 @@ def triton_minimax_sigmoid_bias_topk(
     """
     from tokenspeed_kernel.thirdparty.triton import minimax_biased_grouped_topk
 
+    # The kernel scales only when it renormalizes, so keep fp32 through mul_.
     topk_weights, topk_ids = minimax_biased_grouped_topk(
         router_logits,
         router_logits,
@@ -228,10 +228,11 @@ def triton_minimax_sigmoid_bias_topk(
         topk_group=1,
         num_fused_shared_experts=0,
         routed_scaling_factor=routed_scaling_factor,
-        weights_dtype=torch.float32,
+        weights_dtype=weights_dtype if normalize_topk_weights else torch.float32,
     )
     if not normalize_topk_weights:
         topk_weights.mul_(routed_scaling_factor)
+        topk_weights = topk_weights.to(weights_dtype)
     return topk_weights, topk_ids.to(torch.int32)
 
 
@@ -253,6 +254,7 @@ def torch_sigmoid_bias_topk(
     topk: int,
     routed_scaling_factor: float,
     normalize_topk_weights: bool,
+    weights_dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """PyTorch implementation matching Kimi's existing routing path."""
     scores = router_logits.sigmoid()
@@ -263,7 +265,7 @@ def torch_sigmoid_bias_topk(
     if normalize_topk_weights:
         topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
     topk_weights = topk_weights * routed_scaling_factor
-    return topk_weights.float(), topk_ids.to(torch.int32)
+    return topk_weights.to(weights_dtype), topk_ids.to(torch.int32)
 
 
 import tokenspeed_kernel.ops.moe.gluon.sigmoid_topk  # noqa: E402,F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
@@ -35,6 +35,12 @@ def _gluon_eligible(
     )
 
 
+#: GB200, cold L2: packed wins to 256 rows and ties the grouped kernel at 320.
+_K3_PACKED_TOPK_MAX_ROWS_NVIDIA = 256
+#: Unmeasured past one row on CDNA4, so it keeps what it was tuned at.
+_K3_PACKED_TOPK_MAX_ROWS_CDNA4 = 1
+
+
 def moe_sigmoid_bias_topk(
     router_logits: torch.Tensor,
     correction_bias: torch.Tensor,
@@ -92,18 +98,25 @@ def moe_sigmoid_bias_topk(
             torch.empty(shape, device=router_logits.device, dtype=torch.int32),
         )
     platform = Platform.get()
+    if platform.is_nvidia:
+        packed_max_rows = _K3_PACKED_TOPK_MAX_ROWS_NVIDIA
+    elif platform.is_cdna4:
+        packed_max_rows = _K3_PACKED_TOPK_MAX_ROWS_CDNA4
+    else:
+        packed_max_rows = 0
     if (
         solution is None
-        and (platform.is_cdna4 or platform.is_nvidia)
-        and router_logits.shape == (1, 896)
+        and router_logits.shape[1] == 896
+        and 0 < tokens <= packed_max_rows
         and router_logits.dtype == torch.float32
         and correction_bias.dtype == torch.float32
         and topk == 16
+        # The packed kernel raises on these layouts; the grouped one reads strides.
+        and router_logits.is_cuda
+        and router_logits.is_contiguous()
+        and correction_bias.is_contiguous()
     ):
-        # The packed-key single-CTA kernel wins on both vendors for the K3
-        # decode shape: one bitonic top-16 instead of the grouped multi-pass
-        # (NVIDIA B300: 3.7us vs 7.0us for the minimax path, bit-identical
-        # selection and weights).
+        # Selection matches the grouped kernel; the weights differ by an fp32 ulp.
         topk_weights, topk_ids = kimi3_sigmoid_bias_topk(
             router_logits,
             correction_bias,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/decode_sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/decode_sigmoid_topk.py
@@ -83,6 +83,7 @@ def _decode_sigmoid_bias_topk(
     routed_scaling_factor: float,
     normalize_topk_weights: bool,
     logical_to_physical_map: torch.Tensor | None = None,
+    weights_dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Route one decode token using biased sigmoid scores.
 
@@ -96,7 +97,7 @@ def _decode_sigmoid_bias_topk(
             router expert ids to physical expert ids.
 
     Returns:
-        ``(topk_weights, topk_ids)`` shaped ``[1, topk]`` with FP32 weights
+        ``(topk_weights, topk_ids)`` shaped ``[1, topk]`` with ``weights_dtype``
         and INT32 ids.
     """
     experts = router_logits.shape[1] if router_logits.ndim == 2 else 0
@@ -138,7 +139,7 @@ def _decode_sigmoid_bias_topk(
     )
     topk_weights = torch.empty(
         (1, topk),
-        dtype=torch.float32,
+        dtype=weights_dtype,
         device=router_logits.device,
     )
     padded_experts = triton.next_power_of_2(experts)
@@ -183,6 +184,7 @@ def triton_decode_sigmoid_bias_topk(
     topk: int,
     routed_scaling_factor: float,
     normalize_topk_weights: bool,
+    weights_dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return _decode_sigmoid_bias_topk(
         router_logits,
@@ -190,6 +192,7 @@ def triton_decode_sigmoid_bias_topk(
         topk=topk,
         routed_scaling_factor=routed_scaling_factor,
         normalize_topk_weights=normalize_topk_weights,
+        weights_dtype=weights_dtype,
     )
 
 
@@ -216,6 +219,7 @@ def triton_decode_sigmoid_bias_topk_mapped(
     routed_scaling_factor: float,
     normalize_topk_weights: bool,
     logical_to_physical_map: torch.Tensor,
+    weights_dtype: torch.dtype = torch.float32,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     return _decode_sigmoid_bias_topk(
         router_logits,
@@ -224,6 +228,7 @@ def triton_decode_sigmoid_bias_topk_mapped(
         routed_scaling_factor=routed_scaling_factor,
         normalize_topk_weights=normalize_topk_weights,
         logical_to_physical_map=logical_to_physical_map,
+        weights_dtype=weights_dtype,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/kimi3_sigmoid_topk.py
@@ -32,6 +32,11 @@ def _kimi3_sigmoid_bias_topk_kernel(
     num_experts: tl.constexpr = 896
     padded_experts: tl.constexpr = 1024
     topk: tl.constexpr = 16
+    # One program per row; every reduction below is row-local.
+    row = tl.program_id(0)
+    logits += row * num_experts
+    topk_ids += row * topk
+    topk_weights += row * topk
     expert = tl.arange(0, padded_experts)
     valid = expert < num_experts
 
@@ -52,7 +57,9 @@ def _kimi3_sigmoid_bias_topk_kernel(
         mask=valid,
         other=0.0,
     ).to(tl.float32)
-    choice = tl.where(valid, scores + bias, -float("inf"))
+    choice = scores + bias
+    # Squash NaN like the grouped kernel: the packed key sorts NaN above finite.
+    choice = tl.where(valid & (choice == choice), choice, -float("inf"))
 
     # Pack the ordered FP32 selection score and inverse expert id. A single
     # bitonic top-k then implements the reference's descending score order and
@@ -94,10 +101,10 @@ def kimi3_sigmoid_bias_topk(
     weights_dtype: torch.dtype = torch.float32,
     enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Route one Kimi K3 decode token to its top 16 of 896 experts.
+    """Route Kimi K3 tokens to their top 16 of 896 experts, one row per CTA.
 
     Args:
-        router_logits: Contiguous FP32 logits shaped ``[1, 896]``.
+        router_logits: Contiguous FP32 logits shaped ``[tokens, 896]``.
         correction_bias: Contiguous FP32 selection bias shaped ``[896]``.
         routed_scaling_factor: Scale applied to selected route weights.
         normalize_topk_weights: Normalize selected sigmoid scores when true.
@@ -112,16 +119,22 @@ def kimi3_sigmoid_bias_topk(
             that writes ``router_logits`` is chained on the same stream/graph.
 
     Returns:
-        ``(topk_weights, topk_ids)`` shaped ``[1, 16]`` with ``weights_dtype``
+        ``(topk_weights, topk_ids)`` shaped ``[tokens, 16]`` with ``weights_dtype``
         weights and INT32 ids (physical ids when a dispatch map is given).
     """
     if (
-        router_logits.shape != (1, 896)
+        router_logits.dim() != 2
+        or router_logits.shape[1] != 896
+        # The kernel offsets its row base with an INT32 program id.
+        or not 0 < router_logits.shape[0] <= (2**31 - 1) // 896
         or router_logits.dtype != torch.float32
         or not router_logits.is_cuda
         or not router_logits.is_contiguous()
     ):
-        raise ValueError("Kimi K3 top-k requires contiguous GPU FP32 logits [1, 896]")
+        raise ValueError(
+            "Kimi K3 top-k requires contiguous GPU FP32 logits [tokens, 896]"
+        )
+    tokens = router_logits.shape[0]
     if (
         correction_bias.shape != (896,)
         or correction_bias.dtype != torch.float32
@@ -141,12 +154,12 @@ def kimi3_sigmoid_bias_topk(
         )
 
     topk_ids = torch.empty(
-        (1, 16),
+        (tokens, 16),
         dtype=torch.int32,
         device=router_logits.device,
     )
     topk_weights = torch.empty(
-        (1, 16),
+        (tokens, 16),
         dtype=weights_dtype,
         device=router_logits.device,
     )
@@ -155,7 +168,7 @@ def kimi3_sigmoid_bias_topk(
     pdl_kwargs = (
         {"launch_pdl": True} if enable_pdl and current_platform().is_nvidia else {}
     )
-    _kimi3_sigmoid_bias_topk_kernel[(1,)](
+    _kimi3_sigmoid_bias_topk_kernel[(tokens,)](
         router_logits,
         correction_bias,
         topk_ids,

--- a/tokenspeed-kernel/test/ops/moe/test_sigmoid_bias_topk_nvidia.py
+++ b/tokenspeed-kernel/test/ops/moe/test_sigmoid_bias_topk_nvidia.py
@@ -122,9 +122,8 @@ def test_decode_shape_uses_lean_kernel_and_is_exact(normalize, scale):
 @pytest.mark.parametrize("tokens", [1, 2])
 @pytest.mark.parametrize("map_dtype", [torch.int32, torch.int64])
 def test_static_dispatch_map_and_weights_dtype(tokens, map_dtype):
-    """The optional logical->physical map must translate the selected ids on
-    both the lean decode kernel (tokens=1) and the registry fallback
-    (tokens=2), and bf16 weight output must match the fp32 path."""
+    """The optional logical->physical map must translate the selected ids at
+    both row counts, and bf16 weight output must match the fp32 path."""
     torch.manual_seed(11)
     logits = torch.randn(tokens, 896, dtype=torch.float32, device="cuda")
     bias = torch.randn(896, dtype=torch.float32, device="cuda")

--- a/tokenspeed-kernel/test/ops/test_kimi3_sigmoid_topk_multitoken.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_sigmoid_topk_multitoken.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The K3 packed-key top-k covers a speculative verify window.
+
+A verify round routes ``bs * draft_tokens`` rows at once, so while the packed
+path accepted a single row, every speculative deployment fell through to the
+grouped kernel -- slower, and returning fp32 weights the wrapper then cast per
+layer. These pin the multi-row behaviour, the dispatch boundary, and that the
+two kernels still agree on where a token routes.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from tokenspeed_kernel.ops.moe import moe_sigmoid_bias_topk  # noqa: E402
+from tokenspeed_kernel.ops.moe import sigmoid_topk as sigmoid_topk_mod  # noqa: E402
+from tokenspeed_kernel.ops.moe.triton.kimi3_sigmoid_topk import (  # noqa: E402
+    kimi3_sigmoid_bias_topk,
+)
+from tokenspeed_kernel.thirdparty.triton import (  # noqa: E402
+    minimax_biased_grouped_topk,
+)
+
+EXPERTS, TOPK = 896, 16
+
+
+def _experts(ids):
+    """Selection is a set, so compare it in ascending expert order."""
+    return ids.sort(dim=-1).values.to(torch.int64)
+
+
+def _by_expert(weights, ids):
+    """Reorder weights to match ``_experts``, so two kernels line up."""
+    return weights.gather(1, ids.to(torch.int64).argsort(dim=-1))
+
+
+def _reference(logits, bias, *, normalize, scale):
+    scores = logits.sigmoid()
+    ids = torch.topk(scores + bias.unsqueeze(0), TOPK, dim=-1, sorted=False).indices
+    weights = scores.gather(1, ids)
+    if normalize:
+        weights = weights / weights.sum(dim=-1, keepdim=True)
+    return weights * scale, ids
+
+
+# 128 rows is where the packed path peaks, so pin correctness there too.
+@pytest.mark.parametrize("tokens", [1, 2, 4, 8, 128])
+@pytest.mark.parametrize("normalize", [False, True])
+def test_packed_topk_matches_reference_for_a_verify_window(tokens, normalize):
+    torch.manual_seed(11 + tokens)
+    logits = (torch.randn(tokens, EXPERTS, device="cuda") * 0.2).float()
+    bias = (torch.randn(EXPERTS, device="cuda") * 0.01).float()
+
+    weights, ids = kimi3_sigmoid_bias_topk(
+        logits,
+        bias,
+        routed_scaling_factor=2.5,
+        normalize_topk_weights=normalize,
+        logical_to_physical_map=None,
+        weights_dtype=torch.float32,
+    )
+    assert weights.shape == (tokens, TOPK)
+    assert ids.shape == (tokens, TOPK)
+
+    ref_w, ref_ids = _reference(logits, bias, normalize=normalize, scale=2.5)
+    assert torch.equal(_experts(ids), _experts(ref_ids)), (tokens, normalize)
+    torch.testing.assert_close(
+        _by_expert(weights, ids),
+        _by_expert(ref_w, ref_ids),
+        atol=1e-6,
+        rtol=1e-5,
+    )
+
+
+@pytest.mark.parametrize("tokens", [1, 4, 256])
+def test_dispatcher_sends_a_verify_window_to_the_packed_kernel(tokens, monkeypatch):
+    """The dtype alone proves nothing -- the grouped path reaches bf16 by
+    casting. Observe the call instead: which kernel ran, and that it was asked
+    for the output dtype directly, which is what retires the per-layer cast.
+    """
+    calls = []
+    real = sigmoid_topk_mod.kimi3_sigmoid_bias_topk
+
+    def spy(*args, **kwargs):
+        calls.append(kwargs["weights_dtype"])
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(sigmoid_topk_mod, "kimi3_sigmoid_bias_topk", spy)
+
+    torch.manual_seed(5)
+    logits = (torch.randn(tokens, EXPERTS, device="cuda") * 0.2).float()
+    bias = (torch.randn(EXPERTS, device="cuda") * 0.01).float()
+    weights, ids = moe_sigmoid_bias_topk(
+        logits,
+        bias,
+        TOPK,
+        routed_scaling_factor=2.5,
+        normalize_topk_weights=True,
+        weights_dtype=torch.bfloat16,
+    )
+
+    assert calls == [torch.bfloat16]
+    assert weights.dtype is torch.bfloat16 and ids.dtype is torch.int32
+    assert weights.shape == (tokens, TOPK)
+
+    ref_w, ref_ids = _reference(logits, bias, normalize=True, scale=2.5)
+    assert torch.equal(_experts(ids), _experts(ref_ids))
+    torch.testing.assert_close(
+        _by_expert(weights, ids).float(),
+        _by_expert(ref_w, ref_ids),
+        atol=8e-3,
+        rtol=8e-3,
+    )
+
+
+def test_dispatcher_hands_rows_past_the_cap_to_the_grouped_kernel(monkeypatch):
+    """One row past the measured crossover the packed kernel must not run."""
+    cap = sigmoid_topk_mod._K3_PACKED_TOPK_MAX_ROWS_NVIDIA
+    calls = []
+    monkeypatch.setattr(
+        sigmoid_topk_mod,
+        "kimi3_sigmoid_bias_topk",
+        lambda *a, **k: calls.append(k) or pytest.fail("packed ran past the cap"),
+    )
+
+    torch.manual_seed(7)
+    logits = (torch.randn(cap + 1, EXPERTS, device="cuda") * 0.2).float()
+    bias = (torch.randn(EXPERTS, device="cuda") * 0.01).float()
+    weights, ids = moe_sigmoid_bias_topk(
+        logits, bias, TOPK, routed_scaling_factor=2.5, weights_dtype=torch.bfloat16
+    )
+    assert not calls
+    assert weights.shape == (cap + 1, TOPK) and weights.dtype is torch.bfloat16
+
+
+def test_dispatcher_keeps_a_strided_window_on_the_grouped_kernel():
+    """A column slice of a wider verify buffer is a layout the packed kernel
+    rejects outright, so the gate has to leave it on the strided path."""
+    torch.manual_seed(3)
+    wide = (torch.randn(4, EXPERTS + 128, device="cuda") * 0.2).float()
+    logits = wide[:, :EXPERTS]
+    assert not logits.is_contiguous()
+    bias = (torch.randn(EXPERTS, device="cuda") * 0.01).float()
+
+    weights, ids = moe_sigmoid_bias_topk(
+        logits, bias, TOPK, routed_scaling_factor=2.5, weights_dtype=torch.bfloat16
+    )
+    ref_w, ref_ids = _reference(logits.contiguous(), bias, normalize=True, scale=2.5)
+    assert torch.equal(_experts(ids), _experts(ref_ids))
+    torch.testing.assert_close(
+        _by_expert(weights, ids).float(),
+        _by_expert(ref_w, ref_ids),
+        atol=8e-3,
+        rtol=8e-3,
+    )
+
+
+def _grouped(logits, bias, *, normalize, scale):
+    weights, ids = minimax_biased_grouped_topk(
+        logits,
+        logits,
+        bias,
+        topk=TOPK,
+        renormalize=normalize,
+        num_expert_group=1,
+        topk_group=1,
+        num_fused_shared_experts=0,
+        routed_scaling_factor=scale,
+        weights_dtype=torch.float32,
+    )
+    return weights, ids.to(torch.int32)
+
+
+@pytest.mark.parametrize(
+    ("tag", "spread", "bias_spread"),
+    [
+        ("random", 0.2, 0.01),
+        ("wide", 2.0, 0.05),
+        ("near-ties", 1e-4, 1e-6),
+    ],
+)
+def test_packed_selects_the_same_experts_as_the_grouped_kernel(
+    tag, spread, bias_spread
+):
+    """Routing must not move: a different expert set changes model output.
+
+    The weights may differ in the last fp32 ulp, since the normalizing sum
+    reduces in a different order, and that is checked to vanish in bf16.
+    """
+    torch.manual_seed(19)
+    logits = (torch.randn(4, EXPERTS, device="cuda") * spread).float()
+    bias = (torch.randn(EXPERTS, device="cuda") * bias_spread).float()
+
+    pw, pi = kimi3_sigmoid_bias_topk(
+        logits,
+        bias,
+        routed_scaling_factor=2.5,
+        normalize_topk_weights=True,
+        logical_to_physical_map=None,
+        weights_dtype=torch.float32,
+    )
+    gw, gi = _grouped(logits, bias, normalize=True, scale=2.5)
+
+    assert torch.equal(_experts(pi), _experts(gi)), tag
+    got, ref = _by_expert(pw, pi), _by_expert(gw, gi)
+    assert (got - ref).abs().max().item() < 1e-7, tag
+    assert torch.equal(got.to(torch.bfloat16), ref.to(torch.bfloat16)), tag
+
+
+def test_packed_breaks_exact_ties_like_the_grouped_kernel():
+    """Every seventh expert shares a score, so ordering is decided by the
+    tie-break alone -- the packed key encodes the expert index for this."""
+    logits = torch.zeros(4, EXPERTS, device="cuda").float()
+    logits[:, ::7] = 1.0
+    bias = torch.zeros(EXPERTS, device="cuda").float()
+
+    _, pi = kimi3_sigmoid_bias_topk(
+        logits,
+        bias,
+        routed_scaling_factor=1.0,
+        normalize_topk_weights=True,
+        logical_to_physical_map=None,
+        weights_dtype=torch.float32,
+    )
+    _, gi = _grouped(logits, bias, normalize=True, scale=1.0)
+    assert torch.equal(_experts(pi), _experts(gi))
+
+
+def test_packed_drops_nan_rows_like_the_grouped_kernel():
+    """Padding rows arrive as NaN, and the packed key is built from raw fp32
+    bits, so an unsquashed NaN outranks every finite score. The two kernels
+    must agree wherever a finite score exists; an all-NaN row has no meaningful
+    selection, so only its ids being in range is required.
+    """
+    logits = (torch.randn(4, EXPERTS, device="cuda") * 0.2).float()
+    logits[1, 17] = float("nan")
+    logits[3, :] = float("nan")
+    bias = (torch.randn(EXPERTS, device="cuda") * 0.01).float()
+
+    pw, pi = kimi3_sigmoid_bias_topk(
+        logits,
+        bias,
+        routed_scaling_factor=2.5,
+        normalize_topk_weights=True,
+        logical_to_physical_map=None,
+        weights_dtype=torch.float32,
+    )
+    gw, gi = _grouped(logits, bias, normalize=True, scale=2.5)
+
+    finite = [0, 1, 2]
+    assert 17 not in pi[1].tolist()
+    assert torch.equal(_experts(pi[finite]), _experts(gi[finite]))
+    # A NaN weight in a kept row would poison that row's normalizing sum.
+    assert torch.isfinite(pw[finite]).all()
+    assert ((pi >= 0) & (pi < EXPERTS)).all()

--- a/tokenspeed-kernel/test/ops/test_kimi3_sigmoid_topk_multitoken.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_sigmoid_topk_multitoken.py
@@ -137,7 +137,11 @@ def test_dispatcher_sends_a_verify_window_to_the_packed_kernel(tokens, monkeypat
 
 
 def test_dispatcher_hands_rows_past_the_cap_to_the_grouped_kernel(monkeypatch):
-    """One row past the measured crossover the packed kernel must not run."""
+    """One row past the crossover the packed kernel must not run, and the
+    grouped kernel must be asked for the output dtype rather than returning
+    fp32 for the wrapper to cast."""
+    import tokenspeed_kernel.thirdparty.triton as thirdparty_triton
+
     cap = sigmoid_topk_mod._K3_PACKED_TOPK_MAX_ROWS_NVIDIA
     calls = []
     monkeypatch.setattr(
@@ -145,6 +149,14 @@ def test_dispatcher_hands_rows_past_the_cap_to_the_grouped_kernel(monkeypatch):
         "kimi3_sigmoid_bias_topk",
         lambda *a, **k: calls.append(k) or pytest.fail("packed ran past the cap"),
     )
+    grouped_dtypes = []
+    real_grouped = thirdparty_triton.minimax_biased_grouped_topk
+
+    def grouped_spy(*args, **kwargs):
+        grouped_dtypes.append(kwargs["weights_dtype"])
+        return real_grouped(*args, **kwargs)
+
+    monkeypatch.setattr(thirdparty_triton, "minimax_biased_grouped_topk", grouped_spy)
 
     torch.manual_seed(7)
     logits = (torch.randn(cap + 1, EXPERTS, device="cuda") * 0.2).float()
@@ -153,6 +165,7 @@ def test_dispatcher_hands_rows_past_the_cap_to_the_grouped_kernel(monkeypatch):
         logits, bias, TOPK, routed_scaling_factor=2.5, weights_dtype=torch.bfloat16
     )
     assert not calls
+    assert grouped_dtypes == [torch.bfloat16]
     assert weights.shape == (cap + 1, TOPK) and weights.dtype is torch.bfloat16
 
 


### PR DESCRIPTION
The packed-key K3 top-k only accepted a [1, 896] logits tensor, so every speculative deployment fell through to the grouped minimax kernel: a verify round routes bs * draft_tokens rows at once and never matched the gate.

Every reduction in the kernel is row-local, so covering the window is just a program id and a base-pointer offset -- the rows fan out over SMs instead of leaving one CTA resident. The wrapper accepts [tokens, 896] and the dispatcher gates on the row count.

Device time per call on GB200, walking a ring of logits buffers larger than L2 so neither arm replays out of cache:

    rows        1     16     64    128    192    256    320    512
    packed   3.37   3.53   3.59   3.57   5.58   5.58   7.57   9.51 us
    grouped  5.70   5.79   6.82   7.35   7.43   7.44   7.47   7.63 us

The kernels tie at 320 rows, so the cap sits at 256. It is NVIDIA-only: CDNA4 has never run this kernel past one row, so it keeps the row count it was tuned at rather than inheriting a number measured on another vendor.

The packed path also writes weights_dtype directly, retiring the per-layer fp32 -> bf16 cast the grouped adapter forced.

Routing is unchanged wherever a finite score exists: expert selection is bit-identical to the grouped kernel including exact ties, and the route weights differ only in the last fp32 ulp (~5e-8, from a different reduction order in the normalizing sum), which vanishes in the bf16 the weights are consumed in. NaN padding rows are squashed to -inf as the grouped kernel does, since the packed key is built from raw fp32 bits and would otherwise sort a NaN above every finite score. A row that is entirely NaN has no meaningful selection and the two kernels are only required to keep its ids in range.

The gate also mirrors the specialized kernel's layout requirements, so a strided slice of a wider verify buffer keeps reaching the grouped kernel instead of hitting the specialization's ValueError.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
