### PR TITLE
perf(gfx1250): port strided KDA decode and fused AttnRes

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
@@ -411,7 +411,7 @@ class KdaAttnBackend(MambaAttnBackend):
             return result.out
         return rmsnorm_gated_sigmoid(
             result.out.reshape(-1, num_value_heads * head_v_dim).contiguous(),
-            output_gate.contiguous(),
+            output_gate,
             norm_weight,
             norm_eps,
             num_value_heads,
@@ -472,7 +472,7 @@ class KdaAttnBackend(MambaAttnBackend):
         if output_gate is not None:
             core_attn_out = rmsnorm_gated_sigmoid(
                 core_attn_out.reshape(-1, num_value_heads * head_v_dim).contiguous(),
-                output_gate.contiguous(),
+                output_gate,
                 norm_weight,
                 norm_eps,
                 num_value_heads,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/attn_res.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/attn_res.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Fused Kimi K3 AttnRes mixing and output RMSNorm for gfx1250."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon
+
+gfx1250 = gl.amd.gfx1250
+_BLOCK_H = gl.constexpr(8192)
+_LOAD_ELEMS = gl.constexpr(2)
+
+
+@gluon.jit
+def _load_candidate(
+    prefix,
+    block_residual,
+    token,
+    hidden,
+    hidden_mask,
+    stride_block_t: gl.constexpr,
+    stride_block_n: gl.constexpr,
+    candidate: gl.constexpr,
+    N: gl.constexpr,
+):
+    if candidate == N - 1:
+        return prefix
+    # Candidate offsets can exceed int32; fold the block stride into the pointer.
+    ptr = block_residual + candidate * stride_block_n
+    return gfx1250.buffer_load(
+        ptr,
+        (token * stride_block_t + hidden).to(gl.int32),
+        mask=hidden_mask,
+        other=0.0,
+    ).to(gl.float32)
+
+
+@gluon.jit
+def _attn_res_rmsnorm_kernel(
+    layer_residual,
+    delta,
+    block_residual,
+    res_weight,
+    score_rms_weight,
+    output_rms_weight,
+    output,
+    stride_layer_t: gl.constexpr,
+    stride_delta_t: gl.constexpr,
+    stride_block_t: gl.constexpr,
+    stride_block_n: gl.constexpr,
+    stride_output_t: gl.constexpr,
+    H: gl.constexpr,
+    N: gl.constexpr,
+    BLOCK_WRITE_IDX: gl.constexpr,
+    HAS_DELTA: gl.constexpr,
+    WRITE_BLOCK: gl.constexpr,
+    SCORE_EPS: gl.constexpr,
+    OUTPUT_EPS: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+):
+    token = gl.program_id(0)
+    hidden_layout: gl.constexpr = gl.BlockedLayout(
+        [_LOAD_ELEMS], [32], [NUM_WARPS], [0]
+    )
+    hidden = gl.arange(0, _BLOCK_H, layout=hidden_layout)
+    hidden_mask = hidden < H
+
+    prefix = gfx1250.buffer_load(
+        layer_residual,
+        (token * stride_layer_t + hidden).to(gl.int32),
+        mask=hidden_mask,
+        other=0.0,
+    ).to(gl.float32)
+    if HAS_DELTA:
+        prefix += gfx1250.buffer_load(
+            delta,
+            (token * stride_delta_t + hidden).to(gl.int32),
+            mask=hidden_mask,
+            other=0.0,
+        ).to(gl.float32)
+        prefix = prefix.to(layer_residual.dtype.element_ty).to(gl.float32)
+        gfx1250.buffer_store(
+            prefix.to(layer_residual.dtype.element_ty),
+            layer_residual,
+            (token * stride_layer_t + hidden).to(gl.int32),
+            mask=hidden_mask,
+        )
+    if WRITE_BLOCK:
+        block_write_ptr = block_residual + BLOCK_WRITE_IDX * stride_block_n
+        gfx1250.buffer_store(
+            prefix.to(block_residual.dtype.element_ty),
+            block_write_ptr,
+            (token * stride_block_t + hidden).to(gl.int32),
+            mask=hidden_mask,
+        )
+
+    if N == 1:
+        mixed = prefix
+    else:
+        scorer = gfx1250.buffer_load(
+            res_weight,
+            hidden.to(gl.int32),
+            mask=hidden_mask,
+            other=0.0,
+        ).to(gl.float32)
+        scorer *= gfx1250.buffer_load(
+            score_rms_weight,
+            hidden.to(gl.int32),
+            mask=hidden_mask,
+            other=0.0,
+        ).to(gl.float32)
+        max_logit = -float("inf")
+        denominator = 0.0
+        mixed = gl.zeros([_BLOCK_H], gl.float32, hidden_layout)
+        for candidate in gl.static_range(N):
+            value = _load_candidate(
+                prefix,
+                block_residual,
+                token,
+                hidden,
+                hidden_mask,
+                stride_block_t,
+                stride_block_n,
+                candidate,
+                N,
+            )
+            square_sum = gl.sum(value * value, axis=0)
+            # Match the established high-precision score reduction.
+            dot = gl.sum((value * scorer).to(gl.float64), axis=0).to(gl.float32)
+            score = dot * gl.rsqrt(square_sum / H + SCORE_EPS)
+            next_max = gl.maximum(max_logit, score)
+            old_scale = gl.exp(max_logit - next_max)
+            candidate_scale = gl.exp(score - next_max)
+            denominator = denominator * old_scale + candidate_scale
+            mixed = mixed * old_scale + candidate_scale * value
+            max_logit = next_max
+        mixed /= denominator
+
+    # Preserve the AttnRes BF16 boundary before output RMSNorm.
+    mixed = mixed.to(gl.bfloat16).to(gl.float32)
+    inverse_rms = gl.rsqrt(gl.sum(mixed * mixed, axis=0) / H + OUTPUT_EPS)
+    output_weight = gfx1250.buffer_load(
+        output_rms_weight,
+        hidden.to(gl.int32),
+        mask=hidden_mask,
+        other=0.0,
+    ).to(gl.float32)
+    gfx1250.buffer_store(
+        (mixed * inverse_rms * output_weight).to(output.dtype.element_ty),
+        output,
+        (token * stride_output_t + hidden).to(gl.int32),
+        mask=hidden_mask,
+    )
+
+
+def attn_res_rmsnorm_gfx1250(
+    *,
+    layer_residual: torch.Tensor,
+    block_residual: torch.Tensor,
+    res_weight: torch.Tensor,
+    score_rms_weight: torch.Tensor,
+    score_eps: float,
+    output_rms_weight: torch.Tensor,
+    output_eps: float,
+    num_valid_blocks: int,
+    delta: torch.Tensor | None = None,
+    block_write_idx: int = -1,
+) -> torch.Tensor:
+    """Mix AttnRes candidates and apply the following RMSNorm in one launch."""
+    tokens, hidden = layer_residual.shape
+    if layer_residual.dtype != torch.bfloat16 or hidden not in {
+        4096,
+        5120,
+        6144,
+        7168,
+        8192,
+    }:
+        raise ValueError(
+            "gfx1250 AttnRes requires BF16 input with "
+            "H in {4096, 5120, 6144, 7168, 8192}"
+        )
+    if not 0 <= num_valid_blocks <= 11:
+        raise ValueError("gfx1250 AttnRes supports at most 11 block snapshots")
+    if (
+        block_residual.ndim != 3
+        or block_residual.shape[0] != tokens
+        or block_residual.shape[2] != hidden
+    ):
+        raise ValueError(
+            "gfx1250 AttnRes requires token-major block storage [T, blocks, H]"
+        )
+    if block_residual.shape[1] < num_valid_blocks:
+        raise ValueError("num_valid_blocks is outside block_residual")
+    if block_write_idx >= 0 and (
+        block_write_idx != num_valid_blocks
+        or block_write_idx >= block_residual.shape[1]
+    ):
+        raise ValueError("block_write_idx must append within block_residual")
+    if delta is not None and (
+        delta.shape != layer_residual.shape
+        or delta.dtype != layer_residual.dtype
+        or delta.device != layer_residual.device
+        or delta.stride(1) != 1
+    ):
+        raise ValueError("gfx1250 AttnRes delta must match layer_residual")
+    if layer_residual.stride(1) != 1 or block_residual.stride(2) != 1:
+        raise ValueError("gfx1250 AttnRes requires a contiguous hidden dimension")
+
+    output = torch.empty_like(layer_residual)
+    num_warps = 4
+    delta_tensor = layer_residual if delta is None else delta
+    _attn_res_rmsnorm_kernel[(tokens,)](
+        layer_residual,
+        delta_tensor,
+        block_residual,
+        res_weight,
+        score_rms_weight,
+        output_rms_weight,
+        output,
+        stride_layer_t=layer_residual.stride(0),
+        stride_delta_t=delta_tensor.stride(0),
+        stride_block_t=block_residual.stride(0),
+        stride_block_n=block_residual.stride(1),
+        stride_output_t=output.stride(0),
+        H=hidden,
+        N=num_valid_blocks + 1,
+        BLOCK_WRITE_IDX=0 if block_write_idx < 0 else block_write_idx,
+        HAS_DELTA=delta is not None,
+        WRITE_BLOCK=block_write_idx >= 0,
+        SCORE_EPS=score_eps,
+        OUTPUT_EPS=output_eps,
+        NUM_WARPS=num_warps,
+        num_warps=num_warps,
+    )
+    return output
+
+
+__all__ = ["attn_res_rmsnorm_gfx1250"]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/decode.py
@@ -45,6 +45,11 @@ def _kda_recurrent_decode_kernel(
     H: gl.constexpr,
     K: gl.constexpr,
     V: gl.constexpr,
+    Q_TOKEN_STRIDE: gl.constexpr,
+    K_TOKEN_STRIDE: gl.constexpr,
+    V_TOKEN_STRIDE: gl.constexpr,
+    G_TOKEN_STRIDE: gl.constexpr,
+    BETA_TOKEN_STRIDE: gl.constexpr,
     BK: gl.constexpr,
     BV: gl.constexpr,
     NUM_SLOTS: gl.constexpr,
@@ -111,17 +116,17 @@ def _kda_recurrent_decode_kernel(
 
     token_idx = begin
     q_value = gl.load(
-        q + (token_idx * H + head_idx) * K + key_offsets,
+        q + token_idx * Q_TOKEN_STRIDE + head_idx * K + key_offsets,
         mask=key_mask,
         other=0.0,
     ).to(gl.float32)
     k_value = gl.load(
-        k + (token_idx * H + head_idx) * K + key_offsets,
+        k + token_idx * K_TOKEN_STRIDE + head_idx * K + key_offsets,
         mask=key_mask,
         other=0.0,
     ).to(gl.float32)
     gate_value = gl.load(
-        raw_g + (token_idx * H + head_idx) * K + key_offsets,
+        raw_g + token_idx * G_TOKEN_STRIDE + head_idx * K + key_offsets,
         mask=key_mask,
         other=0.0,
     ).to(gl.float32)
@@ -138,7 +143,9 @@ def _kda_recurrent_decode_kernel(
             1.0 + gl.exp(-gl.abs(gate_value))
         )
         log_decay = -a_value * softplus
-    beta_value = gl.load(raw_beta + token_idx * H + head_idx).to(gl.float32)
+    beta_value = gl.load(raw_beta + token_idx * BETA_TOKEN_STRIDE + head_idx).to(
+        gl.float32
+    )
     beta_value = 1.0 / (1.0 + gl.exp(-beta_value))
 
     scale: gl.constexpr = K**-0.5
@@ -157,7 +164,7 @@ def _kda_recurrent_decode_kernel(
         other=0.0,
     ).to(gl.float32)
     v_value = gl.load(
-        v + (token_idx * H + head_idx) * V + value_offsets,
+        v + token_idx * V_TOKEN_STRIDE + head_idx * V + value_offsets,
         mask=value_mask,
         other=0.0,
     ).to(gl.float32)
@@ -462,19 +469,27 @@ def gluon_kda_recurrent_decode_gfx1250(
         raise ValueError("state_pool pages must not overlap")
     if A_log.shape != (heads,) or dt_bias.numel() != heads * key_dim:
         raise ValueError("invalid KDA gate parameter shapes")
+    expected_inner_strides = (
+        (q, key_dim),
+        (k, key_dim),
+        (g_raw, key_dim),
+        (v, value_dim),
+    )
+    if any(
+        tensor.stride(-1) != 1 or tensor.stride(-2) != width
+        for tensor, width in expected_inner_strides
+    ):
+        raise ValueError("KDA inputs must have contiguous head vectors")
+    if beta_logits.stride(-1) != 1:
+        raise ValueError("KDA beta logits must have contiguous heads")
 
-    q = q.contiguous()
-    k = k.contiguous()
-    v = v.contiguous()
-    g_raw = g_raw.contiguous()
-    beta_logits = beta_logits.contiguous()
     A_log = A_log.contiguous()
     dt_bias = dt_bias.view(heads, key_dim).contiguous()
     read_indices = read_indices.to(device=q.device, dtype=torch.int32).contiguous()
     write_indices = write_indices.to(device=q.device, dtype=torch.int32).contiguous()
     cu_seqlens = cu_seqlens.to(device=q.device, dtype=torch.int32).contiguous()
 
-    output = torch.empty_like(v)
+    output = torch.empty(v.shape, dtype=v.dtype, device=v.device)
     block_key = triton.next_power_of_2(key_dim)
     block_value = min(32, triton.next_power_of_2(value_dim))
     _kda_recurrent_decode_kernel[(triton.cdiv(value_dim, block_value), tokens * heads)](
@@ -493,6 +508,11 @@ def gluon_kda_recurrent_decode_gfx1250(
         H=heads,
         K=key_dim,
         V=value_dim,
+        Q_TOKEN_STRIDE=q.stride(1),
+        K_TOKEN_STRIDE=k.stride(1),
+        V_TOKEN_STRIDE=v.stride(1),
+        G_TOKEN_STRIDE=g_raw.stride(1),
+        BETA_TOKEN_STRIDE=beta_logits.stride(1),
         BK=block_key,
         BV=block_value,
         NUM_SLOTS=state_pool.shape[0],

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attn_res/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attn_res/__init__.py
@@ -29,9 +29,9 @@ from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 __all__ = ["attn_res_fwd", "attn_res_fwd_available"]
 
 # The Blackwell launcher instantiates aligned hidden sizes in [4096, 8192].
-# gfx950 currently specializes Kimi K3's H=7168 fused-output-norm path.
+# AMD Gluon currently specializes Kimi K3's H=7168 fused-output-norm path.
 _MAX_BLACKWELL_TOKENS = 16384
-_MAX_GFX950_TOKENS = 65536
+_MAX_AMD_GLUON_TOKENS = 65536
 _MAX_N = 12
 
 
@@ -88,11 +88,11 @@ def _select_attn_res_kernel(
         and delta.stride(-1) == 1
     )
     platform = Platform.get()
-    if platform.is_cdna4:
+    if platform.is_cdna4 or platform.is_cdna5:
         eligible = (
             hidden_size == 7168
             and out_norm_weight is not None
-            and 1 <= tokens <= _MAX_GFX950_TOKENS
+            and 1 <= tokens <= _MAX_AMD_GLUON_TOKENS
         )
     else:
         eligible = (

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attn_res/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attn_res/gluon.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Registration shim for the AMD gfx950 Gluon AttnRes kernel."""
+"""Registration shims for AMD Gluon AttnRes kernels."""
 
 from __future__ import annotations
 
@@ -29,16 +29,20 @@ from tokenspeed_kernel.signature import format_signatures
 
 try:
     from tokenspeed_kernel_amd.ops.gfx950.attention.kda.attn_res import (
-        attn_res_rmsnorm_gfx950 as _attn_res_rmsnorm_impl,
+        attn_res_rmsnorm_gfx950 as _attn_res_rmsnorm_gfx950_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.kda.attn_res import (
+        attn_res_rmsnorm_gfx1250 as _attn_res_rmsnorm_gfx1250_impl,
     )
 except ImportError as exc:
     _IMPORT_ERROR = exc
-    _attn_res_rmsnorm_impl = None
+    _attn_res_rmsnorm_gfx950_impl = None
+    _attn_res_rmsnorm_gfx1250_impl = None
 else:
     _IMPORT_ERROR = None
 
 
-if _attn_res_rmsnorm_impl is not None:
+if _attn_res_rmsnorm_gfx950_impl is not None:
 
     @register_kernel(
         "attn_res",
@@ -84,7 +88,64 @@ if _attn_res_rmsnorm_impl is not None:
         """Adapt block-major runtime storage to the Gluon token-major kernel."""
         if out_norm_weight is None:
             raise ValueError("Gluon AttnRes forward requires an output RMSNorm")
-        return _attn_res_rmsnorm_impl(
+        return _attn_res_rmsnorm_gfx950_impl(
+            layer_residual=layer_residual,
+            block_residual=block_residual.transpose(0, 1),
+            res_weight=res_weight,
+            score_rms_weight=rms_weight,
+            score_eps=eps,
+            output_rms_weight=out_norm_weight,
+            output_eps=out_norm_eps,
+            delta=delta,
+            num_valid_blocks=num_valid_blocks,
+            block_write_idx=block_write_idx,
+        )
+
+    @register_kernel(
+        "attn_res",
+        "fwd",
+        name="gluon_attn_res_fwd_gfx1250",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(12, 5),
+            max_arch_version=ArchVersion(12, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=format_signatures(
+            ("layer_residual", "block_residual"), "dense", {torch.bfloat16}
+        ),
+        priority=Priority.SPECIALIZED,
+        traits={
+            "delta_compatible": frozenset({True}),
+            "fused_output_norm": frozenset({True}),
+            "has_delta": frozenset({False, True}),
+            "hidden_dimension_contiguous": frozenset({True}),
+            "inputs_on_same_gpu": frozenset({True}),
+            "large_prefill": frozenset({False, True}),
+            "hidden_size": frozenset({4096, 5120, 6144, 7168, 8192}),
+            "partial_block_storage": frozenset({False, True}),
+            "separate_output_eps": frozenset({False, True}),
+            "writes_block": frozenset({False, True}),
+        },
+        tags={"decode", "prefill", "fusion", "gfx1250"},
+    )
+    def gluon_attn_res_fwd_gfx1250(
+        *,
+        layer_residual: torch.Tensor,
+        block_residual: torch.Tensor,
+        res_weight: torch.Tensor,
+        rms_weight: torch.Tensor,
+        eps: float,
+        out_norm_weight: torch.Tensor | None,
+        out_norm_eps: float,
+        delta: torch.Tensor | None,
+        num_valid_blocks: int,
+        block_write_idx: int,
+    ) -> torch.Tensor:
+        """Adapt block-major runtime storage to the gfx1250 kernel."""
+        if out_norm_weight is None:
+            raise ValueError("Gluon AttnRes forward requires an output RMSNorm")
+        return _attn_res_rmsnorm_gfx1250_impl(
             layer_residual=layer_residual,
             block_residual=block_residual.transpose(0, 1),
             res_weight=res_weight,
@@ -104,5 +165,10 @@ else:
             "gluon_attn_res_fwd_gfx950 requires tokenspeed-kernel-amd"
         ) from _IMPORT_ERROR
 
+    def gluon_attn_res_fwd_gfx1250(**kwargs) -> torch.Tensor:
+        raise ImportError(
+            "gluon_attn_res_fwd_gfx1250 requires tokenspeed-kernel-amd"
+        ) from _IMPORT_ERROR
 
-__all__ = ["gluon_attn_res_fwd_gfx950"]
+
+__all__ = ["gluon_attn_res_fwd_gfx950", "gluon_attn_res_fwd_gfx1250"]


### PR DESCRIPTION
- Port token-stride support for Q/K/V/g/beta inputs #1133 to gfx1250.
- Remove unnecessary projection and output-gate contiguous copies.
- Port the fused AttnRes + output RMSNorm kernel #1089 to gfx1250.