### PR TITLE
perf(metadata): fuse the speculative round's KDA metadata into single launches

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
@@ -36,6 +36,12 @@ from tokenspeed_kernel.ops.attention import (
     try_kda_fused_paged_decode,
     try_kda_fused_paged_verify,
 )
+from tokenspeed_kernel.ops.attention.triton.capture_payload import (
+    capture_replay_payload,
+)
+from tokenspeed_kernel.ops.attention.triton.verify_state_blocks import (
+    commit_state_pages,
+)
 from typing_extensions import override
 
 from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
@@ -513,9 +519,15 @@ class KdaAttnBackend(MambaAttnBackend):
                 )
             qkv, f_a, beta, _ = self._replay_payload(layer_id)
             rows = batch_size * draft_token_num
-            qkv[:rows, : mixed_qkv.shape[-1]].copy_(mixed_qkv[:rows])
-            f_a[:rows, : f_a_out.shape[-1]].copy_(f_a_out[:rows])
-            beta[:rows, : beta_raw.shape[-1]].copy_(beta_raw[:rows])
+            capture_replay_payload(
+                (mixed_qkv[:rows], f_a_out[:rows], beta_raw[:rows]),
+                (
+                    qkv[:rows, : mixed_qkv.shape[-1]],
+                    f_a[:rows, : f_a_out.shape[-1]],
+                    beta[:rows, : beta_raw.shape[-1]],
+                ),
+                rows,
+            )
             num_value_heads = value_dim // attn_tp_size // head_v_dim
             if layer_id not in self._replay_weights:
                 # Parameters are stable objects; model weight updates copy into
@@ -658,19 +670,22 @@ class KdaAttnBackend(MambaAttnBackend):
         bs = accepted_length.shape[0]
         # Runtime accept lengths count draft matches; the target token itself
         # always advances state, matching the established scratch commit.
-        steps = accepted_length.to(torch.int64).clamp(min=1, max=draft_token_num)
-        new_last = committed[:bs] + steps - 1
-        slot = torch.div(
-            new_last.clamp_min(0),
-            self._checkpoint_granularity,
-            rounding_mode="floor",
+        group_ids = list(self._replay_group_ids or self._state_groups())
+        write_stack = torch.empty(
+            (len(group_ids), bs), dtype=torch.int32, device=accepted_length.device
         )
-        pages_by_group = {}
-        for group_id in self._state_groups():
-            rows = tables[group_id]
-            safe = slot.clamp(max=rows.shape[1] - 1)
-            pages_by_group[group_id] = (
-                rows[:bs].gather(1, safe.unsqueeze(1)).squeeze(1).to(torch.int32)
+        steps = torch.empty(bs, dtype=torch.int32, device=accepted_length.device)
+        for out_row, group_id in enumerate(group_ids):
+            commit_state_pages(
+                accepted_length,
+                committed,
+                tables[group_id],
+                batch_size=bs,
+                draft_tokens=draft_token_num,
+                granularity=self._checkpoint_granularity,
+                pages_out=write_stack,
+                out_row=out_row,
+                steps_out=steps,
             )
         rows = bs * draft_token_num
         if self._batched_replay_ready:
@@ -680,12 +695,10 @@ class KdaAttnBackend(MambaAttnBackend):
                     for group_id in self._replay_group_ids
                 ]
             ).to(torch.int32)
-            write_pages = torch.stack(
-                [pages_by_group[group_id] for group_id in self._replay_group_ids]
-            )
-            self._batched_replay_launch(read_pages, write_pages, steps.to(torch.int32))
+            self._batched_replay_launch(read_pages, write_stack, steps)
             self._verify_commit_ctx = None
             return
+        pages_by_group = {g: write_stack[i] for i, g in enumerate(group_ids)}
         for layer_id, weights in self._replay_weights.items():
             conv_w, f_b, A_log, dt_bias, num_heads, head_dim, lower_bound = weights
             group_id = self._state_group_for(layer_id)
@@ -705,7 +718,7 @@ class KdaAttnBackend(MambaAttnBackend):
                 state_out=state,
                 read_indices=read_pages_by_group[group_id][:bs],
                 write_indices=pages_by_group[group_id],
-                accepted_length=steps.to(torch.int32),
+                accepted_length=steps,
                 num_heads=num_heads,
                 head_dim=head_dim,
                 draft_token_num=draft_token_num,

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -40,6 +40,9 @@ from tokenspeed_kernel.ops.attention.triton.linear.index import (
     set_total_chunks_hint,
     set_total_chunks_hint_uniform,
 )
+from tokenspeed_kernel.ops.attention.triton.verify_state_blocks import (
+    verify_state_blocks,
+)
 
 from tokenspeed.runtime.execution.breakable_cuda_graph import (
     break_point,
@@ -476,13 +479,6 @@ class MambaAttnBackend(AttentionBackend):
         pages, the committed lengths, and the per-group group tables (kept
         for the commit's dynamic page resolve).
         """
-        committed = (seq_lens[:bs].to(torch.int64) - draft_token_num).clamp_min(0)
-        in_slots = torch.div(
-            (committed - 1).clamp_min(0),
-            self._checkpoint_granularity,
-            rounding_mode="floor",
-        )
-        has_history = committed > 0
         state_in_blocks: dict[str, torch.Tensor] = {}
         tables: dict[str, torch.Tensor] = {}
         cache_metadata = kwargs.get("cache_metadata")
@@ -497,11 +493,23 @@ class MambaAttnBackend(AttentionBackend):
             )
             for group_id in self._state_groups()
         }
+        if not rows_by_group:
+            return (
+                {},
+                (seq_lens[:bs].to(torch.int64) - draft_token_num).clamp_min(0),
+                {},
+            )
+        committed = torch.empty(bs, dtype=torch.int64, device=seq_lens.device)
         for group_id, rows in rows_by_group.items():
-            slots_safe = in_slots.clamp(min=0, max=rows.shape[1] - 1)
-            pages = rows[:bs].gather(1, slots_safe.unsqueeze(1)).squeeze(1)
-            pages = torch.where(has_history, pages, torch.full_like(pages, -1)).to(
-                torch.int32
+            pages = torch.empty(bs, dtype=torch.int32, device=seq_lens.device)
+            verify_state_blocks(
+                seq_lens,
+                rows,
+                batch_size=bs,
+                draft_tokens=draft_token_num,
+                granularity=self._checkpoint_granularity,
+                pages_out=pages,
+                committed_out=committed,
             )
             state_in_blocks[group_id] = pages
             tables[group_id] = rows

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/capture_payload.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/capture_payload.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Stage a layer's three replay payloads in one launch."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+
+
+@triton.jit(
+    do_not_specialize=["rows", "n_a", "n_b", "n_c", "sa", "sb", "sc", "da", "db", "dc"]
+)
+def _capture_payload_kernel(
+    src_a,
+    dst_a,
+    src_b,
+    dst_b,
+    src_c,
+    dst_c,
+    rows,
+    n_a,
+    n_b,
+    n_c,
+    sa,
+    sb,
+    sc,
+    da,
+    db,
+    dc,
+    BLOCK: tl.constexpr,
+):
+    which = tl.program_id(1)
+    off = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    if which == 0:
+        live = off < rows * n_a
+        r, c = off // n_a, off % n_a
+        v = tl.load(src_a + r * sa + c, mask=live, other=0)
+        tl.store(dst_a + r * da + c, v, mask=live)
+    elif which == 1:
+        live = off < rows * n_b
+        r, c = off // n_b, off % n_b
+        v = tl.load(src_b + r * sb + c, mask=live, other=0)
+        tl.store(dst_b + r * db + c, v, mask=live)
+    else:
+        live = off < rows * n_c
+        r, c = off // n_c, off % n_c
+        v = tl.load(src_c + r * sc + c, mask=live, other=0)
+        tl.store(dst_c + r * dc + c, v, mask=live)
+
+
+def capture_replay_payload(
+    sources: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    destinations: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    rows: int,
+) -> None:
+    """Copy the leading ``rows`` of three projections into their payload rows.
+
+    A speculative verify stages each layer's projections so the commit can
+    replay them, which as three ``copy_`` calls costs three launches per layer
+    on every decode step. The three are independent, so one launch with a
+    payload-selecting grid dimension does the same work.
+
+    Args:
+        sources: Projection outputs; row ``i`` of each is copied. Rows may be a
+            slice of a wider buffer, so only the inner dimension must be dense.
+        destinations: Payload rows, each ``[>=rows, >=source width]``; a wider
+            row keeps its trailing columns.
+        rows: Live rows, ``batch_size * draft_tokens``.
+    """
+    widths = []
+    for src, dst in zip(sources, destinations):
+        if src.dim() != 2 or dst.dim() != 2:
+            raise ValueError("payload capture takes 2-D sources and destinations")
+        if src.dtype != dst.dtype:
+            raise ValueError("payload capture cannot convert dtypes")
+        if src.stride(1) != 1 or dst.stride(1) != 1:
+            raise ValueError("payload capture needs a dense inner dimension")
+        if src.shape[0] < rows:
+            raise ValueError(f"source holds {src.shape[0]} rows, need {rows}")
+        if dst.shape[0] < rows or dst.shape[1] < src.shape[1]:
+            raise ValueError(
+                f"payload row {tuple(dst.shape)} cannot hold "
+                f"({rows}, {src.shape[1]})"
+            )
+        widths.append(src.shape[1])
+    if rows <= 0:
+        return
+
+    block = 1024
+    grid = (triton.cdiv(rows * max(widths), block), 3)
+    _capture_payload_kernel[grid](
+        sources[0],
+        destinations[0],
+        sources[1],
+        destinations[1],
+        sources[2],
+        destinations[2],
+        rows,
+        widths[0],
+        widths[1],
+        widths[2],
+        sources[0].stride(0),
+        sources[1].stride(0),
+        sources[2].stride(0),
+        destinations[0].stride(0),
+        destinations[1].stride(0),
+        destinations[2].stride(0),
+        BLOCK=block,
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/verify_state_blocks.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/verify_state_blocks.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Committed-state pages for a speculative verify and its commit."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+
+
+@triton.jit(
+    do_not_specialize=["bs", "num_slots", "draft_tokens", "granularity", "table_stride"]
+)
+def _verify_state_blocks_kernel(
+    seq_lens,
+    table,
+    pages_out,
+    committed_out,
+    bs,
+    num_slots,
+    draft_tokens,
+    granularity,
+    table_stride,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    live = row < bs
+    committed = tl.maximum(
+        tl.load(seq_lens + row, mask=live, other=0).to(tl.int64) - draft_tokens, 0
+    )
+    slot = tl.minimum(tl.maximum(committed - 1, 0) // granularity, num_slots - 1)
+    page = tl.load(table + row * table_stride + slot, mask=live, other=0)
+    # A request with no committed history has no state page to read.
+    tl.store(pages_out + row, tl.where(committed > 0, page, -1).to(tl.int32), mask=live)
+    tl.store(committed_out + row, committed, mask=live)
+
+
+def verify_state_blocks(
+    seq_lens: torch.Tensor,
+    table: torch.Tensor,
+    *,
+    batch_size: int,
+    draft_tokens: int,
+    granularity: int,
+    pages_out: torch.Tensor,
+    committed_out: torch.Tensor,
+) -> None:
+    """Resolve each request's committed-state page and committed length.
+
+    Verify reads state at the last committed position, which the torch spelling
+    derives with a dozen elementwise launches (cast, sub, clamp, sub, clamp,
+    div, compare, clamp, gather, full, where, cast) over ``[batch_size]``
+    integers. The whole derivation is row-local.
+
+    Args:
+        seq_lens: Integer sequence lengths ``[>=batch_size]``.
+        table: Group page table ``[>=batch_size, num_slots]``, dense inner.
+        batch_size: Live requests.
+        draft_tokens: Speculative window subtracted to reach the committed tip.
+        granularity: Positions per checkpoint slot.
+        pages_out: INT32 destination ``[>=batch_size]``; -1 where a request has
+            no committed history.
+        committed_out: INT64 destination ``[>=batch_size]``.
+    """
+    if seq_lens.stride(0) != 1 or table.stride(1) != 1:
+        raise ValueError("verify state blocks need unit-stride seq_lens and table rows")
+    if granularity < 1:
+        raise ValueError(f"granularity must be positive, got {granularity}")
+    if batch_size > table.shape[0] or batch_size > seq_lens.shape[0]:
+        raise ValueError("batch_size exceeds the seq_lens or table rows")
+    if pages_out.dtype != torch.int32 or committed_out.dtype != torch.int64:
+        raise ValueError("pages_out must be INT32 and committed_out INT64")
+    if pages_out.numel() < batch_size or committed_out.numel() < batch_size:
+        raise ValueError("outputs cannot hold batch_size rows")
+    if batch_size == 0:
+        return
+
+    block = 256
+    _verify_state_blocks_kernel[(triton.cdiv(batch_size, block),)](
+        seq_lens,
+        table,
+        pages_out,
+        committed_out,
+        batch_size,
+        table.shape[1],
+        draft_tokens,
+        granularity,
+        table.stride(0),
+        BLOCK=block,
+    )
+
+
+@triton.jit(
+    do_not_specialize=[
+        "bs",
+        "num_slots",
+        "draft_tokens",
+        "granularity",
+        "table_stride",
+        "out_row",
+    ]
+)
+def _commit_state_pages_kernel(
+    accepted,
+    committed,
+    table,
+    pages_out,
+    steps_out,
+    bs,
+    num_slots,
+    draft_tokens,
+    granularity,
+    table_stride,
+    out_row,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    live = row < bs
+    # The target token always advances state, so a round commits at least one.
+    steps = tl.minimum(
+        tl.maximum(tl.load(accepted + row, mask=live, other=1).to(tl.int64), 1),
+        draft_tokens,
+    )
+    last = tl.load(committed + row, mask=live, other=0) + steps - 1
+    slot = tl.minimum(tl.maximum(last, 0) // granularity, num_slots - 1)
+    page = tl.load(table + row * table_stride + slot, mask=live, other=0)
+    tl.store(pages_out + out_row * bs + row, page.to(tl.int32), mask=live)
+    tl.store(steps_out + row, steps.to(tl.int32), mask=live)
+
+
+def commit_state_pages(
+    accepted_length: torch.Tensor,
+    committed: torch.Tensor,
+    table: torch.Tensor,
+    *,
+    batch_size: int,
+    draft_tokens: int,
+    granularity: int,
+    pages_out: torch.Tensor,
+    out_row: int,
+    steps_out: torch.Tensor,
+) -> None:
+    """Resolve where each request's accepted state is written back.
+
+    The commit's torch spelling took a dozen elementwise launches to turn accept
+    lengths into per-group write pages, then stacked the groups. Writing row
+    ``out_row`` of a preallocated ``[groups, batch]`` buffer skips the stack too.
+
+    Args:
+        accepted_length: Draft matches per request ``[>=batch_size]``.
+        committed: Committed lengths from the verify resolve ``[>=batch_size]``.
+        table: Group page table ``[>=batch_size, num_slots]``, dense inner.
+        batch_size: Live requests.
+        draft_tokens: Speculative window; a round commits at most this many.
+        granularity: Positions per checkpoint slot.
+        pages_out: INT32 ``[groups, >=batch_size]`` destination.
+        out_row: Which group row to fill.
+        steps_out: INT32 destination ``[>=batch_size]`` for the clamped steps.
+    """
+    if accepted_length.stride(0) != 1 or table.stride(1) != 1:
+        raise ValueError("commit state pages need unit-stride inputs")
+    if granularity < 1:
+        raise ValueError(f"granularity must be positive, got {granularity}")
+    if pages_out.dtype != torch.int32 or steps_out.dtype != torch.int32:
+        raise ValueError("pages_out and steps_out must be INT32")
+    if not 0 <= out_row < pages_out.shape[0]:
+        raise ValueError(f"out_row {out_row} outside {pages_out.shape[0]} groups")
+    if pages_out.shape[1] < batch_size or steps_out.numel() < batch_size:
+        raise ValueError("outputs cannot hold batch_size rows")
+    if batch_size == 0:
+        return
+
+    block = 256
+    _commit_state_pages_kernel[(triton.cdiv(batch_size, block),)](
+        accepted_length,
+        committed,
+        table,
+        pages_out,
+        steps_out,
+        batch_size,
+        table.shape[1],
+        draft_tokens,
+        granularity,
+        table.stride(0),
+        out_row,
+        BLOCK=block,
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/verify_state_blocks.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/verify_state_blocks.py
@@ -53,6 +53,21 @@ def _verify_state_blocks_kernel(
     tl.store(committed_out + row, committed, mask=live)
 
 
+def _torch_verify_state_blocks(
+    seq_lens, table, batch_size, draft_tokens, granularity, pages_out, committed_out
+):
+    """Portable spelling, kept for non-CUDA callers (the backends' CPU tests)."""
+    committed = (seq_lens[:batch_size].to(torch.int64) - draft_tokens).clamp_min(0)
+    slots = torch.div(
+        (committed - 1).clamp_min(0), granularity, rounding_mode="floor"
+    ).clamp(min=0, max=table.shape[1] - 1)
+    pages = table[:batch_size].gather(1, slots.unsqueeze(1)).squeeze(1)
+    pages_out[:batch_size].copy_(
+        torch.where(committed > 0, pages, torch.full_like(pages, -1)).to(torch.int32)
+    )
+    committed_out[:batch_size].copy_(committed)
+
+
 def verify_state_blocks(
     seq_lens: torch.Tensor,
     table: torch.Tensor,
@@ -80,18 +95,35 @@ def verify_state_blocks(
             no committed history.
         committed_out: INT64 destination ``[>=batch_size]``.
     """
-    if seq_lens.stride(0) != 1 or table.stride(1) != 1:
-        raise ValueError("verify state blocks need unit-stride seq_lens and table rows")
+    if (
+        seq_lens.stride(0) != 1
+        or table.stride(1) != 1
+        or pages_out.stride(0) != 1
+        or committed_out.stride(0) != 1
+    ):
+        raise ValueError("verify state blocks need unit-stride rows")
     if granularity < 1:
         raise ValueError(f"granularity must be positive, got {granularity}")
     if batch_size > table.shape[0] or batch_size > seq_lens.shape[0]:
         raise ValueError("batch_size exceeds the seq_lens or table rows")
+    if table.shape[1] < 1:
+        raise ValueError("a table without slots has no page to resolve")
     if pages_out.dtype != torch.int32 or committed_out.dtype != torch.int64:
         raise ValueError("pages_out must be INT32 and committed_out INT64")
     if pages_out.numel() < batch_size or committed_out.numel() < batch_size:
         raise ValueError("outputs cannot hold batch_size rows")
     if batch_size == 0:
         return
+    if not table.is_cuda:
+        return _torch_verify_state_blocks(
+            seq_lens,
+            table,
+            batch_size,
+            draft_tokens,
+            granularity,
+            pages_out,
+            committed_out,
+        )
 
     block = 256
     _verify_state_blocks_kernel[(triton.cdiv(batch_size, block),)](
@@ -116,6 +148,7 @@ def verify_state_blocks(
         "granularity",
         "table_stride",
         "out_row",
+        "out_stride",
     ]
 )
 def _commit_state_pages_kernel(
@@ -130,6 +163,7 @@ def _commit_state_pages_kernel(
     granularity,
     table_stride,
     out_row,
+    out_stride,
     BLOCK: tl.constexpr,
 ):
     row = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
@@ -142,8 +176,30 @@ def _commit_state_pages_kernel(
     last = tl.load(committed + row, mask=live, other=0) + steps - 1
     slot = tl.minimum(tl.maximum(last, 0) // granularity, num_slots - 1)
     page = tl.load(table + row * table_stride + slot, mask=live, other=0)
-    tl.store(pages_out + out_row * bs + row, page.to(tl.int32), mask=live)
+    tl.store(pages_out + out_row * out_stride + row, page.to(tl.int32), mask=live)
     tl.store(steps_out + row, steps.to(tl.int32), mask=live)
+
+
+def _torch_commit_state_pages(
+    accepted_length,
+    committed,
+    table,
+    batch_size,
+    draft_tokens,
+    granularity,
+    pages_out,
+    out_row,
+    steps_out,
+):
+    """Portable spelling, kept for non-CUDA callers (the backends' CPU tests)."""
+    steps = accepted_length[:batch_size].to(torch.int64).clamp(min=1, max=draft_tokens)
+    last = committed[:batch_size] + steps - 1
+    slots = torch.div(last.clamp_min(0), granularity, rounding_mode="floor").clamp(
+        min=0, max=table.shape[1] - 1
+    )
+    pages = table[:batch_size].gather(1, slots.unsqueeze(1)).squeeze(1)
+    pages_out[out_row, :batch_size].copy_(pages.to(torch.int32))
+    steps_out[:batch_size].copy_(steps.to(torch.int32))
 
 
 def commit_state_pages(
@@ -175,8 +231,14 @@ def commit_state_pages(
         out_row: Which group row to fill.
         steps_out: INT32 destination ``[>=batch_size]`` for the clamped steps.
     """
-    if accepted_length.stride(0) != 1 or table.stride(1) != 1:
-        raise ValueError("commit state pages need unit-stride inputs")
+    if (
+        accepted_length.stride(0) != 1
+        or committed.stride(0) != 1
+        or table.stride(1) != 1
+        or pages_out.stride(1) != 1
+        or steps_out.stride(0) != 1
+    ):
+        raise ValueError("commit state pages need unit-stride rows")
     if granularity < 1:
         raise ValueError(f"granularity must be positive, got {granularity}")
     if pages_out.dtype != torch.int32 or steps_out.dtype != torch.int32:
@@ -185,8 +247,24 @@ def commit_state_pages(
         raise ValueError(f"out_row {out_row} outside {pages_out.shape[0]} groups")
     if pages_out.shape[1] < batch_size or steps_out.numel() < batch_size:
         raise ValueError("outputs cannot hold batch_size rows")
+    if batch_size > table.shape[0] or batch_size > committed.shape[0]:
+        raise ValueError("batch_size exceeds the committed or table rows")
+    if table.shape[1] < 1:
+        raise ValueError("a table without slots has no page to resolve")
     if batch_size == 0:
         return
+    if not table.is_cuda:
+        return _torch_commit_state_pages(
+            accepted_length,
+            committed,
+            table,
+            batch_size,
+            draft_tokens,
+            granularity,
+            pages_out,
+            out_row,
+            steps_out,
+        )
 
     block = 256
     _commit_state_pages_kernel[(triton.cdiv(batch_size, block),)](
@@ -201,5 +279,6 @@ def commit_state_pages(
         granularity,
         table.stride(0),
         out_row,
+        pages_out.stride(0),
         BLOCK=block,
     )

--- a/tokenspeed-kernel/test/ops/attention/test_capture_payload.py
+++ b/tokenspeed-kernel/test/ops/attention/test_capture_payload.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The fused payload capture must land exactly where three copy_ calls did.
+
+This stages what a commit replays, so a misplaced row silently replays another
+request's projection: the comparison is bitwise, and the buffer outside the
+copied region has to be untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from tokenspeed_kernel.ops.attention.triton.capture_payload import (  # noqa: E402
+    capture_replay_payload,
+)
+
+WIDTHS = (2304, 128, 6)
+
+
+def _stacks(layers, rows, widths, pad=0, seed=0):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    src = [
+        torch.randn(rows + 3, w, device="cuda", dtype=torch.bfloat16, generator=g)
+        for w in widths
+    ]
+    dst = [
+        torch.randn(
+            layers, rows, w + pad, device="cuda", dtype=torch.bfloat16, generator=g
+        )
+        for w in widths
+    ]
+    return src, dst
+
+
+@pytest.mark.parametrize("rows", [1, 8, 128, 1024])
+@pytest.mark.parametrize("pad", [0, 16])
+def test_matches_three_copies(rows, pad):
+    """Wide windows also cover the grid: 1024 rows spans several programs for
+    the 2304-wide payload while the 6-wide one masks all but the first."""
+    src, dst = _stacks(4, rows, WIDTHS, pad=pad, seed=rows)
+    want = [d.clone() for d in dst]
+    for s, w, width in zip(src, want, WIDTHS):
+        w[2][:rows, :width].copy_(s[:rows])
+
+    capture_replay_payload(
+        tuple(s[:rows] for s in src),
+        tuple(d[2][:rows, :width] for d, width in zip(dst, WIDTHS)),
+        rows,
+    )
+    for got, expected in zip(dst, want):
+        assert torch.equal(got, expected)
+
+
+def test_nothing_outside_the_written_rows_moves():
+    """The row belongs to one layer inside a stack every layer shares, so a
+    stray write lands in another layer's replay payload."""
+    rows, capacity = 8, 24
+    src, dst = _stacks(4, capacity, WIDTHS, pad=16, seed=5)
+    before = [d.clone() for d in dst]
+    capture_replay_payload(
+        tuple(s[:rows] for s in src),
+        tuple(d[1][:rows, :width] for d, width in zip(dst, WIDTHS)),
+        rows,
+    )
+    for got, was, width in zip(dst, before, WIDTHS):
+        for layer in (0, 2, 3):
+            assert torch.equal(got[layer], was[layer])
+        assert torch.equal(got[1][:, width:], was[1][:, width:])
+        assert torch.equal(got[1][rows:], was[1][rows:])
+
+
+def test_a_source_row_inside_a_wider_projection():
+    """The projection hands column slices, so the source row stride exceeds
+    its width; the kernel must follow that stride, not assume packing."""
+    rows = 8
+    wide = torch.randn(rows, 4096, device="cuda", dtype=torch.bfloat16)
+    src = (wide[:, :2304], wide[:, 2304:2432], wide[:, 2432:2438])
+    dst = [torch.zeros(rows, w, device="cuda", dtype=torch.bfloat16) for w in WIDTHS]
+    want = [s.clone() for s in src]
+    capture_replay_payload(src, tuple(dst), rows)
+    for got, expected in zip(dst, want):
+        assert torch.equal(got, expected)
+
+
+def test_layouts_the_kernel_cannot_address_are_rejected():
+    """Each of these silently read or wrote the wrong elements before the
+    wrapper checked for it."""
+    rows = 8
+    src, _ = _stacks(1, rows, WIDTHS, seed=2)
+    dst = [torch.empty(rows, w, device="cuda", dtype=torch.bfloat16) for w in WIDTHS]
+
+    wide = torch.randn(rows, 8192, device="cuda", dtype=torch.bfloat16)
+    with pytest.raises(ValueError, match="dense inner"):
+        capture_replay_payload(
+            (wide[:, ::2][:, :2304], wide[:, :128], wide[:, :6]), tuple(dst), rows
+        )
+
+    small = [
+        torch.empty(rows, w - 1, device="cuda", dtype=torch.bfloat16) for w in WIDTHS
+    ]
+    with pytest.raises(ValueError, match="cannot hold"):
+        capture_replay_payload(tuple(s[:rows] for s in src), tuple(small), rows)
+
+    short = [
+        torch.randn(rows - 1, w, device="cuda", dtype=torch.bfloat16) for w in WIDTHS
+    ]
+    with pytest.raises(ValueError, match="need 8"):
+        capture_replay_payload(tuple(short), tuple(dst), rows)

--- a/tokenspeed-kernel/test/ops/attention/test_verify_state_blocks.py
+++ b/tokenspeed-kernel/test/ops/attention/test_verify_state_blocks.py
@@ -279,3 +279,107 @@ def test_commit_rejects_a_group_row_outside_the_buffer():
             out_row=2,
             steps_out=steps,
         )
+
+
+def test_commit_honours_a_destination_row_stride_wider_than_the_batch():
+    """A group buffer wider than the batch is inside the contract; a row offset
+    that assumes packing shifts every later group's write indices."""
+    bs = 8
+    accepted = torch.randint(0, 5, (bs,), device="cuda", dtype=torch.int32)
+    committed = torch.randint(0, 4096, (bs,), device="cuda", dtype=torch.int64)
+    table = torch.randint(1, 900, (bs, 24), device="cuda", dtype=torch.int32)
+    wide = torch.full((3, bs + 1), -9, dtype=torch.int32, device="cuda")
+    steps = torch.empty(bs, dtype=torch.int32, device="cuda")
+    commit_state_pages(
+        accepted,
+        committed,
+        table,
+        batch_size=bs,
+        draft_tokens=4,
+        granularity=64,
+        pages_out=wide,
+        out_row=1,
+        steps_out=steps,
+    )
+    want_p, _ = _commit_reference(
+        accepted, committed, table, bs=bs, draft_tokens=4, granularity=64
+    )
+    assert torch.equal(wide[1, :bs], want_p)
+    assert (wide[0] == -9).all() and (wide[2] == -9).all()
+    assert wide[1, bs].item() == -9
+
+
+def test_a_table_without_slots_is_rejected_by_both_resolves():
+    """The torch chain raised on the gather; an unchecked kernel reads past the
+    table instead."""
+    bs = 4
+    empty = torch.empty((bs, 0), dtype=torch.int32, device="cuda")
+    pages = torch.empty(bs, dtype=torch.int32, device="cuda")
+    committed = torch.zeros(bs, dtype=torch.int64, device="cuda")
+    with pytest.raises(ValueError, match="no page to resolve"):
+        verify_state_blocks(
+            torch.zeros(bs, dtype=torch.int32, device="cuda"),
+            empty,
+            batch_size=bs,
+            draft_tokens=4,
+            granularity=64,
+            pages_out=pages,
+            committed_out=committed,
+        )
+    with pytest.raises(ValueError, match="no page to resolve"):
+        commit_state_pages(
+            torch.zeros(bs, dtype=torch.int32, device="cuda"),
+            committed,
+            empty,
+            batch_size=bs,
+            draft_tokens=4,
+            granularity=64,
+            pages_out=torch.empty((1, bs), dtype=torch.int32, device="cuda"),
+            out_row=0,
+            steps_out=torch.empty(bs, dtype=torch.int32, device="cuda"),
+        )
+
+
+def test_cpu_callers_get_the_portable_path():
+    """The backends' metadata tests build these tensors on CPU, where the torch
+    spelling this replaces worked; the wrapper must not demand a GPU."""
+    bs = 6
+    seq_lens = torch.randint(0, 4096, (bs,), dtype=torch.int32)
+    table = torch.randint(0, 900, (bs, 24), dtype=torch.int32)
+    pages = torch.empty(bs, dtype=torch.int32)
+    committed = torch.empty(bs, dtype=torch.int64)
+    verify_state_blocks(
+        seq_lens,
+        table,
+        batch_size=bs,
+        draft_tokens=4,
+        granularity=64,
+        pages_out=pages,
+        committed_out=committed,
+    )
+    want_p, want_c = _reference(
+        seq_lens, table, batch_size=bs, draft_tokens=4, granularity=64
+    )
+    assert torch.equal(pages, want_p)
+    assert torch.equal(committed, want_c)
+
+    accepted = torch.randint(0, 5, (bs,), dtype=torch.int32)
+    stack = torch.full((2, bs), -9, dtype=torch.int32)
+    steps = torch.empty(bs, dtype=torch.int32)
+    commit_state_pages(
+        accepted,
+        committed,
+        table,
+        batch_size=bs,
+        draft_tokens=4,
+        granularity=64,
+        pages_out=stack,
+        out_row=1,
+        steps_out=steps,
+    )
+    want_wp, want_s = _commit_reference(
+        accepted, committed, table, bs=bs, draft_tokens=4, granularity=64
+    )
+    assert torch.equal(stack[1], want_wp)
+    assert torch.equal(steps, want_s)
+    assert (stack[0] == -9).all()

--- a/tokenspeed-kernel/test/ops/attention/test_verify_state_blocks.py
+++ b/tokenspeed-kernel/test/ops/attention/test_verify_state_blocks.py
@@ -1,0 +1,281 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The fused committed-state resolve must match the torch chain exactly.
+
+The page it returns is where verify reads a request's recurrent state. A wrong
+page silently feeds another request's state into this one, so the comparison is
+integer equality.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+
+from tokenspeed_kernel.ops.attention.triton.verify_state_blocks import (  # noqa: E402
+    verify_state_blocks,
+)
+
+
+def _reference(seq_lens, table, *, batch_size, draft_tokens, granularity):
+    """The elementwise chain the kernel replaces, kept verbatim."""
+    committed = (seq_lens[:batch_size].to(torch.int64) - draft_tokens).clamp_min(0)
+    in_slots = torch.div(
+        (committed - 1).clamp_min(0), granularity, rounding_mode="floor"
+    )
+    has_history = committed > 0
+    slots_safe = in_slots.clamp(min=0, max=table.shape[1] - 1)
+    pages = table[:batch_size].gather(1, slots_safe.unsqueeze(1)).squeeze(1)
+    pages = torch.where(has_history, pages, torch.full_like(pages, -1)).to(torch.int32)
+    return pages, committed
+
+
+def _run(seq_lens, table, *, batch_size, draft_tokens, granularity):
+    pages = torch.empty(batch_size, dtype=torch.int32, device="cuda")
+    committed = torch.empty(batch_size, dtype=torch.int64, device="cuda")
+    verify_state_blocks(
+        seq_lens,
+        table,
+        batch_size=batch_size,
+        draft_tokens=draft_tokens,
+        granularity=granularity,
+        pages_out=pages,
+        committed_out=committed,
+    )
+    return pages, committed
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "draft_tokens"), [(1, 1), (1, 4), (3, 4), (8, 2), (32, 4), (512, 4)]
+)
+@pytest.mark.parametrize("granularity", [1, 64])
+def test_matches_the_torch_chain(batch_size, draft_tokens, granularity):
+    g = torch.Generator(device="cuda").manual_seed(batch_size + draft_tokens)
+    seq_lens = torch.randint(
+        0, 4096, (batch_size,), device="cuda", dtype=torch.int32, generator=g
+    )
+    table = torch.randint(
+        0, 900, (batch_size, 24), device="cuda", dtype=torch.int32, generator=g
+    )
+    got_p, got_c = _run(
+        seq_lens,
+        table,
+        batch_size=batch_size,
+        draft_tokens=draft_tokens,
+        granularity=granularity,
+    )
+    want_p, want_c = _reference(
+        seq_lens,
+        table,
+        batch_size=batch_size,
+        draft_tokens=draft_tokens,
+        granularity=granularity,
+    )
+    assert torch.equal(got_p, want_p)
+    assert torch.equal(got_c, want_c)
+
+
+def test_a_request_without_committed_history_gets_no_page():
+    """seq_len <= draft means nothing is committed yet; verify must not read a
+    state page for it."""
+    seq_lens = torch.tensor([0, 1, 4, 5], device="cuda", dtype=torch.int32)
+    table = torch.randint(1, 900, (4, 24), device="cuda", dtype=torch.int32)
+    got_p, got_c = _run(seq_lens, table, batch_size=4, draft_tokens=4, granularity=64)
+    want_p, want_c = _reference(
+        seq_lens, table, batch_size=4, draft_tokens=4, granularity=64
+    )
+    assert torch.equal(got_p, want_p)
+    assert got_p[:3].tolist() == [-1, -1, -1]
+    assert torch.equal(got_c, want_c)
+
+
+def test_a_sequence_past_the_table_clamps_to_the_last_slot():
+    """The torch chain clamped the slot; reading past the table would be worse."""
+    seq_lens = torch.tensor([100000], device="cuda", dtype=torch.int32)
+    table = torch.randint(1, 900, (1, 8), device="cuda", dtype=torch.int32)
+    got_p, _ = _run(seq_lens, table, batch_size=1, draft_tokens=4, granularity=64)
+    want_p, _ = _reference(
+        seq_lens, table, batch_size=1, draft_tokens=4, granularity=64
+    )
+    assert torch.equal(got_p, want_p)
+    assert got_p.item() == table[0, -1].item()
+
+
+def test_rows_past_the_batch_are_not_read():
+    seq_lens = torch.randint(1, 4096, (8,), device="cuda", dtype=torch.int32)
+    table = torch.randint(1, 900, (8, 24), device="cuda", dtype=torch.int32)
+    small, _ = _run(seq_lens, table, batch_size=3, draft_tokens=4, granularity=64)
+    small = small.clone()
+    seq_lens[3:] = 999999
+    table[3:] = -7
+    again, _ = _run(seq_lens, table, batch_size=3, draft_tokens=4, granularity=64)
+    assert torch.equal(small, again)
+
+
+def test_layouts_and_arguments_the_kernel_cannot_serve_are_rejected():
+    seq_lens = torch.randint(1, 4096, (8,), device="cuda", dtype=torch.int32)
+    table = torch.randint(1, 900, (8, 24), device="cuda", dtype=torch.int32)
+    pages = torch.empty(8, dtype=torch.int32, device="cuda")
+    committed = torch.empty(8, dtype=torch.int64, device="cuda")
+    kw = dict(
+        batch_size=8,
+        draft_tokens=4,
+        granularity=64,
+        pages_out=pages,
+        committed_out=committed,
+    )
+
+    with pytest.raises(ValueError, match="unit-stride"):
+        verify_state_blocks(
+            torch.zeros(16, device="cuda", dtype=torch.int32)[::2], table, **kw
+        )
+    with pytest.raises(ValueError, match="granularity"):
+        verify_state_blocks(seq_lens, table, **{**kw, "granularity": 0})
+    with pytest.raises(ValueError, match="exceeds"):
+        verify_state_blocks(seq_lens, table, **{**kw, "batch_size": 9})
+    with pytest.raises(ValueError, match="INT32"):
+        verify_state_blocks(
+            seq_lens,
+            table,
+            **{**kw, "pages_out": torch.empty(8, dtype=torch.int64, device="cuda")},
+        )
+
+
+from tokenspeed_kernel.ops.attention.triton.verify_state_blocks import (  # noqa: E402
+    commit_state_pages,
+)
+
+
+def _commit_reference(accepted, committed, table, *, bs, draft_tokens, granularity):
+    """The elementwise chain the commit kernel replaces, kept verbatim."""
+    steps = accepted.to(torch.int64).clamp(min=1, max=draft_tokens)
+    new_last = committed[:bs] + steps - 1
+    slot = torch.div(new_last.clamp_min(0), granularity, rounding_mode="floor")
+    safe = slot.clamp(max=table.shape[1] - 1)
+    pages = table[:bs].gather(1, safe.unsqueeze(1)).squeeze(1).to(torch.int32)
+    return pages, steps.to(torch.int32)
+
+
+@pytest.mark.parametrize("bs", [1, 3, 8, 512])
+@pytest.mark.parametrize("draft_tokens", [1, 4])
+def test_commit_matches_the_torch_chain(bs, draft_tokens):
+    g = torch.Generator(device="cuda").manual_seed(bs + draft_tokens)
+    accepted = torch.randint(
+        0, draft_tokens + 2, (bs,), device="cuda", dtype=torch.int32, generator=g
+    )
+    committed = torch.randint(
+        0, 4096, (bs,), device="cuda", dtype=torch.int64, generator=g
+    )
+    table = torch.randint(
+        0, 900, (bs, 24), device="cuda", dtype=torch.int32, generator=g
+    )
+    pages = torch.empty((3, bs), dtype=torch.int32, device="cuda")
+    steps = torch.empty(bs, dtype=torch.int32, device="cuda")
+    commit_state_pages(
+        accepted,
+        committed,
+        table,
+        batch_size=bs,
+        draft_tokens=draft_tokens,
+        granularity=64,
+        pages_out=pages,
+        out_row=1,
+        steps_out=steps,
+    )
+    want_p, want_s = _commit_reference(
+        accepted, committed, table, bs=bs, draft_tokens=draft_tokens, granularity=64
+    )
+    assert torch.equal(pages[1], want_p)
+    assert torch.equal(steps, want_s)
+
+
+def test_commit_always_advances_at_least_one_step():
+    """A round with no draft matches still advanced by the target token."""
+    accepted = torch.zeros(4, device="cuda", dtype=torch.int32)
+    committed = torch.tensor([0, 1, 63, 64], device="cuda", dtype=torch.int64)
+    table = torch.randint(1, 900, (4, 24), device="cuda", dtype=torch.int32)
+    pages = torch.empty((1, 4), dtype=torch.int32, device="cuda")
+    steps = torch.empty(4, dtype=torch.int32, device="cuda")
+    commit_state_pages(
+        accepted,
+        committed,
+        table,
+        batch_size=4,
+        draft_tokens=4,
+        granularity=64,
+        pages_out=pages,
+        out_row=0,
+        steps_out=steps,
+    )
+    want_p, want_s = _commit_reference(
+        accepted, committed, table, bs=4, draft_tokens=4, granularity=64
+    )
+    assert torch.equal(steps, want_s)
+    assert steps.tolist() == [1, 1, 1, 1]
+    assert torch.equal(pages[0], want_p)
+
+
+def test_commit_writes_only_its_group_row():
+    """Groups share one [groups, batch] buffer; a stray write lands in another
+    group's write indices."""
+    bs = 8
+    accepted = torch.randint(0, 5, (bs,), device="cuda", dtype=torch.int32)
+    committed = torch.randint(0, 4096, (bs,), device="cuda", dtype=torch.int64)
+    table = torch.randint(1, 900, (bs, 24), device="cuda", dtype=torch.int32)
+    pages = torch.full((3, bs), -9, dtype=torch.int32, device="cuda")
+    steps = torch.empty(bs, dtype=torch.int32, device="cuda")
+    commit_state_pages(
+        accepted,
+        committed,
+        table,
+        batch_size=bs,
+        draft_tokens=4,
+        granularity=64,
+        pages_out=pages,
+        out_row=2,
+        steps_out=steps,
+    )
+    assert (pages[0] == -9).all() and (pages[1] == -9).all()
+    assert not (pages[2] == -9).any()
+
+
+def test_commit_rejects_a_group_row_outside_the_buffer():
+    bs = 4
+    accepted = torch.zeros(bs, device="cuda", dtype=torch.int32)
+    committed = torch.zeros(bs, device="cuda", dtype=torch.int64)
+    table = torch.randint(1, 900, (bs, 8), device="cuda", dtype=torch.int32)
+    pages = torch.empty((2, bs), dtype=torch.int32, device="cuda")
+    steps = torch.empty(bs, dtype=torch.int32, device="cuda")
+    with pytest.raises(ValueError, match="out_row"):
+        commit_state_pages(
+            accepted,
+            committed,
+            table,
+            batch_size=bs,
+            draft_tokens=4,
+            granularity=64,
+            pages_out=pages,
+            out_row=2,
+            steps_out=steps,
+        )


### PR DESCRIPTION
Three chains on the KDA decode path spelled small integer functions as torch elementwise ops over [batch] tensors, where the launches cost far more than the work. Each is row-local, so each becomes one Triton launch:

  - verify stages every layer's projections for the commit to replay, which as three copy_ calls per layer was 207 launches a step;
  - verify resolves each request's committed-state page through cast, sub, clamp, sub, clamp, div, compare, then per group clamp, gather, full, where, cast;
  - the commit turns accept lengths into per-group write pages the same way and stacked the groups afterwards, which writing rows of a preallocated [groups, batch] buffer removes as well.

Measured on GB200 by graph replay, the payload capture saves 1.23us a layer at four rows and 0.34us at 128; a profiled decode step issues 138 fewer kernels and 207 fewer elementwise launches, and its elementwise time falls from 662us to 207us.

The kernels take their geometry as runtime arguments with Triton's integer specialization disabled, so a new batch size reuses the compiled kernel rather than building one inside the metadata refresh that precedes graph.replay(). They address their inputs with unit-stride arithmetic and reject the strided layouts the torch spellings tolerated. A state group set that is empty keeps its torch path, which still owes the caller the committed lengths.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
