### PR TITLE
fix(kernel): lift merge_state's per-block head cap with gridDim.y tiling

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/merge_state.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/merge_state.cu
@@ -38,40 +38,48 @@ __global__ void MergeStateKernel(DTypeIn* v_a, float* s_a, DTypeIn* v_b, float* 
 
   uint32_t tx = threadIdx.x, ty = threadIdx.y;
   uint32_t pos = blockIdx.x;
-  uint32_t head_idx = ty;
+  uint32_t head_idx = blockIdx.y * blockDim.y + ty;
+  // Rows past num_heads are launch padding (gridDim.y * blockDim.y rounds up
+  // to cover all heads). They skip every load/store but must still reach the
+  // sync below — an early return would diverge around __syncwarp/__syncthreads.
+  const bool active = head_idx < num_heads;
 
 #if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   asm volatile("griddepcontrol.wait;");
 #endif
-  // Load phase: snapshot every aliasable input into registers before any store fires.
-  float s_a_val = s_a[pos * num_heads + head_idx] * lse_scale_log2;
-  float s_b_val = s_b[pos * num_heads + head_idx] * lse_scale_log2;
-  vec_t<float, kVecSize> v_a_vec, v_b_vec, v_merged_vec;
-  v_a_vec.cast_load(v_a + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
-  v_b_vec.cast_load(v_b + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
+  float s_a_val = 0.f, s_b_val = 0.f, s_max = 0.f;
+  if (active) {
+    // Load phase: snapshot every aliasable input into registers before any store fires.
+    s_a_val = s_a[pos * num_heads + head_idx] * lse_scale_log2;
+    s_b_val = s_b[pos * num_heads + head_idx] * lse_scale_log2;
+    vec_t<float, kVecSize> v_a_vec, v_b_vec, v_merged_vec;
+    v_a_vec.cast_load(v_a + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
+    v_b_vec.cast_load(v_b + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
 
-  // Compute phase: register-only.
-  float s_max = max(s_a_val, s_b_val);
-  s_a_val = math::ptx_exp2(s_a_val - s_max);
-  s_b_val = math::ptx_exp2(s_b_val - s_max);
-  float a_scale = s_a_val / (s_a_val + s_b_val);
-  float b_scale = s_b_val / (s_a_val + s_b_val);
+    // Compute phase: register-only.
+    s_max = max(s_a_val, s_b_val);
+    s_a_val = math::ptx_exp2(s_a_val - s_max);
+    s_b_val = math::ptx_exp2(s_b_val - s_max);
+    float a_scale = s_a_val / (s_a_val + s_b_val);
+    float b_scale = s_b_val / (s_a_val + s_b_val);
 #pragma unroll
-  for (uint32_t i = 0; i < kVecSize; ++i) {
-    v_merged_vec[i] = a_scale * v_a_vec[i] + b_scale * v_b_vec[i];
+    for (uint32_t i = 0; i < kVecSize; ++i) {
+      v_merged_vec[i] = a_scale * v_a_vec[i] + b_scale * v_b_vec[i];
+    }
+
+    // v_merged store: per-lane disjoint slice, no cross-lane ordering needed.
+    v_merged_vec.cast_store(v_merged + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
   }
 
-  // v_merged store: per-lane disjoint slice, no cross-lane ordering needed.
-  v_merged_vec.cast_store(v_merged + (pos * num_heads + head_idx) * HeadDim + tx * kVecSize);
-
   // s_merged store: kBdx lanes share one slot. Sync so every lane's s_a load
-  // is complete before the writer fires, then a single lane writes.
+  // is complete before the writer fires, then a single lane writes. Every
+  // row — active or padding — participates in the sync.
   if constexpr (kBdx <= 32) {
     __syncwarp();
   } else {
     __syncthreads();
   }
-  if (tx == 0) {
+  if (active && tx == 0) {
     s_merged[pos * num_heads + head_idx] =
         (math::ptx_log2(s_a_val + s_b_val) + s_max) * lse_scale_inv;
   }
@@ -93,8 +101,17 @@ cudaError_t MergeState(DTypeIn* v_a, float* s_a, DTypeIn* v_b, float* s_b, DType
   DISPATCH_HEAD_DIM(head_dim, HeadDim, {
     constexpr size_t kVecSize = std::max(16U / sizeof(DTypeIn), HeadDim / 32U);
     constexpr size_t kBdx = HeadDim / kVecSize;
-    uint32_t bdy = num_heads;
-    dim3 nblks(seq_len);
+    // Blocks are capped at 1024 threads, so large head counts (e.g. MLA at
+    // attn tp=1: 96 heads x kBdx=16 = 1536) tile across gridDim.y: groups is
+    // the fewest blocks that respect the cap, and bdy spreads the heads
+    // evenly so the whole launch carries at most bdy-1 padding rows, which
+    // the kernel masks with its `active` guard (96 heads -> 2x48 exact;
+    // 97 -> 2x49 with a single padding row). ceil(H/ceil(H/M)) <= M, so the
+    // cap holds for every head count.
+    constexpr uint32_t kMaxBdy = static_cast<uint32_t>(1024 / kBdx);
+    uint32_t groups = (num_heads + kMaxBdy - 1) / kMaxBdy;
+    uint32_t bdy = (num_heads + groups - 1) / groups;
+    dim3 nblks(seq_len, groups);
     dim3 nthrs(static_cast<uint32_t>(kBdx), bdy);
     auto kernel = MergeStateKernel<HeadDim, DTypeIn, DTypeO>;
 
@@ -147,6 +164,10 @@ void merge_state(TensorView v_a, TensorView s_a, TensorView v_b, TensorView s_b,
   unsigned int seq_len = v_a.size(0);
   unsigned int num_heads = v_a.size(1);
   unsigned int head_dim = v_a.size(2);
+  // An empty head axis would make the launcher's group math divide by zero
+  // (groups = ceil(0/kMaxBdy) = 0, host-side SIGFPE); reject it as a
+  // catchable error instead.
+  TVM_FFI_ICHECK_GT(num_heads, 0) << "merge_state requires num_heads > 0";
 
   cudaSetDevice(v_a.device().device_id);
   const cudaStream_t stream = get_stream(v_a.device());

--- a/tokenspeed-kernel/test/thirdparty/test_merge_state.py
+++ b/tokenspeed-kernel/test/thirdparty/test_merge_state.py
@@ -93,7 +93,59 @@ SHAPES = [
     (4096, 8, 128),
     (256, 12, 128),  # non-pow2 H — masking
     (256, 16, 64),  # different head_dim
+    (256, 64, 128),  # exactly at the 1024-thread block cap (kBdx=16)
+    (256, 96, 128),  # above the cap — MLA at attn tp=1; tiles across gridDim.y
+    (256, 96, 256),  # above the cap at kBdx=32 — one head row per warp
+    (256, 97, 128),  # above the cap, prime H — 2x49 tiling, one padding row
+    (256, 128, 128),  # pow2 H above the cap
+    (64, 96, 512),  # kBdx=32 with kMaxBdy=32 — gridDim.y=3
+    (256, 65, 128),  # just above the cap — 2x33, maximal relative padding
+    (256, 100, 128),  # balanced-ceil lands exact: 2x50, guard dormant
 ]
+
+
+# The production caller (DeepSeek chunked-KV prefill) merges with
+# ``inplace=True`` and PDL enabled, so the aliasing contract must hold on the
+# multi-block (gridDim.y > 1) geometries introduced by the head tiling — the
+# out-of-place sweeps above never alias.
+@pytest.mark.parametrize(
+    "T,H,D",
+    [
+        (31, 8, 64),  # single-block geometry (baseline)
+        (256, 96, 128),  # gridDim.y=2 — MLA at attn tp=1
+        (64, 96, 512),  # gridDim.y=3 at kBdx=32
+        (256, 97, 128),  # 2x49 with one padding row — guard active under aliasing
+    ],
+)
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_inplace_alias_multiblock(
+    device: str, T: int, H: int, D: int, enable_pdl: bool
+) -> None:
+    """inplace=True must write the merge through the v_a/s_a aliases."""
+    v_a, s_a, v_b, s_b = _make_inputs(T, H, D, device, torch.bfloat16, seed=3)
+    v_ref, s_ref = _reference_merge(v_a, s_a, v_b, s_b, LSE_LN)
+
+    v_out, s_out = merge_state(v_a, s_a, v_b, s_b, inplace=True, enable_pdl=enable_pdl)
+    torch.cuda.synchronize()
+
+    assert v_out.data_ptr() == v_a.data_ptr()
+    assert s_out.data_ptr() == s_a.data_ptr()
+    assert torch.allclose(v_a.float(), v_ref.float(), atol=5e-2, rtol=1e-2)
+    assert torch.allclose(s_a, s_ref, atol=1e-4, rtol=1e-5)
+
+
+def test_rejects_zero_heads(device: str) -> None:
+    """An empty head axis must raise (catchable), not SIGFPE in the tiled
+    launcher's group math."""
+    v_a, s_a, v_b, s_b = _make_inputs(4, 1, 128, device, torch.bfloat16)
+    empty = (
+        v_a[:, :0],
+        s_a[:, :0],
+        v_b[:, :0],
+        s_b[:, :0],
+    )
+    with pytest.raises(Exception, match="num_heads"):
+        merge_state(*[t.contiguous() for t in empty])
 
 
 @pytest.mark.parametrize("T,H,D", SHAPES)


### PR DESCRIPTION
## Problem

The vendored `merge_state` launcher packs the entire head axis into `blockDim.y`, so a block carries `kBdx * num_heads` threads. Head counts above `1024 / kBdx` make `cudaLaunchKernelEx` reject the launch (`merge_state launch failed: invalid argument`):

- 96 MLA heads at attn tp=1 (attention DP) with head_dim 128 -> 16x96 = **1536 threads > 1024**
- head_dim >= 256 (kBdx=32) lowers the cliff to **64 heads**

Under Kimi-K3 NVFP4 DP8 every chunked-KV prefill merge (long prompt crossing chunks, or any prefix-cache hit) crashed the scheduler; GPQA died at ~30/198.

## Fix

Tile the head axis across `gridDim.y` with balanced groups:

- `groups = ceil(H / kMaxBdy)`, `bdy = ceil(H / groups)` -> the whole launch carries at most `bdy - 1` padding rows (96 heads -> 2x48 exact; 97 -> 2x49, one padding row). `ceil(H / ceil(H / M)) <= M` guarantees the 1024-thread cap for every head count.
- Padding rows are masked by an `active` guard that skips every load/store but still reaches the `__syncwarp`/`__syncthreads`, so the in-place aliasing contract (outputs may alias `v_a`/`s_a`) and PDL behavior are unchanged.
- Head counts at or below the cap keep their original launch geometry bit-for-bit.
- An empty head axis is rejected loudly (`num_heads > 0`) instead of dividing by zero in the group math.

## Validation

- Unit sweep: H in {1..128, incl. prime 97 and 65} x head_dim {64,128,256,512} x bf16/fp16 x inplace x PDL vs a PyTorch reference — the suite grows 29 -> 62 tests, including the production combination (96 heads, inplace=True, PDL, gridDim.y=2) and a guard-active aliasing case.
- Outputs are **bitwise identical** to the old kernel on every previously working shape (88 shape/dtype combos compared across binaries).
- E2E on 8xB300, Kimi-K3 NVFP4 `--data-parallel-size 8`: 7k-token cross-chunk prompts, prefix-cache hits, and 16-way concurrent long prompts all pass; **full GPQA-diamond completes 198/198 at 0.929 mean_acc** with zero scheduler exceptions (previously crashed at ~30 questions).

## Notes

Upstream flashinfer's `MergeState` / `MergeStateInPlace` (incl. current main) still carry the same geometry; vLLM and sglang sidestep it with their own flat 1D merge kernels. This fix keeps the 2D structure because the in-place aliasing contract depends on the intra-block sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
