### PR TITLE
perf(metadata): fuse the paged write-location and page-table expansions

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
@@ -39,6 +39,9 @@ must also define ``self._cache_contract_bound`` / ``self._cache_groups_bound``
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.attention.triton.mla_write_locations import (
+    mla_write_locations,
+)
 
 
 class MlaCacheGroupMixin:
@@ -145,26 +148,21 @@ class MlaCacheGroupMixin:
         layout the verify read path builds.
         """
         page_size = self.kernel_page_size
-        last = (seq_lens[:batch_size].to(torch.int64) - 1).clamp_min(0)
-        if q_len_per_req == 1:
-            positions = last.unsqueeze(1)
-        else:
-            steps = torch.arange(
-                1 - q_len_per_req, 1, device=seq_lens.device, dtype=torch.int64
-            )
-            positions = (last.unsqueeze(1) + steps).clamp_min(0)
-        page_indices = torch.div(positions, page_size, rounding_mode="floor")
-        pages = table[:batch_size].gather(1, page_indices)
-        if validate_pages and pages.numel() and not bool((pages > 0).all().item()):
-            raise RuntimeError(
-                "MLA write location resolves to the null page 0 or a " "-1 table hole"
-            )
-        locations = (
-            pages.clamp_min(0).to(torch.int64) * page_size + (positions % page_size)
-        ).reshape(-1)
-        if out is not None:
-            out[: batch_size * q_len_per_req].copy_(locations)
-            return out
+        locations = mla_write_locations(
+            seq_lens,
+            table,
+            page_size=page_size,
+            q_len_per_req=q_len_per_req,
+            batch_size=batch_size,
+            out=out,
+        )
+        if validate_pages and locations.numel():
+            # Page 0 is the null page, so a write there lands below one page.
+            if not bool((locations >= page_size).all().item()):
+                raise RuntimeError(
+                    "MLA write location resolves to the null page 0 or a "
+                    "-1 table hole"
+                )
         return locations
 
     def _verify_q_len(self, forward_mode) -> int:

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -41,6 +41,9 @@ from tokenspeed_kernel.ops.attention.tokenspeed_mla import (
     tokenspeed_mla_prefill,
     warmup_compile_prefill,
 )
+from tokenspeed_kernel.ops.attention.triton.mla_write_locations import (
+    mla_write_locations,
+)
 
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
@@ -288,6 +291,17 @@ class CuteDSLMLABackend(AttentionBackend):
                 "MLA write location resolves to the null page 0 or a " "-1 table hole"
             )
 
+    def _maybe_debug_check_write_locations(
+        self, locations: torch.Tensor, page_size: int
+    ) -> None:
+        """Same check on absolute locations: the null page lies below one page."""
+        if not cache_debug_enabled() or locations.numel() == 0:
+            return
+        if not bool((locations >= page_size).all().item()):
+            raise RuntimeError(
+                "MLA write location resolves to the null page 0 or a " "-1 table hole"
+            )
+
     def _cache_decode_out_cache_loc(
         self,
         bs: int,
@@ -306,24 +320,16 @@ class CuteDSLMLABackend(AttentionBackend):
         of allocating a fresh tensor. No host sync on either path.
         """
         page_size = self.kernel_page_size
-        last = (seq_lens[:bs].to(torch.int64) - 1).clamp_min(0)
-        if q_len_per_req == 1:
-            pos = last.unsqueeze(1)
-        else:
-            steps = torch.arange(
-                1 - q_len_per_req, 1, device=seq_lens.device, dtype=torch.int64
-            )
-            pos = (last.unsqueeze(1) + steps).clamp_min(0)  # [bs, q_len]
-        page_idx = torch.div(pos, page_size, rounding_mode="floor")
-        pages = group_table[:bs].gather(1, page_idx)
-        self._maybe_debug_check_write_pages(pages)
-        locs = (
-            pages.clamp_min(0).to(torch.int64) * page_size + (pos % page_size)
-        ).reshape(-1)
-        if out is not None:
-            out[: bs * q_len_per_req].copy_(locs)
-            return out
-        return locs
+        locations = mla_write_locations(
+            seq_lens,
+            group_table,
+            page_size=page_size,
+            q_len_per_req=q_len_per_req,
+            batch_size=bs,
+            out=out,
+        )
+        self._maybe_debug_check_write_locations(locations, page_size)
+        return locations
 
     def _extend_out_cache_loc(
         self,

--- a/python/tokenspeed/runtime/layers/attention/page_table.py
+++ b/python/tokenspeed/runtime/layers/attention/page_table.py
@@ -17,6 +17,9 @@
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.attention.triton.page_table import (
+    expand_page_table as fused_expand_page_table,
+)
 
 
 def _page_ratio(block_granularity: int, kernel_page_size: int) -> int:
@@ -55,8 +58,11 @@ def expand_page_table(
     if ratio == 1 and out is None and max_kernel_pages <= page_table.shape[1]:
         return page_table[:, :max_kernel_pages]
 
+    # The fused kernel writes every column it is handed, zeros included.
+    fused = ratio != 1 and rows > 0 and page_table.is_cuda
     if out is None:
-        out = torch.zeros(
+        alloc = torch.empty if fused else torch.zeros
+        out = alloc(
             (rows, max_kernel_pages),
             dtype=page_table.dtype,
             device=page_table.device,
@@ -68,9 +74,14 @@ def expand_page_table(
             )
         if out.dtype != page_table.dtype or out.device != page_table.device:
             raise ValueError("out must have the same dtype and device as page_table")
-        out[:rows].zero_()
+        if not fused:
+            out[:rows].zero_()
 
     result = out[:rows, :max_kernel_pages]
+    if fused:
+        return fused_expand_page_table(
+            page_table, out, ratio=ratio, max_kernel_pages=max_kernel_pages
+        )
     if ratio == 1:
         copy_columns = min(max_kernel_pages, page_table.shape[1])
         result[:, :copy_columns].copy_(page_table[:, :copy_columns])

--- a/test/runtime/test_paged_helpers_use_the_fused_kernels.py
+++ b/test/runtime/test_paged_helpers_use_the_fused_kernels.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The runtime helpers must reach the fused kernels, not just agree with them.
+
+The kernel suites call the helpers directly, so they stay green if the runtime
+were wired back to its torch chains. These observe the dispatch instead: revert
+the wiring and they fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from tokenspeed.runtime.layers.attention import (  # noqa: E402
+    page_table as page_table_mod,
+)
+
+
+def test_expansion_dispatches_to_the_fused_kernel(monkeypatch):
+    calls = []
+    real = page_table_mod.fused_expand_page_table
+
+    def spy(*args, **kwargs):
+        calls.append(kwargs.get("ratio"))
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(page_table_mod, "fused_expand_page_table", spy)
+    table = torch.randint(1, 500, (3, 8), device="cuda", dtype=torch.int32)
+    out = page_table_mod.expand_page_table(
+        table, block_granularity=128, kernel_page_size=64, max_kernel_pages=16
+    )
+    assert calls == [2], "the CUDA expansion must go through the fused kernel"
+    assert out.shape == (3, 16)
+
+
+def test_the_fused_allocation_is_not_zero_filled_first(monkeypatch):
+    """The kernel writes every column, so a zeroed allocation is a wasted fill.
+    Production callers omit `out`, which is exactly this path."""
+    seen = []
+    real_zeros = torch.zeros
+
+    def spy(*args, **kwargs):
+        seen.append(args)
+        return real_zeros(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "zeros", spy)
+    table = torch.randint(1, 500, (3, 8), device="cuda", dtype=torch.int32)
+    page_table_mod.expand_page_table(
+        table, block_granularity=128, kernel_page_size=64, max_kernel_pages=16
+    )
+    assert seen == [], "the fused path must allocate without a zero fill"
+
+
+def test_a_cpu_table_keeps_the_portable_path(monkeypatch):
+    """The backends' unit tests build CPU tensors; they must not reach Triton."""
+    calls = []
+    monkeypatch.setattr(
+        page_table_mod,
+        "fused_expand_page_table",
+        lambda *a, **k: calls.append(1) or pytest.fail("CPU reached the CUDA kernel"),
+    )
+    table = torch.randint(1, 500, (2, 4), dtype=torch.int32)
+    out = page_table_mod.expand_page_table(
+        table, block_granularity=128, kernel_page_size=64, max_kernel_pages=8
+    )
+    assert not calls
+    assert out.shape == (2, 8)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mla_write_locations.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mla_write_locations.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Absolute MLA latent write locations in one launch."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit(
+    do_not_specialize=["total", "q_len", "num_pages", "table_stride", "page_size"]
+)
+def _mla_write_locations_kernel(
+    seq_lens,
+    table,
+    out,
+    total,
+    q_len,
+    num_pages,
+    table_stride,
+    page_size,
+    BLOCK: tl.constexpr,
+):
+    # Flat over bs*q_len: a per-batch constexpr would JIT just before replay.
+    idx = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    live = idx < total
+    row = idx // q_len
+    step = idx % q_len
+    last = tl.maximum(tl.load(seq_lens + row, mask=live, other=0).to(tl.int64) - 1, 0)
+    # Verify writes the trailing q_len positions, request-major.
+    pos = tl.maximum(last + (step - (q_len - 1)), 0)
+    page_index = tl.minimum(pos // page_size, num_pages - 1)
+    page = tl.load(table + row * table_stride + page_index, mask=live, other=0).to(
+        tl.int64
+    )
+    tl.store(out + idx, tl.maximum(page, 0) * page_size + pos % page_size, mask=live)
+
+
+def _torch_write_locations(seq_lens, table, page_size, q_len_per_req, batch_size, out):
+    """Portable spelling, kept for non-CUDA callers (the backends' CPU tests)."""
+    last = (seq_lens[:batch_size].to(torch.int64) - 1).clamp_min(0)
+    steps = torch.arange(
+        1 - q_len_per_req, 1, device=seq_lens.device, dtype=torch.int64
+    )
+    positions = (last.unsqueeze(1) + steps).clamp_min(0)
+    pages = table[:batch_size].gather(
+        1, torch.div(positions, page_size, rounding_mode="floor")
+    )
+    locations = (
+        pages.clamp_min(0).to(torch.int64) * page_size + (positions % page_size)
+    ).reshape(-1)
+    if out is None:
+        return locations
+    out[: batch_size * q_len_per_req].copy_(locations)
+    return out[: batch_size * q_len_per_req]
+
+
+def mla_write_locations(
+    seq_lens: torch.Tensor,
+    table: torch.Tensor,
+    *,
+    page_size: int,
+    q_len_per_req: int,
+    batch_size: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Resolve where each decoded token writes into the paged latent cache.
+
+    The torch spelling of this is a chain of a dozen elementwise launches
+    (cast, sub, clamp, arange, add, clamp, div, gather, clamp, cast, mul,
+    remainder, add) over ``[batch_size]`` integers, which on a decode step costs
+    launch overhead only. Every step is row-local, so one program covers the
+    whole batch.
+
+    Args:
+        seq_lens: Integer sequence lengths ``[>=batch_size]``.
+        table: Page table ``[>=batch_size, num_pages]``; entries below zero are
+            table holes and clamp to the null page.
+        page_size: Tokens per page in the kernel's paging.
+        q_len_per_req: Trailing positions written per request (1 for plain
+            decode, the speculative window on target verify).
+        batch_size: Live requests; rows past it are ignored.
+        out: Optional INT64 destination written in place, so a CUDA-graph
+            replay keeps the buffer the capture recorded.
+
+    Returns:
+        INT64 absolute write locations ``[batch_size * q_len_per_req]``,
+        flattened request-major. With ``out`` this is a view of its prefix.
+
+    A sequence longer than the table can address (``num_pages * page_size``)
+    resolves to the last page rather than raising: the kernel cannot fail
+    loudly without a host sync, and reading past the table would be worse.
+    The debug validators catch that case where they already sync.
+    """
+    if seq_lens.device != table.device:
+        raise ValueError("MLA write locations need colocated seq_lens and table")
+    # Unit-stride arithmetic below; the torch spelling honoured any stride.
+    if seq_lens.stride(0) != 1 or table.stride(1) != 1:
+        raise ValueError("MLA write locations need unit-stride seq_lens and table rows")
+    if batch_size < 0 or batch_size > table.shape[0]:
+        raise ValueError(
+            f"batch_size {batch_size} exceeds the table's {table.shape[0]} rows"
+        )
+    if q_len_per_req < 1:
+        raise ValueError(f"q_len_per_req must be positive, got {q_len_per_req}")
+    total = batch_size * q_len_per_req
+    if out is None:
+        out = torch.empty(total, dtype=torch.int64, device=table.device)
+    elif out.dtype != torch.int64:
+        raise ValueError(f"out must be INT64, got {out.dtype}")
+    elif out.device != table.device:
+        raise ValueError("out must live on the table's device")
+    elif out.stride(0) != 1:
+        raise ValueError("out must be unit-stride")
+    elif out.numel() < total:
+        raise ValueError(f"out holds {out.numel()} entries, need {total}")
+    elif out.data_ptr() == table.data_ptr():
+        raise ValueError("out must not alias the page table")
+    if total == 0:
+        return out[:0]
+    if not table.is_cuda:
+        return _torch_write_locations(
+            seq_lens, table, page_size, q_len_per_req, batch_size, out
+        )
+
+    block = 256
+    _mla_write_locations_kernel[(triton.cdiv(total, block),)](
+        seq_lens,
+        table,
+        out,
+        total,
+        q_len_per_req,
+        table.shape[1],
+        table.stride(0),
+        page_size,
+        BLOCK=block,
+    )
+    return out[:total]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mla_write_locations.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/mla_write_locations.py
@@ -23,8 +23,7 @@
 from __future__ import annotations
 
 import torch
-import triton
-import triton.language as tl
+from tokenspeed_kernel._triton import tl, triton
 
 
 @triton.jit(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/page_table.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/page_table.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Expand scheduler pages into kernel pages in one launch."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit(
+    do_not_specialize=[
+        "logical_cols",
+        "value_cols",
+        "table_stride",
+        "out_stride",
+        "out_cols",
+        "ratio",
+    ]
+)
+def _expand_page_table_kernel(
+    table,
+    out,
+    logical_cols,
+    value_cols,
+    table_stride,
+    out_stride,
+    out_cols,
+    ratio,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    col = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    inside = col < out_cols
+    logical = col // ratio
+    # Columns past the expanded region stay zero, as the torch spelling left them.
+    valid = inside & (col < value_cols) & (logical < logical_cols)
+    page = tl.load(table + row * table_stride + logical, mask=valid, other=0)
+    value = tl.where(valid, tl.maximum(page, 0) * ratio + col % ratio, 0)
+    tl.store(out + row * out_stride + col, value, mask=inside)
+
+
+def expand_page_table(
+    page_table: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    ratio: int,
+    max_kernel_pages: int,
+) -> torch.Tensor:
+    """Write ``page * ratio + offset`` for every kernel page of every request.
+
+    The torch spelling allocates an intermediate ``[rows, cols, ratio]`` tensor
+    and runs zero/arange/clamp/mul/add/copy; each is launch-bound at decode
+    sizes. One program block covers a tile of the output, so the whole table
+    expands in a single launch with no intermediate.
+
+    Args:
+        page_table: Scheduler page ids ``[rows, logical_cols]``; negative
+            entries are table holes and clamp to the null page.
+        out: Destination ``[>=rows, >=max_kernel_pages]``, same dtype and
+            device; its full width is written (expanded values then zeros), so
+            a stale tail cannot survive.
+        ratio: Kernel pages per scheduler page.
+        max_kernel_pages: Kernel-page columns the caller will read.
+
+    Returns:
+        The ``[rows, max_kernel_pages]`` view of ``out``.
+    """
+    if page_table.ndim != 2 or out.ndim != 2:
+        raise ValueError("page_table and out must both be 2-D")
+    if out.dtype != page_table.dtype or out.device != page_table.device:
+        raise ValueError("out must match page_table dtype and device")
+    # Unit-stride arithmetic below; the torch spelling handled any stride.
+    if page_table.stride(1) != 1 or out.stride(1) != 1:
+        raise ValueError("page_table and out rows must be unit-stride")
+    if out.data_ptr() == page_table.data_ptr():
+        raise ValueError("out must not alias page_table")
+    rows, logical_cols = page_table.shape
+    if out.shape[0] < rows or out.shape[1] < max_kernel_pages:
+        raise ValueError(
+            f"out shape {tuple(out.shape)} cannot hold ({rows}, {max_kernel_pages})"
+        )
+    if ratio < 1:
+        raise ValueError(f"ratio must be positive, got {ratio}")
+    if rows == 0 or out.shape[1] == 0:
+        return out[:rows, :max_kernel_pages]
+
+    out_cols = out.shape[1]
+    # Fixed so a new table width cannot trigger a recompile.
+    block = 256
+    _expand_page_table_kernel[(rows, triton.cdiv(out_cols, block))](
+        page_table,
+        out,
+        logical_cols,
+        max_kernel_pages,
+        page_table.stride(0),
+        out.stride(0),
+        out_cols,
+        ratio,
+        BLOCK=block,
+    )
+    return out[:rows, :max_kernel_pages]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/page_table.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/page_table.py
@@ -23,8 +23,7 @@
 from __future__ import annotations
 
 import torch
-import triton
-import triton.language as tl
+from tokenspeed_kernel._triton import tl, triton
 
 
 @triton.jit(

--- a/tokenspeed-kernel/test/ops/attention/test_expand_page_table.py
+++ b/tokenspeed-kernel/test/ops/attention/test_expand_page_table.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The fused page-table expansion must match the torch spelling exactly.
+
+These are cache page ids: a wrong column sends a kernel reading another
+request's KV, so the comparison is integer equality.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from tokenspeed_kernel.ops.attention.triton.page_table import (  # noqa: E402
+    expand_page_table,
+)
+
+
+def _reference(page_table, out, ratio, max_kernel_pages):
+    """The zero/arange/clamp/mul/add/copy chain the kernel replaces."""
+    rows, logical_columns = page_table.shape
+    out[:rows].zero_()
+    result = out[:rows, :max_kernel_pages]
+    offsets = torch.arange(ratio, dtype=page_table.dtype, device=page_table.device)
+    expanded = (page_table.clamp_min(0).unsqueeze(-1) * ratio + offsets).reshape(
+        rows, logical_columns * ratio
+    )
+    copy_columns = min(max_kernel_pages, expanded.shape[1])
+    result[:, :copy_columns].copy_(expanded[:, :copy_columns])
+    return result
+
+
+@pytest.mark.parametrize(
+    ("ratio", "rows", "logical_cols"),
+    [(2, 1, 1), (2, 3, 32), (4, 1, 5), (4, 16, 32), (8, 3, 5), (8, 16, 1)],
+)
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+def test_matches_the_torch_chain(ratio, rows, logical_cols, dtype):
+    torch.manual_seed(rows * 100 + logical_cols)
+    table = torch.randint(0, 500, (rows, logical_cols), device="cuda", dtype=dtype)
+    max_kernel_pages = logical_cols * ratio
+    got_buf = torch.full((rows, max_kernel_pages), -7, device="cuda", dtype=dtype)
+    want_buf = torch.full((rows, max_kernel_pages), -7, device="cuda", dtype=dtype)
+    got = expand_page_table(
+        table, got_buf, ratio=ratio, max_kernel_pages=max_kernel_pages
+    )
+    want = _reference(table, want_buf, ratio, max_kernel_pages)
+    assert torch.equal(got, want), (ratio, rows, logical_cols, dtype)
+
+
+@pytest.mark.parametrize("ratio", [2, 4])
+def test_holes_clamp_to_the_null_page(ratio):
+    table = torch.randint(0, 500, (4, 8), device="cuda", dtype=torch.int32)
+    table[:, ::2] = -1
+    cols = 8 * ratio
+    got = expand_page_table(
+        table,
+        torch.empty((4, cols), device="cuda", dtype=torch.int32),
+        ratio=ratio,
+        max_kernel_pages=cols,
+    )
+    want = _reference(
+        table, torch.empty((4, cols), device="cuda", dtype=torch.int32), ratio, cols
+    )
+    assert torch.equal(got, want)
+
+
+def test_narrow_request_leaves_the_tail_zero():
+    """Asking for fewer kernel pages than the table holds must zero the rest,
+    not leave whatever the buffer held before."""
+    table = torch.randint(1, 500, (3, 8), device="cuda", dtype=torch.int32)
+    buf = torch.full((3, 64), 99, device="cuda", dtype=torch.int32)
+    got = expand_page_table(table, buf, ratio=4, max_kernel_pages=10)
+    assert got.shape == (3, 10)
+    want = _reference(
+        table, torch.full((3, 64), 99, device="cuda", dtype=torch.int32), 4, 10
+    )
+    assert torch.equal(got, want)
+    # The columns the caller will not read must not keep the stale 99s either.
+    assert torch.equal(buf[:, 10:], torch.zeros_like(buf[:, 10:]))
+
+
+def test_writes_in_place_for_graph_replay():
+    """Replay needs the recorded buffer, so the result must be that buffer
+    with the expansion actually in it."""
+    table = torch.randint(1, 500, (2, 4), device="cuda", dtype=torch.int32)
+    buf = torch.empty((2, 16), device="cuda", dtype=torch.int32)
+    ptr = buf.data_ptr()
+    got = expand_page_table(table, buf, ratio=4, max_kernel_pages=16)
+    assert got.data_ptr() == ptr
+    want = _reference(
+        table, torch.empty((2, 16), device="cuda", dtype=torch.int32), 4, 16
+    )
+    assert torch.equal(got, want)
+
+
+def test_strided_inputs_are_rejected_not_misread():
+    """A strided column view would make the kernel read the wrong pages."""
+    wide = torch.randint(1, 500, (2, 8), device="cuda", dtype=torch.int32)
+    out = torch.empty((2, 8), device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match="unit-stride"):
+        expand_page_table(wide[:, ::2], out, ratio=2, max_kernel_pages=8)
+    wide_out = torch.empty((2, 16), device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match="unit-stride"):
+        expand_page_table(wide[:, :4], wide_out[:, ::2], ratio=2, max_kernel_pages=8)
+
+
+def test_output_aliasing_the_table_is_rejected():
+    table = torch.randint(1, 500, (2, 8), device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match="alias"):
+        expand_page_table(table, table, ratio=2, max_kernel_pages=8)
+
+
+def test_more_columns_than_one_program_block():
+    """A fixed cache table can exceed the block width; the second column
+    program must cover its own range."""
+    table = torch.randint(1, 500, (3, 400), device="cuda", dtype=torch.int32)
+    cols = 400 * 4
+    got = expand_page_table(
+        table,
+        torch.empty((3, cols), device="cuda", dtype=torch.int32),
+        ratio=4,
+        max_kernel_pages=cols,
+    )
+    want = _reference(
+        table, torch.empty((3, cols), device="cuda", dtype=torch.int32), 4, cols
+    )
+    assert torch.equal(got, want)
+
+
+def test_a_pitched_row_view_is_followed():
+    """Grouped replay hands rows of a wider stack, so stride(0) > shape[1]."""
+    stack = torch.randint(1, 500, (4, 64), device="cuda", dtype=torch.int32)
+    table = stack[:2, :5]
+    assert table.stride(0) > table.shape[1]
+    out_stack = torch.empty((4, 64), device="cuda", dtype=torch.int32)
+    out = out_stack[:2, :20]
+    got = expand_page_table(table, out, ratio=4, max_kernel_pages=20)
+    want = _reference(
+        table.contiguous(),
+        torch.empty((2, 20), device="cuda", dtype=torch.int32),
+        4,
+        20,
+    )
+    assert torch.equal(got, want)

--- a/tokenspeed-kernel/test/ops/attention/test_mla_write_locations.py
+++ b/tokenspeed-kernel/test/ops/attention/test_mla_write_locations.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The fused MLA write-location kernel must match the torch chain exactly.
+
+These are cache write addresses: an off-by-one silently corrupts another
+request's KV, so the comparison is integer equality, not a tolerance.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from tokenspeed_kernel.ops.attention.triton.mla_write_locations import (  # noqa: E402
+    mla_write_locations,
+)
+
+
+def _reference(seq_lens, table, *, page_size, q_len_per_req, batch_size):
+    """The elementwise chain the kernel replaces, kept verbatim."""
+    last = (seq_lens[:batch_size].to(torch.int64) - 1).clamp_min(0)
+    if q_len_per_req == 1:
+        positions = last.unsqueeze(1)
+    else:
+        steps = torch.arange(
+            1 - q_len_per_req, 1, device=seq_lens.device, dtype=torch.int64
+        )
+        positions = (last.unsqueeze(1) + steps).clamp_min(0)
+    page_indices = torch.div(positions, page_size, rounding_mode="floor")
+    pages = table[:batch_size].gather(1, page_indices)
+    return (
+        pages.clamp_min(0).to(torch.int64) * page_size + (positions % page_size)
+    ).reshape(-1)
+
+
+def _inputs(batch_size, num_pages, page_size, seed=0, holes=False):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    high = num_pages * page_size
+    seq_lens = torch.randint(
+        1, high, (batch_size,), device="cuda", dtype=torch.int32, generator=g
+    )
+    table = torch.randint(
+        1, 4096, (batch_size, num_pages), device="cuda", dtype=torch.int32, generator=g
+    )
+    if holes:
+        table[:, ::3] = -1
+    return seq_lens, table
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "q_len_per_req"),
+    [(1, 1), (1, 4), (2, 2), (3, 4), (5, 1), (8, 2), (32, 4)],
+)
+@pytest.mark.parametrize("page_size", [1, 64])
+def test_matches_the_torch_chain(batch_size, q_len_per_req, page_size):
+    seq_lens, table = _inputs(batch_size, 16, page_size, seed=batch_size)
+    got = mla_write_locations(
+        seq_lens,
+        table,
+        page_size=page_size,
+        q_len_per_req=q_len_per_req,
+        batch_size=batch_size,
+    )
+    want = _reference(
+        seq_lens,
+        table,
+        page_size=page_size,
+        q_len_per_req=q_len_per_req,
+        batch_size=batch_size,
+    )
+    assert torch.equal(got, want), (batch_size, q_len_per_req, page_size)
+
+
+@pytest.mark.parametrize("q_len_per_req", [1, 4])
+def test_table_holes_clamp_to_the_null_page(q_len_per_req):
+    """Negative table entries are holes; both paths must resolve them the same."""
+    seq_lens, table = _inputs(4, 16, 64, seed=7, holes=True)
+    got = mla_write_locations(
+        seq_lens, table, page_size=64, q_len_per_req=q_len_per_req, batch_size=4
+    )
+    want = _reference(
+        seq_lens, table, page_size=64, q_len_per_req=q_len_per_req, batch_size=4
+    )
+    assert torch.equal(got, want)
+
+
+def test_short_sequences_clamp_at_zero():
+    """A request shorter than the speculative window still writes in range."""
+    table = torch.randint(1, 100, (3, 16), device="cuda", dtype=torch.int32)
+    seq_lens = torch.tensor([0, 1, 2], device="cuda", dtype=torch.int32)
+    got = mla_write_locations(
+        seq_lens, table, page_size=64, q_len_per_req=4, batch_size=3
+    )
+    want = _reference(seq_lens, table, page_size=64, q_len_per_req=4, batch_size=3)
+    assert torch.equal(got, want)
+
+
+def test_writes_in_place_for_graph_replay():
+    """Replay needs the recorded buffer, so out must keep its data_ptr."""
+    seq_lens, table = _inputs(4, 16, 64, seed=3)
+    out = torch.zeros(64, dtype=torch.int64, device="cuda")
+    ptr = out.data_ptr()
+    got = mla_write_locations(
+        seq_lens, table, page_size=64, q_len_per_req=4, batch_size=4, out=out
+    )
+    assert got.data_ptr() == ptr
+    assert torch.equal(
+        got, _reference(seq_lens, table, page_size=64, q_len_per_req=4, batch_size=4)
+    )
+    # Rows past the live batch must be left alone, not zero-filled or scribbled.
+    assert torch.equal(out[16:], torch.zeros(48, dtype=torch.int64, device="cuda"))
+
+
+def test_rows_past_the_batch_are_not_read():
+    """A stale row beyond batch_size must not change the answer."""
+    seq_lens, table = _inputs(8, 16, 64, seed=11)
+    small = mla_write_locations(
+        seq_lens, table, page_size=64, q_len_per_req=4, batch_size=3
+    ).clone()
+    seq_lens[3:] = 999999
+    table[3:] = -5
+    again = mla_write_locations(
+        seq_lens, table, page_size=64, q_len_per_req=4, batch_size=3
+    )
+    assert torch.equal(small, again)
+
+
+def test_strided_inputs_are_rejected_not_misread():
+    """The kernel walks these with unit-stride arithmetic; a strided view would
+    silently address the wrong elements, so it has to be refused."""
+    seq_lens, table = _inputs(4, 16, 64, seed=5)
+    strided_lens = torch.zeros(8, device="cuda", dtype=torch.int32)[::2]
+    with pytest.raises(ValueError, match="unit-stride"):
+        mla_write_locations(
+            strided_lens, table, page_size=64, q_len_per_req=1, batch_size=4
+        )
+    wide = torch.zeros((4, 32), device="cuda", dtype=torch.int32)
+    with pytest.raises(ValueError, match="unit-stride"):
+        mla_write_locations(
+            seq_lens, wide[:, ::2], page_size=64, q_len_per_req=1, batch_size=4
+        )
+    backing = torch.zeros(64, dtype=torch.int64, device="cuda")
+    with pytest.raises(ValueError, match="unit-stride"):
+        mla_write_locations(
+            seq_lens,
+            table,
+            page_size=64,
+            q_len_per_req=1,
+            batch_size=4,
+            out=backing[::2],
+        )
+
+
+def test_output_aliasing_the_table_is_rejected():
+    """Read and write of one allocation in a single launch has no ordering."""
+    table = torch.zeros((4, 16), device="cuda", dtype=torch.int64)
+    with pytest.raises(ValueError, match="alias"):
+        mla_write_locations(
+            table[:, 0].contiguous(),
+            table,
+            page_size=64,
+            q_len_per_req=1,
+            batch_size=4,
+            out=table.view(-1),
+        )
+
+
+@pytest.mark.parametrize("batch_size", [128, 256])
+def test_more_locations_than_one_program_block(batch_size):
+    """A production batch writes more locations than a block covers, so the
+    grid's later programs have to carry their own range."""
+    seq_lens, table = _inputs(batch_size, 16, 64, seed=batch_size)
+    got = mla_write_locations(
+        seq_lens, table, page_size=64, q_len_per_req=4, batch_size=batch_size
+    )
+    want = _reference(
+        seq_lens, table, page_size=64, q_len_per_req=4, batch_size=batch_size
+    )
+    assert torch.equal(got, want)


### PR DESCRIPTION
Two decode-path helpers spelled a small integer function as a chain of torch elementwise ops over [batch] tensors, where the launches cost far more than the work. _cache_decode_out_cache_loc ran thirteen of them (cast, sub, clamp, arange, add, clamp, div, gather, clamp, cast, mul, remainder, add, copy) and expand_page_table ran six plus a [rows, cols, ratio] intermediate. Each now runs in one Triton launch, and the expansion no longer zero-fills an allocation the kernel overwrites -- the callers that omit `out` are the ones that take that path.

Measured on GB200 by graph replay, flat in batch size and table width, which is what identifies the old cost as launch overhead rather than work:

    write locations   12.7-16.1 us -> 1.45 us
    page expansion     5.5-6.7  us -> 1.18 us

In a profiled decode step the model issues 28 fewer kernels.

Both live in shared attention infrastructure -- the MLA backends and the page table helper -- so every model on paged MLA gets them, and both keep the torch path for the CPU tensors the backend unit tests construct.

The kernels take their geometry as runtime arguments with Triton's integer specialization disabled, so a new batch size or table width reuses the compiled kernel instead of building one inside the metadata refresh that runs just before graph.replay(). Element type still selects a variant, as it must.

They address their inputs with unit-stride arithmetic and reject the strided layouts and output aliasing the torch spellings tolerated, rather than reading the wrong elements. On CUDA a sequence longer than its table can address resolves to the last page instead of faulting through gather; the portable path still raises. That is stated as a precondition and checked where the debug validators already sync.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
