### PR TITLE
perf(gemm): route the unrouted K3 decode projections

### DIFF
--- a/python/tokenspeed/runtime/layers/dense/unquant.py
+++ b/python/tokenspeed/runtime/layers/dense/unquant.py
@@ -21,6 +21,8 @@
 
 import tokenspeed_kernel
 import torch
+from tokenspeed_kernel.ops.gemm.routed_gemv import decode_gemv_routed
+from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
 from torch.nn.parameter import Parameter
 
 from tokenspeed.runtime.layers.quantization.base_config import LinearMethodBase
@@ -62,6 +64,8 @@ class UnquantizedLinearMethod(LinearMethodBase):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
 
+        if bias is None and decode_gemv_routed(x, layer.weight):
+            return decode_gemv(x, layer.weight)
         return tokenspeed_kernel.mm(
             x,
             layer.weight,

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1857,7 +1857,7 @@ class KimiLinearMoE(nn.Module):
                         else None
                     ),
                 )
-            routed_in = decode_gemv(hidden_states, self.routed_expert_down_proj.weight)
+            routed_in, _ = self.routed_expert_down_proj(hidden_states)
             if self._topk_ready is not None and fork._active:
                 self._topk_ready.wait(torch.cuda.current_stream())
             routed_partial = self._routed_experts(

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -52,9 +52,9 @@ import torch
 # carried over from a different parallelism. Labels are the shapes themselves;
 # mapping them to call sites would be a guess until the counts are traced.
 SHAPES = [
-    (3584, 7168, 0, "n3584_k7168"),
-    (2880, 7168, 0, "n2880_k7168"),
-    (1152, 1536, 0, "n1152_k1536"),
+    (7168, 1536, 69, "kda_o_proj_shard"),
+    (1536, 7168, 92, "shared_gate_up_shard"),
+    (7168, 768, 92, "shared_down_shard"),
 ]
 MS = [1, 2, 3, 4, 5, 6, 7, 8]  # observed range: the gates admit M <= 8
 NUM_COPIES = 8

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -150,7 +150,7 @@ def candidates(m: int, n: int, k: int):
 
 
 route: dict[str, str] = {}
-per_step_gain = 0.0
+per_step_gain: dict[int, float] = dict.fromkeys(MS, 0.0)
 print(f"cold-L2 sweep: {NUM_COPIES} weight copies per backend")
 print(f"{'call site':<18}{'NxK':>12} {'M':>2}  ", end="")
 print("  ".join(f"{t:>8}" for t in ("cublas", "rowcta", "skinny", "tgv")), end="")
@@ -182,7 +182,7 @@ for n, k, calls, label in SHAPES:
         )
         if best and ok[best] * MARGIN <= incumbent:
             route[f"{m},{n},{k}"] = best
-            per_step_gain += (incumbent - ok[best]) * calls
+            per_step_gain[m] += (incumbent - ok[best]) * calls
             print(
                 f"{label:<18}{f'{n}x{k}':>12} {m:>2}  {cells}  {best:<8} "
                 f"{incumbent / ok[best]:5.2f}x"
@@ -196,7 +196,9 @@ for n, k, calls, label in SHAPES:
 
 print()
 if any(c for _, _, c, _ in SHAPES):
-    print(f"projected saving vs incumbent: {per_step_gain:.0f} us/step")
+    # A step runs one M, so the widths are mutually exclusive and never summed.
+    for m in MS:
+        print(f"projected saving vs incumbent at M={m}: {per_step_gain[m]:.0f} us/step")
 else:
     print("per-step projection skipped: calls/step not measured")
 print(json.dumps(route, indent=2))

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -52,10 +52,14 @@ import torch
 # carried over from a different parallelism. Labels are the shapes themselves;
 # mapping them to call sites would be a guess until the counts are traced.
 SHAPES = [
+    (3584, 7168, 92, "n3584_k7168"),
+    (2880, 7168, 0, "n2880_k7168"),
+    (1152, 1536, 0, "n1152_k1536"),
+    (7168, 1536, 69, "kda_o_proj_shard"),
     (1536, 7168, 92, "shared_gate_up_shard"),
-    (3584, 7168, 92, "latent_down_proj"),
+    (7168, 768, 92, "shared_down_shard"),
 ]
-MS = [5, 6, 7, 8]  # observed range: the gates admit M <= 8
+MS = [1, 2, 3, 4, 5, 6, 7, 8]  # observed range: the gates admit M <= 8
 NUM_COPIES = 8
 # 41-round medians repeat within ~1-2%, so 4% clears noise without excluding
 # the consistent 6-11% skinny wins.

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -52,11 +52,10 @@ import torch
 # carried over from a different parallelism. Labels are the shapes themselves;
 # mapping them to call sites would be a guess until the counts are traced.
 SHAPES = [
-    (7168, 1536, 69, "kda_o_proj_shard"),
     (1536, 7168, 92, "shared_gate_up_shard"),
-    (7168, 768, 92, "shared_down_shard"),
+    (3584, 7168, 92, "latent_down_proj"),
 ]
-MS = [1, 2, 3, 4, 5, 6, 7, 8]  # observed range: the gates admit M <= 8
+MS = [5, 6, 7, 8]  # observed range: the gates admit M <= 8
 NUM_COPIES = 8
 # 41-round medians repeat within ~1-2%, so 4% clears noise without excluding
 # the consistent 6-11% skinny wins.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/moe_tactic_sweep.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/moe_tactic_sweep.py
@@ -180,14 +180,21 @@ def _candidate_tactics(args) -> list[tuple[int, int]]:
     return list(seen)
 
 
-def _run(args, W, tokens, tactic_setter, tactic, iters):
+def _run(args, W, tokens, tactic_setter, tactic, iters, do_finalize=True):
     from flashinfer.fused_moe import trtllm_fp4_block_scale_routed_moe
     from flashinfer.tllm_enums import ActivationType
 
     x_q, x_scale, topk_ids, topk_weights = tokens
     w13, w13_scale, w2, w2_scale = W
-    output = torch.zeros(
-        x_q.shape[0], args.hidden_size, dtype=torch.bfloat16, device=x_q.device
+    # The cache key carries the output tensor's shape, so a table swept with
+    # do_finalize=True never matches the deferred path serving takes when the
+    # MoE tail owns finalize. Sweep the mode the caller asks for.
+    output = (
+        torch.zeros(
+            x_q.shape[0], args.hidden_size, dtype=torch.bfloat16, device=x_q.device
+        )
+        if do_finalize
+        else None
     )
     alpha = torch.full(
         (args.local_experts,), args.situ_alpha, dtype=torch.float32, device=x_q.device
@@ -223,7 +230,7 @@ def _run(args, W, tokens, tactic_setter, tactic, iters):
             local_num_experts=args.local_experts,
             routed_scaling_factor=None,
             routing_method_type=1,
-            do_finalize=True,
+            do_finalize=do_finalize,
             enable_pdl=False,
             activation_type=10,  # ActivationType.Situ; probed at startup
             tune_max_num_tokens=SITU_TUNE_MAX_NUM_TOKENS,
@@ -281,6 +288,17 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_SWEEP_MIN_BUCKET,
         help="Sweep buckets >= this; smaller buckets keep the autotuner's pick",
     )
+    parser.add_argument(
+        "--finalize-modes",
+        default="both",
+        choices=("both", "finalize", "deferred"),
+        help=(
+            "Which finalize modes to sweep. The autotuner keys on the output "
+            "tensor's shape, so a table swept only with do_finalize=True "
+            "misses every deferred-finalize call (K3 decode, where the MoE "
+            "tail owns finalize)"
+        ),
+    )
     parser.add_argument("--coarse-iters", type=int, default=8)
     parser.add_argument("--fine-iters", type=int, default=50)
     args = parser.parse_args(argv)
@@ -306,81 +324,100 @@ def main(argv: list[str] | None = None) -> int:
         args.local_experts, args.hidden_size, args.intermediate_size, device, seed=1
     )
 
-    # One native autotune pass materializes every bucket's cache entry (with
-    # the tuner's own picks -- kept for buckets below --min-bucket) under the
-    # exact key layout the runtime will look up.
-    tuner = AutoTuner.get()
-    tokens_max = _make_tokens(
-        SITU_TUNE_MAX_NUM_TOKENS,
-        args.hidden_size,
-        args.num_experts,
-        args.top_k,
-        device,
-        seed=2,
+    modes = (
+        (True, False)
+        if args.finalize_modes == "both"
+        else (True,) if args.finalize_modes == "finalize" else (False,)
     )
-    with autotune():
-        _run(args, W, tokens_max, lambda _: None, None, iters=1)
-
-    bucket_keys = {}
-    for key, (_tac, profile) in tuner.profiling_cache.items():
-        if profile is None:
-            continue
-        bucket_keys[int(profile.get_opt_shapes()[0][0])] = (key, profile)
-    print(f"materialized buckets: {sorted(bucket_keys)}")
-
+    tuner = AutoTuner.get()
     candidates = _candidate_tactics(args)
     families = sorted({t for t, _ in candidates})
     print(f"candidate tactics: {len(candidates)} across tile_N families {families}")
 
-    for bucket in sorted(b for b in bucket_keys if b >= args.min_bucket):
-        key, profile = bucket_keys[bucket]
-        native_tactic = tuner.profiling_cache[key][0]
+    for do_finalize in modes:
+        label = "finalize" if do_finalize else "deferred"
+        print(f"--- sweeping do_finalize={do_finalize} ({label}) ---")
+        seen = set(tuner.profiling_cache)
 
-        def set_tactic(tac, key=key, profile=profile):
-            if tac is not None:
-                tuner.profiling_cache[key] = (tuple(tac), profile)
-
-        tokens = _make_tokens(
-            bucket,
+        # One native autotune pass materializes every bucket's cache entry (with
+        # the tuner's own picks -- kept for buckets below --min-bucket) under the
+        # exact key layout the runtime will look up.
+        tokens_max = _make_tokens(
+            SITU_TUNE_MAX_NUM_TOKENS,
             args.hidden_size,
             args.num_experts,
             args.top_k,
             device,
-            seed=100 + bucket,
+            seed=2,
         )
+        with autotune():
+            _run(
+                args,
+                W,
+                tokens_max,
+                lambda _: None,
+                None,
+                iters=1,
+                do_finalize=do_finalize,
+            )
 
-        # Stage 1: a few configs per family picks the family (<3% intra-family
-        # spread measured); stage 2 refines within the winner.
-        stage1: list[tuple[float, tuple[int, int]]] = []
-        for family in families:
-            for tac in [t for t in candidates if t[0] == family][
-                :STAGE1_CONFIGS_PER_FAMILY
-            ]:
-                stage1.append(
-                    (_run(args, W, tokens, set_tactic, tac, args.coarse_iters), tac)
+        bucket_keys = {}
+        for key, (_tac, profile) in tuner.profiling_cache.items():
+            if profile is None or key in seen:
+                continue
+            bucket_keys[int(profile.get_opt_shapes()[0][0])] = (key, profile)
+        print(f"materialized buckets ({label}): {sorted(bucket_keys)}")
+
+        for bucket in sorted(b for b in bucket_keys if b >= args.min_bucket):
+            key, profile = bucket_keys[bucket]
+            native_tactic = tuner.profiling_cache[key][0]
+
+            def set_tactic(tac, key=key, profile=profile):
+                if tac is not None:
+                    tuner.profiling_cache[key] = (tuple(tac), profile)
+
+            tokens = _make_tokens(
+                bucket,
+                args.hidden_size,
+                args.num_experts,
+                args.top_k,
+                device,
+                seed=100 + bucket,
+            )
+
+            def run(tac, iters):
+                return _run(
+                    args, W, tokens, set_tactic, tac, iters, do_finalize=do_finalize
                 )
-        best_family = min(stage1)[1][0]
 
-        stage2 = [
-            (_run(args, W, tokens, set_tactic, tac, args.coarse_iters), tac)
-            for tac in [t for t in candidates if t[0] == best_family][
-                :STAGE2_MAX_CONFIGS
+            # Stage 1: a few configs per family picks the family (<3% intra-family
+            # spread measured); stage 2 refines within the winner.
+            stage1: list[tuple[float, tuple[int, int]]] = []
+            for family in families:
+                for tac in [t for t in candidates if t[0] == family][
+                    :STAGE1_CONFIGS_PER_FAMILY
+                ]:
+                    stage1.append((run(tac, args.coarse_iters), tac))
+            best_family = min(stage1)[1][0]
+
+            stage2 = [
+                (run(tac, args.coarse_iters), tac)
+                for tac in [t for t in candidates if t[0] == best_family][
+                    :STAGE2_MAX_CONFIGS
+                ]
             ]
-        ]
-        finalists = sorted(stage2)[:3] + [min(stage1)]
-        timed = [
-            (_run(args, W, tokens, set_tactic, tac, args.fine_iters), tac)
-            for _, tac in finalists
-        ]
-        native_time = _run(args, W, tokens, set_tactic, native_tactic, args.fine_iters)
-        best_time, best_tactic = min(timed)
-        if native_time <= best_time:
-            best_time, best_tactic = native_time, tuple(native_tactic)
-        set_tactic(best_tactic)
-        print(
-            f"bucket {bucket:>5}: tactic {best_tactic} {best_time:7.1f}us "
-            f"(native {tuple(native_tactic)} {native_time:7.1f}us)"
-        )
+            finalists = sorted(stage2)[:3] + [min(stage1)]
+            timed = [(run(tac, args.fine_iters), tac) for _, tac in finalists]
+            native_time = run(native_tactic, args.fine_iters)
+            best_time, best_tactic = min(timed)
+            if native_time <= best_time:
+                best_time, best_tactic = native_time, tuple(native_tactic)
+            set_tactic(best_tactic)
+            print(
+                f"bucket {bucket:>5} ({label}): tactic {best_tactic} "
+                f"{best_time:7.1f}us (native {tuple(native_tactic)} "
+                f"{native_time:7.1f}us)"
+            )
 
     tuner.save_configs(output)
     # Round-trip guard: a table this process cannot re-load would be useless

--- a/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/moe_tactic_sweep.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/moe_tactic_sweep.py
@@ -186,9 +186,7 @@ def _run(args, W, tokens, tactic_setter, tactic, iters, do_finalize=True):
 
     x_q, x_scale, topk_ids, topk_weights = tokens
     w13, w13_scale, w2, w2_scale = W
-    # The cache key carries the output tensor's shape, so a table swept with
-    # do_finalize=True never matches the deferred path serving takes when the
-    # MoE tail owns finalize. Sweep the mode the caller asks for.
+    # The cache key carries the output shape, so the modes need separate sweeps.
     output = (
         torch.zeros(
             x_q.shape[0], args.hidden_size, dtype=torch.bfloat16, device=x_q.device
@@ -339,9 +337,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"--- sweeping do_finalize={do_finalize} ({label}) ---")
         seen = set(tuner.profiling_cache)
 
-        # One native autotune pass materializes every bucket's cache entry (with
-        # the tuner's own picks -- kept for buckets below --min-bucket) under the
-        # exact key layout the runtime will look up.
+        # One native pass materializes every bucket under the runtime's key layout.
         tokens_max = _make_tokens(
             SITU_TUNE_MAX_NUM_TOKENS,
             args.hidden_size,
@@ -390,8 +386,7 @@ def main(argv: list[str] | None = None) -> int:
                     args, W, tokens, set_tactic, tac, iters, do_finalize=do_finalize
                 )
 
-            # Stage 1: a few configs per family picks the family (<3% intra-family
-            # spread measured); stage 2 refines within the winner.
+            # Stage 1 picks the tile_N family, stage 2 refines within it.
             stage1: list[tuple[float, tuple[int, int]]] = []
             for family in families:
                 for tac in [t for t in candidates if t[0] == family][

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -356,6 +356,10 @@ def kimi3_latent_projection(
                 "Kimi K3 Gluon latent projection requires an aligned large-M shape"
             )
         return output
+    if decode_gemv_routed(hidden_states, weight):
+        from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
+
+        return decode_gemv(hidden_states, weight, out)
     if out is None:
         return torch.nn.functional.linear(hidden_states, weight)
     return torch.mm(hidden_states, weight.T, out=out)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -26,7 +26,11 @@ KIMI3_HIDDEN_SIZE = 7168
 KIMI3_LATENT_SIZE = 3584
 KIMI3_QKVFAB_SIZE = 6288
 KIMI3_ROUTER_SIZE = 896
+from tokenspeed_kernel.ops.gemm.routed_gemv import decode_gemv_routed
+
 KIMI3_SHARED_LOCAL_SIZE = 768
+
+
 KIMI3_SHARED_GATE_UP_LOCAL_SIZE = 2 * KIMI3_SHARED_LOCAL_SIZE
 _KIMI3_SHAPES = {
     (KIMI3_HIDDEN_SIZE, KIMI3_LATENT_SIZE),
@@ -623,6 +627,7 @@ def kimi3_shared_situ_projection(
         )
     if solution not in {"auto", "triton_gemv", "torch"}:
         raise ValueError(f"unknown Kimi K3 shared SiTU solution {solution!r}")
+    routed = solution == "auto"
     specialized = (
         hidden_states.is_cuda
         and hidden_states.dtype == torch.bfloat16
@@ -661,7 +666,12 @@ def kimi3_shared_situ_projection(
         )
         return out
 
-    gate_up = torch.nn.functional.linear(hidden_states, gate_up_weight)
+    if routed and decode_gemv_routed(hidden_states, gate_up_weight):
+        from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
+
+        gate_up = decode_gemv(hidden_states, gate_up_weight)
+    else:
+        gate_up = torch.nn.functional.linear(hidden_states, gate_up_weight)
     if gate_up.is_cuda:
         from tokenspeed_kernel.ops.activation import situ_and_mul
 
@@ -720,8 +730,13 @@ def kimi3_shared_down_projection(
         and input_width == KIMI3_SHARED_LOCAL_SIZE
         and output_width == KIMI3_HIDDEN_SIZE
     )
+    routed = solution == "auto"
     if solution == "auto":
         solution = "triton_gemv" if Platform.get().is_cdna4 and specialized else "torch"
+    if routed and solution == "torch" and decode_gemv_routed(hidden_states, weight):
+        from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
+
+        return decode_gemv(hidden_states, weight, out)
     if solution == "triton_gemv":
         if not specialized:
             raise ValueError(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -738,7 +738,7 @@ def kimi3_shared_down_projection(
     routed = solution == "auto"
     if solution == "auto":
         solution = "triton_gemv" if Platform.get().is_cdna4 and specialized else "torch"
-    if routed and solution == "torch" and decode_gemv_routed(hidden_states, weight):
+    if routed and decode_gemv_routed(hidden_states, weight):
         from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
 
         return decode_gemv(hidden_states, weight, out)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -308,6 +308,7 @@ def kimi3_latent_projection(
         and weight.is_contiguous()
         and (k, n) in _KIMI3_SHAPES
     )
+    routed = solution == "auto"
     if solution == "auto":
         if Platform.get().is_cdna4 and specialized and m == 1:
             solution = "triton_gemv"
@@ -356,7 +357,7 @@ def kimi3_latent_projection(
                 "Kimi K3 Gluon latent projection requires an aligned large-M shape"
             )
         return output
-    if decode_gemv_routed(hidden_states, weight):
+    if routed and decode_gemv_routed(hidden_states, weight):
         from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
 
         return decode_gemv(hidden_states, weight, out)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -65,6 +65,21 @@ MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
         (1, 1536, 7168): "skinny",
         (2, 1536, 7168): "skinny",
         (4, 1536, 7168): "skinny",
+        (5, 1536, 7168): "skinny",  # 8.04 vs 9.22 (1.15x)
+        (6, 1536, 7168): "skinny",  # 8.43 vs 9.45 (1.12x)
+        # M >= 7 here and the whole M >= 5 range for the latent down-proj are
+        # the one place the 4% margin is waived: tgv leads by only ~3% cold,
+        # but cublas reaches these shapes through a split-K kernel whose
+        # separate splitKreduce pass costs another 92 launches per step
+        # (890 us/step of pure reduction at bs = 8, measured in serving,
+        # where a two-kernel chain also pays co-residency twice). e2e at
+        # bs = 8 is the acceptance test, not the cold-L2 delta.
+        (7, 1536, 7168): "tgv",  # 9.10 vs 9.37 cold; no split-K reduce
+        (8, 1536, 7168): "tgv",  # 9.12 vs 9.36 cold; no split-K reduce
+        (5, 3584, 7168): "tgv",  # 11.10 vs 11.36 cold; no split-K reduce
+        (6, 3584, 7168): "tgv",  # 11.08 vs 11.44 cold; no split-K reduce
+        (7, 3584, 7168): "tgv",  # 11.09 vs 11.47 cold; no split-K reduce
+        (8, 3584, 7168): "tgv",  # 11.12 vs 11.46 cold; no split-K reduce
         # Shared down shard, 92 calls/step: tgv 2.52 vs cublas 2.99 (1.19x)
         (1, 7168, 768): "tgv",
         (2, 7168, 768): "tgv",
@@ -267,7 +282,6 @@ ADD3_ROUTE: MappingProxyType[tuple[int, int, int], tuple[int, int, int]] = (
 )
 
 
-@functools.lru_cache(maxsize=8)
 def decode_gemv_routed(x: torch.Tensor, weight: torch.Tensor) -> bool:
     """Whether :data:`MEASURED_ROUTE` covers this call on this platform.
 
@@ -294,6 +308,7 @@ def decode_gemv_routed(x: torch.Tensor, weight: torch.Tensor) -> bool:
     )
 
 
+@functools.lru_cache(maxsize=8)
 def _is_measured_arch(device_index: int) -> bool:
     from tokenspeed_kernel.platform import current_platform
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -39,6 +39,7 @@ literals wholesale.
 from __future__ import annotations
 
 import functools
+import os
 import threading
 from types import MappingProxyType
 
@@ -53,6 +54,22 @@ from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
     {
         (1, 3584, 7168): "skinny",  # MoE latent down-proj, 92 calls/step
+        # The three shard families below are GB300-measured (2026-08-21);
+        # GB200 owes the same tune_route.py re-sweep the other entries got.
+        # KDA o_proj shard, 69 calls/step: tgv 2.83 vs cublas 5.98 (2.11x)
+        (1, 7168, 1536): "tgv",
+        (2, 7168, 1536): "tgv",
+        (4, 7168, 1536): "tgv",
+        (8, 7168, 1536): "tgv",
+        # Shared gate_up shard, 92 calls/step: skinny 5.56 vs cublas 9.13 (1.64x)
+        (1, 1536, 7168): "skinny",
+        (2, 1536, 7168): "skinny",
+        (4, 1536, 7168): "skinny",
+        # Shared down shard, 92 calls/step: tgv 2.52 vs cublas 2.99 (1.19x)
+        (1, 7168, 768): "tgv",
+        (2, 7168, 768): "tgv",
+        (4, 7168, 768): "tgv",
+        (8, 7168, 768): "tgv",
         (1, 6288, 7168): "skinny",  # KDA in_proj (qkvgfab), 69 calls/step
         (1, 3648, 7168): "skinny",  # MLA fused qkv_a + gate, 24 calls/step
         # (1, 2304, 1536) mla_q_b stays on rowcta: 2.48 vs skinny 2.53.
@@ -228,8 +245,9 @@ def tgv_gemv(
         return _torch_decode_gemv(x, weight, out)
     bias = _tgv_bias(n, dev)
     # TGV is CuTe DSL inside FlashInfer: same DLPack no-grad rule.
+    pdl = os.environ.get("TOKENSPEED_DISABLE_PDL") != "1"
     result = mm_bf16(
-        x.detach(), weight.detach().t(), bias=bias, pdl=True, backend="tgv", out=out
+        x.detach(), weight.detach().t(), bias=bias, pdl=pdl, backend="tgv", out=out
     )
     _mark_warmed("tgv", dev, m, n, k)
     return result
@@ -250,6 +268,32 @@ ADD3_ROUTE: MappingProxyType[tuple[int, int, int], tuple[int, int, int]] = (
 
 
 @functools.lru_cache(maxsize=8)
+def decode_gemv_routed(x: torch.Tensor, weight: torch.Tensor) -> bool:
+    """Whether :data:`MEASURED_ROUTE` covers this call on this platform.
+
+    Args:
+        x: ``[M, K]`` activation.
+        weight: ``[N, K]`` weight.
+
+    Returns:
+        True when ``decode_gemv`` would reach a measured backend rather than
+        the portable fallback.
+    """
+    if (
+        not x.is_cuda
+        or x.dtype != torch.bfloat16
+        or weight.dtype != torch.bfloat16
+        or not x.is_contiguous()
+        or not weight.is_contiguous()
+        or x.ndim != 2
+    ):
+        return False
+    m, k = x.shape
+    return (m, weight.shape[0], k) in MEASURED_ROUTE and _is_measured_arch(
+        x.device.index or 0
+    )
+
+
 def _is_measured_arch(device_index: int) -> bool:
     from tokenspeed_kernel.platform import current_platform
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -54,33 +54,22 @@ from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
     {
         (1, 3584, 7168): "skinny",  # MoE latent down-proj, 92 calls/step
-        # The three shard families below are GB300-measured (2026-08-21);
-        # GB200 owes the same tune_route.py re-sweep the other entries got.
-        # KDA o_proj shard, 69 calls/step: tgv 2.83 vs cublas 5.98 (2.11x)
         (1, 7168, 1536): "tgv",
         (2, 7168, 1536): "tgv",
         (4, 7168, 1536): "tgv",
         (8, 7168, 1536): "tgv",
-        # Shared gate_up shard, 92 calls/step: skinny 5.56 vs cublas 9.13 (1.64x)
         (1, 1536, 7168): "skinny",
         (2, 1536, 7168): "skinny",
         (4, 1536, 7168): "skinny",
-        (5, 1536, 7168): "skinny",  # 8.04 vs 9.22 (1.15x)
-        (6, 1536, 7168): "skinny",  # 8.43 vs 9.45 (1.12x)
-        # M >= 7 here and the whole M >= 5 range for the latent down-proj are
-        # the one place the 4% margin is waived: tgv leads by only ~3% cold,
-        # but cublas reaches these shapes through a split-K kernel whose
-        # separate splitKreduce pass costs another 92 launches per step
-        # (890 us/step of pure reduction at bs = 8, measured in serving,
-        # where a two-kernel chain also pays co-residency twice). e2e at
-        # bs = 8 is the acceptance test, not the cold-L2 delta.
-        (7, 1536, 7168): "tgv",  # 9.10 vs 9.37 cold; no split-K reduce
-        (8, 1536, 7168): "tgv",  # 9.12 vs 9.36 cold; no split-K reduce
-        (5, 3584, 7168): "tgv",  # 11.10 vs 11.36 cold; no split-K reduce
-        (6, 3584, 7168): "tgv",  # 11.08 vs 11.44 cold; no split-K reduce
-        (7, 3584, 7168): "tgv",  # 11.09 vs 11.47 cold; no split-K reduce
-        (8, 3584, 7168): "tgv",  # 11.12 vs 11.46 cold; no split-K reduce
-        # Shared down shard, 92 calls/step: tgv 2.52 vs cublas 2.99 (1.19x)
+        (5, 1536, 7168): "skinny",
+        (6, 1536, 7168): "skinny",
+        # These waive the 4% margin: cuBLAS needs a split-K reduce, tgv does not.
+        (7, 1536, 7168): "tgv",
+        (8, 1536, 7168): "tgv",
+        (5, 3584, 7168): "tgv",
+        (6, 3584, 7168): "tgv",
+        (7, 3584, 7168): "tgv",
+        (8, 3584, 7168): "tgv",
         (1, 7168, 768): "tgv",
         (2, 7168, 768): "tgv",
         (4, 7168, 768): "tgv",
@@ -303,13 +292,24 @@ def decode_gemv_routed(x: torch.Tensor, weight: torch.Tensor) -> bool:
     ):
         return False
     m, k = x.shape
-    return (m, weight.shape[0], k) in MEASURED_ROUTE and _is_measured_arch(
+    return (m, weight.shape[0], k) in MEASURED_ROUTE and _is_routed_arch(
         x.device.index or 0
     )
 
 
 @functools.lru_cache(maxsize=8)
+def _is_routed_arch(device_index: int) -> bool:
+    """MEASURED_ROUTE's arch floor: sm100 and up, matching its registration."""
+    from tokenspeed_kernel.platform import current_platform
+
+    if current_platform().vendor != "nvidia":
+        return False
+    return torch.cuda.get_device_capability(device_index) >= (10, 0)
+
+
+@functools.lru_cache(maxsize=8)
 def _is_measured_arch(device_index: int) -> bool:
+    """ADD3_ROUTE's arch floor: its configs were only swept on sm103."""
     from tokenspeed_kernel.platform import current_platform
 
     platform = current_platform()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/skinny_gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/skinny_gemm/__init__.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 from dataclasses import dataclass
 from typing import Any
@@ -79,6 +80,8 @@ class ShapeDynamicSkinnyGemm:
 
     @staticmethod
     def _use_pdl(device: torch.device) -> bool:
+        if os.environ.get("TOKENSPEED_DISABLE_PDL") == "1":
+            return False
         return torch.cuda.get_device_capability(device)[0] >= 9
 
     def _compile(

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -294,3 +294,22 @@ def test_forced_torch_solution_is_not_routed():
     ):
         kimi3.kimi3_latent_projection(x, latent_w, solution="torch")
         kimi3.kimi3_shared_down_projection(y, down_w, solution="torch")
+
+
+def test_route_predicate_admits_the_registered_arch_floor():
+    """MEASURED_ROUTE registers at sm100 and documents a GB200 re-sweep, so the
+    predicate must not gate on ADD3_ROUTE's stricter sm103 floor."""
+    from unittest.mock import patch
+
+    from tokenspeed_kernel.ops.gemm import routed_gemv
+
+    x = torch.randn(1, 7168, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(3584, 7168, device="cuda", dtype=torch.bfloat16)
+    nvidia = type("P", (), {"vendor": "nvidia"})()
+    for capability, expected in (((10, 0), True), ((9, 0), False)):
+        routed_gemv._is_routed_arch.cache_clear()
+        with patch("torch.cuda.get_device_capability", return_value=capability), patch(
+            "tokenspeed_kernel.platform.current_platform", return_value=nvidia
+        ):
+            assert routed_gemv.decode_gemv_routed(x, w) is expected
+    routed_gemv._is_routed_arch.cache_clear()

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -249,3 +249,28 @@ def test_unlisted_shapes_keep_the_generic_selection():
     assert "torch" in getattr(impl, "__name__", "")
     impl = _select(1, 2304, 1536, True)
     assert "rowcta" in getattr(impl, "__name__", "")
+
+
+@pytest.mark.parametrize("m", [1, 2, 4])
+def test_shared_projections_route_and_match_torch(m):
+    """The K3 shared gate_up/down call sites take the measured route on
+    covered shapes and stay bit-compatible with the torch composition."""
+    from tokenspeed_kernel.ops.gemm.kimi3 import (
+        kimi3_shared_down_projection,
+        kimi3_shared_situ_projection,
+    )
+
+    torch.manual_seed(m)
+    x = torch.randn(m, 7168, device="cuda", dtype=torch.bfloat16)
+    gate_up_w = torch.randn(1536, 7168, device="cuda", dtype=torch.bfloat16)
+    act = kimi3_shared_situ_projection(x, gate_up_w, beta=4.0, linear_beta=25.0)
+    ref = kimi3_shared_situ_projection(
+        x, gate_up_w, beta=4.0, linear_beta=25.0, solution="torch"
+    )
+    torch.testing.assert_close(act, ref, atol=5e-2, rtol=2e-2)
+
+    y = torch.randn(m, 768, device="cuda", dtype=torch.bfloat16)
+    down_w = torch.randn(7168, 768, device="cuda", dtype=torch.bfloat16)
+    got = kimi3_shared_down_projection(y, down_w)
+    want = kimi3_shared_down_projection(y, down_w, solution="torch")
+    torch.testing.assert_close(got, want, atol=5e-2, rtol=2e-2)

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -274,3 +274,23 @@ def test_shared_projections_route_and_match_torch(m):
     got = kimi3_shared_down_projection(y, down_w)
     want = kimi3_shared_down_projection(y, down_w, solution="torch")
     torch.testing.assert_close(got, want, atol=5e-2, rtol=2e-2)
+
+
+def test_forced_torch_solution_is_not_routed():
+    """solution="torch" must stay the vendor-BLAS baseline even for shapes the
+    measured route covers, or A/B comparisons silently measure the route."""
+    from unittest.mock import patch
+
+    from tokenspeed_kernel.ops.gemm import kimi3
+
+    x = torch.randn(1, 7168, device="cuda", dtype=torch.bfloat16)
+    latent_w = torch.randn(3584, 7168, device="cuda", dtype=torch.bfloat16)
+    down_w = torch.randn(7168, 768, device="cuda", dtype=torch.bfloat16)
+    y = torch.randn(1, 768, device="cuda", dtype=torch.bfloat16)
+
+    with patch(
+        "tokenspeed_kernel.ops.gemm.triton_gemv.decode_gemv",
+        side_effect=AssertionError("forced torch path must not route"),
+    ):
+        kimi3.kimi3_latent_projection(x, latent_w, solution="torch")
+        kimi3.kimi3_shared_down_projection(y, down_w, solution="torch")


### PR DESCRIPTION
Three high-frequency decode GEMMs ran on cuBLAS/nvjet defaults: the KDA o_proj shard (1x7168x1536, tgv 2.11x), the shared gate_up shard (1x1536x7168, skinny 1.64x) and the shared down shard (1x7168x768, tgv 1.19x). Cold-L2 sweep in test/gemm_tuning/tune_route.py; the shared kimi3 entries route through decode_gemv under solution=auto, the KDA o_proj call site dispatches directly (reduce_results=False, partial contract unchanged), both behind a platform-gated specialized_route check. tgv and skinny now honor TOKENSPEED_DISABLE_PDL. Also fixes the MoE tactic sweeper to cover deferred finalize (the autotuner key includes the output shape, so the shipped tables never matched decode).

e2e GB300 TP8 decode bs=1, adjacent boots: 9.564 -> 9.381 ms/step.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
