### PR TITLE
perf(kernel): size gfx1250 MoE decode tile size by expert load

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
@@ -432,7 +432,7 @@ class MoEConfig:
                 )
             )
 
-        if self.USE_WMMA_SCALED:
+        if self.USE_WMMA_SCALED and WITH_X_MX_SCALE:
             self.shared_layout_x_scale = gl.constexpr(
                 gl.PaddedSharedLayout.with_identity_for(
                     [[256, 8]],
@@ -440,6 +440,10 @@ class MoEConfig:
                     [1, 0],
                 )
             )
+        else:
+            self.shared_layout_x_scale = gl.constexpr(0)
+
+        if self.USE_WMMA_SCALED and WITH_W_MX_SCALE:
             self.shared_layout_w_scale = gl.constexpr(
                 gl.PaddedSharedLayout.with_identity_for(
                     [[256, 8]],
@@ -448,7 +452,6 @@ class MoEConfig:
                 )
             )
         else:
-            self.shared_layout_x_scale = gl.constexpr(0)
             self.shared_layout_w_scale = gl.constexpr(0)
 
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
@@ -1233,6 +1233,20 @@ def _validate_schedule(
             raise ValueError("pingpong requires num_buffers=3")
 
 
+def _resolve_block_m(
+    decode: bool,
+    m: int,
+    num_experts: int | None,
+    *,
+    is_combine: bool,
+) -> int:
+    """Use stage defaults for prefill and expert occupancy for decode."""
+    if not decode:
+        return 256 if is_combine else 128
+    rows_per_expert = max(1, m // num_experts)
+    return max(16, min(triton.next_power_of_2(rows_per_expert), 128))
+
+
 def matmul(
     a,
     b,
@@ -1247,7 +1261,7 @@ def matmul(
     x_global_scale: torch.Tensor | float | None = None,
     num_buffers: int = 2,
     scale_block: int = 32,
-    block_m: int = 128,
+    block_m: int,
     block_n: int = 128,
     block_k: int = 256,
     group_m: int = 8,
@@ -1274,6 +1288,7 @@ def matmul(
         precision_config: MX scale/output dtype configuration.
         x_global_scale: Optional scalar activation dequantization scale.
         fused_activation: Optional SwiGLU activation descriptor.
+        block_m: Concrete row tile resolved by the caller.
         decode: Select the small-M, M-ragged decode kernel.
 
     Returns:
@@ -1498,7 +1513,7 @@ def gluon_mxfp_dispatch_swiglu(
     swiglu_alpha: float = 1.0,
     swiglu_limit: float = 0.0,
     swiglu_beta: float = 1.0,
-    block_m: int = 128,
+    block_m: int | None = None,
     block_n: int = 256,
     block_k: int = 256,
     num_warps: int = 4,
@@ -1528,6 +1543,10 @@ def gluon_mxfp_dispatch_swiglu(
     if x_format != "e2m1" and x_scale is not None:
         raise ValueError("x_scale is only supported for e2m1/MXFP4 activation input")
     gather_tensor = _index_tensor(gather_indx, "src_indx")
+    m = int(x.shape[-2] if gather_tensor is None else gather_tensor.shape[0])
+    num_experts = None if a_ragged_metadata is None else a_ragged_metadata.n_slices
+    if block_m is None:
+        block_m = _resolve_block_m(decode, m, num_experts, is_combine=False)
     activation = FusedActivation(
         FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
         (float(swiglu_alpha), float(swiglu_limit), float(swiglu_beta)),
@@ -1573,7 +1592,7 @@ def gluon_mxfp_combine(
     n_tokens: int | None = None,
     n_expts_act: int | None = None,
     out_dtype: torch.dtype = torch.bfloat16,
-    block_m: int = 256,
+    block_m: int | None = None,
     block_n: int = 256,
     block_k: int = 256,
     num_warps: int = 4,
@@ -1601,6 +1620,11 @@ def gluon_mxfp_combine(
     if x_format != "e2m1" and x_scale is not None:
         raise ValueError("x_scale is only supported for e2m1/MXFP4 activation input")
     scatter_tensor = _index_tensor(scatter_indx, "dst_indx")
+    num_experts = None if a_ragged_metadata is None else a_ragged_metadata.n_slices
+    if block_m is None:
+        block_m = _resolve_block_m(
+            decode, int(x.shape[-2]), num_experts, is_combine=True
+        )
     precision = PrecisionConfig(
         out_dtype=out_dtype,
         a_mx_scale=x_scale,
@@ -1739,6 +1763,7 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
     swiglu_limit: float = 7.0,
     swiglu_beta: float = 1.0,
     decode: bool = False,
+    block_m: int | None = None,
 ) -> torch.Tensor:
     """Dispatch + combine for gfx1250 MXFP4-weight MoE with precomputed top-k.
 
@@ -1758,6 +1783,7 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
         swiglu_limit: Optional SwiGLU clamp limit; ``0`` disables clamping.
         swiglu_beta: SwiGLU linear branch offset.
         decode: Select the small-M decode kernel for both MoE projections.
+        block_m: Optional row-tile override; unset values resolve per projection.
 
     Returns:
         Tensor shaped ``(n_tokens, hidden_size)``.
@@ -1811,7 +1837,7 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
         swiglu_alpha=swiglu_alpha,
         swiglu_limit=swiglu_limit,
         swiglu_beta=swiglu_beta,
-        block_m=128,
+        block_m=block_m,
         block_n=256,
         block_k=256,
         num_warps=4,
@@ -1833,7 +1859,7 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
         a_ragged_metadata=ragged_metadata,
         scatter_indx=scatter_indx,
         out_dtype=out_dtype,
-        block_m=256,
+        block_m=block_m,
         block_n=256,
         block_k=256,
         num_warps=4,
@@ -1946,17 +1972,26 @@ def gluon_mxfp_ragged_matmul(
     precision = PrecisionConfig(
         out_dtype=out_dtype, a_mx_scale=x_mx_scale, b_mx_scale=w_mx_scale
     )
+    gather_tensor = _index_tensor(gather_indx, "src_indx")
+    decode = bool(launch_kwargs.pop("decode", False))
+    m = int(x.shape[-2] if gather_tensor is None else gather_tensor.shape[0])
+    num_experts = None if a_ragged_metadata is None else a_ragged_metadata.n_slices
+    block_m = launch_kwargs.pop("block_m", None)
+    if block_m is None:
+        block_m = _resolve_block_m(decode, m, num_experts, is_combine=False)
     out, _ = matmul(
         x,
         w,
         bias,
         a_ragged_metadata=a_ragged_metadata,
-        gather_indx=_index_tensor(gather_indx, "src_indx"),
+        gather_indx=gather_tensor,
         scatter_indx=_index_tensor(scatter_indx, "dst_indx"),
         precision_config=precision,
+        block_m=block_m,
         x_global_scale=x_global_scale,
         scale_preshuffle=scale_preshuffle,
         w_transpose=w_transpose,
+        decode=decode,
         **launch_kwargs,
     )
     return out

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_amd.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_amd.py
@@ -34,6 +34,9 @@ from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.weight_preprocess import (  # no
     preprocess_gluon_mxfp4_gfx950_moe_weights,
 )
 from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4.fused import (  # noqa: E402
+    _resolve_block_m,
+)
+from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4.fused import (  # noqa: E402
     gluon_mxfp_precomputed_mxfp4_fused_moe as _gfx1250_static_moe,
 )
 from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4.weight_preprocess import (  # noqa: E402
@@ -378,12 +381,73 @@ def test_static_fp8_activation_moe_gfx950_smoke() -> None:
 
 
 @pytest.mark.parametrize(
-    "decode,num_tokens",
-    [(False, 4), (True, 1), (True, 2), (True, 4), (True, 8), (True, 16)],
+    "tokens,expected_block_m",
+    [
+        (64, 16),
+        (128, 16),
+        (256, 16),
+        (512, 16),
+        (1024, 16),
+        (2048, 32),
+        (4096, 64),
+        (16384, 128),
+    ],
+)
+def test_gfx1250_resolve_block_m_tracks_decode_occupancy(
+    tokens: int,
+    expected_block_m: int,
+) -> None:
+    num_experts, top_k = 256, 4
+    assert (
+        _resolve_block_m(
+            True,
+            tokens * top_k,
+            num_experts,
+            is_combine=False,
+        )
+        == expected_block_m
+    )
+
+
+@pytest.mark.parametrize(
+    "decode,num_experts,is_combine,expected_block_m",
+    [
+        (False, None, False, 128),
+        (False, None, True, 256),
+    ],
+)
+def test_gfx1250_resolve_block_m_defaults(
+    decode: bool,
+    num_experts: int | None,
+    is_combine: bool,
+    expected_block_m: int,
+) -> None:
+    assert (
+        _resolve_block_m(
+            decode,
+            256,
+            num_experts,
+            is_combine=is_combine,
+        )
+        == expected_block_m
+    )
+
+
+@pytest.mark.parametrize(
+    "decode,num_tokens,block_m",
+    [
+        pytest.param(False, 4, None, id="prefill-default"),
+        *[
+            pytest.param(True, num_tokens, None, id=f"decode-m{num_tokens}-adaptive")
+            for num_tokens in (1, 2, 4, 8, 16)
+        ],
+        pytest.param(True, 4, 128, id="decode-explicit-bm128"),
+    ],
 )
 def test_static_fp8_activation_moe_gfx1250(
     decode: bool,
     num_tokens: int,
+    block_m: int | None,
 ) -> None:
     if not is_cdna5():
         pytest.skip("gfx1250 is required for the CDNA5 static FP8 MoE kernel")
@@ -447,6 +511,7 @@ def test_static_fp8_activation_moe_gfx1250(
         w13_mx_scale=module.w13_precision_config.b_mx_scale,
         w2_mx_scale=module.w2_precision_config.b_mx_scale,
         decode=decode,
+        block_m=block_m,
     )
     expected = _fp8_mxfp4_swiglu_moe_reference(
         hidden_states,


### PR DESCRIPTION
The gfx1250 fused MoE path currently reuses prefill-sized row tiles during decode: `BLOCK_M=128` for dispatch and `BLOCK_M=256` for combine. Decode distributes relatively few routed rows across many experts, so these tiles are mostly padding. This PR selects a smaller row tile from the average number of routed rows per expert while preserving the existing prefill defaults and explicit `block_m` overrides.

### Motivation

For a model with 256 experts and top-4 routing, `rows_per_expert = tokens * top_k / num_experts = tokens / 64`. At the measured decode batch sizes of 64–1024 tokens, each expert receives only 1–16 rows on average, making a 128-row tile 87%–99% padding.

The decode policy computes `routed_rows // num_experts`, rounds it up to a power of two, and clamps the result to 16–128. This selects `BLOCK_M=16` for every measured decode batch, then grows to 32 at 2048 tokens and 64 at 4096 tokens.

### Benchmark results

Measurements were collected on a real gfx1250 accelerator at the production MoE shape: 256 experts with top-4 routing, FP8 activations, MXFP4 weights, `K=5120`, and pre-SwiGLU `N=10240`. Each configuration used two warmups and eight timed launches, ran in its own subprocess, and had a cooldown between launches. The sweep contained 153 usable configurations spanning `BLOCK_M=16–256`, `BLOCK_N=64–256`, four or eight warps, two to four buffers, and two schedules.

Times below are medians in microseconds:

| Tokens | Rows/expert | Best small tile | `BLOCK_M=128` | Difference | Same-boot evidence |
|---:|---:|---:|---:|---:|---|
| 64 | 1 | 1266.3 (`BM32`) | 2002.8 | +58.2% | No clean pair |
| 128 | 2 | 1240.3 (`BM16`) | 1566.6 | +26.3% | +26.3% |
| 256 | 4 | 1299.5 (`BM16`) | 1748.8 | +34.6% | +16.1% to +36.9% |
| 512 | 8 | 1322.0 (`BM16`) | 1800.1 | +36.2% | +32.4% |
| 1024 | 16 | 1288.5 (`BM16`) | 1796.6 | +39.4% | +26.1% to +29.5% |

The cross-boot comparisons show a 26%–58% penalty for `BLOCK_M=128`. The 58% result at 64 tokens has no clean same-boot comparison and should not be interpreted to that precision, but every available same-boot comparison still shows a 16%–37% penalty.

Boot variation was measured independently: a fixed reference configuration varied by 25.3% peak-to-trough across 18 boots. Within a configuration, the median coefficient of variation was 4.5%, corresponding to approximately 6.4% uncertainty when comparing two independent measurements. The observed row-tile effects remain well above that noise floor. `BLOCK_M=256` was slower still wherever measured, taking 30%–90% longer than the corresponding `BLOCK_M=128` measurements.

Controlled follow-up measurements fixed `BLOCK_M=16` and repeated configurations within one boot. Changing `BLOCK_N`, warp count, or pipeline depth affected runtime by approximately 3%, within the 4.2%–5.4% repeat-to-repeat spread. This indicates that row-tile size is the dominant decode parameter; the measurements do not justify adding a broader scheduling policy.

### Implementation

- Resolve automatic `BLOCK_M` selection before invoking the expert matmul.
- Keep the existing prefill defaults: 128 for dispatch and 256 for combine.
- Derive decode `BLOCK_M` from routed rows per expert, with a 16-row floor and 128-row cap.
- Preserve an explicitly supplied `block_m` as an override.
