### PR TITLE
feat(runtime): push scheduler load snapshots

### DIFF
--- a/python/tokenspeed/runtime/engine/async_llm.py
+++ b/python/tokenspeed/runtime/engine/async_llm.py
@@ -64,7 +64,6 @@ from tokenspeed.runtime.engine.io_struct import (
     FlushCacheReqInput,
     FlushCacheReqOutput,
     GenerateReqInput,
-    GetLoadReqInput,
     HealthCheckOutput,
     OpenSessionReqInput,
     OpenSessionReqOutput,
@@ -72,8 +71,8 @@ from tokenspeed.runtime.engine.io_struct import (
     TokenizedGenerateReqInput,
     UpdateWeightFromDiskReqInput,
     UpdateWeightFromDiskReqOutput,
-    WatchLoadUpdateReq,
 )
+from tokenspeed.runtime.engine.load_snapshot import LoadSnapshotStore
 from tokenspeed.runtime.engine.output_processor import OutputProcessor, ReqState
 from tokenspeed.runtime.engine.parallel_sampling import (
     prepare_parallel_sampling_replica,
@@ -187,6 +186,7 @@ class AsyncLLM(SchedulerControlClient, EngineClient):
         self.model_update_lock = RWLock()
         self.model_update_result: Awaitable[UpdateWeightFromDiskReqOutput] | None = None
         self.asyncio_tasks = set()
+        self.load_snapshot_store = LoadSnapshotStore(server_args.mapping.attn.dp_size)
 
         # Frontend admission barrier paired with the scheduler's native pause.
         # It prevents requests buffered by a paused scheduler from holding the
@@ -582,20 +582,6 @@ class AsyncLLM(SchedulerControlClient, EngineClient):
     async def close_session(self, obj: CloseSessionReqInput) -> None:
         await self.engine_core_client.send_to_scheduler.send_pyobj(obj)
 
-    async def watch_load_thread(self):
-        # Only for dp_controller when dp_size > 1
-        if (
-            not self.server_args.mapping.attn.has_dp
-            or self.server_args.load_balance_method == "round_robin"
-        ):
-            return
-
-        while True:
-            await asyncio.sleep(self.server_args.load_watch_interval)
-            loads = await self.get_load_communicator(GetLoadReqInput())
-            load_udpate_req = WatchLoadUpdateReq(loads=loads)
-            self.engine_core_client.send_to_scheduler.send_pyobj(load_udpate_req)
-
     def get_log_request_metadata(self):
         max_length = None
         skip_names = None
@@ -693,7 +679,7 @@ class AsyncLLM(SchedulerControlClient, EngineClient):
             loop.create_task(print_exception_wrapper(self.sigterm_watchdog))
         )
         self.asyncio_tasks.add(
-            loop.create_task(print_exception_wrapper(self.watch_load_thread))
+            loop.create_task(print_exception_wrapper(self.load_snapshot_loop))
         )
 
     def _maybe_launch_rl_control_plane(self, loop):

--- a/python/tokenspeed/runtime/engine/core_client.py
+++ b/python/tokenspeed/runtime/engine/core_client.py
@@ -45,9 +45,34 @@ change.
 import zmq
 import zmq.asyncio
 
-from tokenspeed.runtime.engine.io_struct import AsyncIpcReceiver, IpcSender
+from tokenspeed.runtime.engine.io_struct import (
+    AsyncIpcReceiver,
+    IpcSender,
+    LoadSnapshot,
+    MsgpackDecoder,
+)
 from tokenspeed.runtime.utils import get_zmq_socket
 from tokenspeed.runtime.utils.server_args import PortArgs
+
+
+class AsyncLoadSnapshotReceiver:
+    """Decode the scheduler's fixed one-frame msgpack load snapshot wire."""
+
+    def __init__(self, socket) -> None:
+        self._socket = socket
+        self._decoder = MsgpackDecoder(LoadSnapshot)
+
+    async def recv_pyobj(self, flags: int = 0) -> LoadSnapshot:
+        frames = await self._socket.recv_multipart(flags)
+        if len(frames) != 1:
+            raise RuntimeError("LoadSnapshot must arrive as exactly one frame")
+        return self._decoder.decode(frames[0])
+
+    def close(self, linger: int | None = None) -> None:
+        self._socket.close(linger=linger)
+
+    def __getattr__(self, name: str):
+        return getattr(self._socket, name)
 
 
 class EngineCoreClient:
@@ -75,4 +100,4 @@ class EngineCoreClient:
         recv_load_snapshot = self.context.socket(zmq.PULL)
         recv_load_snapshot.setsockopt(zmq.RCVHWM, 1)
         recv_load_snapshot.bind(port_args.metrics_ipc_name)
-        self.recv_load_snapshot = AsyncIpcReceiver(recv_load_snapshot)
+        self.recv_load_snapshot = AsyncLoadSnapshotReceiver(recv_load_snapshot)

--- a/python/tokenspeed/runtime/engine/core_client.py
+++ b/python/tokenspeed/runtime/engine/core_client.py
@@ -20,7 +20,7 @@
 
 """Frontend-side scheduler IPC client for ``AsyncLLM``.
 
-``EngineCoreClient`` owns the ZMQ context and the two sockets that
+``EngineCoreClient`` owns the ZMQ context and the three sockets that
 ``AsyncLLM`` uses to talk to the scheduler subprocess:
 
 * ``send_to_scheduler`` — ``PUSH`` socket on
@@ -31,6 +31,9 @@
   ``PortArgs.tokenizer_ipc_name``; receives ``BatchStrOut`` /
   ``BatchTokenIDOut`` / ``BatchEmbeddingOut`` and control-plane replies from
   the scheduler.
+* ``recv_load_snapshot`` — ``PULL`` socket on
+  ``PortArgs.metrics_ipc_name``; receives the newest immutable load snapshot
+  published independently by each scheduler rank.
 
 Concrete (not ABC): tokenspeed has a single transport (ZMQ in-proc
 over ``PortArgs``-provided names) and a single caller (``AsyncLLM``),
@@ -66,3 +69,10 @@ class EngineCoreClient:
                 self.context, zmq.PUSH, port_args.scheduler_input_ipc_name, True
             )
         )
+        # Metrics are published by multiple scheduler ranks. Keep only one
+        # outstanding snapshot per frontend receiver without conflating the
+        # independent publisher streams.
+        recv_load_snapshot = self.context.socket(zmq.PULL)
+        recv_load_snapshot.setsockopt(zmq.RCVHWM, 1)
+        recv_load_snapshot.bind(port_args.metrics_ipc_name)
+        self.recv_load_snapshot = AsyncIpcReceiver(recv_load_snapshot)

--- a/python/tokenspeed/runtime/engine/core_client.py
+++ b/python/tokenspeed/runtime/engine/core_client.py
@@ -26,7 +26,7 @@
 * ``send_to_scheduler`` — ``PUSH`` socket on
   ``PortArgs.scheduler_input_ipc_name``; carries tokenized requests,
   weight-sync / session / memory-occupation control messages, and the
-  load-update watcher.
+  accepted load snapshots forwarded to the DP controller.
 * ``recv_from_detokenizer`` — ``PULL`` socket on
   ``PortArgs.tokenizer_ipc_name``; receives ``BatchStrOut`` /
   ``BatchTokenIDOut`` / ``BatchEmbeddingOut`` and control-plane replies from

--- a/python/tokenspeed/runtime/engine/data_parallel_controller.py
+++ b/python/tokenspeed/runtime/engine/data_parallel_controller.py
@@ -25,7 +25,6 @@ import multiprocessing as mp
 import os
 import signal
 import threading
-from collections import deque
 from enum import Enum, auto
 
 import psutil
@@ -78,46 +77,79 @@ class DPBudget:
         # - SHORTEST_QUEUE: by num_reqs (running + waiting)
         # - MINIMUM_CACHE_USAGE: by num_pages (page usage)
         self.method = method
-        self.budget_queue = deque()
+        self.reported_metrics: dict[int, int] = {}
+        self.reported_request_counts: dict[int, int] = {}
+        self.reservations: dict[int, int] = {}
+        self.rank_order: list[int] = []
 
-    def update_budget(self, loads: list[GetLoadReqOutput]):
-        """Update the budget queue.
+    def update_budget(
+        self,
+        loads: list[GetLoadReqOutput],
+        reset_rank: int | None = None,
+    ):
+        """Reconcile reported load while retaining speculative reservations.
 
         For SHORTEST_QUEUE, use num_reqs instead of num_waiting_reqs to balance decode running batch.
         For MINIMUM_CACHE_USAGE, use num_pages as cache usage metric.
         """
-        # method update_budget and method dispatch happen in the same thread, so clearing budget_queue is safe
-        self.budget_queue.clear()
-
         if not loads:
+            self.clear()
             return
 
         if self.method == LoadBalanceMethod.MINIMUM_CACHE_USAGE:
-            metrics = [load.num_pages for load in loads]
+            metrics = {load.dp_rank: load.num_pages for load in loads}
         else:
-            metrics = [load.num_reqs for load in loads]
+            metrics = {load.dp_rank: load.num_reqs for load in loads}
+        request_counts = {load.dp_rank: load.num_reqs for load in loads}
+        rank_order = [load.dp_rank for load in loads]
 
-        max_metric = max(metrics)
-        if all(x == max_metric for x in metrics):
+        if rank_order != self.rank_order:
+            self.rank_order = rank_order
+            self.reported_metrics = metrics
+            self.reported_request_counts = request_counts
+            self.reservations = {rank: 0 for rank in rank_order}
             return
 
-        while any(x != metrics[0] for x in metrics):
-            min_load = min(metrics)
-            min_indices = [i for i, x in enumerate(metrics) if x == min_load]
-            second_min_load = min(x for x in metrics if x > min_load)
-            self.budget_queue.extend(
-                [loads[i].dp_rank for i in min_indices] * (second_min_load - min_load)
+        # Reservations count controller-dispatched requests. Only growth in the
+        # scheduler's request count can acknowledge them; cache-page growth is
+        # an independent signal used solely by MINIMUM_CACHE_USAGE scoring.
+        for rank in rank_order:
+            if rank == reset_rank:
+                self.reservations[rank] = 0
+                continue
+
+            reflected_reservations = (
+                request_counts[rank] - self.reported_request_counts[rank]
             )
-            for idx in min_indices:
-                metrics[idx] = second_min_load
+            if reflected_reservations > 0:
+                self.reservations[rank] = max(
+                    0,
+                    self.reservations[rank] - reflected_reservations,
+                )
+        self.reported_metrics = metrics
+        self.reported_request_counts = request_counts
 
     def dispatch(self):
-        if self.budget_queue:
-            return self.budget_queue.popleft()
-        return None
+        if not self.rank_order:
+            return None
+
+        effective_metrics = [
+            self.reported_metrics[rank] + self.reservations[rank]
+            for rank in self.rank_order
+        ]
+        minimum = min(effective_metrics)
+        if all(metric == minimum for metric in effective_metrics):
+            return None
+
+        target_rank = self.rank_order[effective_metrics.index(minimum)]
+        self.reservations[target_rank] += 1
+        return target_rank
 
     def clear(self):
-        self.budget_queue.clear()
+        self.reported_metrics.clear()
+        self.reported_request_counts.clear()
+        self.reservations.clear()
+        self.rank_order.clear()
 
 
 class DataParallelController:
@@ -163,6 +195,9 @@ class DataParallelController:
         # Load balance budget
         self.dp_budget = DPBudget(self.load_balance_method)
         self.load_snapshot_store = LoadSnapshotStore(server_args.mapping.attn.dp_size)
+        self.load_snapshot_epochs: list[str | None] = [
+            None
+        ] * server_args.mapping.attn.dp_size
 
         # Launch data parallel workers
         self.scheduler_procs = []
@@ -190,12 +225,24 @@ class DataParallelController:
             worker.send_pyobj(obj)
 
     def handle_load_snapshot(self, snapshot: LoadSnapshot):
+        previous_epoch = (
+            self.load_snapshot_epochs[snapshot.dp_rank]
+            if 0 <= snapshot.dp_rank < len(self.load_snapshot_epochs)
+            else None
+        )
         if not self.load_snapshot_store.accept(snapshot):
             return
+        self.load_snapshot_epochs[snapshot.dp_rank] = snapshot.epoch
 
         loads = self.load_snapshot_store.project_loads()
         if loads:
-            self.dp_budget.update_budget(loads)
+            epoch_changed = (
+                previous_epoch is not None and previous_epoch != snapshot.epoch
+            )
+            self.dp_budget.update_budget(
+                loads,
+                reset_rank=snapshot.dp_rank if epoch_changed else None,
+            )
         else:
             self.dp_budget.clear()
 

--- a/python/tokenspeed/runtime/engine/data_parallel_controller.py
+++ b/python/tokenspeed/runtime/engine/data_parallel_controller.py
@@ -32,15 +32,16 @@ import psutil
 import setproctitle
 import zmq
 
-from tokenspeed.runtime.engine.event_loop import run_event_loop
 from tokenspeed.runtime.engine.io_struct import (
     BlockReqInput,
+    GetLoadReqOutput,
     IpcReceiver,
     IpcSender,
+    LoadSnapshot,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
-    WatchLoadUpdateReq,
 )
+from tokenspeed.runtime.engine.load_snapshot import LoadSnapshotStore
 from tokenspeed.runtime.engine.request import Req
 from tokenspeed.runtime.utils import (
     configure_logger,
@@ -79,7 +80,7 @@ class DPBudget:
         self.method = method
         self.budget_queue = deque()
 
-    def update_budget(self, load_update: WatchLoadUpdateReq):
+    def update_budget(self, loads: list[GetLoadReqOutput]):
         """Update the budget queue.
 
         For SHORTEST_QUEUE, use num_reqs instead of num_waiting_reqs to balance decode running batch.
@@ -88,7 +89,6 @@ class DPBudget:
         # method update_budget and method dispatch happen in the same thread, so clearing budget_queue is safe
         self.budget_queue.clear()
 
-        loads = load_update.loads
         if not loads:
             return
 
@@ -115,6 +115,9 @@ class DPBudget:
         if self.budget_queue:
             return self.budget_queue.popleft()
         return None
+
+    def clear(self):
+        self.budget_queue.clear()
 
 
 class DataParallelController:
@@ -159,6 +162,7 @@ class DataParallelController:
 
         # Load balance budget
         self.dp_budget = DPBudget(self.load_balance_method)
+        self.load_snapshot_store = LoadSnapshotStore(server_args.mapping.attn.dp_size)
 
         # Launch data parallel workers
         self.scheduler_procs = []
@@ -185,8 +189,15 @@ class DataParallelController:
         for worker in self.workers:
             worker.send_pyobj(obj)
 
-    def handle_load_update_req(self, obj):
-        self.dp_budget.update_budget(obj)
+    def handle_load_snapshot(self, snapshot: LoadSnapshot):
+        if not self.load_snapshot_store.accept(snapshot):
+            return
+
+        loads = self.load_snapshot_store.project_loads()
+        if loads:
+            self.dp_budget.update_budget(loads)
+        else:
+            self.dp_budget.clear()
 
     def init_dispatcher(self):
         self._request_dispatcher = TypeBasedDispatcher(
@@ -194,7 +205,7 @@ class DataParallelController:
                 (TokenizedGenerateReqInput, self.dispatching),
                 (TokenizedEmbeddingReqInput, self.dispatching),
                 (BlockReqInput, self.send_to_all_workers),
-                (WatchLoadUpdateReq, self.handle_load_update_req),
+                (LoadSnapshot, self.handle_load_snapshot),
             ]
         )
         self._request_dispatcher.add_fallback_fn(self.send_control_message)
@@ -280,6 +291,8 @@ class DataParallelController:
         port_args: PortArgs,
         dp_rank: int,
     ):
+        from tokenspeed.runtime.engine.event_loop import run_event_loop
+
         scheduler_pipe_readers = []
         mapping_template = server_args.mapping
         attn_tp_size = mapping_template.attn.tp_size
@@ -342,6 +355,11 @@ class DataParallelController:
         self.workers[worker_id].send_pyobj(req)
 
     def budget_scheduler(self, req):
+        if not self.load_snapshot_store.is_complete_fresh():
+            self.dp_budget.clear()
+            self.round_robin_scheduler(req)
+            return
+
         target_worker = self.dp_budget.dispatch()
         if target_worker is None:
             self.round_robin_scheduler(req)

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -1516,16 +1516,32 @@ class EventLoop:
         }
 
     def _observe_load_snapshot(self, stats: dict) -> None:
-        """Copy the already-sampled scheduler scalars into the publisher mailbox."""
+        """Project the latest pre-forward planning sample onto each load sink."""
+        num_running = len(self.output_processor.rid_to_state)
+        num_waiting = stats["num_queue_reqs"]
+        num_active_pages = stats["num_active_pages"]
+        max_total_pages = self._scheduler_cache_geometry.num_usable_pages
         self.load_snapshot_publisher.observe(
             (
-                len(self.output_processor.rid_to_state),
-                stats["num_queue_reqs"],
-                stats["num_active_pages"],
+                num_running,
+                num_waiting,
+                num_active_pages,
                 stats["num_cached_pages"],
-                self._scheduler_cache_geometry.num_usable_pages,
+                max_total_pages,
             )
         )
+        # Only direct-ZMQ attention TP0 exposes this setter. Its observation
+        # and output send run on this scheduler thread, so the adapter merely
+        # replaces a tuple; the snapshot rides the next ordinary output batch.
+        output_sink = getattr(self, "send_to_tokenizer", None)
+        set_direct_snapshot = getattr(output_sink, "set_load_snapshot", None)
+        if set_direct_snapshot is not None:
+            set_direct_snapshot(
+                num_running,
+                num_waiting,
+                num_active_pages,
+                max_total_pages,
+            )
 
     def _record_scheduler_iteration_metrics(
         self, stats: dict, num_iteration_tokens: int

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -546,7 +546,6 @@ class EventLoop:
             vocab_size=self.model_config.vocab_size,
             recv_func=self.recv_from_tokenizer,
             send_func=self.send_to_tokenizer,
-            get_load_fn=self._get_load,
             clear_cache_fn=self.scheduler.clear_cache,
             architectures=self.model_config.hf_config.architectures,
             pause_controller=self._pause,
@@ -1446,22 +1445,6 @@ class EventLoop:
                         abort.request_id = req_id
                         processed.append(abort)
         return processed
-
-    def _get_load(self):
-        """Return load metrics for the DP load balancer."""
-        from tokenspeed.runtime.engine.io_struct import GetLoadReqOutput
-
-        available = self.scheduler.available_kv_pages()
-        num_used_pages = self._scheduler_cache_geometry.num_usable_pages - available
-        num_waiting = self.scheduler.waiting_size()
-        # num_reqs: running + waiting (used by SHORTEST_QUEUE balancing)
-        num_running = len(self.output_processor.rid_to_state)
-        return GetLoadReqOutput(
-            dp_rank=self.dp_rank,
-            num_reqs=num_running + num_waiting,
-            num_waiting_reqs=num_waiting,
-            num_pages=num_used_pages,
-        )
 
     def _dp_sync_and_check(self, forward_op) -> DpForwardMetadata:
         """Synchronize DP ranks with CPU-only metadata.

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -792,6 +792,7 @@ class EventLoop:
             )
             ec.add_event(e)
         self.scheduler.advance(ec)
+        self._mark_load_snapshot_dirty()
         logger.debug("[cache_poll] scheduler.advance() done")
         self._publish_scheduler_kv_events()
 
@@ -1095,6 +1096,7 @@ class EventLoop:
             self.send_to_tokenizer = _NullSender()
 
     def _init_load_snapshot_publisher(self) -> None:
+        self._load_snapshot_observed_while_paused = False
         if self.attn_tp_rank != 0:
             self.load_snapshot_publisher = NullLoadSnapshotPublisher()
         elif self.server_args.zmq_msgpack:
@@ -1184,6 +1186,11 @@ class EventLoop:
 
     def _process_new_requests(self):
         recv_reqs = self.request_handler.recv_reqs()
+        if recv_reqs:
+            # A paused loop still accepts control messages and registers new
+            # requests into its Python-side buffers. Re-sample once after that
+            # batch instead of heartbeating the pre-mutation tuple forever.
+            self._mark_load_snapshot_dirty()
         # Snapshot the pause state before dispatch: process_requests may flip it
         # mid-batch. If it was not blocked before but is after, a pause control
         # message was processed in this very batch — which is what makes the
@@ -1534,6 +1541,10 @@ class EventLoop:
             )
         )
 
+    def _mark_load_snapshot_dirty(self) -> None:
+        """Request one fresh scheduler sample on the next paused iteration."""
+        self._load_snapshot_observed_while_paused = False
+
     def _record_scheduler_iteration_metrics(
         self, stats: dict, num_iteration_tokens: int
     ) -> None:
@@ -1594,8 +1605,13 @@ class EventLoop:
             )
             advance_forward(self.scheduler, request_changes)
             self._publish_scheduler_kv_events()
+
+        if self.attn_tp_rank == 0 and (
+            prev_results is not None or not self._load_snapshot_observed_while_paused
+        ):
             stats = self._get_scheduler_stats()
             self._observe_load_snapshot(stats)
+            self._load_snapshot_observed_while_paused = True
 
         if self.has_dp:
             dp_metadata = self._dp_sync_and_check(None)
@@ -1623,7 +1639,10 @@ class EventLoop:
     def event_loop(self):
         """Non-overlapping scheduler loop."""
         while not self._shutdown_complete():
+            num_tracked_reqs = len(self.output_processor.rid_to_state)
             self._process_new_requests()
+            if len(self.output_processor.rid_to_state) != num_tracked_reqs:
+                self._mark_load_snapshot_dirty()
             # EPD prefill: admit requests whose async embedding receives completed
             # this cycle (rank-synced). Fixed position right after
             # _process_new_requests so the drain's TP collective ordering is
@@ -1633,6 +1652,7 @@ class EventLoop:
             if self._pause.forward_blocked:
                 self._paused_idle_step()
                 continue
+            self._load_snapshot_observed_while_paused = False
             execution_plan = self.scheduler.next_execution_plan()
             self._publish_scheduler_kv_events()
             cache_zero_event = self.model_executor.zero_cache_pages(
@@ -1777,7 +1797,10 @@ class EventLoop:
             torch.cuda.default_stream().wait_stream(
                 self.model_executor.execution_stream
             )
+            num_tracked_reqs = len(self.output_processor.rid_to_state)
             self._process_new_requests()
+            if len(self.output_processor.rid_to_state) != num_tracked_reqs:
+                self._mark_load_snapshot_dirty()
             self._commit_cache_results()
             if self._pause.forward_blocked:
                 # Freeze: commit any in-flight (overlapped) step — a forward
@@ -1786,6 +1809,7 @@ class EventLoop:
                 prev_results = None
                 prev_forward_op = None
                 continue
+            self._load_snapshot_observed_while_paused = False
             execution_plan = self.scheduler.next_execution_plan()
             self._publish_scheduler_kv_events()
 

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -40,6 +40,7 @@ from tokenspeed.runtime.distributed.process_group_manager import (
 from tokenspeed.runtime.engine.generation_output_processor import OutputProcesser
 from tokenspeed.runtime.engine.io_struct import IpcReceiver, IpcSender
 from tokenspeed.runtime.engine.load_snapshot import (
+    DirectLoadSnapshotSink,
     LoadSnapshotPublisher,
     NullLoadSnapshotPublisher,
 )
@@ -1094,16 +1095,18 @@ class EventLoop:
             self.send_to_tokenizer = _NullSender()
 
     def _init_load_snapshot_publisher(self) -> None:
-        if self.attn_tp_rank == 0 and not self.server_args.zmq_msgpack:
+        if self.attn_tp_rank != 0:
+            self.load_snapshot_publisher = NullLoadSnapshotPublisher()
+        elif self.server_args.zmq_msgpack:
+            self.load_snapshot_publisher = DirectLoadSnapshotSink(
+                self.send_to_tokenizer.set_load_snapshot
+            )
+        else:
             self.load_snapshot_publisher = LoadSnapshotPublisher(
                 self.port_args.metrics_ipc_name,
                 self.dp_rank,
                 self.server_args.load_watch_interval,
             )
-        else:
-            # Direct-ZMQ will project the observation onto ordinary output
-            # batches; it must not create this standard-serving PUSH socket.
-            self.load_snapshot_publisher = NullLoadSnapshotPublisher()
 
     def _init_msgpack_transport(self, context):
         """Complete the SMG startup handshake and return the wrapped msgpack
@@ -1530,18 +1533,6 @@ class EventLoop:
                 max_total_pages,
             )
         )
-        # Only direct-ZMQ attention TP0 exposes this setter. Its observation
-        # and output send run on this scheduler thread, so the adapter merely
-        # replaces a tuple; the snapshot rides the next ordinary output batch.
-        output_sink = getattr(self, "send_to_tokenizer", None)
-        set_direct_snapshot = getattr(output_sink, "set_load_snapshot", None)
-        if set_direct_snapshot is not None:
-            set_direct_snapshot(
-                num_running,
-                num_waiting,
-                num_active_pages,
-                max_total_pages,
-            )
 
     def _record_scheduler_iteration_metrics(
         self, stats: dict, num_iteration_tokens: int

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -39,6 +39,10 @@ from tokenspeed.runtime.distributed.process_group_manager import (
 )
 from tokenspeed.runtime.engine.generation_output_processor import OutputProcesser
 from tokenspeed.runtime.engine.io_struct import IpcReceiver, IpcSender
+from tokenspeed.runtime.engine.load_snapshot import (
+    LoadSnapshotPublisher,
+    NullLoadSnapshotPublisher,
+)
 from tokenspeed.runtime.engine.memory_occupation import MemoryOccupationController
 from tokenspeed.runtime.engine.pause import PauseController
 from tokenspeed.runtime.engine.request_handler import RequestHandler
@@ -494,6 +498,7 @@ class EventLoop:
             self.kv_event_publisher = NullEventPublisher(attn_dp_rank=dp_rank)
 
         self._init_interprocess_comm()
+        self._init_load_snapshot_publisher()
 
         # Pause/resume control state. Shared with the request handler, which
         # drives the control-request side; the event loop reads the gate.
@@ -1089,6 +1094,18 @@ class EventLoop:
             self.recv_from_tokenizer = None
             self.send_to_tokenizer = _NullSender()
 
+    def _init_load_snapshot_publisher(self) -> None:
+        if self.attn_tp_rank == 0 and not self.server_args.zmq_msgpack:
+            self.load_snapshot_publisher = LoadSnapshotPublisher(
+                self.port_args.metrics_ipc_name,
+                self.dp_rank,
+                self.server_args.load_watch_interval,
+            )
+        else:
+            # Direct-ZMQ will project the observation onto ordinary output
+            # batches; it must not create this standard-serving PUSH socket.
+            self.load_snapshot_publisher = NullLoadSnapshotPublisher()
+
     def _init_msgpack_transport(self, context):
         """Complete the SMG startup handshake and return the wrapped msgpack
         input/output sockets."""
@@ -1515,6 +1532,18 @@ class EventLoop:
             "num_queue_reqs": self.scheduler.waiting_size(),
         }
 
+    def _observe_load_snapshot(self, stats: dict) -> None:
+        """Copy the already-sampled scheduler scalars into the publisher mailbox."""
+        self.load_snapshot_publisher.observe(
+            (
+                len(self.output_processor.rid_to_state),
+                stats["num_queue_reqs"],
+                stats["num_active_pages"],
+                stats["num_cached_pages"],
+                self._scheduler_cache_geometry.num_usable_pages,
+            )
+        )
+
     def _record_scheduler_iteration_metrics(
         self, stats: dict, num_iteration_tokens: int
     ) -> None:
@@ -1575,6 +1604,8 @@ class EventLoop:
             )
             advance_forward(self.scheduler, request_changes)
             self._publish_scheduler_kv_events()
+            stats = self._get_scheduler_stats()
+            self._observe_load_snapshot(stats)
 
         if self.has_dp:
             dp_metadata = self._dp_sync_and_check(None)
@@ -1621,6 +1652,7 @@ class EventLoop:
 
             forward_op = self._get_forward_op(execution_plan)
             stats = self._get_scheduler_stats()
+            self._observe_load_snapshot(stats)
             num_iter_tokens = (
                 sum(forward_op.input_lengths) if forward_op is not None else 0
             )
@@ -1774,6 +1806,7 @@ class EventLoop:
 
             forward_op = self._get_forward_op(execution_plan)
             stats = self._get_scheduler_stats()
+            self._observe_load_snapshot(stats)
             num_iter_tokens = (
                 sum(forward_op.input_lengths) if forward_op is not None else 0
             )
@@ -1877,6 +1910,7 @@ class EventLoop:
             prev_forward_op = forward_op
 
     def close(self) -> None:
+        self.load_snapshot_publisher.close()
         # Best-effort: tell an attached SMG frontend this engine is going away
         # (msgpack mode only; the pickle sender has no such helper) so the
         # worker is marked dead instead of staying healthy-idle.

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -712,10 +712,23 @@ class BatchTokenIDOutSlim(BaseBatchReq, kw_only=True):
     # DP the batch itself names its rank. Appended field: defaults to 0 so
     # older peers on either side stay compatible.
     engine_index: int = 0
+    # Latest scheduler load observed before the output is forwarded. Appended
+    # wire tail: older 9- and 10-element prefixes decode all four values as 0.
+    num_running: int = 0
+    num_waiting: int = 0
+    kv_active_pages: int = 0
+    kv_total_pages: int = 0
 
     @classmethod
     def from_full(
-        cls, out: BatchTokenIDOut, engine_index: int = 0
+        cls,
+        out: BatchTokenIDOut,
+        engine_index: int = 0,
+        *,
+        num_running: int = 0,
+        num_waiting: int = 0,
+        kv_active_pages: int = 0,
+        kv_total_pages: int = 0,
     ) -> "BatchTokenIDOutSlim":
         # Token source: ``out.output_ids`` — the not-yet-sent slice of each
         # request's generated ids. NOT ``out.decode_ids``: that is the
@@ -731,6 +744,10 @@ class BatchTokenIDOutSlim(BaseBatchReq, kw_only=True):
             )
         return cls(
             engine_index=engine_index,
+            num_running=num_running,
+            num_waiting=num_waiting,
+            kv_active_pages=kv_active_pages,
+            kv_total_pages=kv_total_pages,
             rids=list(out.rids),
             output_ids=[list(ids) for ids in out.output_ids],
             finished_reasons=[_finish_type(fr) for fr in out.finished_reasons],

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -1059,6 +1059,26 @@ class GetLoadReqOutput(BaseReq, kw_only=True):
     num_pages: int = 0
 
 
+class LoadSnapshot(
+    msgspec.Struct, frozen=True, tag=True, tag_field="_tag", array_like=True
+):
+    """Immutable scheduler load replica sent over engine IPC.
+
+    Fields are positional on the wire. Append any future fields only at the
+    end so older decoders can retain their prefix compatibility.
+    """
+
+    epoch: str
+    sequence: int
+    dp_rank: int
+    num_running_reqs: int
+    num_waiting_reqs: int
+    num_active_pages: int
+    num_used_pages: int
+    max_total_pages: int
+    valid_for_ms: int
+
+
 class WatchLoadUpdateReq(BaseReq, kw_only=True):
     loads: list[GetLoadReqOutput] = []
 
@@ -1247,7 +1267,9 @@ def ipc_message_union():
     """
     types = tuple(
         dict.fromkeys(
-            _walk_subclasses(BaseReq) + _walk_subclasses(BaseBatchReq) + [PickleWrapper]
+            _walk_subclasses(BaseReq)
+            + _walk_subclasses(BaseBatchReq)
+            + [LoadSnapshot, PickleWrapper]
         )
     )
     return Union[types]  # noqa: UP007 — dynamic union over a runtime tuple

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -1048,10 +1048,6 @@ class RpcReqOutput(BaseReq, kw_only=True):
     message: str
 
 
-class GetLoadReqInput(BaseReq, kw_only=True):
-    pass
-
-
 class GetLoadReqOutput(BaseReq, kw_only=True):
     dp_rank: int = 0
     num_reqs: int = 0
@@ -1077,10 +1073,6 @@ class LoadSnapshot(
     num_used_pages: int
     max_total_pages: int
     valid_for_ms: int
-
-
-class WatchLoadUpdateReq(BaseReq, kw_only=True):
-    loads: list[GetLoadReqOutput] = []
 
 
 class BlockReqType(Enum):

--- a/python/tokenspeed/runtime/engine/load_snapshot.py
+++ b/python/tokenspeed/runtime/engine/load_snapshot.py
@@ -85,6 +85,26 @@ class NullLoadSnapshotPublisher:
         return None
 
 
+class DirectLoadSnapshotSink:
+    """Project shared observations onto the next direct-ZMQ output batch."""
+
+    def __init__(self, set_load_snapshot: Callable[[int, int, int, int], None]) -> None:
+        self._set_load_snapshot = set_load_snapshot
+
+    def observe(self, values: _LoadValues) -> None:
+        num_running, num_waiting, num_active_pages, _, max_total_pages = values
+        self._set_load_snapshot(
+            num_running,
+            num_waiting,
+            num_active_pages,
+            max_total_pages,
+        )
+
+    @staticmethod
+    def close() -> None:
+        return None
+
+
 class LoadSnapshotPublisher:
     """Publish the newest scheduler load tuple from a private transport thread.
 

--- a/python/tokenspeed/runtime/engine/load_snapshot.py
+++ b/python/tokenspeed/runtime/engine/load_snapshot.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Validated local replicas of scheduler-published load snapshots."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from tokenspeed.runtime.engine.io_struct import GetLoadReqOutput, LoadSnapshot
+
+
+@dataclass(frozen=True)
+class _StoredSnapshot:
+    snapshot: LoadSnapshot
+    received_at: float
+
+
+class LoadSnapshotStore:
+    """Keep one ordered, locally-expiring snapshot for each DP rank."""
+
+    def __init__(
+        self, dp_size: int, clock: Callable[[], float] = time.monotonic
+    ) -> None:
+        if dp_size <= 0:
+            raise ValueError("dp_size must be positive")
+        self._dp_size = dp_size
+        self._clock = clock
+        self._snapshots: dict[int, _StoredSnapshot] = {}
+        self._retired_epochs: list[set[str]] = [set() for _ in range(dp_size)]
+
+    def accept(self, snapshot: LoadSnapshot) -> bool:
+        """Validate and store a newer snapshot, returning whether it was accepted."""
+        if not self._is_valid(snapshot):
+            return False
+
+        rank = snapshot.dp_rank
+        if snapshot.epoch in self._retired_epochs[rank]:
+            return False
+
+        previous = self._snapshots.get(rank)
+        if previous is not None:
+            if snapshot.epoch == previous.snapshot.epoch:
+                if snapshot.sequence <= previous.snapshot.sequence:
+                    return False
+            else:
+                self._retired_epochs[rank].add(previous.snapshot.epoch)
+
+        copied = LoadSnapshot(
+            snapshot.epoch,
+            snapshot.sequence,
+            snapshot.dp_rank,
+            snapshot.num_running_reqs,
+            snapshot.num_waiting_reqs,
+            snapshot.num_active_pages,
+            snapshot.num_used_pages,
+            snapshot.max_total_pages,
+            snapshot.valid_for_ms,
+        )
+        self._snapshots[rank] = _StoredSnapshot(copied, self._clock())
+        return True
+
+    def fresh_snapshots(self) -> list[LoadSnapshot]:
+        """Return every currently fresh snapshot in rank order."""
+        return self._fresh_snapshots(self._clock())
+
+    def _fresh_snapshots(self, now: float) -> list[LoadSnapshot]:
+        return [
+            stored.snapshot
+            for _, stored in sorted(self._snapshots.items())
+            if self._is_fresh(stored, now)
+        ]
+
+    def project_loads(self) -> list[GetLoadReqOutput]:
+        """Return the public load schema only for a complete, fresh replica."""
+        snapshots = self._fresh_snapshots(self._clock())
+        if len(snapshots) != self._dp_size:
+            return []
+        return [
+            GetLoadReqOutput(
+                dp_rank=snapshot.dp_rank,
+                num_reqs=snapshot.num_running_reqs + snapshot.num_waiting_reqs,
+                num_waiting_reqs=snapshot.num_waiting_reqs,
+                num_pages=snapshot.num_used_pages,
+            )
+            for snapshot in snapshots
+        ]
+
+    def is_complete_fresh(self) -> bool:
+        """Whether every expected rank has a currently valid snapshot."""
+        return len(self._fresh_snapshots(self._clock())) == self._dp_size
+
+    def _is_valid(self, snapshot: LoadSnapshot) -> bool:
+        if not isinstance(snapshot, LoadSnapshot):
+            return False
+        if not 0 <= snapshot.dp_rank < self._dp_size:
+            return False
+        if snapshot.sequence < 0 or snapshot.valid_for_ms < 0:
+            return False
+        if any(
+            value < 0
+            for value in (
+                snapshot.num_running_reqs,
+                snapshot.num_waiting_reqs,
+                snapshot.num_active_pages,
+                snapshot.num_used_pages,
+            )
+        ):
+            return False
+        if snapshot.max_total_pages <= 0:
+            return False
+        return (
+            snapshot.num_active_pages <= snapshot.max_total_pages
+            and snapshot.num_used_pages <= snapshot.max_total_pages
+        )
+
+    @staticmethod
+    def _is_fresh(stored: _StoredSnapshot, now: float) -> bool:
+        return now - stored.received_at <= stored.snapshot.valid_for_ms / 1_000

--- a/python/tokenspeed/runtime/engine/load_snapshot.py
+++ b/python/tokenspeed/runtime/engine/load_snapshot.py
@@ -22,11 +22,182 @@
 
 from __future__ import annotations
 
+import logging
+import threading
 import time
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from tokenspeed.runtime.engine.io_struct import GetLoadReqOutput, LoadSnapshot
+import zmq
+
+from tokenspeed.runtime.engine.io_struct import (
+    GetLoadReqOutput,
+    LoadSnapshot,
+    MsgpackEncoder,
+)
+
+logger = logging.getLogger(__name__)
+
+_LoadValues = tuple[int, int, int, int, int]
+_SocketFactory = Callable[[str], tuple[object, object]]
+_SEND_RETRY_INTERVAL_S = 0.01
+_CLOSE_TIMEOUT_S = 1.0
+
+
+def _open_snapshot_socket(endpoint: str) -> tuple[zmq.Context, zmq.Socket]:
+    """Create the publisher's private context and configured PUSH socket."""
+    context = zmq.Context()
+    socket = context.socket(zmq.PUSH)
+    socket.setsockopt(zmq.SNDHWM, 1)
+    socket.setsockopt(zmq.CONFLATE, 1)
+    socket.connect(endpoint)
+    return context, socket
+
+
+class NullLoadSnapshotPublisher:
+    """No-op publisher used outside standard-serving attention TP0."""
+
+    @staticmethod
+    def observe(values: _LoadValues) -> None:
+        return None
+
+    @staticmethod
+    def close() -> None:
+        return None
+
+
+class LoadSnapshotPublisher:
+    """Publish the newest scheduler load tuple from a private transport thread.
+
+    ``observe`` is the scheduler-thread boundary: it only compares a tuple,
+    replaces one guarded slot, and notifies the publisher. The background
+    thread owns all snapshot encoding and ZMQ context/socket lifecycle work.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        dp_rank: int,
+        heartbeat_interval: float,
+        socket_factory: _SocketFactory | None = None,
+    ) -> None:
+        self._endpoint = endpoint
+        self._dp_rank = dp_rank
+        self._heartbeat_interval = max(1.0, heartbeat_interval)
+        self._valid_for_ms = int(3 * self._heartbeat_interval * 1_000)
+        self._socket_factory = socket_factory or _open_snapshot_socket
+        self._epoch = uuid.uuid4().hex
+
+        self._condition = threading.Condition()
+        self._latest_values: _LoadValues | None = None
+        self._generation = 0
+        self._closed = False
+        self._sequence = 0
+        self.socket_owner_thread: int | None = None
+
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"load-snapshot-publisher-dp{dp_rank}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def observe(self, values: _LoadValues) -> None:
+        """Replace the mailbox when scalar load state changes."""
+        with self._condition:
+            if self._closed or values == self._latest_values:
+                return
+            self._latest_values = values
+            self._generation += 1
+            self._condition.notify()
+
+    def close(self) -> None:
+        """Stop the publisher without waiting indefinitely for transport."""
+        with self._condition:
+            if self._closed:
+                return
+            self._closed = True
+            self._condition.notify()
+        self._thread.join(timeout=_CLOSE_TIMEOUT_S)
+        if self._thread.is_alive():
+            logger.warning(
+                "Load snapshot publisher did not stop within %.1fs", _CLOSE_TIMEOUT_S
+            )
+
+    def _run(self) -> None:
+        self.socket_owner_thread = threading.get_ident()
+        context = None
+        socket = None
+        try:
+            context, socket = self._socket_factory(self._endpoint)
+            encoder = MsgpackEncoder()
+            pending: LoadSnapshot | None = None
+            pending_generation = -1
+            sent_generation = -1
+            last_sent_at: float | None = None
+
+            while True:
+                with self._condition:
+                    while True:
+                        if self._closed:
+                            return
+
+                        generation = self._generation
+                        values = self._latest_values
+                        if values is not None and generation != pending_generation:
+                            if pending is not None or generation != sent_generation:
+                                pending = self._new_snapshot(values)
+                                pending_generation = generation
+                                break
+
+                        if pending is not None:
+                            break
+
+                        if values is None or last_sent_at is None:
+                            self._condition.wait()
+                            continue
+
+                        heartbeat_remaining = (
+                            last_sent_at + self._heartbeat_interval - time.monotonic()
+                        )
+                        if heartbeat_remaining <= 0:
+                            pending = self._new_snapshot(values)
+                            pending_generation = generation
+                            break
+                        self._condition.wait(timeout=heartbeat_remaining)
+
+                frames = encoder.encode(pending)
+                if len(frames) != 1:
+                    raise RuntimeError("LoadSnapshot must encode as exactly one frame")
+                try:
+                    socket.send(frames[0], flags=zmq.NOBLOCK)
+                except zmq.Again:
+                    with self._condition:
+                        if not self._closed:
+                            self._condition.wait(timeout=_SEND_RETRY_INTERVAL_S)
+                    continue
+
+                sent_generation = pending_generation
+                last_sent_at = time.monotonic()
+                pending = None
+        except Exception:
+            logger.exception("Load snapshot publisher stopped unexpectedly")
+        finally:
+            if socket is not None:
+                socket.close(linger=0)
+            if context is not None:
+                context.term()
+
+    def _new_snapshot(self, values: _LoadValues) -> LoadSnapshot:
+        self._sequence += 1
+        return LoadSnapshot(
+            self._epoch,
+            self._sequence,
+            self._dp_rank,
+            *values,
+            self._valid_for_ms,
+        )
 
 
 @dataclass(frozen=True)

--- a/python/tokenspeed/runtime/engine/load_snapshot.py
+++ b/python/tokenspeed/runtime/engine/load_snapshot.py
@@ -45,14 +45,32 @@ _SEND_RETRY_INTERVAL_S = 0.01
 _CLOSE_TIMEOUT_S = 1.0
 
 
+def _close_snapshot_socket(context: object | None, socket: object | None) -> None:
+    """Close a partially or fully acquired socket before terminating its context."""
+    try:
+        if socket is not None:
+            socket.close(linger=0)
+    finally:
+        if context is not None:
+            context.term()
+
+
 def _open_snapshot_socket(endpoint: str) -> tuple[zmq.Context, zmq.Socket]:
     """Create the publisher's private context and configured PUSH socket."""
     context = zmq.Context()
-    socket = context.socket(zmq.PUSH)
-    socket.setsockopt(zmq.SNDHWM, 1)
-    socket.setsockopt(zmq.CONFLATE, 1)
-    socket.connect(endpoint)
-    return context, socket
+    socket = None
+    try:
+        socket = context.socket(zmq.PUSH)
+        socket.setsockopt(zmq.SNDHWM, 1)
+        socket.setsockopt(zmq.CONFLATE, 1)
+        socket.connect(endpoint)
+        return context, socket
+    except Exception:
+        try:
+            _close_snapshot_socket(context, socket)
+        except Exception:
+            logger.exception("Failed to clean up load snapshot socket setup")
+        raise
 
 
 class NullLoadSnapshotPublisher:
@@ -184,10 +202,10 @@ class LoadSnapshotPublisher:
         except Exception:
             logger.exception("Load snapshot publisher stopped unexpectedly")
         finally:
-            if socket is not None:
-                socket.close(linger=0)
-            if context is not None:
-                context.term()
+            try:
+                _close_snapshot_socket(context, socket)
+            except Exception:
+                logger.exception("Failed to clean up load snapshot publisher")
 
     def _new_snapshot(self, values: _LoadValues) -> LoadSnapshot:
         self._sequence += 1

--- a/python/tokenspeed/runtime/engine/load_snapshot.py
+++ b/python/tokenspeed/runtime/engine/load_snapshot.py
@@ -262,6 +262,7 @@ class LoadSnapshotStore:
         if not self._is_valid(snapshot):
             return False
 
+        now = self._clock()
         rank = snapshot.dp_rank
         if snapshot.epoch in self._retired_epochs[rank]:
             return False
@@ -272,6 +273,8 @@ class LoadSnapshotStore:
                 if snapshot.sequence <= previous.snapshot.sequence:
                     return False
             else:
+                if self._is_fresh(previous, now):
+                    return False
                 self._retired_epochs[rank].add(previous.snapshot.epoch)
 
         copied = LoadSnapshot(
@@ -285,7 +288,7 @@ class LoadSnapshotStore:
             snapshot.max_total_pages,
             snapshot.valid_for_ms,
         )
-        self._snapshots[rank] = _StoredSnapshot(copied, self._clock())
+        self._snapshots[rank] = _StoredSnapshot(copied, now)
         return True
 
     def fresh_snapshots(self) -> list[LoadSnapshot]:

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -48,8 +48,6 @@ from tokenspeed.runtime.engine.io_struct import (
     FlushCacheReqOutput,
     GetInternalStateReq,
     GetInternalStateReqOutput,
-    GetLoadReqInput,
-    GetLoadReqOutput,
     InitWeightsUpdateGroupReqInput,
     InitWeightsUpdateGroupReqOutput,
     IsSchedulerPausedReqInput,
@@ -109,7 +107,6 @@ class RequestHandler:
         vocab_size: int,
         recv_func,
         send_func,
-        get_load_fn=None,
         clear_cache_fn=None,
         architectures: list[str] | None = None,
         pause_controller=None,
@@ -141,7 +138,6 @@ class RequestHandler:
         self.hf_eos_token_id = hf_eos_token_id
         self.max_req_len = max_req_len
         self.vocab_size = vocab_size
-        self.get_load_fn = get_load_fn
         self.clear_cache_fn = clear_cache_fn
 
         self.tokenizer = get_tokenizer(
@@ -235,11 +231,6 @@ class RequestHandler:
                 self.send_func.send_pyobj(
                     SetInternalStateReqOutput(updated=False, server_args={})
                 )
-            elif isinstance(recv_req, GetLoadReqInput):
-                if self.get_load_fn is not None:
-                    self.send_func.send_pyobj(self.get_load_fn())
-                else:
-                    self.send_func.send_pyobj(GetLoadReqOutput())
             elif isinstance(recv_req, InitWeightsUpdateGroupReqInput):
                 # RL weight sync: join the trainer's NCCL group on this worker.
                 ok, msg = self.model_runner.init_weights_update_group(recv_req)

--- a/python/tokenspeed/runtime/engine/scheduler_control_client.py
+++ b/python/tokenspeed/runtime/engine/scheduler_control_client.py
@@ -37,7 +37,6 @@ from tokenspeed.runtime.engine.io_struct import (
     FlushCacheReqOutput,
     GetInternalStateReq,
     GetInternalStateReqOutput,
-    GetLoadReqInput,
     GetLoadReqOutput,
     GetWeightsByNameReqInput,
     GetWeightsByNameReqOutput,
@@ -131,12 +130,6 @@ class SchedulerControlClient:
         self.expert_distribution_communicator = _Communicator(
             self.engine_core_client.send_to_scheduler, server_args.mapping.attn.dp_size
         )
-        self.get_load_communicator = _Communicator(
-            self.engine_core_client.send_to_scheduler,
-            server_args.mapping.attn.dp_size,
-            mode="watching",
-        )
-
         self._result_dispatcher += self._get_communicator_dispatcher()
 
     def _get_communicator_dispatcher(self: AsyncLLM):
@@ -205,10 +198,6 @@ class SchedulerControlClient:
                 (
                     ExpertDistributionReqOutput,
                     self.expert_distribution_communicator.handle_recv,
-                ),
-                (
-                    GetLoadReqOutput,
-                    self.get_load_communicator.handle_recv,
                 ),
             ]
         )
@@ -404,5 +393,17 @@ class SchedulerControlClient:
         return [res.updated for res in responses]
 
     async def get_load(self: AsyncLLM) -> list[GetLoadReqOutput]:
-        req = GetLoadReqInput()
-        return await self.get_load_communicator(req)
+        self.auto_create_handle_loop()
+        return self.load_snapshot_store.project_loads()
+
+    async def load_snapshot_loop(self: AsyncLLM) -> None:
+        """Cache scheduler-published snapshots and relay accepted updates to DP."""
+        while True:
+            snapshot = await self.engine_core_client.recv_load_snapshot.recv_pyobj()
+            if not self.load_snapshot_store.accept(snapshot):
+                continue
+            if (
+                self.server_args.mapping.attn.has_dp
+                and self.server_args.load_balance_method != "round_robin"
+            ):
+                self.engine_core_client.send_to_scheduler.send_pyobj(snapshot)

--- a/python/tokenspeed/runtime/engine/scheduler_control_client.py
+++ b/python/tokenspeed/runtime/engine/scheduler_control_client.py
@@ -406,4 +406,4 @@ class SchedulerControlClient:
                 self.server_args.mapping.attn.has_dp
                 and self.server_args.load_balance_method != "round_robin"
             ):
-                self.engine_core_client.send_to_scheduler.send_pyobj(snapshot)
+                await self.engine_core_client.send_to_scheduler.send_pyobj(snapshot)

--- a/python/tokenspeed/runtime/engine/zmq_msgpack.py
+++ b/python/tokenspeed/runtime/engine/zmq_msgpack.py
@@ -144,13 +144,46 @@ class MsgpackSendSocket:
         self._socket = socket
         self._engine_index = engine_index
         self._encoder = MsgpackEncoder()
+        self._load_snapshot = (0, 0, 0, 0)
+
+    def set_load_snapshot(
+        self,
+        num_running: int,
+        num_waiting: int,
+        kv_active_pages: int,
+        kv_total_pages: int,
+    ) -> None:
+        """Replace the load tail for the next ordinary output batch.
+
+        Observation and output forwarding share the scheduler thread, so this
+        latest-wins assignment needs neither a lock nor a standalone send.
+        """
+        self._load_snapshot = (
+            num_running,
+            num_waiting,
+            kv_active_pages,
+            kv_total_pages,
+        )
 
     def send_pyobj(self, obj) -> None:
         if isinstance(obj, BatchTokenIDOut):
             # The PULL side carries no routing identity, so the batch itself
             # names its producing rank; the frontend attributes per-rank
             # outputs and load by this index under DP.
-            slim = BatchTokenIDOutSlim.from_full(obj, engine_index=self._engine_index)
+            (
+                num_running,
+                num_waiting,
+                kv_active_pages,
+                kv_total_pages,
+            ) = self._load_snapshot
+            slim = BatchTokenIDOutSlim.from_full(
+                obj,
+                engine_index=self._engine_index,
+                num_running=num_running,
+                num_waiting=num_waiting,
+                kv_active_pages=kv_active_pages,
+                kv_total_pages=kv_total_pages,
+            )
             self._socket.send_multipart(self._encoder.encode(slim), copy=False)
         else:
             logger.warning(

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1354,7 +1354,8 @@ class ServerArgs:
             "--load-watch-interval",
             type=float,
             default=ServerArgs.load_watch_interval,
-            help="The interval of load watching in seconds.",
+            help="Heartbeat compatibility interval for load snapshots in seconds. "
+            "Changed load values publish immediately without debounce.",
         )
 
         # Expert parallelism

--- a/test/runtime/test_async_llm_load_snapshot.py
+++ b/test/runtime/test_async_llm_load_snapshot.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+"""Tests for AsyncLLM's scheduler-published load replica."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import zmq
+
+from tokenspeed.runtime.engine import core_client as core_client_module
+from tokenspeed.runtime.engine.io_struct import GetLoadReqOutput, LoadSnapshot
+from tokenspeed.runtime.engine.load_snapshot import LoadSnapshotStore
+from tokenspeed.runtime.engine.scheduler_control_client import SchedulerControlClient
+
+
+class _RecordingSocket:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def setsockopt(self, option, value) -> None:
+        self.calls.append(("setsockopt", option, value))
+
+    def bind(self, endpoint) -> None:
+        self.calls.append(("bind", endpoint))
+
+
+class _RecordingContext:
+    def __init__(self) -> None:
+        self.metrics_socket = _RecordingSocket()
+
+    def socket(self, socket_type):
+        assert socket_type == zmq.PULL
+        return self.metrics_socket
+
+
+class _QueueReceiver:
+    def __init__(self, values) -> None:
+        self.values = list(values)
+
+    async def recv_pyobj(self):
+        if not self.values:
+            raise asyncio.CancelledError
+        return self.values.pop(0)
+
+
+class _RecordingSender:
+    def __init__(self) -> None:
+        self.sent = []
+
+    def send_pyobj(self, value) -> None:
+        self.sent.append(value)
+
+
+def _snapshot(**overrides) -> LoadSnapshot:
+    fields = dict(
+        epoch="epoch-a",
+        sequence=1,
+        dp_rank=0,
+        num_running_reqs=2,
+        num_waiting_reqs=3,
+        num_active_pages=4,
+        num_used_pages=5,
+        max_total_pages=10,
+        valid_for_ms=1_000,
+    )
+    fields.update(overrides)
+    return LoadSnapshot(**fields)
+
+
+def test_engine_core_metrics_pull_keeps_only_the_newest_snapshot(monkeypatch):
+    context = _RecordingContext()
+    monkeypatch.setattr(core_client_module.zmq.asyncio, "Context", lambda _: context)
+    monkeypatch.setattr(
+        core_client_module,
+        "get_zmq_socket",
+        lambda *_: _RecordingSocket(),
+    )
+
+    core_client_module.EngineCoreClient(
+        SimpleNamespace(
+            tokenizer_ipc_name="tcp://tokenizer",
+            scheduler_input_ipc_name="tcp://scheduler",
+            metrics_ipc_name="tcp://metrics",
+        )
+    )
+
+    assert context.metrics_socket.calls == [
+        ("setsockopt", zmq.RCVHWM, 1),
+        ("bind", "tcp://metrics"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_load_snapshot_loop_caches_and_forwards_only_accepted_snapshots():
+    accepted = _snapshot()
+    duplicate = _snapshot()
+    out_of_order = _snapshot(sequence=0)
+    invalid = _snapshot(sequence=2, num_used_pages=11)
+    sender = _RecordingSender()
+    llm = SimpleNamespace()
+    llm.load_snapshot_store = LoadSnapshotStore(dp_size=1)
+    llm.engine_core_client = SimpleNamespace(
+        recv_load_snapshot=_QueueReceiver([accepted, duplicate, out_of_order, invalid]),
+        send_to_scheduler=sender,
+    )
+    llm.server_args = SimpleNamespace(
+        mapping=SimpleNamespace(attn=SimpleNamespace(has_dp=True)),
+        load_balance_method="shortest_queue",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await SchedulerControlClient.load_snapshot_loop(llm)
+
+    assert llm.load_snapshot_store.project_loads() == [
+        GetLoadReqOutput(dp_rank=0, num_reqs=5, num_waiting_reqs=3, num_pages=5)
+    ]
+    assert sender.sent == [accepted]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("has_dp", "load_balance_method"),
+    [(False, "shortest_queue"), (True, "round_robin")],
+)
+async def test_load_snapshot_loop_does_not_forward_without_internal_dp_balancing(
+    has_dp, load_balance_method
+):
+    accepted = _snapshot()
+    sender = _RecordingSender()
+    llm = SimpleNamespace(
+        load_snapshot_store=LoadSnapshotStore(dp_size=1),
+        engine_core_client=SimpleNamespace(
+            recv_load_snapshot=_QueueReceiver([accepted]),
+            send_to_scheduler=sender,
+        ),
+        server_args=SimpleNamespace(
+            mapping=SimpleNamespace(attn=SimpleNamespace(has_dp=has_dp)),
+            load_balance_method=load_balance_method,
+        ),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await SchedulerControlClient.load_snapshot_loop(llm)
+
+    assert llm.load_snapshot_store.project_loads()[0].num_reqs == 5
+    assert sender.sent == []
+
+
+@pytest.mark.asyncio
+async def test_get_load_starts_receivers_and_projects_only_fresh_complete_cache():
+    calls = []
+    now = [0.0]
+    llm = SimpleNamespace(
+        load_snapshot_store=LoadSnapshotStore(dp_size=1, clock=lambda: now[0]),
+        auto_create_handle_loop=lambda: calls.append("started"),
+        engine_core_client=SimpleNamespace(
+            send_to_scheduler=SimpleNamespace(
+                send_pyobj=lambda _: pytest.fail("get_load must not poll the scheduler")
+            )
+        ),
+    )
+
+    assert await SchedulerControlClient.get_load(llm) == []
+    llm.load_snapshot_store.accept(_snapshot(valid_for_ms=1))
+
+    assert await SchedulerControlClient.get_load(llm) == [
+        GetLoadReqOutput(dp_rank=0, num_reqs=5, num_waiting_reqs=3, num_pages=5)
+    ]
+    now[0] = 0.002
+    assert await SchedulerControlClient.get_load(llm) == []
+    assert calls == ["started", "started", "started"]

--- a/test/runtime/test_async_llm_load_snapshot.py
+++ b/test/runtime/test_async_llm_load_snapshot.py
@@ -21,7 +21,12 @@ import pytest
 import zmq
 
 from tokenspeed.runtime.engine import core_client as core_client_module
-from tokenspeed.runtime.engine.io_struct import GetLoadReqOutput, LoadSnapshot
+from tokenspeed.runtime.engine import io_struct as io_struct_module
+from tokenspeed.runtime.engine.io_struct import (
+    GetLoadReqOutput,
+    LoadSnapshot,
+    MsgpackEncoder,
+)
 from tokenspeed.runtime.engine.load_snapshot import LoadSnapshotStore
 from tokenspeed.runtime.engine.scheduler_control_client import SchedulerControlClient
 
@@ -56,12 +61,25 @@ class _QueueReceiver:
         return self.values.pop(0)
 
 
+class _RawFrameSocket:
+    def __init__(self, frames) -> None:
+        self.frames = frames
+
+    async def recv_multipart(self, flags=0):
+        return self.frames
+
+
 class _RecordingSender:
     def __init__(self) -> None:
         self.sent = []
 
-    def send_pyobj(self, value) -> None:
+    async def send_pyobj(self, value) -> None:
         self.sent.append(value)
+
+
+class _FailingSender:
+    async def send_pyobj(self, value) -> None:
+        raise RuntimeError("snapshot forwarding failed")
 
 
 def _snapshot(**overrides) -> LoadSnapshot:
@@ -104,6 +122,17 @@ def test_engine_core_metrics_pull_keeps_only_the_newest_snapshot(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_metrics_receiver_decodes_msgpack_when_pickle_ipc_is_enabled(monkeypatch):
+    snapshot = _snapshot()
+    monkeypatch.setattr(io_struct_module, "USE_PICKLE_IPC", True)
+    receiver = core_client_module.AsyncLoadSnapshotReceiver(
+        _RawFrameSocket(MsgpackEncoder().encode(snapshot))
+    )
+
+    assert await receiver.recv_pyobj() == snapshot
+
+
+@pytest.mark.asyncio
 async def test_load_snapshot_loop_caches_and_forwards_only_accepted_snapshots():
     accepted = _snapshot()
     duplicate = _snapshot()
@@ -128,6 +157,25 @@ async def test_load_snapshot_loop_caches_and_forwards_only_accepted_snapshots():
         GetLoadReqOutput(dp_rank=0, num_reqs=5, num_waiting_reqs=3, num_pages=5)
     ]
     assert sender.sent == [accepted]
+    assert sender.sent[0] is accepted
+
+
+@pytest.mark.asyncio
+async def test_load_snapshot_loop_propagates_forwarding_failure():
+    llm = SimpleNamespace(
+        load_snapshot_store=LoadSnapshotStore(dp_size=1),
+        engine_core_client=SimpleNamespace(
+            recv_load_snapshot=_QueueReceiver([_snapshot()]),
+            send_to_scheduler=_FailingSender(),
+        ),
+        server_args=SimpleNamespace(
+            mapping=SimpleNamespace(attn=SimpleNamespace(has_dp=True)),
+            load_balance_method="shortest_queue",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="snapshot forwarding failed"):
+        await SchedulerControlClient.load_snapshot_loop(llm)
 
 
 @pytest.mark.asyncio

--- a/test/runtime/test_cache_pd_shutdown.py
+++ b/test/runtime/test_cache_pd_shutdown.py
@@ -64,6 +64,7 @@ class _EventLoopHarness:
         self._pause = _PauseHarness(self.trace)
         self.scheduler = _SchedulerHarness(self.trace)
         self.model_executor = _ModelExecutorHarness(self.trace)
+        self.output_processor = SimpleNamespace(rid_to_state={})
         self.has_dp = False
         self.kv_transfer = None
         self._pd_cache_enabled = False
@@ -97,6 +98,9 @@ class _EventLoopHarness:
         self.trace.append("stats")
         return object()
 
+    def _observe_load_snapshot(self, _stats) -> None:
+        self.trace.append("observe_load")
+
     def _record_scheduler_iteration_metrics(
         self, _stats, _num_iter_tokens: int
     ) -> None:
@@ -126,6 +130,7 @@ def test_event_loop_finishes_current_iteration_then_observes_shutdown() -> None:
         "submit_cache",
         "get_forward",
         "stats",
+        "observe_load",
         "pause_finish",
         "metrics",
     ]

--- a/test/runtime/test_data_parallel_controller_load.py
+++ b/test/runtime/test_data_parallel_controller_load.py
@@ -69,17 +69,21 @@ def snapshot(dp_rank: int, **overrides) -> LoadSnapshot:
 
 
 def make_controller(
-    *, clock: FakeClock | None = None, dp_size: int = 2
+    *,
+    clock: FakeClock | None = None,
+    dp_size: int = 2,
+    method: LoadBalanceMethod = LoadBalanceMethod.SHORTEST_QUEUE,
 ) -> DataParallelController:
     controller = DataParallelController.__new__(DataParallelController)
     controller.server_args = SimpleNamespace(disaggregation_mode="null")
     controller.workers = [RecordingWorker() for _ in range(dp_size)]
     controller.round_robin_counter = 0
-    controller.load_balance_method = LoadBalanceMethod.SHORTEST_QUEUE
+    controller.load_balance_method = method
     controller.dp_budget = DPBudget(controller.load_balance_method)
     controller.load_snapshot_store = LoadSnapshotStore(
         dp_size=dp_size, clock=clock or FakeClock()
     )
+    controller.load_snapshot_epochs = [None] * dp_size
     controller.dispatching = controller.budget_scheduler
     controller.init_dispatcher()
     return controller
@@ -164,3 +168,216 @@ def test_fresh_budget_is_not_rebuilt_on_every_dispatch():
 
     assert controller.workers[0].sent == [requests[2]]
     assert controller.workers[1].sent == requests[:2]
+
+
+def test_unchanged_heartbeat_does_not_replenish_consumed_budget():
+    controller = make_controller()
+    controller.round_robin_counter = 1
+    requests = [object(), object(), object()]
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=0))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=2))
+
+    controller.budget_scheduler(requests[0])
+    controller.handle_load_snapshot(snapshot(0, sequence=2, num_running_reqs=0))
+    controller.budget_scheduler(requests[1])
+    controller.budget_scheduler(requests[2])
+
+    assert controller.workers[0].sent == requests[:2]
+    assert controller.workers[1].sent == [requests[2]]
+
+
+def test_policy_irrelevant_snapshot_change_preserves_consumed_budget():
+    controller = make_controller()
+    controller.round_robin_counter = 1
+    requests = [object(), object(), object()]
+    controller.handle_load_snapshot(
+        snapshot(0, num_running_reqs=0, num_active_pages=10, num_used_pages=20)
+    )
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=2))
+
+    controller.budget_scheduler(requests[0])
+    controller.handle_load_snapshot(
+        snapshot(
+            0,
+            sequence=2,
+            num_running_reqs=0,
+            num_active_pages=11,
+            num_used_pages=21,
+        )
+    )
+    controller.budget_scheduler(requests[1])
+    controller.budget_scheduler(requests[2])
+
+    assert controller.workers[0].sent == requests[:2]
+    assert controller.workers[1].sent == [requests[2]]
+
+
+def test_rank_update_preserves_other_rank_reservations():
+    controller = make_controller()
+    controller.round_robin_counter = 1
+    requests = [object(), object(), object(), object()]
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=0))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=2))
+
+    controller.budget_scheduler(requests[0])
+    controller.handle_load_snapshot(snapshot(1, sequence=2, num_running_reqs=3))
+    for request in requests[1:]:
+        controller.budget_scheduler(request)
+
+    assert controller.workers[0].sent == requests[:3]
+    assert controller.workers[1].sent == [requests[3]]
+
+
+def test_shortest_queue_increase_consumes_only_reflected_reservations():
+    controller = make_controller()
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=0))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=10))
+    assert [controller.dp_budget.dispatch() for _ in range(5)] == [0] * 5
+
+    controller.handle_load_snapshot(snapshot(0, sequence=2, num_running_reqs=1))
+
+    assert [controller.dp_budget.dispatch() for _ in range(6)] == [
+        0,
+        0,
+        0,
+        0,
+        0,
+        None,
+    ]
+
+
+def test_minimum_cache_request_increase_consumes_only_reflected_reservations():
+    controller = make_controller(method=LoadBalanceMethod.MINIMUM_CACHE_USAGE)
+    controller.handle_load_snapshot(snapshot(0, num_used_pages=0))
+    controller.handle_load_snapshot(snapshot(1, num_used_pages=10))
+    assert [controller.dp_budget.dispatch() for _ in range(5)] == [0] * 5
+
+    controller.handle_load_snapshot(
+        snapshot(0, sequence=2, num_running_reqs=1, num_used_pages=0)
+    )
+
+    assert [controller.dp_budget.dispatch() for _ in range(7)] == [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        None,
+    ]
+
+
+def test_minimum_cache_page_growth_does_not_acknowledge_request_reservations():
+    controller = make_controller(method=LoadBalanceMethod.MINIMUM_CACHE_USAGE)
+    controller.handle_load_snapshot(snapshot(0, num_used_pages=0))
+    controller.handle_load_snapshot(snapshot(1, num_used_pages=10))
+    assert [controller.dp_budget.dispatch() for _ in range(5)] == [0] * 5
+
+    controller.handle_load_snapshot(snapshot(0, sequence=2, num_used_pages=5))
+
+    assert controller.dp_budget.dispatch() is None
+
+
+def test_reported_metric_decrease_preserves_speculative_reservations():
+    controller = make_controller()
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=5))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=15))
+    assert [controller.dp_budget.dispatch() for _ in range(5)] == [0] * 5
+
+    controller.handle_load_snapshot(snapshot(0, sequence=2, num_running_reqs=4))
+
+    assert [controller.dp_budget.dispatch() for _ in range(7)] == [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        None,
+    ]
+
+
+def test_epoch_switch_resets_only_the_publishing_rank_reservation():
+    clock = FakeClock()
+    controller = make_controller(clock=clock, dp_size=3)
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=0))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=0, valid_for_ms=5_000))
+    controller.handle_load_snapshot(snapshot(2, num_running_reqs=3, valid_for_ms=5_000))
+    assert [controller.dp_budget.dispatch() for _ in range(2)] == [0, 1]
+
+    clock.advance(1.001)
+    controller.handle_load_snapshot(snapshot(0, epoch="boot-b", num_running_reqs=0))
+
+    assert [controller.dp_budget.dispatch() for _ in range(6)] == [
+        0,
+        0,
+        1,
+        0,
+        1,
+        None,
+    ]
+
+
+def test_minimum_cache_usage_preserves_budget_across_heartbeat_and_queue_change():
+    controller = make_controller(method=LoadBalanceMethod.MINIMUM_CACHE_USAGE)
+    controller.round_robin_counter = 1
+    requests = [object(), object(), object(), object(), object()]
+    controller.handle_load_snapshot(
+        snapshot(
+            0,
+            num_running_reqs=100,
+            num_active_pages=5,
+            num_used_pages=10,
+        )
+    )
+    controller.handle_load_snapshot(
+        snapshot(
+            1,
+            num_running_reqs=0,
+            num_active_pages=7,
+            num_used_pages=13,
+        )
+    )
+
+    controller.budget_scheduler(requests[0])
+    controller.handle_load_snapshot(
+        snapshot(
+            0,
+            sequence=2,
+            num_running_reqs=100,
+            num_active_pages=5,
+            num_used_pages=10,
+        )
+    )
+    controller.budget_scheduler(requests[1])
+    controller.handle_load_snapshot(
+        snapshot(
+            0,
+            sequence=3,
+            num_running_reqs=101,
+            num_active_pages=8,
+            num_used_pages=10,
+        )
+    )
+    for request in requests[2:]:
+        controller.budget_scheduler(request)
+
+    assert controller.workers[0].sent == requests[:4]
+    assert controller.workers[1].sent == [requests[4]]
+
+
+def test_stale_minimum_cache_usage_state_falls_back_to_round_robin():
+    clock = FakeClock()
+    controller = make_controller(
+        clock=clock, method=LoadBalanceMethod.MINIMUM_CACHE_USAGE
+    )
+    controller.round_robin_counter = 1
+    request = object()
+    controller.handle_load_snapshot(snapshot(0, num_used_pages=0))
+    controller.handle_load_snapshot(snapshot(1, num_used_pages=2))
+    clock.advance(1.001)
+
+    controller.budget_scheduler(request)
+
+    assert controller.workers[0].sent == []
+    assert controller.workers[1].sent == [request]

--- a/test/runtime/test_data_parallel_controller_load.py
+++ b/test/runtime/test_data_parallel_controller_load.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for DP routing from scheduler-published load snapshots."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tokenspeed.runtime.engine.data_parallel_controller import (
+    DataParallelController,
+    DPBudget,
+    LoadBalanceMethod,
+)
+from tokenspeed.runtime.engine.io_struct import GetLoadReqOutput, LoadSnapshot
+from tokenspeed.runtime.engine.load_snapshot import LoadSnapshotStore
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class RecordingWorker:
+    def __init__(self) -> None:
+        self.sent = []
+
+    def send_pyobj(self, value) -> None:
+        self.sent.append(value)
+
+
+def snapshot(dp_rank: int, **overrides) -> LoadSnapshot:
+    fields = dict(
+        epoch="boot-a",
+        sequence=1,
+        dp_rank=dp_rank,
+        num_running_reqs=0,
+        num_waiting_reqs=0,
+        num_active_pages=0,
+        num_used_pages=0,
+        max_total_pages=100,
+        valid_for_ms=1_000,
+    )
+    fields.update(overrides)
+    return LoadSnapshot(**fields)
+
+
+def make_controller(
+    *, clock: FakeClock | None = None, dp_size: int = 2
+) -> DataParallelController:
+    controller = DataParallelController.__new__(DataParallelController)
+    controller.server_args = SimpleNamespace(disaggregation_mode="null")
+    controller.workers = [RecordingWorker() for _ in range(dp_size)]
+    controller.round_robin_counter = 0
+    controller.load_balance_method = LoadBalanceMethod.SHORTEST_QUEUE
+    controller.dp_budget = DPBudget(controller.load_balance_method)
+    controller.load_snapshot_store = LoadSnapshotStore(
+        dp_size=dp_size, clock=clock or FakeClock()
+    )
+    controller.dispatching = controller.budget_scheduler
+    controller.init_dispatcher()
+    return controller
+
+
+def test_snapshot_is_consumed_locally_and_never_broadcast():
+    controller = make_controller()
+
+    controller._request_dispatcher(snapshot(0))
+
+    assert controller.load_snapshot_store.fresh_snapshots() == [snapshot(0)]
+    assert [worker.sent for worker in controller.workers] == [[], []]
+
+
+def test_complete_fresh_snapshots_route_from_shortest_queue_budget():
+    controller = make_controller()
+    request = object()
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=0))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=2))
+
+    controller.budget_scheduler(request)
+
+    assert controller.workers[0].sent == [request]
+    assert controller.workers[1].sent == []
+
+
+def test_partial_snapshot_set_clears_old_budget_and_falls_back_to_round_robin():
+    controller = make_controller()
+    request = object()
+    controller.dp_budget.update_budget(
+        [
+            GetLoadReqOutput(dp_rank=0, num_reqs=2),
+            GetLoadReqOutput(dp_rank=1, num_reqs=0),
+        ]
+    )
+
+    controller.handle_load_snapshot(snapshot(0))
+    controller.budget_scheduler(request)
+
+    assert controller.workers[0].sent == [request]
+    assert controller.workers[1].sent == []
+
+
+def test_expired_snapshot_set_clears_budget_and_falls_back_to_round_robin():
+    clock = FakeClock()
+    controller = make_controller(clock=clock)
+    request = object()
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=2))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=0))
+    clock.advance(1.001)
+
+    controller.budget_scheduler(request)
+
+    assert controller.workers[0].sent == [request]
+    assert controller.workers[1].sent == []
+
+
+def test_duplicate_and_out_of_order_snapshots_do_not_replace_current_budget():
+    controller = make_controller()
+    first_request = object()
+    second_request = object()
+    controller.handle_load_snapshot(snapshot(0, sequence=2, num_running_reqs=0))
+    controller.handle_load_snapshot(snapshot(1, sequence=2, num_running_reqs=2))
+
+    controller.handle_load_snapshot(snapshot(0, sequence=2, num_running_reqs=100))
+    controller.handle_load_snapshot(snapshot(0, sequence=1, num_running_reqs=100))
+    controller.budget_scheduler(first_request)
+    controller.budget_scheduler(second_request)
+
+    assert controller.workers[0].sent == [first_request, second_request]
+    assert controller.workers[1].sent == []
+
+
+def test_fresh_budget_is_not_rebuilt_on_every_dispatch():
+    controller = make_controller()
+    requests = [object(), object(), object()]
+    controller.handle_load_snapshot(snapshot(0, num_running_reqs=2))
+    controller.handle_load_snapshot(snapshot(1, num_running_reqs=0))
+
+    for request in requests:
+        controller.budget_scheduler(request)
+
+    assert controller.workers[0].sent == [requests[2]]
+    assert controller.workers[1].sent == requests[:2]

--- a/test/runtime/test_io_struct_codec.py
+++ b/test/runtime/test_io_struct_codec.py
@@ -67,6 +67,7 @@ from tokenspeed.runtime.engine.io_struct import (
     IsSchedulerPausedReqOutput,
     IsSleepingReqInput,
     IsSleepingReqOutput,
+    LoadSnapshot,
     MsgpackDecoder,
     MsgpackEncoder,
     OpenSessionReqInput,
@@ -118,6 +119,16 @@ def _roundtrip(obj):
     enc = MsgpackEncoder()
     dec = MsgpackDecoder(ipc_message_union())
     return dec.decode(enc.encode(obj))
+
+
+def test_load_snapshot_round_trips_as_one_tagged_frame():
+    """The scheduler snapshot stays a standalone, single-frame IPC message."""
+    snapshot = LoadSnapshot("boot-a", 1, 0, 2, 3, 4, 5, 6, 1_000)
+
+    frames = MsgpackEncoder().encode(snapshot)
+
+    assert len(frames) == 1
+    assert _roundtrip(snapshot) == snapshot
 
 
 def _batch_token_id_out(**overrides) -> BatchTokenIDOut:

--- a/test/runtime/test_io_struct_codec.py
+++ b/test/runtime/test_io_struct_codec.py
@@ -54,7 +54,6 @@ from tokenspeed.runtime.engine.io_struct import (
     FlushCacheReqOutput,
     GetInternalStateReq,
     GetInternalStateReqOutput,
-    GetLoadReqInput,
     GetLoadReqOutput,
     GetWeightsByNameReqInput,
     GetWeightsByNameReqOutput,
@@ -97,7 +96,6 @@ from tokenspeed.runtime.engine.io_struct import (
     UpdateWeightsFromDistributedReqOutput,
     UpdateWeightsFromTensorReqInput,
     UpdateWeightsFromTensorReqOutput,
-    WatchLoadUpdateReq,
     ipc_message_union,
 )
 from tokenspeed.runtime.sampling.sampling_params import (
@@ -227,9 +225,7 @@ _MESSAGES = [
     HealthCheckOutput(),
     RpcReqInput(method="save", parameters={"p": 1}),
     RpcReqOutput(success=True, message=""),
-    GetLoadReqInput(),
     GetLoadReqOutput(dp_rank=1, num_reqs=2, num_waiting_reqs=1, num_pages=3),
-    WatchLoadUpdateReq(loads=[GetLoadReqOutput(dp_rank=0, num_reqs=5)]),
     BlockReqInput(type=BlockReqType.UNBLOCK),
     _batch_token_id_out(),
     BatchStrOut(

--- a/test/runtime/test_load_snapshot.py
+++ b/test/runtime/test_load_snapshot.py
@@ -49,6 +49,18 @@ class FakeClock:
         self.now += seconds
 
 
+class CountingClock(FakeClock):
+    """A controllable clock that records each monotonic-time read."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.reads = 0
+
+    def __call__(self) -> float:
+        self.reads += 1
+        return super().__call__()
+
+
 class RecordingContext:
     """Record publisher lifecycle calls and the threads that made them."""
 
@@ -384,6 +396,100 @@ def test_event_loop_observation_projects_the_sampled_scheduler_values():
 
 
 @pytest.mark.parametrize(
+    "has_overlap_result",
+    [False, True],
+    ids=["non_overlap_post_finish", "overlap_commit"],
+)
+def test_paused_idle_step_refreshes_load_after_optional_overlap_commit(
+    monkeypatch, has_overlap_result
+):
+    """The first paused step observes post-finish CPU scheduler state once."""
+    pytest.importorskip("tokenspeed_scheduler")
+    from tokenspeed.runtime.engine import event_loop as event_loop_module
+
+    trace = []
+    scheduler_state = {"available": 20, "active": 0, "waiting": 0}
+    loop = event_loop_module.EventLoop.__new__(event_loop_module.EventLoop)
+    loop.scheduler = SimpleNamespace(
+        available_kv_pages=lambda: (
+            trace.append("available"),
+            scheduler_state["available"],
+        )[1],
+        active_kv_pages=lambda: (
+            trace.append("active"),
+            scheduler_state["active"],
+        )[1],
+        waiting_size=lambda: (
+            trace.append("waiting"),
+            scheduler_state["waiting"],
+        )[1],
+    )
+    loop.output_processor = SimpleNamespace(rid_to_state={})
+    loop._scheduler_cache_geometry = SimpleNamespace(num_usable_pages=20)
+    loop.attn_tp_rank = 0
+    loop._load_snapshot_observed_while_paused = False
+    loop.load_snapshot_publisher = SimpleNamespace(
+        observe=lambda values: trace.append(("observe", values))
+    )
+    loop.has_dp = False
+    loop._pause = SimpleNamespace(
+        maybe_finish_drain=lambda scheduler: trace.append("drain")
+    )
+    loop._publish_scheduler_kv_events = lambda: trace.append("kv_events")
+    monkeypatch.setattr(
+        event_loop_module,
+        "advance_forward",
+        lambda scheduler, changes: trace.append(("advance", changes)),
+    )
+    monkeypatch.setattr(
+        event_loop_module.time, "sleep", lambda seconds: trace.append("sleep")
+    )
+
+    prev_forward_op = None
+    prev_results = None
+    if has_overlap_result:
+        loop.output_processor.rid_to_state["finished"] = object()
+        scheduler_state.update(available=16, active=4, waiting=1)
+
+        def commit_results(forward_op, results):
+            trace.append("commit")
+            loop.output_processor.rid_to_state.clear()
+            scheduler_state.update(available=20, active=0, waiting=0)
+            return ["finished"]
+
+        loop._commit_forward_results = commit_results
+        prev_forward_op = object()
+        prev_results = object()
+
+    loop._paused_idle_step(prev_forward_op, prev_results)
+    loop._paused_idle_step()
+    scheduler_state.update(available=18, active=2, waiting=1)
+    loop._mark_load_snapshot_dirty()
+    loop._paused_idle_step()
+
+    expected_prefix = (
+        ["commit", ("advance", ["finished"]), "kv_events"] if has_overlap_result else []
+    )
+    assert trace == [
+        *expected_prefix,
+        "available",
+        "active",
+        "waiting",
+        ("observe", (0, 0, 0, 0, 20)),
+        "drain",
+        "sleep",
+        "drain",
+        "sleep",
+        "available",
+        "active",
+        "waiting",
+        ("observe", (0, 1, 2, 2, 20)),
+        "drain",
+        "sleep",
+    ]
+
+
+@pytest.mark.parametrize(
     ("attn_tp_rank", "zmq_msgpack", "expected_sink"),
     [
         (0, False, "publisher"),
@@ -455,16 +561,42 @@ def test_load_snapshot_is_immutable_and_positional():
         snapshot.sequence = 2
 
 
-def test_store_rejects_duplicate_and_retired_epoch_without_refreshing_age():
-    """Duplicate and retired messages cannot revive stale rank state."""
+def test_store_switches_epoch_only_after_expiry_and_rejects_delayed_epochs():
+    """A fresh live epoch cannot be rolled back by delayed producer messages."""
     clock = FakeClock()
     store = LoadSnapshotStore(dp_size=1, clock=clock)
 
     assert store.accept(make_snapshot(epoch="a", sequence=1))
     clock.advance(0.1)
     assert not store.accept(make_snapshot(epoch="a", sequence=1))
+    assert not store.accept(make_snapshot(epoch="b", sequence=1))
+
+    clock.advance(0.901)
+
     assert store.accept(make_snapshot(epoch="b", sequence=1))
+    assert not store.accept(make_snapshot(epoch="c", sequence=1))
+    assert store.accept(make_snapshot(epoch="b", sequence=2))
     assert not store.accept(make_snapshot(epoch="a", sequence=2))
+    assert [(item.epoch, item.sequence) for item in store.fresh_snapshots()] == [
+        ("b", 2)
+    ]
+
+
+def test_store_epoch_expiry_boundary_uses_one_clock_read_per_accept():
+    """Epoch takeover and receipt use one deterministic local-time sample."""
+    clock = CountingClock()
+    store = LoadSnapshotStore(dp_size=1, clock=clock)
+
+    assert store.accept(make_snapshot(epoch="a", sequence=1))
+    assert clock.reads == 1
+
+    clock.advance(VALID_FOR_SECONDS)
+    assert not store.accept(make_snapshot(epoch="b", sequence=1))
+    assert clock.reads == 2
+
+    clock.advance(0.001)
+    assert store.accept(make_snapshot(epoch="b", sequence=1))
+    assert clock.reads == 3
 
 
 def test_store_rejects_non_increasing_sequence_in_current_epoch():

--- a/test/runtime/test_load_snapshot.py
+++ b/test/runtime/test_load_snapshot.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the scheduler-published load snapshot cache contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from tokenspeed.runtime.engine.io_struct import LoadSnapshot
+from tokenspeed.runtime.engine.load_snapshot import LoadSnapshotStore
+
+VALID_FOR_SECONDS = 1.0
+
+
+class FakeClock:
+    """A controllable monotonic clock for cache expiry behavior."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def make_snapshot(**overrides) -> LoadSnapshot:
+    fields = dict(
+        epoch="boot-a",
+        sequence=1,
+        dp_rank=0,
+        num_running_reqs=2,
+        num_waiting_reqs=3,
+        num_active_pages=4,
+        num_used_pages=5,
+        max_total_pages=10,
+        valid_for_ms=int(VALID_FOR_SECONDS * 1_000),
+    )
+    fields.update(overrides)
+    return LoadSnapshot(**fields)
+
+
+def test_load_snapshot_is_immutable_and_positional():
+    """Snapshots cannot be mutated after their wire values are assigned."""
+    snapshot = LoadSnapshot("boot-a", 1, 0, 2, 3, 4, 5, 10, 1_000)
+
+    with pytest.raises(AttributeError):
+        snapshot.sequence = 2
+
+
+def test_store_rejects_duplicate_and_retired_epoch_without_refreshing_age():
+    """Duplicate and retired messages cannot revive stale rank state."""
+    clock = FakeClock()
+    store = LoadSnapshotStore(dp_size=1, clock=clock)
+
+    assert store.accept(make_snapshot(epoch="a", sequence=1))
+    clock.advance(0.1)
+    assert not store.accept(make_snapshot(epoch="a", sequence=1))
+    assert store.accept(make_snapshot(epoch="b", sequence=1))
+    assert not store.accept(make_snapshot(epoch="a", sequence=2))
+
+
+def test_store_rejects_non_increasing_sequence_in_current_epoch():
+    """Only strictly newer versions can replace a rank's current epoch."""
+    store = LoadSnapshotStore(dp_size=1, clock=FakeClock())
+
+    assert store.accept(make_snapshot(sequence=2))
+    assert not store.accept(make_snapshot(sequence=2))
+    assert not store.accept(make_snapshot(sequence=1))
+    assert store.accept(make_snapshot(sequence=3))
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"dp_rank": -1},
+        {"dp_rank": 2},
+        {"sequence": -1},
+        {"num_running_reqs": -1},
+        {"num_waiting_reqs": -1},
+        {"num_active_pages": -1},
+        {"num_used_pages": -1},
+        {"max_total_pages": 0},
+        {"num_active_pages": 11},
+        {"num_used_pages": 11},
+        {"valid_for_ms": -1},
+    ],
+)
+def test_store_rejects_invalid_snapshot_values(overrides):
+    """Malformed values never enter the replica cache."""
+    store = LoadSnapshotStore(dp_size=2, clock=FakeClock())
+
+    assert not store.accept(make_snapshot(**overrides))
+    assert store.fresh_snapshots() == []
+
+
+def test_store_projects_only_a_complete_fresh_rank_set():
+    """Public loads stay unavailable until every rank has a live snapshot."""
+    clock = FakeClock()
+    store = LoadSnapshotStore(dp_size=2, clock=clock)
+
+    assert store.project_loads() == []
+    assert store.accept(make_snapshot(dp_rank=0))
+    assert store.project_loads() == []
+    assert store.accept(make_snapshot(dp_rank=1))
+    loads = store.project_loads()
+    assert [load.dp_rank for load in loads] == [0, 1]
+    assert [(load.num_reqs, load.num_waiting_reqs, load.num_pages) for load in loads] == [
+        (5, 3, 5),
+        (5, 3, 5),
+    ]
+
+    clock.advance(VALID_FOR_SECONDS + 0.001)
+
+    assert not store.is_complete_fresh()
+    assert store.fresh_snapshots() == []
+    assert store.project_loads() == []
+
+
+def test_store_projection_checks_completeness_at_one_clock_read():
+    """A rank expiring during projection cannot leak a partial public result."""
+    reads = iter((0.0, 0.5, 0.999, 1.001))
+    store = LoadSnapshotStore(dp_size=2, clock=lambda: next(reads))
+
+    assert store.accept(make_snapshot(dp_rank=0))
+    assert store.accept(make_snapshot(dp_rank=1))
+
+    assert [load.dp_rank for load in store.project_loads()] == [0, 1]
+
+
+def test_store_uses_local_receipt_time_and_does_not_refresh_rejection_age():
+    """Only accepted messages extend a snapshot's locally measured lifetime."""
+    clock = FakeClock()
+    store = LoadSnapshotStore(dp_size=1, clock=clock)
+
+    assert store.accept(make_snapshot())
+    clock.advance(0.9)
+    assert not store.accept(make_snapshot())
+    clock.advance(0.101)
+
+    assert store.fresh_snapshots() == []
+
+
+def test_store_rejects_non_positive_dp_size():
+    """A store must have at least one rank to form a complete replica."""
+    with pytest.raises(ValueError, match="dp_size"):
+        LoadSnapshotStore(dp_size=0)

--- a/test/runtime/test_load_snapshot.py
+++ b/test/runtime/test_load_snapshot.py
@@ -350,12 +350,18 @@ def test_publisher_setup_failure_cleans_partial_resources_on_owner_thread(
 
 
 def test_event_loop_observation_projects_the_sampled_scheduler_values():
-    """The shared helper maps the existing sample without another query."""
+    """The shared helper makes one observation without consulting an adapter."""
     pytest.importorskip("tokenspeed_scheduler")
     from tokenspeed.runtime.engine.event_loop import EventLoop
 
+    class StandardObservationLoop(EventLoop):
+        def __getattribute__(self, name):
+            if name == "send_to_tokenizer":
+                raise AssertionError("standard observation consulted output adapter")
+            return super().__getattribute__(name)
+
     observed = []
-    loop = EventLoop.__new__(EventLoop)
+    loop = StandardObservationLoop.__new__(StandardObservationLoop)
     loop.load_snapshot_publisher = SimpleNamespace(
         observe=lambda values: observed.append(values)
     )
@@ -378,29 +384,46 @@ def test_event_loop_observation_projects_the_sampled_scheduler_values():
 
 
 @pytest.mark.parametrize(
-    ("attn_tp_rank", "zmq_msgpack", "should_publish"),
-    [(0, False, True), (1, False, False), (0, True, False)],
+    ("attn_tp_rank", "zmq_msgpack", "expected_sink"),
+    [
+        (0, False, "publisher"),
+        (1, False, "null"),
+        (0, True, "direct"),
+        (1, True, "null"),
+    ],
 )
-def test_event_loop_publisher_is_gated_to_standard_serving_tp0(
-    monkeypatch, attn_tp_rank, zmq_msgpack, should_publish
+def test_event_loop_selects_load_snapshot_sink_once_for_each_mode(
+    monkeypatch, attn_tp_rank, zmq_msgpack, expected_sink
 ):
-    """Non-TP0 and direct-ZMQ engines never open the internal PUSH socket."""
+    """Only standard TP0 opens PUSH; direct TP0 binds its output setter."""
     pytest.importorskip("tokenspeed_scheduler")
     from tokenspeed.runtime.engine import event_loop as event_loop_module
 
-    created = []
+    created_publishers = []
+    direct_setters = []
 
     class FakePublisher:
         def __init__(self, endpoint, dp_rank, heartbeat_interval):
-            created.append((endpoint, dp_rank, heartbeat_interval))
+            created_publishers.append((endpoint, dp_rank, heartbeat_interval))
 
         def observe(self, values):
-            raise AssertionError(values)
+            return None
 
         def close(self):
-            raise AssertionError("unused fake publisher was closed")
+            return None
+
+    class FakeDirectSink:
+        def __init__(self, setter):
+            direct_setters.append(setter)
+
+        def observe(self, values):
+            return None
+
+        def close(self):
+            return None
 
     monkeypatch.setattr(event_loop_module, "LoadSnapshotPublisher", FakePublisher)
+    monkeypatch.setattr(event_loop_module, "DirectLoadSnapshotSink", FakeDirectSink)
     loop = event_loop_module.EventLoop.__new__(event_loop_module.EventLoop)
     loop.attn_tp_rank = attn_tp_rank
     loop.dp_rank = 4
@@ -408,13 +431,20 @@ def test_event_loop_publisher_is_gated_to_standard_serving_tp0(
         zmq_msgpack=zmq_msgpack, load_watch_interval=0.25
     )
     loop.port_args = SimpleNamespace(metrics_ipc_name="tcp://metrics")
+    set_load_snapshot = lambda *values: None
+    loop.send_to_tokenizer = SimpleNamespace(set_load_snapshot=set_load_snapshot)
 
     loop._init_load_snapshot_publisher()
 
-    assert created == ([("tcp://metrics", 4, 0.25)] if should_publish else [])
-    if not should_publish:
-        loop.load_snapshot_publisher.observe(observed_tuple())
-        loop.load_snapshot_publisher.close()
+    assert created_publishers == (
+        [("tcp://metrics", 4, 0.25)] if expected_sink == "publisher" else []
+    )
+    assert direct_setters == ([set_load_snapshot] if expected_sink == "direct" else [])
+    if expected_sink == "null":
+        assert isinstance(
+            loop.load_snapshot_publisher,
+            event_loop_module.NullLoadSnapshotPublisher,
+        )
 
 
 def test_load_snapshot_is_immutable_and_positional():

--- a/test/runtime/test_load_snapshot.py
+++ b/test/runtime/test_load_snapshot.py
@@ -22,9 +22,15 @@
 
 from __future__ import annotations
 
-import pytest
+import threading
+import time
+from types import SimpleNamespace
 
-from tokenspeed.runtime.engine.io_struct import LoadSnapshot
+import pytest
+import zmq
+
+from tokenspeed.runtime.engine import load_snapshot as load_snapshot_module
+from tokenspeed.runtime.engine.io_struct import LoadSnapshot, MsgpackDecoder
 from tokenspeed.runtime.engine.load_snapshot import LoadSnapshotStore
 
 VALID_FOR_SECONDS = 1.0
@@ -43,6 +49,108 @@ class FakeClock:
         self.now += seconds
 
 
+class RecordingContext:
+    """Record publisher lifecycle calls and the threads that made them."""
+
+    def __init__(self, socket) -> None:
+        self.socket_value = socket
+        self.calls = []
+
+    def socket(self, socket_type):
+        self.calls.append(("socket", threading.get_ident(), socket_type))
+        return self.socket_value
+
+    def term(self) -> None:
+        self.calls.append(("term", threading.get_ident()))
+
+
+class RecordingSocket:
+    """A minimal PUSH socket double that decodes successfully sent frames."""
+
+    def __init__(
+        self, failures: int = 0, failure_gate: threading.Event | None = None
+    ) -> None:
+        self.failures = failures
+        self.failure_gate = failure_gate
+        self.calls = []
+        self.decoded_snapshots = []
+        self.send_attempted = threading.Event()
+        self._decoder = MsgpackDecoder(LoadSnapshot)
+
+    def setsockopt(self, option, value) -> None:
+        self.calls.append(("setsockopt", threading.get_ident(), option, value))
+
+    def connect(self, endpoint: str) -> None:
+        self.calls.append(("connect", threading.get_ident(), endpoint))
+
+    def send(self, frame, flags=0) -> None:
+        self.calls.append(("send", threading.get_ident(), flags))
+        self.send_attempted.set()
+        if self.failures:
+            self.failures -= 1
+            if self.failure_gate is not None:
+                self.failure_gate.wait(timeout=2.0)
+            raise zmq.Again()
+        self.decoded_snapshots.append(self._decoder.decode(frame))
+
+    def close(self, linger=None) -> None:
+        self.calls.append(("close", threading.get_ident(), linger))
+
+
+def wait_until(predicate, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.005)
+    raise AssertionError("condition was not met before timeout")
+
+
+def observed_values(**overrides) -> dict:
+    values = dict(
+        num_running_reqs=1,
+        num_waiting_reqs=2,
+        num_active_pages=3,
+        num_used_pages=4,
+        max_total_pages=10,
+    )
+    values.update(overrides)
+    return values
+
+
+def observed_tuple(**overrides) -> tuple[int, int, int, int, int]:
+    values = observed_values(**overrides)
+    return (
+        values["num_running_reqs"],
+        values["num_waiting_reqs"],
+        values["num_active_pages"],
+        values["num_used_pages"],
+        values["max_total_pages"],
+    )
+
+
+def start_publisher(
+    socket: RecordingSocket,
+    *,
+    heartbeat_interval: float = 60.0,
+    factory_gate: threading.Event | None = None,
+):
+    context = RecordingContext(socket)
+
+    def socket_factory(endpoint):
+        if factory_gate is not None:
+            factory_gate.wait(timeout=2.0)
+        return context, socket
+
+    publisher = load_snapshot_module.LoadSnapshotPublisher(
+        "tcp://load-snapshots",
+        dp_rank=2,
+        heartbeat_interval=heartbeat_interval,
+        socket_factory=socket_factory,
+    )
+    return publisher, context
+
+
 def make_snapshot(**overrides) -> LoadSnapshot:
     fields = dict(
         epoch="boot-a",
@@ -57,6 +165,210 @@ def make_snapshot(**overrides) -> LoadSnapshot:
     )
     fields.update(overrides)
     return LoadSnapshot(**fields)
+
+
+def test_changed_values_replace_one_slot_without_waiting_for_interval():
+    """A blocked publisher sends only the newest changed scheduler sample."""
+    factory_gate = threading.Event()
+    socket = RecordingSocket()
+    publisher, _ = start_publisher(socket, factory_gate=factory_gate)
+    try:
+        publisher.observe(observed_tuple(num_running_reqs=1))
+        publisher.observe(observed_tuple(num_running_reqs=2))
+        factory_gate.set()
+
+        wait_until(lambda: len(socket.decoded_snapshots) == 1)
+
+        assert socket.decoded_snapshots[0].num_running_reqs == 2
+        assert socket.decoded_snapshots[0].sequence == 1
+    finally:
+        factory_gate.set()
+        publisher.close()
+
+
+def test_publisher_observe_accepts_one_scalar_tuple():
+    """The scheduler boundary accepts one cheap, immutable scalar value tuple."""
+    socket = RecordingSocket()
+    publisher, _ = start_publisher(socket)
+    try:
+        publisher.observe(observed_tuple())
+        wait_until(lambda: socket.decoded_snapshots)
+
+        assert socket.decoded_snapshots[0].num_running_reqs == 1
+    finally:
+        publisher.close()
+
+
+def test_publisher_observe_does_not_encode_or_touch_zmq(monkeypatch):
+    """Scheduler observation performs only guarded scalar mailbox work."""
+    factory_gate = threading.Event()
+    socket = RecordingSocket()
+    encode_threads = []
+    real_encode = load_snapshot_module.MsgpackEncoder.encode
+
+    def record_encode(self, snapshot):
+        encode_threads.append(threading.get_ident())
+        return real_encode(self, snapshot)
+
+    monkeypatch.setattr(load_snapshot_module.MsgpackEncoder, "encode", record_encode)
+    publisher, context = start_publisher(socket, factory_gate=factory_gate)
+    caller_thread = threading.get_ident()
+    try:
+        publisher.observe(observed_tuple())
+        assert encode_threads == []
+        assert socket.calls == []
+
+        factory_gate.set()
+        wait_until(lambda: socket.decoded_snapshots)
+
+        assert publisher.socket_owner_thread != caller_thread
+        assert set(encode_threads) == {publisher.socket_owner_thread}
+        assert {call[1] for call in socket.calls if call[0] != "close"} == {
+            publisher.socket_owner_thread
+        }
+        assert context.calls == []
+    finally:
+        factory_gate.set()
+        publisher.close()
+
+
+def test_unchanged_values_only_emit_a_heartbeat():
+    """An unchanged observation is quiet until the one-second heartbeat."""
+    socket = RecordingSocket()
+    publisher, _ = start_publisher(socket, heartbeat_interval=0.01)
+    try:
+        publisher.observe(observed_tuple())
+        wait_until(lambda: len(socket.decoded_snapshots) == 1)
+
+        publisher.observe(observed_tuple())
+        time.sleep(0.05)
+        assert len(socket.decoded_snapshots) == 1
+
+        wait_until(lambda: len(socket.decoded_snapshots) == 2, timeout=1.5)
+        first, heartbeat = socket.decoded_snapshots
+        assert (first.sequence, heartbeat.sequence) == (1, 2)
+        assert heartbeat.valid_for_ms == 3_000
+    finally:
+        publisher.close()
+
+
+def test_publisher_retry_is_replaced_by_newest_changed_values():
+    """A nonblocking send failure cannot preserve stale data over a new sample."""
+    failure_gate = threading.Event()
+    socket = RecordingSocket(failures=1, failure_gate=failure_gate)
+    publisher, _ = start_publisher(socket)
+    try:
+        publisher.observe(observed_tuple(num_running_reqs=1))
+        assert socket.send_attempted.wait(timeout=1.0)
+        publisher.observe(observed_tuple(num_running_reqs=7))
+        failure_gate.set()
+
+        wait_until(lambda: socket.decoded_snapshots)
+
+        assert socket.decoded_snapshots[0].num_running_reqs == 7
+        assert socket.decoded_snapshots[0].sequence == 2
+    finally:
+        failure_gate.set()
+        publisher.close()
+
+
+def test_publisher_default_socket_has_bounded_thread_owned_lifecycle(monkeypatch):
+    """The publisher thread creates, configures, uses, and closes its own socket."""
+    caller_thread = threading.get_ident()
+    socket = RecordingSocket()
+    context = RecordingContext(socket)
+    context_created_on = []
+
+    def make_context():
+        context_created_on.append(threading.get_ident())
+        return context
+
+    monkeypatch.setattr(load_snapshot_module.zmq, "Context", make_context)
+    publisher = load_snapshot_module.LoadSnapshotPublisher(
+        "tcp://load-snapshots", dp_rank=0, heartbeat_interval=60.0
+    )
+    publisher.observe(observed_tuple())
+    wait_until(lambda: socket.decoded_snapshots)
+    publisher.close()
+
+    owner = publisher.socket_owner_thread
+    assert owner != caller_thread
+    assert context_created_on == [owner]
+    assert ("socket", owner, zmq.PUSH) in context.calls
+    assert ("setsockopt", owner, zmq.SNDHWM, 1) in socket.calls
+    assert ("setsockopt", owner, zmq.CONFLATE, 1) in socket.calls
+    assert ("connect", owner, "tcp://load-snapshots") in socket.calls
+    assert ("send", owner, zmq.NOBLOCK) in socket.calls
+    assert ("close", owner, 0) in socket.calls
+    assert ("term", owner) in context.calls
+
+
+def test_event_loop_observation_projects_the_sampled_scheduler_values():
+    """The shared helper maps the existing sample without another query."""
+    pytest.importorskip("tokenspeed_scheduler")
+    from tokenspeed.runtime.engine.event_loop import EventLoop
+
+    observed = []
+    loop = EventLoop.__new__(EventLoop)
+    loop.load_snapshot_publisher = SimpleNamespace(
+        observe=lambda values: observed.append(values)
+    )
+    loop.output_processor = SimpleNamespace(rid_to_state={"a": object(), "b": object()})
+    loop._scheduler_cache_geometry = SimpleNamespace(num_usable_pages=20)
+
+    loop._observe_load_snapshot(
+        {"num_queue_reqs": 3, "num_active_pages": 4, "num_cached_pages": 5}
+    )
+
+    assert observed == [
+        observed_tuple(
+            num_running_reqs=2,
+            num_waiting_reqs=3,
+            num_active_pages=4,
+            num_used_pages=5,
+            max_total_pages=20,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("attn_tp_rank", "zmq_msgpack", "should_publish"),
+    [(0, False, True), (1, False, False), (0, True, False)],
+)
+def test_event_loop_publisher_is_gated_to_standard_serving_tp0(
+    monkeypatch, attn_tp_rank, zmq_msgpack, should_publish
+):
+    """Non-TP0 and direct-ZMQ engines never open the internal PUSH socket."""
+    pytest.importorskip("tokenspeed_scheduler")
+    from tokenspeed.runtime.engine import event_loop as event_loop_module
+
+    created = []
+
+    class FakePublisher:
+        def __init__(self, endpoint, dp_rank, heartbeat_interval):
+            created.append((endpoint, dp_rank, heartbeat_interval))
+
+        def observe(self, values):
+            raise AssertionError(values)
+
+        def close(self):
+            raise AssertionError("unused fake publisher was closed")
+
+    monkeypatch.setattr(event_loop_module, "LoadSnapshotPublisher", FakePublisher)
+    loop = event_loop_module.EventLoop.__new__(event_loop_module.EventLoop)
+    loop.attn_tp_rank = attn_tp_rank
+    loop.dp_rank = 4
+    loop.server_args = SimpleNamespace(
+        zmq_msgpack=zmq_msgpack, load_watch_interval=0.25
+    )
+    loop.port_args = SimpleNamespace(metrics_ipc_name="tcp://metrics")
+
+    loop._init_load_snapshot_publisher()
+
+    assert created == ([("tcp://metrics", 4, 0.25)] if should_publish else [])
+    if not should_publish:
+        loop.load_snapshot_publisher.observe(observed_tuple())
+        loop.load_snapshot_publisher.close()
 
 
 def test_load_snapshot_is_immutable_and_positional():
@@ -124,7 +436,9 @@ def test_store_projects_only_a_complete_fresh_rank_set():
     assert store.accept(make_snapshot(dp_rank=1))
     loads = store.project_loads()
     assert [load.dp_rank for load in loads] == [0, 1]
-    assert [(load.num_reqs, load.num_waiting_reqs, load.num_pages) for load in loads] == [
+    assert [
+        (load.num_reqs, load.num_waiting_reqs, load.num_pages) for load in loads
+    ] == [
         (5, 3, 5),
         (5, 3, 5),
     ]

--- a/test/runtime/test_load_snapshot.py
+++ b/test/runtime/test_load_snapshot.py
@@ -68,10 +68,16 @@ class RecordingSocket:
     """A minimal PUSH socket double that decodes successfully sent frames."""
 
     def __init__(
-        self, failures: int = 0, failure_gate: threading.Event | None = None
+        self,
+        failures: int = 0,
+        failure_gate: threading.Event | None = None,
+        connect_error: Exception | None = None,
+        close_error: Exception | None = None,
     ) -> None:
         self.failures = failures
         self.failure_gate = failure_gate
+        self.connect_error = connect_error
+        self.close_error = close_error
         self.calls = []
         self.decoded_snapshots = []
         self.send_attempted = threading.Event()
@@ -82,6 +88,8 @@ class RecordingSocket:
 
     def connect(self, endpoint: str) -> None:
         self.calls.append(("connect", threading.get_ident(), endpoint))
+        if self.connect_error is not None:
+            raise self.connect_error
 
     def send(self, frame, flags=0) -> None:
         self.calls.append(("send", threading.get_ident(), flags))
@@ -95,6 +103,8 @@ class RecordingSocket:
 
     def close(self, linger=None) -> None:
         self.calls.append(("close", threading.get_ident(), linger))
+        if self.close_error is not None:
+            raise self.close_error
 
 
 def wait_until(predicate, timeout: float = 2.0) -> None:
@@ -299,6 +309,42 @@ def test_publisher_default_socket_has_bounded_thread_owned_lifecycle(monkeypatch
     assert ("setsockopt", owner, zmq.CONFLATE, 1) in socket.calls
     assert ("connect", owner, "tcp://load-snapshots") in socket.calls
     assert ("send", owner, zmq.NOBLOCK) in socket.calls
+    assert ("close", owner, 0) in socket.calls
+    assert ("term", owner) in context.calls
+
+
+def test_publisher_setup_failure_cleans_partial_resources_on_owner_thread(
+    monkeypatch,
+):
+    """A failed socket setup still closes and terminates every acquired resource."""
+    caller_thread = threading.get_ident()
+    socket = RecordingSocket(
+        connect_error=RuntimeError("connect failed"),
+        close_error=RuntimeError("close failed"),
+    )
+    context = RecordingContext(socket)
+    context_created_on = []
+
+    def make_context():
+        context_created_on.append(threading.get_ident())
+        return context
+
+    monkeypatch.setattr(load_snapshot_module.zmq, "Context", make_context)
+    publisher = load_snapshot_module.LoadSnapshotPublisher(
+        "tcp://load-snapshots", dp_rank=0, heartbeat_interval=60.0
+    )
+    wait_until(lambda: any(call[0] == "connect" for call in socket.calls))
+
+    close_started = time.monotonic()
+    publisher.close()
+    close_elapsed = time.monotonic() - close_started
+
+    owner = publisher.socket_owner_thread
+    assert owner != caller_thread
+    assert close_elapsed < 0.5
+    assert context_created_on == [owner]
+    assert ("socket", owner, zmq.PUSH) in context.calls
+    assert ("connect", owner, "tcp://load-snapshots") in socket.calls
     assert ("close", owner, 0) in socket.calls
     assert ("term", owner) in context.calls
 

--- a/test/runtime/test_zmq_msgpack.py
+++ b/test/runtime/test_zmq_msgpack.py
@@ -32,12 +32,12 @@ import struct
 import tempfile
 import threading
 from pathlib import Path
-from types import SimpleNamespace
 
 import msgspec
 import pytest
 import zmq
 
+from tokenspeed.runtime.engine import load_snapshot as load_snapshot_module
 from tokenspeed.runtime.engine import zmq_msgpack, zmq_wire
 from tokenspeed.runtime.engine.io_struct import (
     AbortReq,
@@ -530,29 +530,24 @@ def test_send_socket_next_output_uses_latest_load_snapshot():
     ) == (5, 6, 7, 8)
 
 
-def test_event_loop_load_snapshot_projects_active_pages_to_direct_output():
-    """The direct tail carries active pages, not cached/used pages."""
-    pytest.importorskip("tokenspeed_scheduler")
-    from tokenspeed.runtime.engine.event_loop import EventLoop
+def test_direct_load_snapshot_sink_maps_active_pages_without_transport():
+    """The direct sink ignores used pages and only updates the next batch."""
+    socket = _FakeOutputSocket()
+    sender = zmq_msgpack.MsgpackSendSocket(socket)
+    sink = load_snapshot_module.DirectLoadSnapshotSink(sender.set_load_snapshot)
 
-    published = []
-    projected = []
-    loop = EventLoop.__new__(EventLoop)
-    loop.load_snapshot_publisher = SimpleNamespace(
-        observe=lambda values: published.append(values)
-    )
-    loop.send_to_tokenizer = SimpleNamespace(
-        set_load_snapshot=lambda *values: projected.append(values)
-    )
-    loop.output_processor = SimpleNamespace(rid_to_state={"a": object(), "b": object()})
-    loop._scheduler_cache_geometry = SimpleNamespace(num_usable_pages=20)
+    sink.observe((5, 6, 7, 18, 20))
+    sink.close()
 
-    loop._observe_load_snapshot(
-        {"num_queue_reqs": 3, "num_active_pages": 4, "num_cached_pages": 17}
-    )
-
-    assert published == [(2, 3, 4, 17, 20)]
-    assert projected == [(2, 3, 4, 20)]
+    assert socket.sent == []
+    sender.send_pyobj(_make_batch_out())
+    output = _decode_last_slim_output(socket)
+    assert (
+        output.num_running,
+        output.num_waiting,
+        output.kv_active_pages,
+        output.kv_total_pages,
+    ) == (5, 6, 7, 20)
 
 
 def test_send_socket_engine_dead_sentinel():

--- a/test/runtime/test_zmq_msgpack.py
+++ b/test/runtime/test_zmq_msgpack.py
@@ -32,6 +32,7 @@ import struct
 import tempfile
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 
 import msgspec
 import pytest
@@ -251,6 +252,10 @@ def test_slim_out_from_full_roundtrip():
     assert rt.output_token_logprobs_val == [[]]
     assert rt.output_token_logprobs_idx == [[]]
     assert rt.engine_index == 0
+    assert rt.num_running == 0
+    assert rt.num_waiting == 0
+    assert rt.kv_active_pages == 0
+    assert rt.kv_total_pages == 0
 
 
 def test_slim_out_carries_the_producing_engine_index():
@@ -261,14 +266,21 @@ def test_slim_out_carries_the_producing_engine_index():
     assert rt.engine_index == 3
 
 
-def test_slim_out_engine_index_defaults_for_older_senders():
-    # Appended field: a 9-element array from an older sender must still decode.
-    slim = BatchTokenIDOutSlim.from_full(_make_batch_out())
+@pytest.mark.parametrize(("prefix_length", "expected_engine_index"), [(9, 0), (10, 7)])
+def test_slim_out_load_tail_defaults_for_older_senders(
+    prefix_length: int, expected_engine_index: int
+):
+    # Pre-DP 9-element and pre-load 10-element senders both omit the load tail.
+    slim = BatchTokenIDOutSlim.from_full(_make_batch_out(), engine_index=7)
     raw = msgspec.msgpack.decode(_encode_payload(slim))
     rt = msgspec.msgpack.Decoder(BatchTokenIDOutSlim).decode(
-        msgspec.msgpack.encode(raw[:9])
+        msgspec.msgpack.encode(raw[:prefix_length])
     )
-    assert rt.engine_index == 0
+    assert rt.engine_index == expected_engine_index
+    assert rt.num_running == 0
+    assert rt.num_waiting == 0
+    assert rt.kv_active_pages == 0
+    assert rt.kv_total_pages == 0
 
 
 def test_slim_out_sources_output_ids_not_the_detok_window():
@@ -305,22 +317,32 @@ def test_slim_out_carries_logprob_columns():
 
 
 def test_slim_out_is_tagged_positional_tuple():
-    """The wire form must be a 10-element tagged array (the frontend's codec
-    depends on the tag and column order; engine_index is the appended tail)."""
+    """The wire form pins SMG's exact 14-element positional contract."""
     out = _make_batch_out(
         output_token_logprobs_val=[[-0.5]], output_token_logprobs_idx=[[10]]
     )
-    slim = BatchTokenIDOutSlim.from_full(out, engine_index=1)
+    slim = BatchTokenIDOutSlim.from_full(
+        out,
+        engine_index=1,
+        num_running=2,
+        num_waiting=3,
+        kv_active_pages=4,
+        kv_total_pages=20,
+    )
     raw = msgspec.msgpack.decode(_encode_payload(slim))
     assert isinstance(raw, list)
     assert raw[0] == "BatchTokenIDOutSlim"
-    assert len(raw) == 10
+    assert len(raw) == 14
     assert raw[1] == ["r1"]  # rids
     assert raw[2] == [[10, 11]]  # output_ids
     assert raw[3] == ["length"]  # finished_reasons
     assert raw[7] == [[pytest.approx(-0.5)]]
     assert raw[8] == [[10]]
     assert raw[9] == 1  # engine_index (appended)
+    assert raw[10] == 2  # num_running
+    assert raw[11] == 3  # num_waiting
+    assert raw[12] == 4  # kv_active_pages
+    assert raw[13] == 20  # kv_total_pages
 
 
 def test_slim_out_finish_reason_none_maps_to_empty():
@@ -460,6 +482,77 @@ class _FakeOutputSocket:
 
     def close(self) -> None:
         pass
+
+
+def _decode_last_slim_output(socket: _FakeOutputSocket) -> BatchTokenIDOutSlim:
+    return msgspec.msgpack.Decoder(BatchTokenIDOutSlim).decode(socket.sent[-1][-1])
+
+
+def test_send_socket_uses_zero_load_tail_before_observation():
+    socket = _FakeOutputSocket()
+    sender = zmq_msgpack.MsgpackSendSocket(socket, engine_index=5)
+
+    sender.send_pyobj(_make_batch_out())
+
+    output = _decode_last_slim_output(socket)
+    assert output.engine_index == 5
+    assert (
+        output.num_running,
+        output.num_waiting,
+        output.kv_active_pages,
+        output.kv_total_pages,
+    ) == (0, 0, 0, 0)
+
+
+def test_send_socket_load_snapshot_setter_sends_no_frame():
+    socket = _FakeOutputSocket()
+    sender = zmq_msgpack.MsgpackSendSocket(socket)
+
+    sender.set_load_snapshot(1, 2, 3, 4)
+
+    assert socket.sent == []
+
+
+def test_send_socket_next_output_uses_latest_load_snapshot():
+    socket = _FakeOutputSocket()
+    sender = zmq_msgpack.MsgpackSendSocket(socket)
+    sender.set_load_snapshot(1, 2, 3, 4)
+    sender.set_load_snapshot(5, 6, 7, 8)
+
+    sender.send_pyobj(_make_batch_out())
+
+    output = _decode_last_slim_output(socket)
+    assert (
+        output.num_running,
+        output.num_waiting,
+        output.kv_active_pages,
+        output.kv_total_pages,
+    ) == (5, 6, 7, 8)
+
+
+def test_event_loop_load_snapshot_projects_active_pages_to_direct_output():
+    """The direct tail carries active pages, not cached/used pages."""
+    pytest.importorskip("tokenspeed_scheduler")
+    from tokenspeed.runtime.engine.event_loop import EventLoop
+
+    published = []
+    projected = []
+    loop = EventLoop.__new__(EventLoop)
+    loop.load_snapshot_publisher = SimpleNamespace(
+        observe=lambda values: published.append(values)
+    )
+    loop.send_to_tokenizer = SimpleNamespace(
+        set_load_snapshot=lambda *values: projected.append(values)
+    )
+    loop.output_processor = SimpleNamespace(rid_to_state={"a": object(), "b": object()})
+    loop._scheduler_cache_geometry = SimpleNamespace(num_usable_pages=20)
+
+    loop._observe_load_snapshot(
+        {"num_queue_reqs": 3, "num_active_pages": 4, "num_cached_pages": 17}
+    )
+
+    assert published == [(2, 3, 4, 17, 20)]
+    assert projected == [(2, 3, 4, 20)]
 
 
 def test_send_socket_engine_dead_sentinel():


### PR DESCRIPTION
## 1. Problem

TokenSpeed collects load by polling every scheduler and waiting for a reply from each rank. A delayed or missing reply can leave the load watcher stuck, and overlapping callers can race over the same request/reply path.

This affects both public `/v1/loads` queries and internal DP-aware routing. The direct-ZMQ output contract also has load fields that TokenSpeed was not populating.

## 2. High-level approach

Make each scheduler the source of truth for its own load:

- attention TP0 reuses the scheduler statistics already sampled by the event loop
- changed values replace a bounded one-slot mailbox immediately
- a dedicated publisher thread owns serialization and ZMQ transport, so the scheduler thread never sends or blocks on load updates
- `AsyncLLM` and the DP controller keep validated local cache replicas
- direct-ZMQ piggybacks the latest load on ordinary output batches

Unchanged state is refreshed by a heartbeat. Missing, partial, invalid, or stale state is treated as unavailable and internal routing falls back to round robin.

This requires no shared memory, public response change, or protobuf change.

## 3. Changes

- added immutable, versioned `LoadSnapshot` messages with sequence, epoch, rank, queue, and KV-page data
- replaced scheduler load polling with immediate latest-wins publication and unchanged-state heartbeats
- changed `/v1/loads` to read from the frontend cache
- changed the DP controller to route from its own cache with conservative per-rank reservation reconciliation
- removed the old load watcher and scheduler query path
- populated the existing direct-ZMQ load tail without adding a separate stats message or socket
- added validation for ordering, expiry, scheduler restarts, paused-state updates, both DP policies, and wire compatibility

Validation:

- `.venv/bin/pre-commit run --all-files`
- focused runtime suite: `152 passed, 7 skipped, 2 deselected`
- `.venv/bin/python -m compileall -q python/tokenspeed/runtime/engine`

The two deselected codec cases are pre-existing macOS 16 KiB shared-memory page-size failures in `ShmTensorHandle.publish`; the unfiltered focused run otherwise produced the same 152 passes.
