### PR TITLE
fix(runtime): make load queries cancellation-safe

### DIFF
--- a/python/tokenspeed/runtime/engine/scheduler_communicator.py
+++ b/python/tokenspeed/runtime/engine/scheduler_communicator.py
@@ -36,9 +36,7 @@ class _Sender(Protocol):
 class _Communicator(Generic[T]):
     """Note: The communicator now only run up to 1 in-flight request at any time."""
 
-    def __init__(
-        self, sender: _Sender, fan_out: int, mode: _Mode = "queueing"
-    ) -> None:
+    def __init__(self, sender: _Sender, fan_out: int, mode: _Mode = "queueing") -> None:
         self._sender = sender
         self._fan_out = fan_out
         self._mode = mode

--- a/python/tokenspeed/runtime/engine/scheduler_communicator.py
+++ b/python/tokenspeed/runtime/engine/scheduler_communicator.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from collections import deque
+from typing import Generic, Literal, Protocol, TypeVar
+
+T = TypeVar("T")
+_Mode = Literal["queueing", "watching"]
+
+
+class _Sender(Protocol):
+    def send_pyobj(self, obj: object) -> object: ...
+
+
+class _Communicator(Generic[T]):
+    """Note: The communicator now only run up to 1 in-flight request at any time."""
+
+    def __init__(
+        self, sender: _Sender, fan_out: int, mode: _Mode = "queueing"
+    ) -> None:
+        self._sender = sender
+        self._fan_out = fan_out
+        self._mode = mode
+        self._result_event: asyncio.Event | None = None
+        self._result_values: list[T] | None = None
+        self._ready_queue: deque[asyncio.Event] = deque()
+
+        if mode not in ("queueing", "watching"):
+            raise ValueError(f"Invalid communicator mode: {mode}")
+
+    async def queueing_call(self, obj: T) -> list[T]:
+        ready_event = asyncio.Event()
+        if self._result_event is not None or len(self._ready_queue) > 0:
+            self._ready_queue.append(ready_event)
+            await ready_event.wait()
+            if self._result_event is not None or self._result_values is not None:
+                raise RuntimeError("Communicator result state was not reset.")
+
+        if obj:
+            self._sender.send_pyobj(obj)
+
+        self._result_event = asyncio.Event()
+        self._result_values = []
+        await self._result_event.wait()
+        result_values = self._result_values
+        self._result_event = self._result_values = None
+
+        if len(self._ready_queue) > 0:
+            self._ready_queue.popleft().set()
+
+        return result_values
+
+    async def watching_call(self, obj: T) -> list[T]:
+        if self._result_event is None:
+            if self._result_values is not None:
+                raise RuntimeError("Communicator result values were not reset.")
+            self._result_values = []
+            self._result_event = asyncio.Event()
+            if obj:
+                self._sender.send_pyobj(obj)
+
+        result_event = self._result_event
+        result_values = self._result_values
+        if result_event is None or result_values is None:
+            raise RuntimeError("Communicator watching state is incomplete.")
+
+        await result_event.wait()
+        return copy.deepcopy(result_values)
+
+    async def __call__(self, obj: T) -> list[T]:
+        if self._mode == "queueing":
+            return await self.queueing_call(obj)
+        else:
+            return await self.watching_call(obj)
+
+    def handle_recv(self, recv_obj: T) -> None:
+        result_event = self._result_event
+        result_values = self._result_values
+        if result_event is None or result_values is None:
+            raise RuntimeError("Communicator result state is incomplete.")
+
+        result_values.append(recv_obj)
+        if len(result_values) == self._fan_out:
+            if self._mode == "watching":
+                self._result_event = self._result_values = None
+            result_event.set()

--- a/python/tokenspeed/runtime/engine/scheduler_control_client.py
+++ b/python/tokenspeed/runtime/engine/scheduler_control_client.py
@@ -20,19 +20,12 @@
 
 from __future__ import annotations
 
-import asyncio
-import copy
 import logging
 import time
-from collections import deque
 from typing import (
     TYPE_CHECKING,
     Any,
-    Generic,
-    TypeVar,
 )
-
-import zmq
 
 from tokenspeed.runtime.engine.io_struct import (
     DestroyWeightsUpdateGroupReqInput,
@@ -73,6 +66,7 @@ from tokenspeed.runtime.engine.io_struct import (
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
 )
+from tokenspeed.runtime.engine.scheduler_communicator import _Communicator
 from tokenspeed.runtime.utils.dispatch import TypeBasedDispatcher
 from tokenspeed.runtime.utils.env import envs
 from tokenspeed.runtime.utils.server_args import ServerArgs
@@ -80,72 +74,7 @@ from tokenspeed.runtime.utils.server_args import ServerArgs
 if TYPE_CHECKING:
     from tokenspeed.runtime.engine.async_llm import AsyncLLM
 
-T = TypeVar("T")
-
 logger = logging.getLogger(__name__)
-
-
-class _Communicator(Generic[T]):
-    """Note: The communicator now only run up to 1 in-flight request at any time."""
-
-    def __init__(self, sender: zmq.Socket, fan_out: int, mode="queueing"):
-        self._sender = sender
-        self._fan_out = fan_out
-        self._mode = mode
-        self._result_event: asyncio.Event | None = None
-        self._result_values: list[T] | None = None
-        self._ready_queue: deque[asyncio.Future] = deque()
-
-        if mode not in ("queueing", "watching"):
-            raise ValueError(f"Invalid communicator mode: {mode}")
-
-    async def queueing_call(self, obj: T):
-        ready_event = asyncio.Event()
-        if self._result_event is not None or len(self._ready_queue) > 0:
-            self._ready_queue.append(ready_event)
-            await ready_event.wait()
-            if self._result_event is not None or self._result_values is not None:
-                raise RuntimeError("Communicator result state was not reset.")
-
-        if obj:
-            self._sender.send_pyobj(obj)
-
-        self._result_event = asyncio.Event()
-        self._result_values = []
-        await self._result_event.wait()
-        result_values = self._result_values
-        self._result_event = self._result_values = None
-
-        if len(self._ready_queue) > 0:
-            self._ready_queue.popleft().set()
-
-        return result_values
-
-    async def watching_call(self, obj):
-        if self._result_event is None:
-            if self._result_values is not None:
-                raise RuntimeError("Communicator result values were not reset.")
-            self._result_values = []
-            self._result_event = asyncio.Event()
-
-            if obj:
-                self._sender.send_pyobj(obj)
-
-        await self._result_event.wait()
-        result_values = copy.deepcopy(self._result_values)
-        self._result_event = self._result_values = None
-        return result_values
-
-    async def __call__(self, obj):
-        if self._mode == "queueing":
-            return await self.queueing_call(obj)
-        else:
-            return await self.watching_call(obj)
-
-    def handle_recv(self, recv_obj: T):
-        self._result_values.append(recv_obj)
-        if len(self._result_values) == self._fan_out:
-            self._result_event.set()
 
 
 class SchedulerControlClient:
@@ -205,6 +134,7 @@ class SchedulerControlClient:
         self.get_load_communicator = _Communicator(
             self.engine_core_client.send_to_scheduler,
             server_args.mapping.attn.dp_size,
+            mode="watching",
         )
 
         self._result_dispatcher += self._get_communicator_dispatcher()

--- a/test/runtime/test_scheduler_communicator.py
+++ b/test/runtime/test_scheduler_communicator.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import asyncio
+import os
+import sys
+import unittest
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, suite="runtime-1gpu")
+
+from tokenspeed.runtime.engine.scheduler_communicator import _Communicator
+
+
+class _RecordingSender:
+    def __init__(self):
+        self.sent: list[object] = []
+
+    def send_pyobj(self, obj: object):
+        self.sent.append(obj)
+
+
+class TestWatchingCommunicator(unittest.IsolatedAsyncioTestCase):
+    async def test_overlapping_watchers_share_one_complete_result(self):
+        sender = _RecordingSender()
+        communicator = _Communicator(sender, fan_out=2, mode="watching")
+
+        first = asyncio.create_task(communicator("request"))
+        second = asyncio.create_task(communicator("request"))
+        await asyncio.sleep(0)
+        self.assertEqual(sender.sent, ["request"])
+
+        communicator.handle_recv({"rank": 0})
+        self.assertFalse(first.done())
+        self.assertFalse(second.done())
+        communicator.handle_recv({"rank": 1})
+
+        first_result, second_result = await asyncio.gather(first, second)
+        self.assertEqual(first_result, [{"rank": 0}, {"rank": 1}])
+        self.assertEqual(second_result, first_result)
+        self.assertIsNot(first_result, second_result)
+        self.assertIsNot(first_result[0], second_result[0])
+
+    async def test_cancelled_watcher_does_not_cancel_other_watcher_or_reuse(self):
+        sender = _RecordingSender()
+        communicator = _Communicator(sender, fan_out=2, mode="watching")
+
+        cancelled = asyncio.create_task(communicator("first request"))
+        survivor = asyncio.create_task(communicator("first request"))
+        await asyncio.sleep(0)
+        cancelled.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await cancelled
+
+        communicator.handle_recv({"rank": 0})
+        communicator.handle_recv({"rank": 1})
+        self.assertEqual(
+            await survivor,
+            [{"rank": 0}, {"rank": 1}],
+        )
+
+        reused = asyncio.create_task(communicator("second request"))
+        await asyncio.sleep(0)
+        self.assertEqual(sender.sent, ["first request", "second request"])
+        communicator.handle_recv({"rank": 0, "flight": 2})
+        communicator.handle_recv({"rank": 1, "flight": 2})
+        self.assertEqual(
+            await reused,
+            [{"rank": 0, "flight": 2}, {"rank": 1, "flight": 2}],
+        )
+
+    async def test_cancelled_sole_watcher_preserves_and_drains_active_flight(self):
+        sender = _RecordingSender()
+        communicator = _Communicator(sender, fan_out=2, mode="watching")
+
+        cancelled = asyncio.create_task(communicator("first request"))
+        await asyncio.sleep(0)
+        cancelled.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await cancelled
+
+        observer = asyncio.create_task(communicator("duplicate request"))
+        await asyncio.sleep(0)
+        self.assertEqual(sender.sent, ["first request"])
+        communicator.handle_recv({"rank": 0})
+        communicator.handle_recv({"rank": 1})
+        self.assertEqual(
+            await observer,
+            [{"rank": 0}, {"rank": 1}],
+        )
+
+        fresh = asyncio.create_task(communicator("fresh request"))
+        await asyncio.sleep(0)
+        self.assertEqual(sender.sent, ["first request", "fresh request"])
+        communicator.handle_recv({"rank": 0, "flight": 2})
+        communicator.handle_recv({"rank": 1, "flight": 2})
+        self.assertEqual(
+            await fresh,
+            [{"rank": 0, "flight": 2}, {"rank": 1, "flight": 2}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fix the scheduler communicator race that returned `None` to overlapping load-query callers.
- Make the receiver own watching-flight completion so caller cancellation cannot clear shared state early.
- Restore single-flight watching mode for empty, idempotent `GetLoadReqInput` observations and add async cancellation/reuse coverage.

This replaces the temporary serialization workaround from #1197 with coalesced load observations that remain safe when callers use timeouts or cancellation. A cancelled flight still drains every fan-out response before the next flight starts because control replies do not carry request IDs.

## Test Plan

- `PYTHONPATH=python python3 test/runtime/test_scheduler_communicator.py` (3 passed)
- `pre-commit run --all-files`

GPU integration CI was not available on the development Mac.
