### PR TITLE
fix(kernel): fall back for MLA FP8 KV packing

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
@@ -31,8 +31,11 @@ try:
         warmup_compile_prefill,
     )
 except ImportError:
+    from tokenspeed_kernel.ops.attention.tokenspeed_mla.fallback import (
+        mla_kv_pack_quantize_fp8,
+    )
+
     get_num_sm = error_fn
-    mla_kv_pack_quantize_fp8 = error_fn
     tokenspeed_mla_decode = error_fn
     tokenspeed_mla_prefill = error_fn
     warmup_compile_prefill = error_fn

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/fallback.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/fallback.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Portable fallbacks for optional TokenSpeed MLA kernels."""
+
+from typing import Optional, Tuple
+
+import torch
+
+
+def mla_kv_pack_quantize_fp8(
+    k_nope: torch.Tensor,
+    k_pe: torch.Tensor,
+    v: torch.Tensor,
+    k_scale_inv: float = 1.0,
+    v_scale_inv: float = 1.0,
+    k_out: Optional[torch.Tensor] = None,
+    v_out: Optional[torch.Tensor] = None,
+    fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+    enable_pdl: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pack MLA keys and quantize K/V when the fused extension is unavailable.
+
+    ``enable_pdl`` is accepted for API compatibility. PyTorch stream ordering
+    provides the required producer/consumer dependency for this fallback.
+    """
+    del enable_pdl
+
+    if k_nope.ndim != 3:
+        raise ValueError(f"k_nope must be 3D, got shape {tuple(k_nope.shape)}")
+    if v.ndim != 3:
+        raise ValueError(f"v must be 3D, got shape {tuple(v.shape)}")
+    if k_pe.ndim not in (2, 3):
+        raise ValueError(f"k_pe must be 2D or 3D, got shape {tuple(k_pe.shape)}")
+
+    seq_len, num_heads, _ = k_nope.shape
+    if v.shape[:2] != (seq_len, num_heads):
+        raise ValueError(
+            f"v shape {tuple(v.shape)} mismatches k_nope {tuple(k_nope.shape)}"
+        )
+    if k_pe.shape[0] != seq_len:
+        raise ValueError(
+            f"k_pe first dim {k_pe.shape[0]} mismatches k_nope first dim {seq_len}"
+        )
+    if k_pe.ndim == 3:
+        if k_pe.shape[1] != 1:
+            raise ValueError(f"k_pe head dim must be 1, got {k_pe.shape[1]}")
+        k_pe = k_pe.squeeze(1)
+    if fp8_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+        raise ValueError(f"unsupported FP8 dtype: {fp8_dtype}")
+
+    k_pe = k_pe.unsqueeze(1).expand(-1, num_heads, -1)
+    quantized_k = (
+        torch.cat((k_nope, k_pe), dim=-1).float().mul_(k_scale_inv).to(fp8_dtype)
+    )
+    quantized_v = v.float().mul_(v_scale_inv).to(fp8_dtype)
+
+    if k_out is None:
+        k_out = quantized_k
+    else:
+        k_out.copy_(quantized_k)
+    if v_out is None:
+        v_out = quantized_v
+    else:
+        v_out.copy_(quantized_v)
+    return k_out, v_out

--- a/tokenspeed-kernel/test/ops/test_tokenspeed_mla_fallback.py
+++ b/tokenspeed-kernel/test/ops/test_tokenspeed_mla_fallback.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.attention import tokenspeed_mla as kernel_mla
+from tokenspeed_kernel.ops.attention.tokenspeed_mla.fallback import (
+    mla_kv_pack_quantize_fp8,
+)
+from tokenspeed_kernel.platform import current_platform
+
+
+@pytest.mark.parametrize("k_pe_ndim", [2, 3])
+@pytest.mark.parametrize("preallocate", [False, True])
+def test_mla_kv_pack_quantize_fp8_fallback(
+    device: str, k_pe_ndim: int, preallocate: bool
+) -> None:
+    torch.manual_seed(0)
+    seq_len, num_heads, qk_nope, qk_rope, v_head = 7, 4, 8, 4, 8
+    packed_kv = torch.randn(
+        seq_len,
+        num_heads,
+        qk_nope + v_head,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    k_nope = packed_kv[..., :qk_nope]
+    v = packed_kv[..., qk_nope:]
+    k_pe = torch.randn(seq_len, 1, qk_rope, dtype=torch.bfloat16, device=device)
+    if k_pe_ndim == 2:
+        k_pe = k_pe.squeeze(1)
+
+    k_scale_inv, v_scale_inv = 0.5, 1.7
+    expected_k_pe = k_pe.unsqueeze(1) if k_pe.ndim == 2 else k_pe
+    expected_k_pe = expected_k_pe.expand(-1, num_heads, -1)
+    expected_k = (
+        torch.cat((k_nope, expected_k_pe), dim=-1)
+        .float()
+        .mul_(k_scale_inv)
+        .to(torch.float8_e4m3fn)
+    )
+    expected_v = v.float().mul_(v_scale_inv).to(torch.float8_e4m3fn)
+    k_out = torch.empty_like(expected_k) if preallocate else None
+    v_out = torch.empty_like(expected_v) if preallocate else None
+
+    actual_k, actual_v = mla_kv_pack_quantize_fp8(
+        k_nope,
+        k_pe,
+        v,
+        k_scale_inv=k_scale_inv,
+        v_scale_inv=v_scale_inv,
+        k_out=k_out,
+        v_out=v_out,
+        enable_pdl=True,
+    )
+
+    if preallocate:
+        assert k_out is not None
+        assert v_out is not None
+        assert actual_k.data_ptr() == k_out.data_ptr()
+        assert actual_v.data_ptr() == v_out.data_ptr()
+    assert torch.equal(actual_k.view(torch.uint8), expected_k.view(torch.uint8))
+    assert torch.equal(actual_v.view(torch.uint8), expected_v.view(torch.uint8))
+
+
+def test_non_nvidia_public_api_uses_fallback() -> None:
+    if current_platform().is_nvidia:
+        pytest.skip("NVIDIA uses the optional fused tokenspeed-mla implementation")
+
+    assert kernel_mla.mla_kv_pack_quantize_fp8 is mla_kv_pack_quantize_fp8


### PR DESCRIPTION
## Summary

- provide a portable PyTorch fallback for MLA K/V packing and FP8 quantization when the optional `tokenspeed-mla` extension is unavailable
- retain the fused `tokenspeed-mla` implementation when that package imports successfully
- add regression coverage for AMD dispatch, strided inputs, 2D/3D positional keys, scaling, and preallocated outputs

## Root cause

PR #923 enabled FP8 prefill for NoPE models such as Kimi-K3. During chunked prefill, `deepseek_v3.py` consequently calls `mla_kv_pack_quantize_fp8`. The ROCm installation does not include the NVIDIA-oriented optional `tokenspeed-mla` package, so the `tokenspeed-kernel` wrapper currently resolves that function to `error_fn` and all eight TP ranks exit with `RuntimeError: Kernel implementation not found`.

Observed failures:

- https://github.com/lightseekorg/tokenspeed/actions/runs/32536948940/job/96941646433
- https://github.com/lightseekorg/tokenspeed/actions/runs/32542845279/job/96957557263

The later loopback connection errors and HTTP 503 responses are secondary to the model backend exiting.

## Test plan

- `PYTHONPATH=tokenspeed-kernel/python:tokenspeed-kernel-amd/python /home/stwinata/nod/venv/tokenspeed.venv/bin/python -m pytest -q tokenspeed-kernel/test/ops/test_tokenspeed_mla_fallback.py` — 5 passed on AMD Instinct MI350X
- exercised the public fallback on MI350X with the representative failing prefill dimensions: 2211 tokens, 16 heads, BF16 input, FP8 K/V output
- `pre-commit run --all-files` — passed
