### PR TITLE
fix(cli): disable smg load monitoring by default

### DIFF
--- a/python/tokenspeed/cli/serve_smg.py
+++ b/python/tokenspeed/cli/serve_smg.py
@@ -79,12 +79,15 @@ DEFAULT_GRPC_MAX_MESSAGE_BYTES = "536870912"
 # which happens to share the "passthrough" string but configures an unrelated
 # flag (--reasoning-parser).
 DEFAULT_SMG_POLICY = "passthrough"
-# smg reliability knobs we always want disabled when launched under
-# ts serve. These are tokenspeed-internal defaults: not surfaced via
-# the ts CLI, not routed through split_argv.
+# smg reliability and background load-monitoring knobs we always want disabled
+# when launched under ts serve. These are tokenspeed-internal defaults: not
+# surfaced via the ts CLI, not routed through split_argv. This is independent
+# from the routing policy below: disabling load monitoring stops smg's
+# background engine-load polling.
 _DEFAULT_SMG_DISABLE_FLAGS = (
     "--disable-circuit-breaker",
     "--disable-retries",
+    "--disable-load-monitoring",
 )
 
 
@@ -161,7 +164,7 @@ def _gateway_args_with_default_reasoning_parser(gateway_args: list[str]) -> list
 
 
 def _gateway_args_with_smg_disable_defaults(gateway_args: list[str]) -> list[str]:
-    """Append the smg reliability-disable switches if they are not already there."""
+    """Append smg reliability and load-monitoring disable switches when absent."""
     result = list(gateway_args)
     for flag in _DEFAULT_SMG_DISABLE_FLAGS:
         if flag not in result:
@@ -178,7 +181,8 @@ def _gateway_args_with_default_policy(gateway_args: list[str]) -> list[str]:
     Against engines that predate that RPC the subscription surfaced as
     ``NotImplementedError: Method not implemented`` (smg#1794). The ``passthrough``
     policy (smg#1797) forwards every request to the single healthy worker with no
-    load balancing, load monitoring, or KV-event subscription.
+    load-aware routing or KV-event subscription. Separately,
+    ``--disable-load-monitoring`` turns off smg's background engine-load polling.
 
     Default-when-unset: an explicit operator ``--policy`` is preserved.
 

--- a/test/ci_system/serve_qwen35_122b_nvfp4_epd_1e1p2d.sh
+++ b/test/ci_system/serve_qwen35_122b_nvfp4_epd_1e1p2d.sh
@@ -238,6 +238,7 @@ python3 -m smg launch \
   --decode-policy round_robin \
   --request-timeout-secs 1800 \
   --disable-circuit-breaker \
+  --disable-load-monitoring \
   --disable-health-check \
   --log-level info \
   --prometheus-port "$PROMETHEUS_PORT" \

--- a/test/ci_system/serve_qwen35_397b_nvfp4_pd_1p1d.sh
+++ b/test/ci_system/serve_qwen35_397b_nvfp4_pd_1p1d.sh
@@ -216,6 +216,7 @@ python3 -m smg launch \
   --request-timeout-secs 1800 \
   --log-level info \
   --disable-retries \
+  --disable-load-monitoring \
   --disable-circuit-breaker \
   --disable-health-check \
   --prometheus-port "$PROMETHEUS_PORT" \

--- a/test/cli/test_serve_smg_unit.py
+++ b/test/cli/test_serve_smg_unit.py
@@ -149,6 +149,7 @@ def test_gateway_args_defaults_include_port_and_reasoning_parser():
         "passthrough",
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-load-monitoring",
         "--policy",
         "passthrough",
         "--tokenizer-cache-enable-l0",
@@ -219,6 +220,7 @@ def test_smg_disable_flags_appended_when_absent():
         "/tmp/x",
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-load-monitoring",
     ]
 
 
@@ -231,13 +233,21 @@ def test_smg_disable_flags_not_duplicated():
     assert gateway_args == [
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-load-monitoring",
     ]
 
 
-def test_smg_disable_flag_set_covers_both():
+def test_smg_disable_defaults_turn_off_load_monitoring():
+    gateway_args = _gateway_args_with_smg_disable_defaults(["--model", "/tmp/x"])
+
+    assert gateway_args.count("--disable-load-monitoring") == 1
+
+
+def test_smg_disable_flag_set_covers_all_three():
     assert _DEFAULT_SMG_DISABLE_FLAGS == (
         "--disable-circuit-breaker",
         "--disable-retries",
+        "--disable-load-monitoring",
     )
 
 


### PR DESCRIPTION
## Summary

- Pass `--disable-load-monitoring` to the SMG gateway launched by `ts serve`.
- Add the same default to TokenSpeed's direct PD and EPD SMG CI launchers.
- Clarify that passthrough routing does not by itself disable SMG's independent engine-load monitor.

TokenSpeed's internal DP load watcher remains enabled for shortest-queue/min-cache routing. This change only removes redundant SMG background polling from TokenSpeed-owned gateway launches and is defense in depth independent of the communicator race fix.

## Test Plan

- `python -m pytest test/cli/test_serve_smg_unit.py -q` (51 passed)
- `bash -n test/ci_system/serve_qwen35_397b_nvfp4_pd_1p1d.sh`
- `bash -n test/ci_system/serve_qwen35_122b_nvfp4_epd_1e1p2d.sh`
- `pre-commit run --all-files`

GPU integration CI was not available on the development Mac.
