### PR TITLE
fix(kernel): Correct DSA scoring and add GFX950 standard-cache kernel

### DIFF
--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -243,9 +243,9 @@ class GlmDsaIndexer(nn.Module):
         return GlmDsaIndexerOutput(
             query=index_q,
             key=index_k,
-            # Raw bf16 weights: the head-norm constant is folded into
-            # weights_softmax_scale and the fp32 upcast into the top-k
-            # kernels' fused combine.
+            # Raw BF16 weights: the head-normalization constant is folded into
+            # weights_softmax_scale, while the top-k scorer upcasts each signed
+            # head weight before the per-head ReLU reduction.
             weights=weights,
         )
 
@@ -663,8 +663,8 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
         topk: int,
     ) -> GlmDsaPrefillTopK:
         q = indexer_output.query[:num_prefill_tokens].contiguous()
-        # Raw bf16 weights view (may be column-split, non-compact); the top-k
-        # kernel's fused combine upcasts and compacts in one launch.
+        # Raw BF16 weights view (may be column-split and noncompact); the top-k
+        # scorer consumes the row/head strides and upcasts weights in-kernel.
         weights = indexer_output.weights[:num_prefill_tokens]
 
         req_ids = torch.arange(

--- a/tokenspeed-kernel-amd/THIRDPARTYNOTICES
+++ b/tokenspeed-kernel-amd/THIRDPARTYNOTICES
@@ -40,6 +40,12 @@ https://github.com/ROCm/aiter/blob/00b271b95f8a3405fa211e509c63441040557305/aite
 https://github.com/ROCm/aiter/blob/00b271b95f8a3405fa211e509c63441040557305/aiter/ops/triton/_gluon_kernels/gfx1250/attention/pa_decode_sparse.py
 https://github.com/ROCm/aiter/blob/00b271b95f8a3405fa211e509c63441040557305/aiter/ops/triton/_gluon_kernels/gfx1250/attention/pa_prefill_sparse.py
 
+The GFX950 standard-cache DSA scorer scheduling and FP8 matrix structure are
+informed by ROCm/AITER commit b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df.
+Sources:
+https://github.com/ROCm/aiter/blob/b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df/aiter/ops/triton/_gluon_kernels/gfx950/attention/fp8_mqa_logits.py
+https://github.com/ROCm/aiter/blob/b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df/aiter/ops/triton/gluon/pa_mqa_logits.py
+
 Licensed under the MIT License, whose full license text is available below.
 
 ================================================================================

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/indexing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/indexing.py
@@ -24,10 +24,10 @@ from __future__ import annotations
 
 import torch
 from tokenspeed_kernel_amd._triton import gl, gluon
+from tokenspeed_kernel_amd.ops.gfx1250.attention._common import maximum
 
 __all__ = [
     "_check_packed_fp8_inputs",
-    "_combine_scoring_query_heads_kernel",
     "_dsa_decode_logits_fp8_kernel",
     "_dsa_prefill_logits_fp8_kernel",
 ]
@@ -43,42 +43,6 @@ def _score_layout(
 
 
 @gluon.jit
-def _combine_scoring_query_heads_kernel(
-    q,
-    weights,
-    out,
-    q_stride_token,
-    q_stride_head,
-    q_stride_dim,
-    weight_stride_token,
-    weight_stride_head,
-    num_heads: gl.constexpr,
-    head_dim: gl.constexpr,
-    BLOCK_D: gl.constexpr,
-):
-    token = gl.program_id(0)
-    layout: gl.constexpr = _score_layout(1, BLOCK_D, gl.num_warps())
-    dim_layout: gl.constexpr = gl.SliceLayout(0, layout)
-    dims = gl.arange(0, BLOCK_D, layout=dim_layout)
-    combined = gl.zeros([BLOCK_D], dtype=gl.float32, layout=dim_layout)
-    for head in gl.static_range(0, num_heads):
-        q_offsets = token * q_stride_token + head * q_stride_head + dims * q_stride_dim
-        weight_offset = token * weight_stride_token + head * weight_stride_head
-        head_weight = gl.load(weights + weight_offset).to(gl.float32)
-        q_vals = gl.load(
-            q + q_offsets,
-            mask=dims < head_dim,
-            other=0.0,
-        ).to(gl.float32)
-        combined += q_vals * head_weight
-    gl.store(
-        out + token * head_dim + dims,
-        combined,
-        mask=dims < head_dim,
-    )
-
-
-@gluon.jit
 def _dsa_decode_logits_fp8_kernel(
     q,
     index_k_fp8,
@@ -87,6 +51,11 @@ def _dsa_decode_logits_fp8_kernel(
     seq_lens,
     block_table,
     logits,
+    q_stride_token,
+    q_stride_head,
+    q_stride_dim,
+    weight_stride_token,
+    weight_stride_head,
     block_table_stride: gl.constexpr,
     logits_stride: gl.constexpr,
     page_size: gl.constexpr,
@@ -97,7 +66,6 @@ def _dsa_decode_logits_fp8_kernel(
     num_groups: gl.constexpr,
     softmax_scale: gl.constexpr,
     q_len_per_req: gl.constexpr,
-    FOLD_WEIGHTED_HEADS: gl.constexpr,
     BLOCK_N: gl.constexpr,
     BLOCK_D: gl.constexpr,
 ):
@@ -131,16 +99,16 @@ def _dsa_decode_logits_fp8_kernel(
         + block_offset.to(gl.int64) * num_groups
     )
 
-    if FOLD_WEIGHTED_HEADS:
-        weighted_q = gl.zeros([BLOCK_D], gl.float32, layout=dim_layout)
-        for head in gl.static_range(0, num_heads):
-            q_vals = gl.load(
-                q + (token * num_heads + head) * head_dim + dims,
-                mask=dims < head_dim,
-                other=0.0,
-            ).to(gl.float32)
-            head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
-            weighted_q += q_vals * head_weight
+    scores = gl.zeros([BLOCK_N], gl.float32, layout=row_layout)
+    for head in gl.static_range(0, num_heads):
+        head_weight = gl.load(
+            weights + token * weight_stride_token + head * weight_stride_head
+        ).to(gl.float32)
+        q_vals = gl.load(
+            q + token * q_stride_token + head * q_stride_head + dims * q_stride_dim,
+            mask=dims < head_dim,
+            other=0.0,
+        ).to(gl.float32)
         k_vals = gl.load(
             index_k_fp8 + fp8_base[:, None] + dims[None, :],
             mask=valid[:, None] & (dims[None, :] < head_dim),
@@ -152,28 +120,8 @@ def _dsa_decode_logits_fp8_kernel(
             mask=valid,
             other=0.0,
         ).to(gl.float32)
-        scores = gl.sum(k_vals * k_scale[:, None] * weighted_q[None, :], axis=1)
-    else:
-        head_weight: gl.constexpr = 1.0
-        scores = gl.zeros([BLOCK_N], gl.float32, layout=row_layout)
-        for head in gl.static_range(0, num_heads):
-            q_vals = gl.load(
-                q + (token * num_heads + head) * head_dim + dims,
-                mask=dims < head_dim,
-                other=0.0,
-            ).to(gl.float32)
-            k_vals = gl.load(
-                index_k_fp8 + fp8_base[:, None] + dims[None, :],
-                mask=valid[:, None] & (dims[None, :] < head_dim),
-                other=0.0,
-            ).to(gl.float32)
-            k_scale = gl.load(
-                index_k_scale + scale_base,
-                mask=valid,
-                other=0.0,
-            ).to(gl.float32)
-            head_score = gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
-            scores += head_score * head_weight
+        head_score = gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
+        scores += maximum(head_score, 0.0) * head_weight
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))
@@ -189,10 +137,16 @@ def _dsa_prefill_logits_fp8_kernel(
     q,
     index_k_fp8,
     index_k_scale,
+    weights,
     kv_workspace_slots,
     row_starts,
     row_ends,
     logits,
+    q_stride_token,
+    q_stride_head,
+    q_stride_dim,
+    weight_stride_token,
+    weight_stride_head,
     logits_stride: gl.constexpr,
     seq_len_sum: gl.constexpr,
     page_size: gl.constexpr,
@@ -231,10 +185,12 @@ def _dsa_prefill_logits_fp8_kernel(
     )
 
     scores = gl.zeros([BLOCK_N], gl.float32, layout=row_layout)
-    head_weight: gl.constexpr = 1.0
     for head in gl.static_range(0, num_heads):
+        head_weight = gl.load(
+            weights + token * weight_stride_token + head * weight_stride_head
+        ).to(gl.float32)
         q_vals = gl.load(
-            q + (token * num_heads + head) * head_dim + dims,
+            q + token * q_stride_token + head * q_stride_head + dims * q_stride_dim,
             mask=dims < head_dim,
             other=0.0,
         ).to(gl.float32)
@@ -249,7 +205,7 @@ def _dsa_prefill_logits_fp8_kernel(
             other=0.0,
         ).to(gl.float32)
         head_score = gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
-        scores += head_score * head_weight
+        scores += maximum(head_score, 0.0) * head_weight
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
@@ -26,7 +26,6 @@ import torch
 from tokenspeed_kernel_amd._triton import gl, gluon, triton
 from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.indexing import (
     _check_packed_fp8_inputs,
-    _combine_scoring_query_heads_kernel,
     _dsa_decode_logits_fp8_kernel,
     _dsa_prefill_logits_fp8_kernel,
 )
@@ -41,11 +40,6 @@ _MAX_BUCKETS = gl.constexpr(1 << max(_RADIX_BITS))
 _TOPK_BLOCK_N = 2048
 _TOPK_NUM_WARPS = 8
 _TOPK_WAVES_PER_EU = 1
-_PREFILL_LOGITS_BLOCK_N = 128
-_PREFILL_LOGITS_NUM_WARPS = 8
-_PREFILL_LOGITS_WAVES_PER_EU = 1
-_GLM52_SCORING_HEADS = 32
-_GLM52_FUSED_DECODE_MAX_CANDIDATES = 98_304
 
 
 @gluon.constexpr_function
@@ -349,10 +343,10 @@ def _check_score_input_contract(
 ) -> None:
     if weights.device != q.device or index_k_cache.device != q.device:
         raise ValueError("q, weights, and index_k_cache must be on the same device")
-    if not (
-        q.is_contiguous() and weights.is_contiguous() and index_k_cache.is_contiguous()
-    ):
-        raise ValueError("q, weights, and index_k_cache must be contiguous")
+    if q.stride(-1) != 1 or weights.stride(-1) != 1:
+        raise ValueError("q and weights must have contiguous innermost dimensions")
+    if not index_k_cache.is_contiguous():
+        raise ValueError("index_k_cache must be contiguous")
 
 
 def _check_topk_contract(topk: int) -> None:
@@ -404,36 +398,6 @@ def _dsa_topk_indices(
     return out, lens_out
 
 
-def _combine_scoring_query_heads(
-    q: torch.Tensor,
-    weights: torch.Tensor,
-) -> torch.Tensor:
-    """Combine weighted query heads with FP32 accumulation on GFX1250."""
-
-    combined = torch.empty(
-        (q.shape[0], q.shape[2]),
-        dtype=torch.float32,
-        device=q.device,
-    )
-    if q.shape[0] == 0:
-        return combined
-    _combine_scoring_query_heads_kernel[(q.shape[0],)](
-        q,
-        weights,
-        combined,
-        q.stride(0),
-        q.stride(1),
-        q.stride(2),
-        weights.stride(0),
-        weights.stride(1),
-        num_heads=q.shape[1],
-        head_dim=q.shape[2],
-        BLOCK_D=128,
-        num_warps=1,
-    )
-    return combined
-
-
 def gluon_dsa_decode_topk_fp8_gfx1250(
     q: torch.Tensor,
     weights: torch.Tensor,
@@ -461,8 +425,6 @@ def gluon_dsa_decode_topk_fp8_gfx1250(
     if index_k_cache is None:
         raise RuntimeError("Gluon DSA paged top-k requires packed FP8 index_k_cache")
     row_bytes = _check_packed_fp8_inputs(q, index_k_cache, weights, int(page_size))
-    if not weights.is_contiguous():
-        weights = weights.contiguous()
     _check_score_input_contract(q, weights, index_k_cache)
     if seq_lens.dim() != 1:
         raise ValueError(
@@ -500,18 +462,6 @@ def gluon_dsa_decode_topk_fp8_gfx1250(
         return empty_out, empty_lens
 
     max_seq_len = int(block_table.shape[1]) * int(page_size)
-    fold_weighted_heads = (
-        q.shape[1] == _GLM52_SCORING_HEADS
-        and q.shape[0] * max_seq_len <= _GLM52_FUSED_DECODE_MAX_CANDIDATES
-    )
-    if fold_weighted_heads:
-        score_q = q
-        score_num_heads = q.shape[1]
-    else:
-        # Graph replay measurements favor a separate reduction beyond 98,304
-        # candidate slots on gfx1250.
-        score_q = _combine_scoring_query_heads(q, weights)[:, None, :]
-        score_num_heads = 1
     if out is None:
         out = torch.empty((q.shape[0], topk), dtype=torch.int32, device=q.device)
     if lens_out is None:
@@ -523,24 +473,28 @@ def gluon_dsa_decode_topk_fp8_gfx1250(
     )
     block_n = 32
     _dsa_decode_logits_fp8_kernel[(q.shape[0], triton.cdiv(max_seq_len, block_n))](
-        score_q,
+        q,
         index_k_cache.view(torch.float8_e4m3fn),
         index_k_cache.view(torch.float32),
         weights,
         seq_lens,
         block_table,
         logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        weights.stride(0),
+        weights.stride(1),
         block_table.stride(0),
         logits.stride(0),
         page_size=int(page_size),
         row_bytes=row_bytes,
         max_seq_len=max_seq_len,
-        num_heads=score_num_heads,
+        num_heads=q.shape[1],
         head_dim=q.shape[2],
         num_groups=q.shape[2] // 128,
         softmax_scale=float(softmax_scale),
         q_len_per_req=q_len_per_req,
-        FOLD_WEIGHTED_HEADS=fold_weighted_heads,
         BLOCK_N=block_n,
         BLOCK_D=128,
         num_warps=4,
@@ -584,8 +538,6 @@ def gluon_dsa_prefill_topk_fp8_gfx1250(
             "Gluon DSA top-k requires packed FP8 index_k_cache and page_size"
         )
     row_bytes = _check_packed_fp8_inputs(q, index_k_cache, weights, int(page_size))
-    if not weights.is_contiguous():
-        weights = weights.contiguous()
     _check_score_input_contract(q, weights, index_k_cache)
     if kv_workspace_slots.dim() != 1:
         raise ValueError(
@@ -634,10 +586,9 @@ def gluon_dsa_prefill_topk_fp8_gfx1250(
     else:
         max_query_rows = max(1, int(max_logits_bytes) // (max(seq_len_sum, 1) * 4))
 
-    block_n = _PREFILL_LOGITS_BLOCK_N
+    block_n = 32
     for start in range(0, q.shape[0], max_query_rows):
         end = min(start + max_query_rows, q.shape[0])
-        combined_q = _combine_scoring_query_heads(q[start:end], weights[start:end])
         logits = torch.empty(
             (end - start, seq_len_sum),
             dtype=torch.float32,
@@ -646,25 +597,31 @@ def gluon_dsa_prefill_topk_fp8_gfx1250(
         _dsa_prefill_logits_fp8_kernel[
             (end - start, triton.cdiv(seq_len_sum, block_n))
         ](
-            combined_q[:, None, :],
+            q[start:end],
             index_k_cache.view(torch.float8_e4m3fn),
             index_k_cache.view(torch.float32),
+            weights[start:end],
             kv_workspace_slots,
             row_starts[start:end],
             row_ends[start:end],
             logits,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            weights.stride(0),
+            weights.stride(1),
             logits.stride(0),
             seq_len_sum=seq_len_sum,
             page_size=int(page_size),
             row_bytes=row_bytes,
-            num_heads=1,
+            num_heads=q.shape[1],
             head_dim=q.shape[2],
             num_groups=q.shape[2] // 128,
             softmax_scale=float(softmax_scale),
             BLOCK_N=block_n,
             BLOCK_D=128,
-            num_warps=_PREFILL_LOGITS_NUM_WARPS,
-            waves_per_eu=_PREFILL_LOGITS_WAVES_PER_EU,
+            num_warps=4,
+            waves_per_eu=1,
         )
         _dsa_topk_indices(
             logits,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/indexing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/indexing.py
@@ -24,10 +24,10 @@ from __future__ import annotations
 
 import torch
 from tokenspeed_kernel_amd._triton import gl, gluon
+from tokenspeed_kernel_amd.ops.gfx950.attention._common import maximum
 
 __all__ = [
     "_check_packed_fp8_inputs",
-    "_combine_scoring_query_heads_kernel",
     "_dsa_decode_logits_fp8_kernel",
     "_dsa_prefill_logits_fp8_kernel",
 ]
@@ -40,41 +40,6 @@ def _score_layout(
     NUM_WARPS: gl.constexpr,
 ):
     return gl.BlockedLayout([1, 8], [8, 8], [NUM_WARPS, 1], [1, 0])
-
-
-@gluon.jit
-def _combine_scoring_query_heads_kernel(
-    q,
-    weights,
-    out,
-    num_heads: gl.constexpr,
-    head_dim: gl.constexpr,
-    BLOCK_D: gl.constexpr,
-):
-    token = gl.program_id(0)
-    layout: gl.constexpr = _score_layout(1, BLOCK_D, gl.num_warps())
-    dim_layout: gl.constexpr = gl.SliceLayout(0, layout)
-    dims = gl.arange(0, BLOCK_D, layout=dim_layout)
-    combined = gl.full(
-        [BLOCK_D],
-        value=0.0,
-        dtype=gl.float32,
-        layout=dim_layout,
-    )
-    for head in gl.static_range(0, num_heads):
-        head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
-        q_vals = gl.amd.cdna4.buffer_load(
-            ptr=q,
-            offsets=((token * num_heads + head) * head_dim + dims).to(gl.int32),
-            mask=dims < head_dim,
-            other=0.0,
-        ).to(gl.float32)
-        combined += q_vals * head_weight
-    gl.store(
-        out + token * head_dim + dims,
-        combined,
-        mask=dims < head_dim,
-    )
 
 
 @gluon.jit
@@ -96,7 +61,6 @@ def _dsa_decode_logits_fp8_kernel(
     num_groups: gl.constexpr,
     softmax_scale: gl.constexpr,
     q_len_per_req: gl.constexpr,
-    FOLD_WEIGHTED_HEADS: gl.constexpr,
     BLOCK_N: gl.constexpr,
     BLOCK_D: gl.constexpr,
 ):
@@ -134,24 +98,22 @@ def _dsa_decode_logits_fp8_kernel(
         dtype=gl.float32,
         layout=row_layout,
     )
-    if FOLD_WEIGHTED_HEADS:
+    for head in gl.static_range(0, num_heads):
+        head_score = gl.full(
+            [BLOCK_N],
+            value=0.0,
+            dtype=gl.float32,
+            layout=row_layout,
+        )
+        head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
         for dim_start in gl.static_range(0, head_dim, BLOCK_D):
             dims = dim_start + dim_offsets
-            weighted_q = gl.full(
-                [BLOCK_D],
-                value=0.0,
-                dtype=gl.float32,
-                layout=dim_layout,
-            )
-            for head in gl.static_range(0, num_heads):
-                head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
-                q_vals = gl.amd.cdna4.buffer_load(
-                    ptr=q,
-                    offsets=((token * num_heads + head) * head_dim + dims).to(gl.int32),
-                    mask=dims < head_dim,
-                    other=0.0,
-                ).to(gl.float32)
-                weighted_q += q_vals * head_weight
+            q_vals = gl.amd.cdna4.buffer_load(
+                ptr=q,
+                offsets=((token * num_heads + head) * head_dim + dims).to(gl.int32),
+                mask=dims < head_dim,
+                other=0.0,
+            ).to(gl.float32)
             k_vals = gl.amd.cdna4.buffer_load(
                 ptr=index_k_fp8,
                 offsets=(fp8_base[:, None] + dims[None, :]).to(gl.int32),
@@ -164,40 +126,8 @@ def _dsa_decode_logits_fp8_kernel(
                 mask=valid,
                 other=0.0,
             ).to(gl.float32)
-            scores += gl.sum(k_vals * k_scale[:, None] * weighted_q[None, :], axis=1)
-    else:
-        head_weight: gl.constexpr = 1.0
-        for head in gl.static_range(0, num_heads):
-            head_score = gl.full(
-                [BLOCK_N],
-                value=0.0,
-                dtype=gl.float32,
-                layout=row_layout,
-            )
-            for dim_start in gl.static_range(0, head_dim, BLOCK_D):
-                dims = dim_start + dim_offsets
-                q_vals = gl.amd.cdna4.buffer_load(
-                    ptr=q,
-                    offsets=((token * num_heads + head) * head_dim + dims).to(gl.int32),
-                    mask=dims < head_dim,
-                    other=0.0,
-                ).to(gl.float32)
-                k_vals = gl.amd.cdna4.buffer_load(
-                    ptr=index_k_fp8,
-                    offsets=(fp8_base[:, None] + dims[None, :]).to(gl.int32),
-                    mask=valid[:, None] & (dims[None, :] < head_dim),
-                    other=0.0,
-                ).to(gl.float32)
-                k_scale = gl.amd.cdna4.buffer_load(
-                    ptr=index_k_scale,
-                    offsets=(scale_base + dim_start // 128).to(gl.int32),
-                    mask=valid,
-                    other=0.0,
-                ).to(gl.float32)
-                head_score += gl.sum(
-                    k_vals * k_scale[:, None] * q_vals[None, :], axis=1
-                )
-            scores += head_score * head_weight
+            head_score += gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
+        scores += maximum(head_score, 0.0) * head_weight
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))
@@ -213,6 +143,7 @@ def _dsa_prefill_logits_fp8_kernel(
     q,
     index_k_fp8,
     index_k_scale,
+    weights,
     kv_workspace_slots,
     row_starts,
     row_ends,
@@ -259,9 +190,8 @@ def _dsa_prefill_logits_fp8_kernel(
         dtype=gl.float32,
         layout=row_layout,
     )
-    head_weight: gl.constexpr = 1.0
-
     for head in gl.static_range(0, num_heads):
+        head_weight = gl.load(weights + token * num_heads + head).to(gl.float32)
         head_score = gl.full(
             [BLOCK_N],
             value=0.0,
@@ -289,7 +219,7 @@ def _dsa_prefill_logits_fp8_kernel(
                 other=0.0,
             ).to(gl.float32)
             head_score += gl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
-        scores += head_score * head_weight
+        scores += maximum(head_score, 0.0) * head_weight
 
     scores *= softmax_scale
     scores = gl.where(valid, scores, -float("inf"))

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/sparse_mla.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/sparse_mla.py
@@ -31,9 +31,12 @@ import torch
 from tokenspeed_kernel_amd._triton import gl, gluon, triton
 from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.indexing import (
     _check_packed_fp8_inputs,
-    _combine_scoring_query_heads_kernel,
     _dsa_decode_logits_fp8_kernel,
     _dsa_prefill_logits_fp8_kernel,
+)
+from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.standard_cache_logits import (
+    _dsa_standard_decode_logits_kernel,
+    _dsa_standard_prefill_logits_kernel,
 )
 
 _ONEBLOCK_RADIX_SCHEDULE = (12, 12, 8)
@@ -63,8 +66,6 @@ _PERSISTENT_NUM_BUCKETS = gl.constexpr(1 << 11)
 _PERSISTENT_NUM_PASSES = gl.constexpr(3)
 _PERSISTENT_COUNTER_STRIDE = gl.constexpr(32)
 _PERSISTENT_WORKSPACE_CACHE_MAXSIZE = 16
-_GLM52_SCORING_HEADS = 32
-_GLM52_FUSED_DECODE_MAX_CANDIDATES = 16384
 
 _persistent_topk_workspace_cache: OrderedDict[
     tuple[int, int, int], tuple[torch.Tensor, ...]
@@ -74,7 +75,9 @@ _persistent_topk_workspace_lock = Lock()
 
 __all__ = [
     "gluon_dsa_decode_topk_fp8_gfx950",
+    "gluon_dsa_decode_topk_standard_gfx950",
     "gluon_dsa_prefill_topk_fp8_gfx950",
+    "gluon_dsa_prefill_topk_standard_gfx950",
 ]
 
 
@@ -1897,31 +1900,6 @@ def _dsa_topk_indices(
     )
 
 
-def _combine_scoring_query_heads(
-    q: torch.Tensor,
-    weights: torch.Tensor,
-) -> torch.Tensor:
-    if not weights.is_contiguous():
-        weights = weights.contiguous()
-    combined = torch.empty(
-        (q.shape[0], q.shape[2]),
-        dtype=torch.float32,
-        device=q.device,
-    )
-    if q.shape[0] == 0:
-        return combined
-    _combine_scoring_query_heads_kernel[(q.shape[0],)](
-        q,
-        weights,
-        combined,
-        num_heads=q.shape[1],
-        head_dim=q.shape[2],
-        BLOCK_D=128,
-        num_warps=4,
-    )
-    return combined
-
-
 def gluon_dsa_decode_topk_fp8_gfx950(
     q: torch.Tensor,
     weights: torch.Tensor,
@@ -1987,18 +1965,6 @@ def gluon_dsa_decode_topk_fp8_gfx950(
         )
         return empty_out, empty_lens
     max_seq_len = int(block_table.shape[1]) * int(page_size)
-    fold_weighted_heads = (
-        q.shape[1] == _GLM52_SCORING_HEADS
-        and q.shape[0] * max_seq_len <= _GLM52_FUSED_DECODE_MAX_CANDIDATES
-    )
-    if fold_weighted_heads:
-        score_q = q
-        score_num_heads = q.shape[1]
-    else:
-        # Fusing avoids a launch for small grids; larger grids would repeat the
-        # head reduction once per cache tile, so reduce it once before scoring.
-        score_q = _combine_scoring_query_heads(q, weights)[:, None, :]
-        score_num_heads = 1
     if out is None:
         out = torch.empty((q.shape[0], topk), dtype=torch.int32, device=q.device)
     if lens_out is None:
@@ -2009,7 +1975,7 @@ def gluon_dsa_decode_topk_fp8_gfx950(
     block_n = 32
     score_grid = (q.shape[0], triton.cdiv(max_seq_len, block_n))
     _dsa_decode_logits_fp8_kernel[score_grid](
-        score_q,
+        q,
         index_k_cache.view(torch.float8_e4m3fn),
         index_k_cache.view(torch.float32),
         weights,
@@ -2021,12 +1987,11 @@ def gluon_dsa_decode_topk_fp8_gfx950(
         page_size=int(page_size),
         row_bytes=row_bytes,
         max_seq_len=max_seq_len,
-        num_heads=score_num_heads,
+        num_heads=q.shape[1],
         head_dim=q.shape[2],
         num_groups=q.shape[2] // 128,
         softmax_scale=float(softmax_scale),
         q_len_per_req=q_len_per_req,
-        FOLD_WEIGHTED_HEADS=fold_weighted_heads,
         BLOCK_N=block_n,
         BLOCK_D=128,
         num_warps=4,
@@ -2121,16 +2086,16 @@ def gluon_dsa_prefill_topk_fp8_gfx950(
     block_n = 32
     for start in range(0, q.shape[0], max_query_rows):
         end = min(start + max_query_rows, q.shape[0])
-        combined_q = _combine_scoring_query_heads(q[start:end], weights[start:end])
         logits = torch.empty(
             (end - start, seq_len_sum), dtype=torch.float32, device=q.device
         )
         _dsa_prefill_logits_fp8_kernel[
             (end - start, triton.cdiv(seq_len_sum, block_n))
         ](
-            combined_q[:, None, :],
+            q[start:end],
             index_k_cache.view(torch.float8_e4m3fn),
             index_k_cache.view(torch.float32),
+            weights[start:end],
             kv_workspace_slots,
             row_starts[start:end],
             row_ends[start:end],
@@ -2139,13 +2104,300 @@ def gluon_dsa_prefill_topk_fp8_gfx950(
             seq_len_sum=seq_len_sum,
             page_size=int(page_size),
             row_bytes=row_bytes,
-            num_heads=1,
+            num_heads=q.shape[1],
             head_dim=q.shape[2],
             num_groups=q.shape[2] // 128,
             softmax_scale=float(softmax_scale),
             BLOCK_N=block_n,
             BLOCK_D=128,
             num_warps=4,
+        )
+        _dsa_topk_indices(
+            logits,
+            row_starts[start:end],
+            row_ends[start:end],
+            topk=topk,
+            out=out[start:end],
+            lens_out=lens_out[start:end],
+        )
+    return out, lens_out
+
+
+def _check_standard_scorer_inputs(
+    q: torch.Tensor,
+    q_scales: torch.Tensor | None,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    page_size: int,
+) -> tuple[int, bool]:
+    if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise TypeError(
+            f"standard-cache DSA scorer expects BF16 or FP8 q, got {q.dtype}"
+        )
+    if weights.dtype not in (torch.bfloat16, torch.float32):
+        raise TypeError(f"DSA weights must be BF16 or FP32, got {weights.dtype}")
+    if q.dim() != 3 or q.shape[1] not in (32, 64) or q.shape[2] != 128:
+        raise ValueError(
+            "standard-cache DSA scorer requires q=[tokens, 32|64, 128], got "
+            f"{tuple(q.shape)}"
+        )
+    if weights.shape != q.shape[:2]:
+        raise ValueError(
+            f"weights must have shape {tuple(q.shape[:2])}, got {tuple(weights.shape)}"
+        )
+    if q.stride(-1) != 1 or weights.stride(-1) != 1:
+        raise ValueError("q and weights must have contiguous innermost dimensions")
+    if page_size != 64:
+        raise ValueError(
+            f"standard-cache DSA scorer requires page_size=64, got {page_size}"
+        )
+    if index_k_cache.dtype != torch.uint8 or not index_k_cache.is_contiguous():
+        raise TypeError("index_k_cache must be a contiguous uint8 tensor")
+    row_bytes = 128 + 4
+    if index_k_cache.dim() != 2 or index_k_cache.shape[1] != row_bytes:
+        raise ValueError(
+            f"index_k_cache must have shape [slots, {row_bytes}], got "
+            f"{tuple(index_k_cache.shape)}"
+        )
+    if index_k_cache.shape[0] % page_size:
+        raise ValueError("index_k_cache slot count must be page aligned")
+    if weights.device != q.device or index_k_cache.device != q.device:
+        raise ValueError("q, weights, and index_k_cache must be on the same device")
+    q_is_fp8 = q.dtype == torch.float8_e4m3fn
+    if q_is_fp8:
+        if q_scales is None:
+            raise ValueError("FP8 q requires per-token/head q_scales")
+        if (
+            q_scales.dtype != torch.float32
+            or q_scales.shape != q.shape[:2]
+            or q_scales.device != q.device
+            or q_scales.stride(-1) != 1
+        ):
+            raise ValueError(
+                "q_scales must be FP32 [tokens, heads] with a contiguous head axis"
+            )
+    elif q_scales is not None:
+        raise ValueError("q_scales is only valid with FP8 q")
+    return row_bytes, q_is_fp8
+
+
+def gluon_dsa_decode_topk_standard_gfx950(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    *,
+    page_size: int,
+    topk: int,
+    softmax_scale: float,
+    q_len_per_req: int = 1,
+    index_k_cache: torch.Tensor | None = None,
+    q_scales: torch.Tensor | None = None,
+    seq_lens_2d: torch.Tensor | None = None,
+    plan: object | None = None,
+    out: torch.Tensor | None = None,
+    lens_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Score the standard paged cache and return global top-k slots."""
+    del plan, seq_lens_2d
+    topk = int(topk)
+    q_len_per_req = int(q_len_per_req)
+    _check_topk_contract(topk)
+    if q_len_per_req not in (1, 2, 3, 4, 5, 6):
+        raise ValueError(f"q_len_per_req must be in 1..6, got {q_len_per_req}")
+    if index_k_cache is None:
+        raise RuntimeError("standard-cache DSA scorer requires index_k_cache")
+    row_bytes, q_is_fp8 = _check_standard_scorer_inputs(
+        q, q_scales, weights, index_k_cache, int(page_size)
+    )
+    if seq_lens.dtype != torch.int32 or block_table.dtype != torch.int32:
+        raise TypeError("seq_lens and block_table must be int32")
+    if not seq_lens.is_contiguous() or not block_table.is_contiguous():
+        raise ValueError("seq_lens and block_table must be contiguous")
+    if seq_lens.device != q.device or block_table.device != q.device:
+        raise ValueError("decode metadata must be on the same device as q")
+    if q.shape[0] != seq_lens.numel() * q_len_per_req:
+        raise ValueError("q rows must equal seq_lens rows times q_len_per_req")
+    if block_table.dim() != 2 or block_table.shape[0] < seq_lens.numel():
+        raise ValueError("block_table must have at least one row per request")
+    if out is None:
+        out = torch.empty((q.shape[0], topk), dtype=torch.int32, device=q.device)
+    if lens_out is None:
+        lens_out = torch.empty((q.shape[0],), dtype=torch.int32, device=q.device)
+    if q.shape[0] == 0:
+        return out, lens_out
+
+    max_candidates = int(block_table.shape[1]) * int(page_size)
+    if max_candidates == 0:
+        out.fill_(-1)
+        lens_out.zero_()
+        return out, lens_out
+    logits = torch.empty(
+        (q.shape[0], max_candidates), dtype=torch.float32, device=q.device
+    )
+    if q.shape[1] == 32 and q_is_fp8:
+        block_n = 64
+        waves_per_eu = 4
+    else:
+        block_n = 32
+        waves_per_eu = 2
+    chunk_n = 256
+    num_warps = 1
+    q_scale_arg = q_scales if q_scales is not None else weights
+    grid = (q.shape[0], triton.cdiv(max_candidates, chunk_n))
+    _dsa_standard_decode_logits_kernel[grid](
+        q,
+        q_scale_arg,
+        index_k_cache.view(torch.float8_e4m3fn),
+        index_k_cache.view(torch.float32),
+        weights,
+        seq_lens,
+        block_table,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q_scale_arg.stride(0),
+        q_scale_arg.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        block_table.stride(0),
+        logits.stride(0),
+        float(softmax_scale),
+        max_candidates,
+        q_len_per_req,
+        PAGE_SIZE=int(page_size),
+        ROW_BYTES=row_bytes,
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=block_n,
+        CHUNK_N=chunk_n,
+        NUM_WARPS=num_warps,
+        Q_IS_FP8=q_is_fp8,
+        USE_BUFFER_LOAD=index_k_cache.nbytes < 2**31,
+        USE_BUFFER_STORE=logits.nbytes < 2**31,
+        num_warps=num_warps,
+        waves_per_eu=waves_per_eu,
+    )
+    return _dsa_topk_indices(
+        logits,
+        seq_lens,
+        seq_lens,
+        block_table=block_table,
+        page_size=int(page_size),
+        topk=topk,
+        q_len_per_req=q_len_per_req,
+        out=out,
+        lens_out=lens_out,
+    )
+
+
+def gluon_dsa_prefill_topk_standard_gfx950(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    kv_workspace_slots: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    *,
+    topk: int,
+    softmax_scale: float,
+    index_k_cache: torch.Tensor | None = None,
+    page_size: int | None = None,
+    index_k_fp8: torch.Tensor | None = None,
+    index_k_scale: torch.Tensor | None = None,
+    q_scales: torch.Tensor | None = None,
+    max_logits_bytes: int | None = None,
+    out: torch.Tensor | None = None,
+    lens_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Score workspace slots in-kernel and return workspace-row top-k ids."""
+    del index_k_fp8, index_k_scale
+    topk = int(topk)
+    _check_topk_contract(topk)
+    if index_k_cache is None or page_size is None:
+        raise RuntimeError("standard-cache DSA scorer requires cache and page_size")
+    row_bytes, q_is_fp8 = _check_standard_scorer_inputs(
+        q, q_scales, weights, index_k_cache, int(page_size)
+    )
+    if (
+        kv_workspace_slots.dtype != torch.int64
+        or row_starts.dtype != torch.int32
+        or row_ends.dtype != torch.int32
+    ):
+        raise TypeError("workspace slots must be int64 and row bounds must be int32")
+    if (
+        kv_workspace_slots.shape != (kv_workspace_slots.numel(),)
+        or row_starts.shape != (q.shape[0],)
+        or row_ends.shape != (q.shape[0],)
+    ):
+        raise ValueError("workspace slots must be 1-D and row bounds must be [tokens]")
+    if not (
+        kv_workspace_slots.is_contiguous()
+        and row_starts.is_contiguous()
+        and row_ends.is_contiguous()
+    ):
+        raise ValueError("prefill metadata must be contiguous")
+    if not (
+        kv_workspace_slots.device == row_starts.device == row_ends.device == q.device
+    ):
+        raise ValueError("prefill metadata must be on the same device as q")
+    if out is None:
+        out = torch.empty((q.shape[0], topk), dtype=torch.int32, device=q.device)
+    if lens_out is None:
+        lens_out = torch.empty((q.shape[0],), dtype=torch.int32, device=q.device)
+    if q.shape[0] == 0:
+        return out, lens_out
+    workspace_rows = int(kv_workspace_slots.numel())
+    if workspace_rows == 0:
+        out.fill_(-1)
+        lens_out.zero_()
+        return out, lens_out
+
+    max_query_rows = q.shape[0]
+    if max_logits_bytes is not None:
+        max_query_rows = max(1, int(max_logits_bytes) // (max(workspace_rows, 1) * 4))
+    q_scale_arg = q_scales if q_scales is not None else weights
+    block_n = 128
+    num_warps = 4
+    waves_per_eu = 4 if q.shape[1] == 32 else 2
+    dummy_table = row_starts
+    for start in range(0, q.shape[0], max_query_rows):
+        end = min(start + max_query_rows, q.shape[0])
+        logits = torch.empty(
+            (end - start, workspace_rows), dtype=torch.float32, device=q.device
+        )
+        _dsa_standard_prefill_logits_kernel[(end - start, 1)](
+            q[start:end],
+            q_scale_arg[start:end],
+            index_k_cache.view(torch.float8_e4m3fn),
+            index_k_cache.view(torch.float32),
+            weights[start:end],
+            kv_workspace_slots,
+            row_starts[start:end],
+            row_ends[start:end],
+            dummy_table,
+            logits,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q_scale_arg.stride(0),
+            q_scale_arg.stride(1),
+            weights.stride(0),
+            weights.stride(1),
+            logits.stride(0),
+            float(softmax_scale),
+            workspace_rows,
+            PAGE_SIZE=int(page_size),
+            ROW_BYTES=row_bytes,
+            NUM_HEADS=q.shape[1],
+            HEAD_DIM=q.shape[2],
+            BLOCK_N=block_n,
+            NUM_WARPS=num_warps,
+            Q_IS_FP8=q_is_fp8,
+            USE_BUFFER_LOAD=index_k_cache.nbytes < 2**31,
+            USE_BUFFER_STORE=logits.nbytes < 2**31,
+            num_warps=num_warps,
+            waves_per_eu=waves_per_eu,
         )
         _dsa_topk_indices(
             logits,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/standard_cache_logits.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/standard_cache_logits.py
@@ -1,0 +1,723 @@
+# Copyright (c) 2026 LightSeek Foundation
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""GFX950 DSA logits kernels for TokenSpeed's standard cache.
+
+The scheduling and FP8 matrix structure follow the corresponding AITER scorer
+design. This implementation directly supports TokenSpeed's standard page-64
+block-split cache, resolves prefill workspace indirection in the key loader,
+adds native BF16 matrix computation, and evaluates 64 heads as two 32-head
+reductions over one resident key tile.
+"""
+
+from tokenspeed_kernel_amd._triton import gl, gluon, tl
+
+__all__ = [
+    "_dsa_standard_decode_logits_kernel",
+    "_dsa_standard_prefill_logits_kernel",
+]
+
+
+@gluon.jit
+def _relu_f32(value):
+    return gl.maximum(value, 0.0, propagate_nan=tl.PropagateNan.ALL)
+
+
+@gluon.constexpr_function
+def _make_key_blocked_layout(
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+):
+    vector_width: gl.constexpr = 16
+    head_threads: gl.constexpr = HEAD_DIM // vector_width
+    return gl.BlockedLayout(
+        size_per_thread=[vector_width, 1],
+        threads_per_warp=[head_threads, 64 // head_threads],
+        warps_per_cta=[1, NUM_WARPS],
+        order=[0, 1],
+    )
+
+
+@gluon.constexpr_function
+def _make_key_shared_layout():
+    return gl.SwizzledSharedLayout(vec=1, per_phase=1, max_phase=1, order=[0, 1])
+
+
+@gluon.constexpr_function
+def _make_mfma_layout(
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+):
+    if Q_IS_FP8:
+        mfma_layout = gl.amd.AMDMFMALayout(
+            version=4,
+            instr_shape=[32, 32, 64],
+            transposed=False,
+            warps_per_cta=[1, NUM_WARPS],
+        )
+    else:
+        mfma_layout = gl.amd.AMDMFMALayout(
+            version=4,
+            instr_shape=[32, 32, 16],
+            transposed=False,
+            warps_per_cta=[1, NUM_WARPS],
+        )
+    return mfma_layout
+
+
+@gluon.constexpr_function
+def _make_dot_layout(
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    operand_index: gl.constexpr,
+):
+    mfma_layout = _make_mfma_layout(BLOCK_N, NUM_WARPS, Q_IS_FP8)
+    k_width: gl.constexpr = 16 if Q_IS_FP8 else 8
+    return gl.DotOperandLayout(
+        operand_index=operand_index,
+        parent=mfma_layout,
+        k_width=k_width,
+    )
+
+
+@gluon.jit
+def _candidate_slots(
+    positions,
+    valid,
+    kv_workspace_slots,
+    block_table,
+    request_id,
+    block_table_stride,
+    PAGE_SIZE: gl.constexpr,
+    IS_PREFILL: gl.constexpr,
+):
+    if IS_PREFILL:
+        return gl.amd.cdna4.buffer_load(
+            ptr=kv_workspace_slots,
+            offsets=positions.to(gl.int32),
+            mask=valid,
+            other=0,
+        ).to(gl.int64)
+    page_indices = positions // PAGE_SIZE
+    pages = gl.amd.cdna4.buffer_load(
+        ptr=block_table,
+        offsets=(request_id * block_table_stride + page_indices).to(gl.int32),
+        mask=valid,
+        other=0,
+    ).to(gl.int64)
+    return pages * PAGE_SIZE + positions % PAGE_SIZE
+
+
+@gluon.jit
+def _load_key_tile_to_shared(
+    index_k_fp8,
+    key_shared,
+    buffer_id,
+    candidate_start,
+    candidate_end,
+    kv_workspace_slots,
+    block_table,
+    request_id,
+    block_table_stride,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    IS_PREFILL: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+):
+    blocked: gl.constexpr = _make_key_blocked_layout(HEAD_DIM, BLOCK_N, NUM_WARPS)
+    dims = gl.arange(0, HEAD_DIM, layout=gl.SliceLayout(1, blocked))[:, None]
+    columns = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, blocked))[None, :]
+    positions = candidate_start + columns
+    valid = positions < candidate_end
+    slots = _candidate_slots(
+        positions,
+        valid,
+        kv_workspace_slots,
+        block_table,
+        request_id,
+        block_table_stride,
+        PAGE_SIZE,
+        IS_PREFILL,
+    )
+    pages = slots // PAGE_SIZE
+    page_rows = slots - pages * PAGE_SIZE
+    byte_offsets = pages * (PAGE_SIZE * ROW_BYTES) + page_rows * HEAD_DIM + dims
+    if USE_BUFFER_LOAD:
+        gl.amd.cdna4.async_copy.buffer_load_to_shared(
+            key_shared.index(buffer_id),
+            index_k_fp8,
+            byte_offsets.to(gl.int32),
+            mask=valid,
+        )
+    else:
+        gl.amd.cdna4.async_copy.global_load_to_shared(
+            key_shared.index(buffer_id),
+            index_k_fp8 + byte_offsets,
+            mask=valid,
+        )
+    gl.amd.cdna4.async_copy.commit_group()
+
+
+@gluon.jit
+def _load_key_scales(
+    index_k_scale,
+    candidate_start,
+    candidate_end,
+    kv_workspace_slots,
+    block_table,
+    request_id,
+    block_table_stride,
+    output_layout: gl.constexpr,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    IS_PREFILL: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+):
+    columns = gl.arange(0, BLOCK_N, layout=output_layout)
+    positions = candidate_start + columns
+    valid = positions < candidate_end
+    slots = _candidate_slots(
+        positions,
+        valid,
+        kv_workspace_slots,
+        block_table,
+        request_id,
+        block_table_stride,
+        PAGE_SIZE,
+        IS_PREFILL,
+    )
+    pages = slots // PAGE_SIZE
+    page_rows = slots - pages * PAGE_SIZE
+    scale_offsets = (
+        pages * ((PAGE_SIZE * ROW_BYTES) // 4) + (PAGE_SIZE * HEAD_DIM) // 4 + page_rows
+    )
+    if USE_BUFFER_LOAD:
+        scales = gl.amd.cdna4.buffer_load(
+            ptr=index_k_scale,
+            offsets=scale_offsets.to(gl.int32),
+            mask=valid,
+            other=0.0,
+        ).to(gl.float32)
+    else:
+        scales = gl.load(
+            index_k_scale + scale_offsets,
+            mask=valid,
+            other=0.0,
+        ).to(gl.float32)
+    return scales, valid
+
+
+@gluon.jit
+def _load_query_tile(
+    q,
+    weights,
+    q_scales,
+    row_id,
+    head_offset: gl.constexpr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_w_row,
+    stride_w_head,
+    stride_qs_row,
+    stride_qs_head,
+    layout_q: gl.constexpr,
+    mfma_layout: gl.constexpr,
+    dot_a_layout: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+):
+    heads = gl.arange(0, 32, layout=gl.SliceLayout(1, layout_q))[:, None]
+    dims = gl.arange(0, HEAD_DIM, layout=gl.SliceLayout(0, layout_q))[None, :]
+    q_values = gl.amd.cdna4.buffer_load(
+        ptr=q,
+        offsets=(
+            row_id * stride_q_row
+            + (head_offset + heads) * stride_q_head
+            + dims * stride_q_dim
+        ).to(gl.int32),
+        cache=".cg",
+    )
+    weight_heads = gl.arange(0, 32, layout=gl.SliceLayout(1, mfma_layout))
+    head_weights = gl.amd.cdna4.buffer_load(
+        ptr=weights,
+        offsets=(
+            row_id * stride_w_row + (head_offset + weight_heads) * stride_w_head
+        ).to(gl.int32),
+        cache=".cg",
+    ).to(gl.float32)
+    if Q_IS_FP8:
+        query_scales = gl.amd.cdna4.buffer_load(
+            ptr=q_scales,
+            offsets=(
+                row_id * stride_qs_row + (head_offset + weight_heads) * stride_qs_head
+            ).to(gl.int32),
+            cache=".cg",
+        ).to(gl.float32)
+        head_weights *= query_scales
+    return gl.convert_layout(q_values, dot_a_layout), head_weights
+
+
+@gluon.jit
+def _score_head_tile(
+    query,
+    key,
+    head_weights,
+    mfma_layout: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+):
+    accumulator = gl.zeros([32, BLOCK_N], dtype=gl.float32, layout=mfma_layout)
+    if Q_IS_FP8:
+        head_scores = gl.amd.cdna4.mfma_scaled(
+            a=query,
+            a_scale=None,
+            a_format="e4m3",
+            b=key,
+            b_scale=None,
+            b_format="e4m3",
+            acc=accumulator,
+        )
+    else:
+        head_scores = gl.amd.cdna4.mfma(query, key, accumulator)
+    head_scores = _relu_f32(head_scores)
+    return gl.sum(head_scores * head_weights[:, None], axis=0)
+
+
+@gluon.jit
+def _score_key_tile(
+    query_0,
+    weight_0,
+    query_1,
+    weight_1,
+    raw_key,
+    key_scales,
+    model_scale,
+    mfma_layout: gl.constexpr,
+    dot_b_layout: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+):
+    if Q_IS_FP8:
+        key = raw_key
+    else:
+        key = raw_key.to(gl.bfloat16)
+    key = gl.convert_layout(key, dot_b_layout)
+    scores = _score_head_tile(
+        query_0,
+        key,
+        weight_0,
+        mfma_layout,
+        BLOCK_N,
+        Q_IS_FP8,
+    )
+    if NUM_HEADS == 64:
+        scores += _score_head_tile(
+            query_1,
+            key,
+            weight_1,
+            mfma_layout,
+            BLOCK_N,
+            Q_IS_FP8,
+        )
+    return scores * key_scales * model_scale
+
+
+@gluon.jit
+def _standard_cache_logits_body(
+    q,
+    q_scales,
+    index_k_fp8,
+    index_k_scale,
+    weights,
+    kv_workspace_slots,
+    row_starts,
+    row_ends,
+    seq_lens,
+    block_table,
+    logits,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_qs_row,
+    stride_qs_head,
+    stride_w_row,
+    stride_w_head,
+    block_table_stride,
+    logits_stride,
+    model_scale,
+    max_candidates,
+    q_len_per_req,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    CHUNK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    IS_PREFILL: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+    USE_BUFFER_STORE: gl.constexpr,
+):
+    row_id = gl.program_id(0)
+    split_id = gl.program_id(1)
+    if IS_PREFILL:
+        request_id = row_id
+        candidate_start = gl.maximum(gl.load(row_starts + row_id), 0)
+        candidate_end = gl.minimum(gl.load(row_ends + row_id), max_candidates)
+    else:
+        request_id = row_id // q_len_per_req
+        q_offset = row_id - request_id * q_len_per_req
+        candidate_start = split_id * CHUNK_N
+        candidate_end = gl.load(seq_lens + request_id).to(gl.int32)
+        if q_len_per_req != 1:
+            candidate_end = candidate_end - (q_len_per_req - 1) + q_offset
+        candidate_end = gl.minimum(candidate_end, candidate_start + CHUNK_N)
+        candidate_end = gl.minimum(candidate_end, max_candidates)
+    candidate_start = gl.minimum(candidate_start, candidate_end)
+
+    blocked: gl.constexpr = _make_key_blocked_layout(HEAD_DIM, BLOCK_N, NUM_WARPS)
+    shared_layout: gl.constexpr = _make_key_shared_layout()
+    mfma_layout: gl.constexpr = _make_mfma_layout(BLOCK_N, NUM_WARPS, Q_IS_FP8)
+    dot_a_layout: gl.constexpr = _make_dot_layout(BLOCK_N, NUM_WARPS, Q_IS_FP8, 0)
+    dot_b_layout: gl.constexpr = _make_dot_layout(BLOCK_N, NUM_WARPS, Q_IS_FP8, 1)
+    key_shared = gl.allocate_shared_memory(
+        index_k_fp8.type.element_ty,
+        [2, HEAD_DIM, BLOCK_N],
+        layout=shared_layout,
+    )
+    q_groups: gl.constexpr = HEAD_DIM // 16
+    layout_q: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 16],
+        threads_per_warp=[64 // q_groups, q_groups],
+        warps_per_cta=[NUM_WARPS, 1],
+        order=[1, 0],
+    )
+    query_0, weight_0 = _load_query_tile(
+        q,
+        weights,
+        q_scales,
+        row_id,
+        0,
+        stride_q_row,
+        stride_q_head,
+        stride_q_dim,
+        stride_w_row,
+        stride_w_head,
+        stride_qs_row,
+        stride_qs_head,
+        layout_q,
+        mfma_layout,
+        dot_a_layout,
+        HEAD_DIM,
+        Q_IS_FP8,
+    )
+    if NUM_HEADS == 64:
+        query_1, weight_1 = _load_query_tile(
+            q,
+            weights,
+            q_scales,
+            row_id,
+            32,
+            stride_q_row,
+            stride_q_head,
+            stride_q_dim,
+            stride_w_row,
+            stride_w_head,
+            stride_qs_row,
+            stride_qs_head,
+            layout_q,
+            mfma_layout,
+            dot_a_layout,
+            HEAD_DIM,
+            Q_IS_FP8,
+        )
+    else:
+        query_1 = query_0
+        weight_1 = weight_0
+
+    tile_count = tl.cdiv(candidate_end - candidate_start, BLOCK_N)
+    _load_key_tile_to_shared(
+        index_k_fp8,
+        key_shared,
+        0,
+        candidate_start,
+        candidate_end,
+        kv_workspace_slots,
+        block_table,
+        request_id,
+        block_table_stride,
+        PAGE_SIZE,
+        ROW_BYTES,
+        HEAD_DIM,
+        BLOCK_N,
+        NUM_WARPS,
+        IS_PREFILL,
+        USE_BUFFER_LOAD,
+    )
+    _load_key_tile_to_shared(
+        index_k_fp8,
+        key_shared,
+        1,
+        candidate_start + BLOCK_N,
+        candidate_end,
+        kv_workspace_slots,
+        block_table,
+        request_id,
+        block_table_stride,
+        PAGE_SIZE,
+        ROW_BYTES,
+        HEAD_DIM,
+        BLOCK_N,
+        NUM_WARPS,
+        IS_PREFILL,
+        USE_BUFFER_LOAD,
+    )
+
+    output_layout: gl.constexpr = gl.SliceLayout(0, mfma_layout)
+    output_columns = gl.arange(0, BLOCK_N, layout=output_layout)
+    current_buffer: gl.int32 = 0
+    for tile_id in tl.range(0, tile_count):
+        tile_start = candidate_start + tile_id * BLOCK_N
+        key_scales, valid = _load_key_scales(
+            index_k_scale,
+            tile_start,
+            candidate_end,
+            kv_workspace_slots,
+            block_table,
+            request_id,
+            block_table_stride,
+            output_layout,
+            PAGE_SIZE,
+            ROW_BYTES,
+            HEAD_DIM,
+            BLOCK_N,
+            IS_PREFILL,
+            USE_BUFFER_LOAD,
+        )
+        if tile_id + 1 < tile_count:
+            gl.amd.cdna4.async_copy.wait_group(1)
+        else:
+            # The final tile must be complete before it is read. This also
+            # drains the speculative masked preload for a one-tile span.
+            gl.amd.cdna4.async_copy.wait_group(0)
+        raw_key = key_shared.index(current_buffer).load(layout=blocked)
+        if tile_id + 2 < tile_count:
+            _load_key_tile_to_shared(
+                index_k_fp8,
+                key_shared,
+                current_buffer,
+                tile_start + 2 * BLOCK_N,
+                candidate_end,
+                kv_workspace_slots,
+                block_table,
+                request_id,
+                block_table_stride,
+                PAGE_SIZE,
+                ROW_BYTES,
+                HEAD_DIM,
+                BLOCK_N,
+                NUM_WARPS,
+                IS_PREFILL,
+                USE_BUFFER_LOAD,
+            )
+        scores = _score_key_tile(
+            query_0,
+            weight_0,
+            query_1,
+            weight_1,
+            raw_key,
+            key_scales,
+            model_scale,
+            mfma_layout,
+            dot_b_layout,
+            NUM_HEADS,
+            BLOCK_N,
+            Q_IS_FP8,
+        )
+        output_offsets = (
+            row_id.to(gl.int64) * logits_stride
+            + tile_start.to(gl.int64)
+            + output_columns.to(gl.int64)
+        )
+        if USE_BUFFER_STORE:
+            gl.amd.cdna4.buffer_store(
+                scores,
+                ptr=logits,
+                offsets=output_offsets.to(gl.int32),
+                mask=valid,
+            )
+        else:
+            gl.store(logits + output_offsets, scores, mask=valid)
+        current_buffer = 1 - current_buffer
+    # Empty spans still issued two fully masked speculative preloads.
+    gl.amd.cdna4.async_copy.wait_group(0)
+
+
+@gluon.jit
+def _dsa_standard_prefill_logits_kernel(
+    q,
+    q_scales,
+    index_k_fp8,
+    index_k_scale,
+    weights,
+    kv_workspace_slots,
+    row_starts,
+    row_ends,
+    block_table,
+    logits,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_qs_row,
+    stride_qs_head,
+    stride_w_row,
+    stride_w_head,
+    logits_stride,
+    model_scale,
+    workspace_rows,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+    USE_BUFFER_STORE: gl.constexpr,
+):
+    _standard_cache_logits_body(
+        q,
+        q_scales,
+        index_k_fp8,
+        index_k_scale,
+        weights,
+        kv_workspace_slots,
+        row_starts,
+        row_ends,
+        row_ends,
+        block_table,
+        logits,
+        stride_q_row,
+        stride_q_head,
+        stride_q_dim,
+        stride_qs_row,
+        stride_qs_head,
+        stride_w_row,
+        stride_w_head,
+        0,
+        logits_stride,
+        model_scale,
+        workspace_rows,
+        1,
+        PAGE_SIZE,
+        ROW_BYTES,
+        NUM_HEADS,
+        HEAD_DIM,
+        BLOCK_N,
+        BLOCK_N,
+        NUM_WARPS,
+        Q_IS_FP8,
+        True,
+        USE_BUFFER_LOAD,
+        USE_BUFFER_STORE,
+    )
+
+
+@gluon.jit
+def _dsa_standard_decode_logits_kernel(
+    q,
+    q_scales,
+    index_k_fp8,
+    index_k_scale,
+    weights,
+    seq_lens,
+    block_table,
+    logits,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_qs_row,
+    stride_qs_head,
+    stride_w_row,
+    stride_w_head,
+    block_table_stride,
+    logits_stride,
+    model_scale,
+    max_candidates,
+    q_len_per_req,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    CHUNK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+    USE_BUFFER_STORE: gl.constexpr,
+):
+    _standard_cache_logits_body(
+        q,
+        q_scales,
+        index_k_fp8,
+        index_k_scale,
+        weights,
+        block_table,
+        seq_lens,
+        seq_lens,
+        seq_lens,
+        block_table,
+        logits,
+        stride_q_row,
+        stride_q_head,
+        stride_q_dim,
+        stride_qs_row,
+        stride_qs_head,
+        stride_w_row,
+        stride_w_head,
+        block_table_stride,
+        logits_stride,
+        model_scale,
+        max_candidates,
+        q_len_per_req,
+        PAGE_SIZE,
+        ROW_BYTES,
+        NUM_HEADS,
+        HEAD_DIM,
+        BLOCK_N,
+        CHUNK_N,
+        NUM_WARPS,
+        Q_IS_FP8,
+        False,
+        USE_BUFFER_LOAD,
+        USE_BUFFER_STORE,
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -3332,6 +3332,7 @@ def dsa_prefill_topk(
     page_size: int | None = None,
     index_k_fp8: torch.Tensor | None = None,
     index_k_scale: torch.Tensor | None = None,
+    q_scales: torch.Tensor | None = None,
     max_logits_bytes: int | None = None,
     out: torch.Tensor | None = None,
     lens_out: torch.Tensor | None = None,
@@ -3341,7 +3342,8 @@ def dsa_prefill_topk(
     """Compute DSA prefill top-k over packed workspace rows.
 
     Args:
-        q: BF16 indexer query with shape [tokens, index_heads, head_dim].
+        q: BF16 or FP8 E4M3 indexer query with shape
+            [tokens, index_heads, head_dim]. FP8 queries require q_scales.
         weights: Per-token/head weights with shape [tokens, index_heads],
             FP32 or raw BF16 (implementations upcast on the fly).
         kv_workspace_slots: Global KV slot for each workspace row, shape
@@ -3349,13 +3351,20 @@ def dsa_prefill_topk(
         row_starts: Inclusive workspace-row start per query token, shape [tokens].
         row_ends: Exclusive workspace-row end per query token, shape [tokens].
         topk: Number of workspace candidates to select.
-        softmax_scale: Score scale, normally index_head_dim ** -0.5.
-        index_k_cache: Packed FP8 index-K cache with scales (uint8). Used by
-            Triton with kv_workspace_slots and by DeepGEMM to gather workspace
-            rows internally.
+        softmax_scale: Score scale. Each candidate score is exactly
+            ``softmax_scale * sum_h(weights[h] * relu(dot(dequant(q[h]), dequant(k))))``.
+            BF16 queries are already in their compute representation.
+        index_k_cache: Packed paged FP8 index-K cache with scales (uint8). Used
+            with kv_workspace_slots to resolve workspace rows inside the
+            selected implementation.
         page_size: KV cache page size for index_k_cache.
-        index_k_fp8: FP8 index-K rows in workspace-row order. Used by DeepGEMM.
-        index_k_scale: FP8 index-K scales in workspace-row order. Used by DeepGEMM.
+        index_k_fp8: FP8 index-K rows already in workspace-row order. Must be
+            provided together with index_k_scale.
+        index_k_scale: FP8 index-K scales already in workspace-row order. Must
+            be provided together with index_k_fp8.
+        q_scales: Optional positive FP32 scale per token/head for FP8 queries,
+            defining ``dequant(q[token, head]) = q[token, head].float() *
+            q_scales[token, head]``.
         max_logits_bytes: Optional temporary logits memory cap.
         out: Optional contiguous int32 output buffer on q's device with shape
             [tokens, topk].
@@ -3364,10 +3373,10 @@ def dsa_prefill_topk(
         override: Optional exact kernel override name.
         solution: Optional kernel solution to force through normal selection.
 
-    Gluon compacts weights when needed. It requires q, index_k_cache,
-    kv_workspace_slots, row_starts, and row_ends to be contiguous on q's
-    device. kv_workspace_slots must be int64; row_starts and row_ends must be
-    int32.
+    Implementations may accept a strided outer weight dimension, including the
+    fused model projection view. q, index_k_cache, kv_workspace_slots,
+    row_starts, and row_ends must be contiguous on q's device.
+    kv_workspace_slots must be int64; row_starts and row_ends must be int32.
 
     Returns:
         Tuple of workspace row ids and valid counts. Returned indices are
@@ -3382,13 +3391,18 @@ def dsa_prefill_topk(
             f"lens_out must have shape {(q.shape[0],)}, got {tuple(lens_out.shape)}"
         )
     traits = {
+        "index_heads": q.shape[1],
         "head_dim": q.shape[-1],
         "topk": int(topk),
         "page_size": None if page_size is None else int(page_size),
     }
-    has_fp8 = index_k_cache is not None or (
-        index_k_fp8 is not None and index_k_scale is not None
-    )
+    has_workspace_rows = index_k_fp8 is not None and index_k_scale is not None
+    if (index_k_fp8 is None) != (index_k_scale is None):
+        raise ValueError(
+            "index_k_fp8 and index_k_scale must be provided together for "
+            "workspace-row input"
+        )
+    has_fp8 = index_k_cache is not None or has_workspace_rows
     if has_fp8:
         traits["index_k_format"] = "fp8_scaled"
     signature = _attention_format_signature(q=q, weights=weights)
@@ -3417,22 +3431,25 @@ def dsa_prefill_topk(
         kernel_name=kernel.name,
         **shape_params,
     ):
-        return kernel(
-            q=q,
-            weights=weights,
-            kv_workspace_slots=kv_workspace_slots,
-            row_starts=row_starts,
-            row_ends=row_ends,
-            topk=topk,
-            softmax_scale=softmax_scale,
-            index_k_cache=index_k_cache,
-            page_size=page_size,
-            index_k_fp8=index_k_fp8,
-            index_k_scale=index_k_scale,
-            max_logits_bytes=max_logits_bytes,
-            out=out,
-            lens_out=lens_out,
-        )
+        kernel_kwargs = {
+            "q": q,
+            "weights": weights,
+            "kv_workspace_slots": kv_workspace_slots,
+            "row_starts": row_starts,
+            "row_ends": row_ends,
+            "topk": topk,
+            "softmax_scale": softmax_scale,
+            "index_k_cache": index_k_cache,
+            "page_size": page_size,
+            "index_k_fp8": index_k_fp8,
+            "index_k_scale": index_k_scale,
+            "max_logits_bytes": max_logits_bytes,
+            "out": out,
+            "lens_out": lens_out,
+        }
+        if q_scales is not None:
+            kernel_kwargs["q_scales"] = q_scales
+        return kernel(**kernel_kwargs)
 
 
 def dsa_decode_topk(
@@ -3446,6 +3463,7 @@ def dsa_decode_topk(
     softmax_scale: float,
     q_len_per_req: int = 1,
     index_k_cache: torch.Tensor | None = None,
+    q_scales: torch.Tensor | None = None,
     seq_lens_2d: torch.Tensor | None = None,
     plan: object | None = None,
     out: torch.Tensor | None = None,
@@ -3456,7 +3474,8 @@ def dsa_decode_topk(
     """Compute DSA decode top-k over a paged KV cache.
 
     Args:
-        q: BF16 indexer query with shape [tokens, index_heads, head_dim].
+        q: BF16 or FP8 E4M3 indexer query with shape
+            [tokens, index_heads, head_dim]. FP8 queries require q_scales.
         weights: Per-token/head weights with shape [tokens, index_heads],
             FP32 or raw BF16 (implementations upcast on the fly).
         seq_lens: Per-request full KV length, shape [num_reqs] (= tokens /
@@ -3466,11 +3485,16 @@ def dsa_decode_topk(
             shape [num_reqs, max_pages].
         page_size: Number of tokens per KV page.
         topk: Number of KV candidates to select.
-        softmax_scale: Score scale, normally index_head_dim ** -0.5.
+        softmax_scale: Score scale. Each candidate score is exactly
+            ``softmax_scale * sum_h(weights[h] * relu(dot(dequant(q[h]), dequant(k))))``.
+            BF16 queries are already in their compute representation.
         q_len_per_req: Query rows per request (spec-verify next_n). Plain
             decode uses 1, where per-request is equivalent to per-token.
         index_k_cache: Packed FP8 index-K cache with scales (uint8). Used by
             both Triton and DeepGEMM.
+        q_scales: Optional positive FP32 scale per token/head for FP8 queries,
+            defining ``dequant(q[token, head]) = q[token, head].float() *
+            q_scales[token, head]``.
         plan: Optional opaque backend-specific plan.
         out: Optional contiguous int32 output buffer on q's device with shape
             [tokens, topk].
@@ -3479,9 +3503,9 @@ def dsa_decode_topk(
         override: Optional exact kernel override name.
         solution: Optional kernel solution to force through normal selection.
 
-    Gluon compacts weights when needed. It requires q, index_k_cache, seq_lens,
-    and block_table to be contiguous on q's device. seq_lens and block_table
-    must be int32.
+    Implementations may accept a strided outer weight dimension, including the
+    fused model projection view. q, index_k_cache, seq_lens, and block_table
+    must be contiguous on q's device. seq_lens and block_table must be int32.
 
     Returns:
         Tuple of global KV slots and valid counts; invalid entries are -1.
@@ -3495,6 +3519,7 @@ def dsa_decode_topk(
             f"lens_out must have shape {(q.shape[0],)}, got {tuple(lens_out.shape)}"
         )
     traits = {
+        "index_heads": q.shape[1],
         "head_dim": q.shape[-1],
         "topk": int(topk),
         "page_size": int(page_size),
@@ -3530,21 +3555,24 @@ def dsa_decode_topk(
         kernel_name=kernel.name,
         **shape_params,
     ):
-        return kernel(
-            q=q,
-            weights=weights,
-            seq_lens=seq_lens,
-            block_table=block_table,
-            page_size=page_size,
-            topk=topk,
-            softmax_scale=softmax_scale,
-            q_len_per_req=q_len_per_req,
-            index_k_cache=index_k_cache,
-            seq_lens_2d=seq_lens_2d,
-            plan=plan,
-            out=out,
-            lens_out=lens_out,
-        )
+        kernel_kwargs = {
+            "q": q,
+            "weights": weights,
+            "seq_lens": seq_lens,
+            "block_table": block_table,
+            "page_size": page_size,
+            "topk": topk,
+            "softmax_scale": softmax_scale,
+            "q_len_per_req": q_len_per_req,
+            "index_k_cache": index_k_cache,
+            "seq_lens_2d": seq_lens_2d,
+            "plan": plan,
+            "out": out,
+            "lens_out": lens_out,
+        }
+        if q_scales is not None:
+            kernel_kwargs["q_scales"] = q_scales
+        return kernel(**kernel_kwargs)
 
 
 def dsa_plan(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -50,7 +50,13 @@ if current_platform().is_amd:
         gluon_dsa_decode_topk_fp8_gfx950 as _dsa_decode_topk_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.sparse_mla import (
+        gluon_dsa_decode_topk_standard_gfx950 as _dsa_decode_topk_standard_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.sparse_mla import (
         gluon_dsa_prefill_topk_fp8_gfx950 as _dsa_prefill_topk_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.sparse_mla import (
+        gluon_dsa_prefill_topk_standard_gfx950 as _dsa_prefill_topk_standard_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx950.attention.kda.decode import (
         gluon_kda_fused_decode_gfx950 as _kda_fused_decode_impl,
@@ -1108,6 +1114,71 @@ if current_platform().is_amd:
     )
     def gluon_mla_prefill_gfx1250(*args, **kwargs):
         return _mla_prefill_gfx1250_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "dsa_decode_topk",
+        name="gluon_dsa_decode_topk_standard_gfx950",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=frozenset(
+            {
+                format_signature(
+                    q=dense_tensor_format(q_dtype),
+                    weights=dense_tensor_format(weight_dtype),
+                )
+                for q_dtype in (torch.bfloat16, torch.float8_e4m3fn)
+                for weight_dtype in (torch.bfloat16, torch.float32)
+            }
+        ),
+        priority=Priority.SPECIALIZED + 1,
+        traits={
+            "index_heads": frozenset({32, 64}),
+            "head_dim": frozenset({128}),
+            "topk": frozenset({512, 1024, 2048}),
+            "page_size": frozenset({64}),
+            "q_len_per_req": frozenset({1, 2, 3, 4, 5, 6}),
+            "index_k_format": frozenset({"fp8_scaled"}),
+        },
+    )
+    def gluon_dsa_decode_topk_standard_gfx950(*args, **kwargs):
+        return _dsa_decode_topk_standard_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "dsa_prefill_topk",
+        name="gluon_dsa_prefill_topk_standard_gfx950",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=frozenset(
+            {
+                format_signature(
+                    q=dense_tensor_format(q_dtype),
+                    weights=dense_tensor_format(weight_dtype),
+                )
+                for q_dtype in (torch.bfloat16, torch.float8_e4m3fn)
+                for weight_dtype in (torch.bfloat16, torch.float32)
+            }
+        ),
+        priority=Priority.SPECIALIZED + 1,
+        traits={
+            "index_heads": frozenset({32, 64}),
+            "head_dim": frozenset({128}),
+            "topk": frozenset({512, 1024, 2048}),
+            "page_size": frozenset({64}),
+            "index_k_format": frozenset({"fp8_scaled"}),
+        },
+    )
+    def gluon_dsa_prefill_topk_standard_gfx950(*args, **kwargs):
+        return _dsa_prefill_topk_standard_impl(*args, **kwargs)
 
     @register_kernel(
         "attention",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
@@ -154,8 +154,7 @@ def local_topk_to_global_slots(
     else:
         if lens_out.shape != (num_tokens,):
             raise ValueError(
-                "lens_out must have shape "
-                f"({num_tokens},), got {tuple(lens_out.shape)}"
+                f"lens_out must have shape ({num_tokens},), got {tuple(lens_out.shape)}"
             )
         if (
             lens_out.dtype != torch.int32
@@ -413,7 +412,9 @@ def _dsa_decode_logits_fp8_kernel(
                 other=0.0,
             ).to(tl.float32)
             head_score += tl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
-        scores += head_score * head_weight
+        scores += (
+            tl.maximum(head_score, 0.0, propagate_nan=tl.PropagateNan.ALL) * head_weight
+        )
 
     scores *= softmax_scale
     scores = tl.where(valid, scores, -float("inf"))
@@ -489,7 +490,9 @@ def _dsa_prefill_logits_fp8_kernel(
                 other=0.0,
             ).to(tl.float32)
             head_score += tl.sum(k_vals * k_scale[:, None] * q_vals[None, :], axis=1)
-        scores += head_score * head_weight
+        scores += (
+            tl.maximum(head_score, 0.0, propagate_nan=tl.PropagateNan.ALL) * head_weight
+        )
 
     scores *= softmax_scale
     scores = tl.where(valid, scores, -float("inf"))
@@ -527,7 +530,7 @@ def _check_packed_fp8_inputs(
     _check_q_weights(q, weights)
     if q.shape[2] % 128 != 0:
         raise ValueError(
-            "DSA Triton FP8 top-k requires dim multiple of 128, got " f"{q.shape[2]}"
+            f"DSA Triton FP8 top-k requires dim multiple of 128, got {q.shape[2]}"
         )
     if index_k_cache.dtype != torch.uint8:
         raise TypeError(

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
@@ -493,7 +493,7 @@ def _index_scores(
     softmax_scale: float,
 ) -> torch.Tensor:
     per_head = index_k.float() @ q.float().transpose(0, 1)
-    return (per_head * weights.float()).sum(dim=1) * softmax_scale
+    return (per_head.relu() * weights.float()).sum(dim=1) * softmax_scale
 
 
 def _reference_decode_topk(
@@ -507,9 +507,10 @@ def _reference_decode_topk(
     topk: int,
     softmax_scale: float,
     q_len_per_req: int = 1,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
     out = torch.full((q.shape[0], topk), -1, device=q.device, dtype=torch.int32)
     lens = torch.empty((q.shape[0],), device=q.device, dtype=torch.int32)
+    candidate_ids_and_scores: list[tuple[torch.Tensor, torch.Tensor]] = []
     for token in range(q.shape[0]):
         req = token // int(q_len_per_req)
         q_offset = token - req * int(q_len_per_req)
@@ -519,6 +520,12 @@ def _reference_decode_topk(
         count = min(seq_len, int(topk))
         lens[token] = count
         if count == 0:
+            candidate_ids_and_scores.append(
+                (
+                    torch.empty((0,), device=q.device, dtype=torch.long),
+                    torch.empty((0,), device=q.device, dtype=torch.float32),
+                )
+            )
             continue
         offsets = torch.arange(seq_len, device=q.device, dtype=torch.long)
         pages = block_table[req].long().index_select(0, offsets // page_size)
@@ -531,7 +538,8 @@ def _reference_decode_topk(
         )
         selected = torch.topk(scores, count).indices
         out[token, :count] = slots.index_select(0, selected).to(torch.int32)
-    return out, lens
+        candidate_ids_and_scores.append((slots, scores))
+    return out, lens, candidate_ids_and_scores
 
 
 def _reference_prefill_topk(
@@ -544,13 +552,20 @@ def _reference_prefill_topk(
     *,
     topk: int,
     softmax_scale: float,
-) -> tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
     out = torch.full((q.shape[0], topk), -1, device=q.device, dtype=torch.int32)
     candidate_lens = (row_ends - row_starts).clamp_min(0)
     lens = torch.minimum(candidate_lens, torch.full_like(candidate_lens, int(topk)))
+    candidate_ids_and_scores: list[tuple[torch.Tensor, torch.Tensor]] = []
     for token in range(q.shape[0]):
         count = int(lens[token].item())
         if count == 0:
+            candidate_ids_and_scores.append(
+                (
+                    torch.empty((0,), device=q.device, dtype=torch.long),
+                    torch.empty((0,), device=q.device, dtype=torch.float32),
+                )
+            )
             continue
         rows = torch.arange(
             int(row_starts[token].item()),
@@ -567,7 +582,8 @@ def _reference_prefill_topk(
         )
         selected = torch.topk(scores, count).indices
         out[token, :count] = rows.index_select(0, selected).to(torch.int32)
-    return out, lens
+        candidate_ids_and_scores.append((rows, scores))
+    return out, lens, candidate_ids_and_scores
 
 
 def _assert_topk_matches(
@@ -575,13 +591,37 @@ def _assert_topk_matches(
     actual_lens: torch.Tensor,
     expected: torch.Tensor,
     expected_lens: torch.Tensor,
+    candidate_ids_and_scores: list[tuple[torch.Tensor, torch.Tensor]],
 ) -> None:
     torch.testing.assert_close(actual_lens.cpu(), expected_lens.cpu())
     for token in range(actual.shape[0]):
         count = int(expected_lens[token].item())
+        candidate_ids, candidate_scores = candidate_ids_and_scores[token]
+        actual_ids = actual[token, :count].long()
+        assert torch.unique(actual_ids).numel() == count
+        sorted_ids, order = torch.sort(candidate_ids)
+        locations = torch.searchsorted(sorted_ids, actual_ids)
+        assert (locations < sorted_ids.numel()).all()
+        torch.testing.assert_close(sorted_ids[locations], actual_ids)
         actual_selected = torch.sort(actual[token, :count].cpu()).values
         expected_selected = torch.sort(expected[token, :count].cpu()).values
-        torch.testing.assert_close(actual_selected, expected_selected)
+        if not torch.equal(actual_selected, expected_selected):
+            # Per-head ReLU can create exact zero-score ties at the cutoff.
+            actual_only = actual_ids[~torch.isin(actual_ids, expected[token, :count])]
+            expected_only = expected[token, :count].long()[
+                ~torch.isin(expected[token, :count], actual_ids)
+            ]
+            assert actual_only.numel() == expected_only.numel()
+            cutoff = torch.topk(candidate_scores, count).values[-1]
+            for tied_ids in (actual_only, expected_only):
+                tied_locations = torch.searchsorted(sorted_ids, tied_ids)
+                tied_scores = candidate_scores[order[tied_locations]]
+                torch.testing.assert_close(
+                    tied_scores,
+                    torch.full_like(tied_scores, cutoff),
+                    rtol=0.0,
+                    atol=0.0,
+                )
         assert (actual[token, count:] == -1).all()
 
 
@@ -624,7 +664,7 @@ def test_dsa_decode_topk_fp8_glm52_cases(case: _TopKDecodeCase) -> None:
         q_len_per_req=case.q_len_per_req,
         index_k_cache=packed_index_k,
     )
-    expected_slots, expected_lens = _reference_decode_topk(
+    expected_slots, expected_lens, candidate_ids_and_scores = _reference_decode_topk(
         q,
         weights,
         index_k,
@@ -636,7 +676,13 @@ def test_dsa_decode_topk_fp8_glm52_cases(case: _TopKDecodeCase) -> None:
         q_len_per_req=case.q_len_per_req,
     )
 
-    _assert_topk_matches(topk_slots, topk_lens, expected_slots, expected_lens)
+    _assert_topk_matches(
+        topk_slots,
+        topk_lens,
+        expected_slots,
+        expected_lens,
+        candidate_ids_and_scores,
+    )
 
 
 @pytest.mark.parametrize(
@@ -681,7 +727,7 @@ def test_dsa_prefill_topk_fp8_glm52_cases(case: _TopKPrefillCase) -> None:
         index_k_cache=packed_index_k,
         page_size=page_size,
     )
-    expected_indices, expected_lens = _reference_prefill_topk(
+    expected_indices, expected_lens, candidate_ids_and_scores = _reference_prefill_topk(
         q,
         weights,
         index_k,
@@ -692,7 +738,13 @@ def test_dsa_prefill_topk_fp8_glm52_cases(case: _TopKPrefillCase) -> None:
         softmax_scale=softmax_scale,
     )
 
-    _assert_topk_matches(workspace_indices, topk_lens, expected_indices, expected_lens)
+    _assert_topk_matches(
+        workspace_indices,
+        topk_lens,
+        expected_indices,
+        expected_lens,
+        candidate_ids_and_scores,
+    )
 
 
 if is_cdna4():
@@ -714,7 +766,7 @@ else:
 @pytest.mark.parametrize(
     ("seq_len", "capture_graph"),
     _BF16_SPLIT_WEIGHT_DECODE_CASES,
-    ids=("fused-eager", "fused-graph", "precombined-eager", "precombined-graph"),
+    ids=("short-eager", "short-graph", "long-eager", "long-graph"),
 )
 def test_dsa_decode_topk_fp8_accepts_glm52_bf16_split_weights(
     seq_len: int,
@@ -771,7 +823,7 @@ def test_dsa_decode_topk_fp8_accepts_glm52_bf16_split_weights(
             invoke()
         graph.replay()
         torch.cuda.synchronize()
-    expected_slots, expected_lens = _reference_decode_topk(
+    expected_slots, expected_lens, candidate_ids_and_scores = _reference_decode_topk(
         q,
         weights,
         index_k,
@@ -783,7 +835,13 @@ def test_dsa_decode_topk_fp8_accepts_glm52_bf16_split_weights(
         q_len_per_req=q_len_per_req,
     )
 
-    _assert_topk_matches(topk_slots, topk_lens, expected_slots, expected_lens)
+    _assert_topk_matches(
+        topk_slots,
+        topk_lens,
+        expected_slots,
+        expected_lens,
+        candidate_ids_and_scores,
+    )
 
 
 def test_dsa_prefill_topk_fp8_accepts_glm52_bf16_split_weights() -> None:
@@ -825,7 +883,7 @@ def test_dsa_prefill_topk_fp8_accepts_glm52_bf16_split_weights() -> None:
         index_k_cache=packed_index_k,
         page_size=page_size,
     )
-    expected_indices, expected_lens = _reference_prefill_topk(
+    expected_indices, expected_lens, candidate_ids_and_scores = _reference_prefill_topk(
         q,
         weights,
         index_k,
@@ -836,7 +894,13 @@ def test_dsa_prefill_topk_fp8_accepts_glm52_bf16_split_weights() -> None:
         softmax_scale=head_dim**-0.5 * index_heads**-0.5,
     )
 
-    _assert_topk_matches(workspace_indices, topk_lens, expected_indices, expected_lens)
+    _assert_topk_matches(
+        workspace_indices,
+        topk_lens,
+        expected_indices,
+        expected_lens,
+        candidate_ids_and_scores,
+    )
 
 
 def test_dsa_prefill_topk_keeps_late_values_above_threshold() -> None:

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache_gfx950.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache_gfx950.py
@@ -1,0 +1,617 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""GFX950 integration coverage for the standard block-split DSA cache."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+from utils import is_cdna4
+
+if not is_cdna4():
+    pytest.skip(
+        "AMD CDNA4 (GFX950) is required for standard-cache Gluon DSA tests",
+        allow_module_level=True,
+    )
+
+from tokenspeed_kernel.ops.kvcache.triton import (  # isort: skip
+    index_k_block_split_scatter,
+)
+from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.sparse_mla import (  # isort: skip
+    gluon_dsa_decode_topk_standard_gfx950,
+    gluon_dsa_prefill_topk_standard_gfx950,
+)
+from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.standard_cache_logits import (  # isort: skip
+    _dsa_standard_decode_logits_kernel,
+)
+
+_DEVICE = "cuda"
+_PAGE_SIZE = 64
+_HEAD_DIM = 128
+_TOPK = 512
+_SOFTMAX_SCALE = _HEAD_DIM**-0.5
+
+
+@dataclass(frozen=True)
+class _DecodeCase:
+    q_len: int
+    heads: int
+    q_dtype: torch.dtype
+    weight_dtype: torch.dtype
+
+
+_DECODE_CASES = (
+    _DecodeCase(1, 32, torch.bfloat16, torch.bfloat16),
+    _DecodeCase(2, 64, torch.bfloat16, torch.float32),
+    _DecodeCase(3, 32, torch.float8_e4m3fn, torch.bfloat16),
+    _DecodeCase(4, 64, torch.float8_e4m3fn, torch.float32),
+    _DecodeCase(5, 32, torch.bfloat16, torch.float32),
+    _DecodeCase(6, 64, torch.float8_e4m3fn, torch.bfloat16),
+)
+
+
+def _generator(seed: int) -> torch.Generator:
+    generator = torch.Generator(device=_DEVICE)
+    generator.manual_seed(seed)
+    return generator
+
+
+def _prepared_query(
+    tokens: int,
+    heads: int,
+    dtype: torch.dtype,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+    values = (
+        torch.randn(
+            (tokens, heads, _HEAD_DIM),
+            device=_DEVICE,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.15
+    )
+    if dtype == torch.bfloat16:
+        query = values.to(torch.bfloat16)
+        return query, None, query.float()
+
+    scales = (
+        torch.rand(
+            (tokens, heads), device=_DEVICE, dtype=torch.float32, generator=generator
+        )
+        * 0.02
+        + 0.01
+    )
+    query = (values / scales[..., None]).clamp(-448.0, 448.0).to(dtype)
+    return query, scales.contiguous(), query.float() * scales[..., None]
+
+
+def _noncompact_weights(
+    tokens: int,
+    heads: int,
+    dtype: torch.dtype,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    row_stride = 128 + heads
+    backing = torch.empty((tokens, row_stride), device=_DEVICE, dtype=dtype)
+    weights = backing[:, 128:]
+    values = torch.randn(
+        (tokens, heads), device=_DEVICE, dtype=torch.float32, generator=generator
+    )
+    values[:, 0] = values[:, 0].abs() + 0.1
+    values[:, 1] = -(values[:, 1].abs() + 0.1)
+    weights.copy_(values.to(dtype))
+    assert weights.stride() == (row_stride, 1)
+    assert weights.storage_offset() == 128
+    return weights
+
+
+def _pack_standard_cache(
+    keys: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create the page-major FP8-plus-scale layout without scorer helpers."""
+    assert keys.shape[0] % _PAGE_SIZE == 0
+    num_slots = keys.shape[0]
+    num_pages = num_slots // _PAGE_SIZE
+    values = keys.float()
+    scales = values.abs().amax(dim=-1, keepdim=True).clamp_min(1.0e-6) / 448.0
+    key_fp8 = (values / scales).clamp(-448.0, 448.0).to(torch.float8_e4m3fn)
+    reference = key_fp8.float() * scales
+    packed = torch.zeros((num_slots, 132), device=_DEVICE, dtype=torch.uint8)
+    flat = packed.reshape(-1)
+    page_bytes = _PAGE_SIZE * 132
+    fp8_pages = torch.as_strided(
+        flat.view(torch.float8_e4m3fn),
+        (num_pages, _PAGE_SIZE, _HEAD_DIM),
+        (page_bytes, _HEAD_DIM, 1),
+    )
+    scale_pages = torch.as_strided(
+        flat.view(torch.float32),
+        (num_pages, _PAGE_SIZE, 1),
+        (page_bytes // 4, 1, 1),
+        (_PAGE_SIZE * _HEAD_DIM) // 4,
+    )
+    fp8_pages.copy_(key_fp8.reshape(num_pages, _PAGE_SIZE, _HEAD_DIM))
+    scale_pages.copy_(scales.reshape(num_pages, _PAGE_SIZE, 1))
+    return packed, reference, key_fp8, scales
+
+
+def _weighted_relu_scores(
+    query: torch.Tensor,
+    weights: torch.Tensor,
+    keys: torch.Tensor,
+) -> torch.Tensor:
+    """Independent FP32 oracle for the kernel's weighted per-head ReLU."""
+    per_head = keys.float() @ query.float().transpose(0, 1)
+    return (per_head.relu() * weights.float()).sum(dim=1) * _SOFTMAX_SCALE
+
+
+def _expected_decode(
+    query: torch.Tensor,
+    weights: torch.Tensor,
+    keys: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    q_len: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    expected = torch.full(
+        (query.shape[0], _TOPK), -1, device=_DEVICE, dtype=torch.int32
+    )
+    expected_lens = torch.empty(query.shape[0], device=_DEVICE, dtype=torch.int32)
+    for row in range(query.shape[0]):
+        request, q_offset = divmod(row, q_len)
+        valid = int(seq_lens[request].item()) - (q_len - 1) + q_offset
+        count = min(max(valid, 0), _TOPK)
+        expected_lens[row] = count
+        if count == 0:
+            continue
+        positions = torch.arange(valid, device=_DEVICE)
+        pages = block_table[request, positions // _PAGE_SIZE].long()
+        slots = pages * _PAGE_SIZE + positions.remainder(_PAGE_SIZE)
+        scores = _weighted_relu_scores(query[row], weights[row], keys[slots])
+        selected = torch.topk(scores, count).indices
+        expected[row, :count] = slots[selected].to(torch.int32)
+    return expected, expected_lens
+
+
+def _expected_prefill(
+    query: torch.Tensor,
+    weights: torch.Tensor,
+    keys: torch.Tensor,
+    workspace_slots: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    expected = torch.full(
+        (query.shape[0], _TOPK), -1, device=_DEVICE, dtype=torch.int32
+    )
+    expected_lens = torch.empty(query.shape[0], device=_DEVICE, dtype=torch.int32)
+    for row in range(query.shape[0]):
+        start = max(int(row_starts[row].item()), 0)
+        end = min(int(row_ends[row].item()), workspace_slots.numel())
+        count = min(max(end - start, 0), _TOPK)
+        expected_lens[row] = count
+        if count == 0:
+            continue
+        workspace_rows = torch.arange(start, end, device=_DEVICE)
+        slots = workspace_slots[workspace_rows].long()
+        scores = _weighted_relu_scores(query[row], weights[row], keys[slots])
+        selected = torch.topk(scores, count).indices
+        expected[row, :count] = workspace_rows[selected].to(torch.int32)
+    return expected, expected_lens
+
+
+def _assert_topk(
+    actual: torch.Tensor,
+    actual_lens: torch.Tensor,
+    expected: torch.Tensor,
+    expected_lens: torch.Tensor,
+) -> None:
+    torch.testing.assert_close(actual_lens.cpu(), expected_lens.cpu())
+    for row, count_tensor in enumerate(expected_lens):
+        count = int(count_tensor.item())
+        torch.testing.assert_close(
+            torch.sort(actual[row, :count].cpu()).values,
+            torch.sort(expected[row, :count].cpu()).values,
+        )
+        assert (actual[row, count:] == -1).all()
+
+
+@pytest.mark.parametrize(
+    "case",
+    _DECODE_CASES,
+    ids=lambda case: (
+        f"q{case.q_len}-h{case.heads}-"
+        f"{str(case.q_dtype).removeprefix('torch.')}-"
+        f"w{str(case.weight_dtype).removeprefix('torch.')}"
+    ),
+)
+def test_standard_cache_decode_matches_weighted_relu_oracle(case: _DecodeCase) -> None:
+    generator = _generator(100 + case.q_len)
+    seq_lens = torch.tensor((515, 641), device=_DEVICE, dtype=torch.int32)
+    page_count = 11
+    block_table = torch.tensor(
+        (
+            (17, 3, 20, 1, 14, 7, 10, 5, 21, 0, 12),
+            (9, 18, 2, 16, 6, 13, 4, 19, 8, 15, 11),
+        ),
+        device=_DEVICE,
+        dtype=torch.int32,
+    )
+    assert block_table.shape == (2, page_count)
+    keys = (
+        torch.randn(
+            (block_table.numel() * _PAGE_SIZE, _HEAD_DIM),
+            device=_DEVICE,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.15
+    )
+    cache, key_reference, _, _ = _pack_standard_cache(keys)
+    query, q_scales, query_reference = _prepared_query(
+        2 * case.q_len, case.heads, case.q_dtype, generator
+    )
+    weights = _noncompact_weights(
+        2 * case.q_len, case.heads, case.weight_dtype, generator
+    )
+    if case.heads == 64:
+        weights[:, :32].zero_()
+
+    actual, actual_lens = gluon_dsa_decode_topk_standard_gfx950(
+        query,
+        weights,
+        seq_lens,
+        block_table,
+        page_size=_PAGE_SIZE,
+        topk=_TOPK,
+        softmax_scale=_SOFTMAX_SCALE,
+        q_len_per_req=case.q_len,
+        index_k_cache=cache,
+        q_scales=q_scales,
+    )
+    expected, expected_lens = _expected_decode(
+        query_reference,
+        weights,
+        key_reference,
+        seq_lens,
+        block_table,
+        case.q_len,
+    )
+
+    _assert_topk(actual, actual_lens, expected, expected_lens)
+
+
+@pytest.mark.parametrize(
+    ("heads", "q_dtype", "weight_dtype"),
+    (
+        (32, torch.bfloat16, torch.float32),
+        (64, torch.float8_e4m3fn, torch.bfloat16),
+    ),
+)
+def test_standard_cache_prefill_uses_workspace_rows_not_global_slots(
+    heads: int,
+    q_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+) -> None:
+    generator = _generator(200 + heads)
+    num_slots = 22 * _PAGE_SIZE
+    keys = (
+        torch.randn(
+            (num_slots, _HEAD_DIM),
+            device=_DEVICE,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.15
+    )
+    cache, key_reference, _, _ = _pack_standard_cache(keys)
+    workspace_rows = 704
+    workspace_slots = (
+        torch.arange(workspace_rows, device=_DEVICE) * 37 + 41
+    ) % num_slots
+    workspace_slots[96:160] = workspace_slots[11:75]
+    workspace_slots = workspace_slots.to(torch.int64).contiguous()
+    assert not torch.equal(
+        workspace_slots, torch.arange(workspace_rows, device=_DEVICE)
+    )
+    assert workspace_slots.unique().numel() < workspace_slots.numel()
+    row_starts = torch.tensor((7, 130, 260, 0, 530), device=_DEVICE, dtype=torch.int32)
+    row_ends = torch.tensor(
+        (535, 642, 600, 503, 530), device=_DEVICE, dtype=torch.int32
+    )
+    query, q_scales, query_reference = _prepared_query(
+        row_starts.numel(), heads, q_dtype, generator
+    )
+    weights = _noncompact_weights(row_starts.numel(), heads, weight_dtype, generator)
+
+    actual, actual_lens = gluon_dsa_prefill_topk_standard_gfx950(
+        query,
+        weights,
+        workspace_slots,
+        row_starts,
+        row_ends,
+        topk=_TOPK,
+        softmax_scale=_SOFTMAX_SCALE,
+        index_k_cache=cache,
+        page_size=_PAGE_SIZE,
+        q_scales=q_scales,
+        max_logits_bytes=workspace_rows * 4 * 2,
+    )
+    expected, expected_lens = _expected_prefill(
+        query_reference,
+        weights,
+        key_reference,
+        workspace_slots,
+        row_starts,
+        row_ends,
+    )
+
+    _assert_topk(actual, actual_lens, expected, expected_lens)
+    assert (actual[-1] == -1).all()
+
+
+def test_standard_cache_decode_accepts_block_split_writer_output() -> None:
+    generator = _generator(301)
+    num_slots = 11 * _PAGE_SIZE
+    source_keys = (
+        torch.randn(
+            (num_slots, _HEAD_DIM),
+            device=_DEVICE,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.15
+    )
+    _, source_reference, key_fp8, key_scales = _pack_standard_cache(source_keys)
+    cache = torch.zeros((num_slots, 132), device=_DEVICE, dtype=torch.uint8)
+    locations = torch.randperm(num_slots, device=_DEVICE, generator=generator)
+    index_k_block_split_scatter(
+        cache,
+        key_fp8,
+        key_scales,
+        locations,
+        page_size=_PAGE_SIZE,
+        head_dim=_HEAD_DIM,
+        group_size=_HEAD_DIM,
+    )
+    key_reference = torch.empty_like(source_reference)
+    key_reference[locations] = source_reference
+    seq_lens = torch.tensor((515,), device=_DEVICE, dtype=torch.int32)
+    block_table = torch.randperm(11, device=_DEVICE, generator=generator).reshape(1, 11)
+    block_table = block_table.to(torch.int32)
+    query, _, query_reference = _prepared_query(1, 32, torch.bfloat16, generator)
+    weights = _noncompact_weights(1, 32, torch.float32, generator)
+
+    actual, actual_lens = gluon_dsa_decode_topk_standard_gfx950(
+        query,
+        weights,
+        seq_lens,
+        block_table,
+        page_size=_PAGE_SIZE,
+        topk=_TOPK,
+        softmax_scale=_SOFTMAX_SCALE,
+        index_k_cache=cache,
+    )
+    expected, expected_lens = _expected_decode(
+        query_reference,
+        weights,
+        key_reference,
+        seq_lens,
+        block_table,
+        1,
+    )
+
+    _assert_topk(actual, actual_lens, expected, expected_lens)
+
+
+def test_standard_cache_decode_returns_empty_result_for_zero_pages() -> None:
+    generator = _generator(349)
+    query, _, _ = _prepared_query(1, 32, torch.bfloat16, generator)
+    weights = _noncompact_weights(1, 32, torch.float32, generator)
+    seq_lens = torch.zeros((1,), device=_DEVICE, dtype=torch.int32)
+    block_table = torch.empty((1, 0), device=_DEVICE, dtype=torch.int32)
+    cache = torch.empty((0, 132), device=_DEVICE, dtype=torch.uint8)
+    out = torch.zeros((1, _TOPK), device=_DEVICE, dtype=torch.int32)
+    lens_out = torch.full((1,), -1, device=_DEVICE, dtype=torch.int32)
+
+    actual, actual_lens = gluon_dsa_decode_topk_standard_gfx950(
+        query,
+        weights,
+        seq_lens,
+        block_table,
+        page_size=_PAGE_SIZE,
+        topk=_TOPK,
+        softmax_scale=_SOFTMAX_SCALE,
+        index_k_cache=cache,
+        out=out,
+        lens_out=lens_out,
+    )
+
+    assert actual.data_ptr() == out.data_ptr()
+    assert actual_lens.data_ptr() == lens_out.data_ptr()
+    assert (actual == -1).all()
+    assert (actual_lens == 0).all()
+
+
+def test_standard_cache_decode_logits_cover_empty_and_short_spans() -> None:
+    generator = _generator(350)
+    seq_lens = torch.tensor((0, 1, 63, 64, 65), device=_DEVICE, dtype=torch.int32)
+    block_table = torch.tensor(
+        ((0, 1), (1, 0), (0, 1), (1, 0), (0, 1)),
+        device=_DEVICE,
+        dtype=torch.int32,
+    )
+    keys = torch.randn(
+        (2 * _PAGE_SIZE, _HEAD_DIM),
+        device=_DEVICE,
+        dtype=torch.float32,
+        generator=generator,
+    )
+    cache, key_reference, _, _ = _pack_standard_cache(keys)
+    query, _, query_reference = _prepared_query(
+        seq_lens.numel(), 32, torch.bfloat16, generator
+    )
+    weights = _noncompact_weights(seq_lens.numel(), 32, torch.float32, generator)
+    logits = torch.full(
+        (seq_lens.numel(), 2 * _PAGE_SIZE),
+        float("nan"),
+        device=_DEVICE,
+        dtype=torch.float32,
+    )
+
+    _dsa_standard_decode_logits_kernel[(seq_lens.numel(), 1)](
+        query,
+        weights,
+        cache.view(torch.float8_e4m3fn),
+        cache.view(torch.float32),
+        weights,
+        seq_lens,
+        block_table,
+        logits,
+        query.stride(0),
+        query.stride(1),
+        query.stride(2),
+        weights.stride(0),
+        weights.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        block_table.stride(0),
+        logits.stride(0),
+        _SOFTMAX_SCALE,
+        logits.shape[1],
+        1,
+        PAGE_SIZE=_PAGE_SIZE,
+        ROW_BYTES=132,
+        NUM_HEADS=32,
+        HEAD_DIM=_HEAD_DIM,
+        BLOCK_N=64,
+        CHUNK_N=256,
+        NUM_WARPS=2,
+        Q_IS_FP8=False,
+        USE_BUFFER_LOAD=True,
+        USE_BUFFER_STORE=True,
+        num_warps=2,
+        waves_per_eu=4,
+    )
+    torch.cuda.synchronize()
+
+    assert logits[0].isnan().all()
+    for row, length_tensor in enumerate(seq_lens[1:], start=1):
+        length = int(length_tensor.item())
+        positions = torch.arange(length, device=_DEVICE)
+        pages = block_table[row, positions // _PAGE_SIZE].long()
+        slots = pages * _PAGE_SIZE + positions.remainder(_PAGE_SIZE)
+        expected = _weighted_relu_scores(
+            query_reference[row], weights[row], key_reference[slots]
+        )
+        torch.testing.assert_close(
+            logits[row, :length], expected, rtol=2.0e-2, atol=2.0e-2
+        )
+        assert logits[row, length:].isnan().all()
+
+
+@pytest.mark.parametrize("q_len", (1, 2, 3, 4, 5, 6))
+def test_standard_cache_decode_cuda_graph_replays_changed_inputs(q_len: int) -> None:
+    generator = _generator(400 + q_len)
+    heads = 32 if q_len % 2 else 64
+    q_dtype = torch.bfloat16 if q_len in (1, 2, 5) else torch.float8_e4m3fn
+    weight_dtype = torch.bfloat16 if q_len in (1, 3, 6) else torch.float32
+    seq_lens = torch.tensor((515,), device=_DEVICE, dtype=torch.int32)
+    block_table = torch.randperm(11, device=_DEVICE, generator=generator).reshape(1, 11)
+    block_table = block_table.to(torch.int32)
+    keys = (
+        torch.randn(
+            (11 * _PAGE_SIZE, _HEAD_DIM),
+            device=_DEVICE,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.15
+    )
+    cache, _, _, _ = _pack_standard_cache(keys)
+    query, q_scales, _ = _prepared_query(q_len, heads, q_dtype, generator)
+    weights = _noncompact_weights(q_len, heads, weight_dtype, generator)
+    out = torch.empty((q_len, _TOPK), device=_DEVICE, dtype=torch.int32)
+    lens_out = torch.empty((q_len,), device=_DEVICE, dtype=torch.int32)
+
+    def invoke() -> None:
+        gluon_dsa_decode_topk_standard_gfx950(
+            query,
+            weights,
+            seq_lens,
+            block_table,
+            page_size=_PAGE_SIZE,
+            topk=_TOPK,
+            softmax_scale=_SOFTMAX_SCALE,
+            q_len_per_req=q_len,
+            index_k_cache=cache,
+            q_scales=q_scales,
+            out=out,
+            lens_out=lens_out,
+        )
+
+    invoke()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        invoke()
+
+    replacement_query, replacement_scales, replacement_reference = _prepared_query(
+        q_len, heads, q_dtype, _generator(500 + q_len)
+    )
+    replacement_weights = _noncompact_weights(
+        q_len, heads, weight_dtype, _generator(600 + q_len)
+    )
+    replacement_keys = (
+        torch.randn(
+            (11 * _PAGE_SIZE, _HEAD_DIM),
+            device=_DEVICE,
+            dtype=torch.float32,
+            generator=_generator(700 + q_len),
+        )
+        * 0.15
+    )
+    replacement_cache, replacement_key_reference, _, _ = _pack_standard_cache(
+        replacement_keys
+    )
+    query.copy_(replacement_query)
+    weights.copy_(replacement_weights)
+    if q_scales is not None:
+        assert replacement_scales is not None
+        q_scales.copy_(replacement_scales)
+    cache.copy_(replacement_cache)
+    seq_lens.fill_(509)
+    block_table.copy_(torch.roll(block_table, shifts=3, dims=1))
+    graph.replay()
+    torch.cuda.synchronize()
+    expected, expected_lens = _expected_decode(
+        replacement_reference,
+        weights,
+        replacement_key_reference,
+        seq_lens,
+        block_table,
+        q_len,
+    )
+
+    _assert_topk(out, lens_out, expected, expected_lens)

--- a/tokenspeed-kernel/test/ops/test_attention_dsa.py
+++ b/tokenspeed-kernel/test/ops/test_attention_dsa.py
@@ -74,6 +74,19 @@ def _pack_index_k_cache(
     return packed, (x_fp8.float() * scale).reshape_as(index_k)
 
 
+def _assert_topk_sets_match(
+    actual: torch.Tensor,
+    actual_lens: torch.Tensor,
+    expected: torch.Tensor,
+    expected_lens: torch.Tensor,
+) -> None:
+    torch.testing.assert_close(actual_lens.cpu(), expected_lens.cpu())
+    for row in range(actual.shape[0]):
+        count = int(expected_lens[row].item())
+        assert set(actual[row, :count].tolist()) == set(expected[row, :count].tolist())
+        assert (actual[row, count:] == -1).all()
+
+
 def test_dsa_decode_topk_fp8(device: str, require) -> None:
     require("attention", "dsa_decode_topk", "triton", torch.bfloat16, "q")
 
@@ -111,7 +124,7 @@ def test_dsa_decode_topk_fp8(device: str, require) -> None:
             page = int(block_table[token, offset // page_size].item())
             slot = page * page_size + offset % page_size
             per_head = (q[token].float() * index_k[slot].float()).sum(dim=-1)
-            scores.append((per_head * weights[token]).sum() * (128**-0.5))
+            scores.append((per_head.relu() * weights[token]).sum() * (128**-0.5))
             slots.append(slot)
         local = torch.topk(
             torch.stack(scores), int(expected_lens[token].item())
@@ -120,9 +133,7 @@ def test_dsa_decode_topk_fp8(device: str, require) -> None:
             [slots[int(i)] for i in local.tolist()], device=device, dtype=torch.int32
         )
 
-    torch.testing.assert_close(topk_lens.cpu(), expected_lens.cpu())
-    torch.testing.assert_close(topk_slots[:, :65].cpu(), expected[:, :65].cpu())
-    assert (topk_slots[0, int(expected_lens[0].item()) :] == -1).all()
+    _assert_topk_sets_match(topk_slots, topk_lens, expected, expected_lens)
 
 
 @pytest.mark.parametrize("q_len_per_req", [2, 4])
@@ -172,7 +183,7 @@ def test_dsa_decode_topk_fp8_mtp(device: str, q_len_per_req: int, require) -> No
                 page = int(block_table[r, off // page_size].item())
                 slot = page * page_size + off % page_size
                 per_head = (q[token].float() * index_k[slot].float()).sum(dim=-1)
-                scores.append((per_head * weights[token]).sum() * (128**-0.5))
+                scores.append((per_head.relu() * weights[token]).sum() * (128**-0.5))
                 slots.append(slot)
             k = min(causal_len, topk)
             local = torch.topk(torch.stack(scores), k).indices
@@ -220,7 +231,7 @@ def test_dsa_prefill_topk_fp8(device: str, require) -> None:
         for row in range(int(row_starts[token].item()), int(row_ends[token].item())):
             slot = int(kv_workspace_slots[row].item())
             per_head = (q[token].float() * index_k[slot].float()).sum(dim=-1)
-            scores.append((per_head * weights[token]).sum() * (128**-0.5))
+            scores.append((per_head.relu() * weights[token]).sum() * (128**-0.5))
             rows.append(row)
         local = torch.topk(
             torch.stack(scores), int(expected_lens[token].item())
@@ -229,9 +240,12 @@ def test_dsa_prefill_topk_fp8(device: str, require) -> None:
             [rows[int(i)] for i in local.tolist()], device=device, dtype=torch.int32
         )
 
-    torch.testing.assert_close(topk_lens.cpu(), expected_lens.cpu())
-    torch.testing.assert_close(workspace_indices[:, :65].cpu(), expected[:, :65].cpu())
-    assert (workspace_indices[0, int(expected_lens[0].item()) :] == -1).all()
+    _assert_topk_sets_match(
+        workspace_indices,
+        topk_lens,
+        expected,
+        expected_lens,
+    )
 
 
 def test_dsa_plan_triton(device: str) -> None:

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1386,6 +1386,132 @@ def _attention_dsa_prefill_topk_bf16_weights() -> object:
     return _attention_dsa_prefill_topk(weights_dtype=torch.bfloat16)
 
 
+def _attention_dsa_decode_topk_standard(
+    index_heads: int,
+    q_dtype: torch.dtype = torch.bfloat16,
+) -> object:
+    q = torch.empty((2, index_heads, 128), dtype=q_dtype)
+    q_scales = (
+        torch.ones((2, index_heads), dtype=torch.float32)
+        if q_dtype == torch.float8_e4m3fn
+        else None
+    )
+    return tokenspeed_kernel.dsa_decode_topk(
+        q,
+        torch.empty((2, index_heads), dtype=torch.bfloat16),
+        torch.tensor([64, 64], dtype=torch.int32),
+        torch.zeros((2, 1), dtype=torch.int32),
+        page_size=64,
+        topk=512,
+        softmax_scale=1.0,
+        index_k_cache=torch.zeros((128, 132), dtype=torch.uint8),
+        q_scales=q_scales,
+    )
+
+
+def _attention_dsa_prefill_topk_standard(
+    index_heads: int,
+    q_dtype: torch.dtype = torch.bfloat16,
+) -> object:
+    q = torch.empty((2, index_heads, 128), dtype=q_dtype)
+    q_scales = (
+        torch.ones((2, index_heads), dtype=torch.float32)
+        if q_dtype == torch.float8_e4m3fn
+        else None
+    )
+    return tokenspeed_kernel.dsa_prefill_topk(
+        q,
+        torch.empty((2, index_heads), dtype=torch.float32),
+        torch.arange(64, dtype=torch.int64),
+        torch.tensor([0, 8], dtype=torch.int32),
+        torch.tensor([8, 16], dtype=torch.int32),
+        topk=512,
+        softmax_scale=1.0,
+        index_k_cache=torch.zeros((128, 132), dtype=torch.uint8),
+        page_size=64,
+        q_scales=q_scales,
+    )
+
+
+@pytest.mark.parametrize("index_heads", [32, 64])
+@pytest.mark.parametrize("mode", ["decode", "prefill"])
+def test_dsa_topk_selection_receives_index_heads(
+    monkeypatch: pytest.MonkeyPatch,
+    index_heads: int,
+    mode: str,
+) -> None:
+    """The public request exposes head count for exact DSA registrations."""
+    captured: dict[str, object] = {}
+
+    class _SelectedKernel:
+        name = "test_dsa_topk"
+
+        def __call__(self, **kwargs):
+            tokens = kwargs["q"].shape[0]
+            topk = int(kwargs["topk"])
+            return (
+                torch.full((tokens, topk), -1, dtype=torch.int32),
+                torch.zeros((tokens,), dtype=torch.int32),
+            )
+
+    def select_dsa_topk(*args, **kwargs):
+        captured.update(kwargs["traits"])
+        return _SelectedKernel()
+
+    monkeypatch.setattr(_attention_pkg, "select_kernel", select_dsa_topk)
+    q = torch.empty((1, index_heads, 128), dtype=torch.bfloat16)
+    weights = torch.empty((1, index_heads), dtype=torch.float32)
+    index_k_cache = torch.empty((64, 132), dtype=torch.uint8)
+
+    if mode == "decode":
+        tokenspeed_kernel.dsa_decode_topk(
+            q,
+            weights,
+            torch.tensor([1], dtype=torch.int32),
+            torch.zeros((1, 1), dtype=torch.int32),
+            page_size=64,
+            topk=1,
+            softmax_scale=1.0,
+            index_k_cache=index_k_cache,
+        )
+    else:
+        tokenspeed_kernel.dsa_prefill_topk(
+            q,
+            weights,
+            torch.tensor([0], dtype=torch.int64),
+            torch.tensor([0], dtype=torch.int32),
+            torch.tensor([1], dtype=torch.int32),
+            topk=1,
+            softmax_scale=1.0,
+            index_k_cache=index_k_cache,
+            page_size=64,
+        )
+
+    assert captured["index_heads"] == index_heads
+
+
+@pytest.mark.parametrize("missing", ["values", "scales"])
+def test_dsa_prefill_topk_rejects_incomplete_workspace_rows(missing: str) -> None:
+    inputs = {
+        "index_k_fp8": torch.empty((1, 128), dtype=torch.float8_e4m3fn),
+        "index_k_scale": torch.ones((1, 1), dtype=torch.float32),
+    }
+    inputs.pop("index_k_fp8" if missing == "values" else "index_k_scale")
+
+    with pytest.raises(ValueError, match="must be provided together"):
+        tokenspeed_kernel.dsa_prefill_topk(
+            torch.empty((1, 32, 128), dtype=torch.bfloat16),
+            torch.empty((1, 32), dtype=torch.float32),
+            torch.tensor([0], dtype=torch.int64),
+            torch.tensor([0], dtype=torch.int32),
+            torch.tensor([1], dtype=torch.int32),
+            topk=1,
+            softmax_scale=1.0,
+            page_size=64,
+            **inputs,
+        )
+
+
 def _attention_dsa_plan() -> object:
     seq_lens_2d = torch.tensor([[64], [64]], dtype=torch.int32)
     return tokenspeed_kernel.dsa_plan(seq_lens_2d=seq_lens_2d, page_size=64)
@@ -2738,6 +2864,31 @@ _CASES = [
         "gluon_dsa_prefill_topk_fp8_gfx950",
         _attention_dsa_prefill_topk_bf16_weights,
         id_suffix="bf16-weights",
+    ),
+    *(
+        _case(
+            _is_cdna4,
+            "cdna4",
+            "attention",
+            operation,
+            expected,
+            lambda heads=heads, dtype=dtype, invoke=invoke: invoke(heads, dtype),
+            id_suffix=f"h{heads}-{str(dtype).removeprefix('torch.')}",
+        )
+        for operation, expected, invoke in (
+            (
+                "dsa_decode_topk",
+                "gluon_dsa_decode_topk_standard_gfx950",
+                _attention_dsa_decode_topk_standard,
+            ),
+            (
+                "dsa_prefill_topk",
+                "gluon_dsa_prefill_topk_standard_gfx950",
+                _attention_dsa_prefill_topk_standard,
+            ),
+        )
+        for heads in (32, 64)
+        for dtype in (torch.bfloat16, torch.float8_e4m3fn)
     ),
     _case(
         _is_cdna4,


### PR DESCRIPTION
Correct the public DSA top-k contract to apply ReLU to each query-head/key dot product before signed head weighting and reduction. Document scaled FP8 queries, add head-count and cache-layout selection traits, and update the portable and GFX1250 paths to the same formula.

Implement a TokenSpeed-owned GFX950 scorer whose workgroup scheduling and FP8 matrix structure follow AITER commit
b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df. Adapt it to TokenSpeed's standard page-64 scaled-FP8 cache. Resolve prefill workspace slots and load cache rows inside the scorer, without a preshuffled cache or separately materialized gather. Support native BF16 and scaled FP8 queries, 32 or 64 index heads with dimension 128, and strided BF16/FP32 head weights.

Wire the corrected contract through the public DSA API and GLM model path. The GFX950 full-chain matrix completed 192/192 validated cases, and 36/36 retained GLM captures passed in both BF16 and FP8 query modes across 39,648 rows.

Performance compares the full scorer-plus-top-k boundary on one MI355X. All rows use 32 heads, BF16 queries and weights, head dimension 128, page size 64, and top-k 2,048. Medians are 50 GPU-event samples after 10 warmups.

| Shape | Original no-ReLU (us) | New per-head ReLU (us) | Speedup | New latency |
| --- | ---: | ---: | ---: | ---: |
| Decode B1, Q1, context 8,192 | 51.880 | 52.721 | 0.984x | +1.6% |
| Decode B1, Q1, context 40,960 | 97.360 | 89.421 | 1.089x | -8.2% |
| Decode B1, Q1, context 80,000 | 114.161 | 128.082 | 0.891x | +12.2% |
| Decode B16, Q1, context 80,000 | 167.361 | 153.281 | 1.092x | -8.4% |
| Prefill 8,192 rows, context up to 80,000 | 19,333.430 | 17,997.380 | 1.074x | -6.9% |

These are matched shapes and boundaries but different mathematical contracts: each side passed its corresponding independent oracle. The new kernel wins three of five shapes with a 1.023x geometric-mean speedup.

A GLM 5.2 accuracy run compared the ToM non-ReLU version with the corrected ReLU version.

| Evaluation | Upstream (non-ReLU) baseline | Current (ReLU) kernel | Paired result |
| --- | ---: | ---: | --- |
| Needle retrieval | 15/15 | 15/15 | exact p=1.0 |
| Needle strict visible-output sensitivity | 15/15 | 15/15 | exact p=1.0 |
| Default-thinking LongBench-v2 | 2/20 | 1/20 | exact p=1.0 |
| No-thinking LongBench-v2 | 10/20 | 10/20 | exact p=1.0; two wins each |