### PR TITLE
fix(kernel-test): skip NVIDIA-tuned kimi3 multitoken dispatch tests on AMD

### DIFF
--- a/tokenspeed-kernel/test/ops/test_kimi3_sigmoid_topk_multitoken.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_sigmoid_topk_multitoken.py
@@ -35,6 +35,17 @@ import torch
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)
 
+from utils import is_amd  # noqa: E402
+
+if is_amd():
+    pytest.skip(
+        "Packed-kernel row cap (256) and the grouped fallback "
+        "(triton_minimax_sigmoid_bias_topk) pinned here are NVIDIA-tuned; "
+        "AMD/CDNA4 dispatch (row cap 1, gluon fallback) is covered by "
+        "test_kimi3_sigmoid_topk_gfx950.py",
+        allow_module_level=True,
+    )
+
 from tokenspeed_kernel.ops.moe import moe_sigmoid_bias_topk  # noqa: E402
 from tokenspeed_kernel.ops.moe import sigmoid_topk as sigmoid_topk_mod  # noqa: E402
 from tokenspeed_kernel.ops.moe.triton.kimi3_sigmoid_topk import (  # noqa: E402


### PR DESCRIPTION
## Summary
- `test_kimi3_sigmoid_topk_multitoken.py` was failing on the `amd-mi35x-1gpu-test` CI job (see https://github.com/lightseekorg/tokenspeed/actions/runs/32439282126/job/96646612793), causing `main`'s AMD CI to be red.
- Root cause: the test hardcodes NVIDIA-shaped dispatch assumptions — a 256-row packed-kernel cap (`_K3_PACKED_TOPK_MAX_ROWS_NVIDIA`) and an NVIDIA-only fallback kernel (`triton_minimax_sigmoid_bias_topk`, `capability=CapabilityRequirement(vendors={"nvidia"})`). On AMD/CDNA4 the packed cap is 1 row and the fallback is a different, AMD-specific kernel (`gluon_sigmoid_bias_topk_gfx950`), so the test's monkeypatched spies never fire there. This is a test gap, not a dispatcher bug — the dispatcher's platform-tiered caps are intentional.
- Reproduced offline (no AMD hardware needed) by driving the repo's real `Platform`/`CapabilityRequirement`/`KernelRegistry` classes with `Platform.override()` set to a synthetic gfx950/CDNA4 platform; confirmed it reproduces the exact CI failure pattern (`tokens=[4,256]` skip the packed path; the NVIDIA-only grouped kernel is filtered out of selection entirely on AMD).
- Fix: skip this module on AMD via the existing `utils.is_amd()` helper, matching the gating convention already used by the sibling `test_kimi3_sigmoid_topk_gfx950.py` (which covers AMD's actual dispatch path separately).

## Testing
- `pre-commit run --all-files` passes
- No AMD/NVIDIA GPU available locally; verified the skip condition and dispatch-selection logic via a standalone script driving the real `Platform`/`KernelRegistry` classes with a mocked CDNA4 platform (not committed, exploratory only) — relying on CI for the actual hardware run

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GHg3rb3MbKatP2yASngbsc