### PR TITLE
feat(runtime): prefill chunk pipeline + event-loop cohesion refactor

### DIFF
--- a/docs/design/event-loop.md
+++ b/docs/design/event-loop.md
@@ -1,0 +1,138 @@
+# Event Loop: Design Principles
+
+This document records the design principles of the scheduler event loop
+(`python/tokenspeed/runtime/engine/event_loop.py`). It is the reference for
+where new logic belongs, how components feed results back into the scheduler,
+and what the loop body itself is allowed to contain. The rules below were
+established deliberately; treat deviations as bugs in review.
+
+## Principle 1: the event loop is a coordinator, nothing more
+
+`EventLoop.event_loop` sequences components; it does not implement them.
+Domain logic — pause/resume semantics, EPD admission, PD transfer handling,
+L2 cache-op tracking, wire handshakes, multimodal batch assembly — lives in
+its own module and enters the loop as a **single-line hook**. The loop body
+should read, top to bottom, as the schedule of one scheduling round, with no
+feature's internals inlined into it.
+
+Consequences:
+
+* Low-frequency or optional features (pause/resume control, EPD, SMG
+  transport, kvstore) must never make the *normal* scheduling path harder to
+  read. If understanding decode throughput requires skipping over your
+  feature's code, the feature is in the wrong place.
+* When a feature needs several collaborators of the loop, give it a hooks
+  class (see below) instead of weaving branches through the loop and its
+  helpers.
+
+## Principle 2: scheduler feedback is explicit and centralized
+
+`advance_scheduler` (`scheduler_utils.py`) is the **only** caller of
+`scheduler.advance`, and it is invoked **only explicitly and directly in the
+`event_loop` body — never from helpers**. Helpers RETURN their events; the
+loop applies them. Reading the loop body alone must reveal every point where
+the scheduler's state advances, and why.
+
+There are exactly two call sites, each with a documented reason:
+
+* **Head of the round** — completed L2 cache-op events
+  (`_cache_hooks.poll_ready_events()`). These must advance *before*
+  `next_execution_plan`, otherwise cache-gated admissions are delayed by a
+  full round.
+* **Tail of the round** — forward results and PD transfer events, funneled
+  through the single `request_changes` list. These can only exist after
+  dispatch/commit, and must advance before the *next* round plans.
+
+Anything that produces scheduler events (a new transfer backend, a new async
+op kind) either returns events into one of these two points or adds a new
+explicit call site in the loop body with a comment stating why the existing
+points don't fit. It must not call `advance_scheduler` itself.
+
+## Principle 3: correctness never depends on the in-flight depth
+
+The loop is parameterized by `in_flight_depth`: 0 (classic synchronous
+commit), 1 (the overlap schedule), or `pp_size` (the prefill chunk pipeline).
+Dispatched forwards await commit in the `in_flight` queue; the tail commits
+once the queue exceeds the effective depth (0 when the round dispatched no
+new work, so results never wait on future traffic).
+
+The depth is a performance knob only. Any dispatch whose inputs depend on a
+pending commit's side effects must drain the queue first, and
+`_dispatch_depends_on_pending_commit` is the **single registry** of those
+overlap-breaking dependencies (currently: the P-side PD handoff batch and
+eager-grammar batches). New rules go there, not into `event_loop`. Rounds
+that run no real forward (pause/freeze, DP idle) drain the queue fully.
+
+## Principle 4: publishing drains, once per round
+
+`_publish_scheduler_kv_events` has drain semantics: KV events accumulate
+inside the C++ scheduler across any number of mutations (advance,
+`next_execution_plan`), so a single unconditional call at the loop tail
+publishes everything the round produced, in order, as one batch. Do not add
+per-mutation publish calls; they only fragment batches.
+
+The same reasoning fixes the metrics call: scheduler iteration metrics are
+recorded once per round, from the same pre-dispatch snapshot as the
+scheduler stats.
+
+## The hooks pattern
+
+Loop-side integration of a subsystem is a small class whose methods are the
+subsystem's only entry points from the loop. Two shapes exist:
+
+* **Glue hooks** hold a loop back-reference and act on its collaborators;
+  they are stateless (or nearly so) because the real state machine lives in a
+  controller the request handler or executor drives. The controller DECIDES;
+  the hooks ACT with the loop's collaborators.
+* **Self-contained components** own their state outright and depend only on
+  static configuration — they need no loop reference at all. Prefer this
+  shape whenever the subsystem doesn't genuinely need the loop's live state.
+
+Current inventory:
+
+| Attribute      | Class / home                                  | Shape          | Loop entry points |
+| -------------- | --------------------------------------------- | -------------- | ----------------- |
+| `_pause_hooks` | `PauseHooks` — `engine/pause.py`              | glue (PauseController is the state machine) | `apply_transitions`, `withhold_admissions`, `paused_idle_step` |
+| `_epd_hooks`   | `EpdPrefillHooks` — `epd/prefill_hooks.py`    | glue (EpdPrefillAdmission decides)          | `try_stage`, `drain_ready_embeddings`, `assert_embeddings_received` |
+| `_pd_hooks`    | `PdTransferHooks` — `pd/transfer_hooks.py`    | glue (transfer executors decide)            | `poll_transfer_events` |
+| `_cache_hooks` | `L2CacheHooks` — `engine/cache_hooks.py`      | self-contained (static config only)         | `submit`, `poll_ready_events` |
+
+Related placements that follow the same principle without a hooks class: the
+SMG startup handshake lives in `zmq_msgpack.connect_msgpack_engine_for_loop`
+(wire-schema helpers in `zmq_wire`), multimodal batch-context assembly in
+`multimodal/inputs.py::multimodal_context_for_forward`, and P-side layerwise
+KV streaming setup in `DisaggPrefillExecutor.setup_layerwise_transfer`.
+
+All hooks obey Principle 2: they return events or decisions; they never call
+`advance_scheduler`.
+
+## Anatomy of a round
+
+For orientation, one iteration of `event_loop`:
+
+1. Receive and admit new requests (`_process_new_requests`), with the pause
+   and EPD admission hooks inline as single lines.
+2. Poll completed L2 cache ops; **advance the scheduler (head call site)** so
+   this round's plan sees them.
+3. Frozen (`PAUSED_ALL`)? Drain the in-flight queue and run the paused idle
+   step. Otherwise: plan (`next_execution_plan`), derive the forward op,
+   record metrics, and DP-sync (running an idle forward on idle ranks).
+4. Non-idle rounds: gather per-batch state, drain the in-flight queue if the
+   dispatch depends on a pending commit (Principle 3), dispatch, commit from
+   the queue head down to the effective depth, and poll PD transfer events.
+5. **Advance the scheduler (tail call site)** with the round's
+   `request_changes`, publish KV events (once), and resolve any pending
+   pause/release drain.
+
+## Checklist for extending the loop
+
+* New logic that reacts to scheduler/transfer/cache progress: put it in the
+  matching hooks class (or add one), return events, and apply them at an
+  existing advance point.
+* New reason a dispatch cannot overlap a pending commit: add it to
+  `_dispatch_depends_on_pending_commit`.
+* New per-round work: add a single-line hook call at a fixed position in the
+  loop (rank-identical across ranks if it contains collectives), not a
+  branch of feature code.
+* Never call `scheduler.advance`, `advance_scheduler`, or the KV event
+  publisher from a helper or hooks class.

--- a/python/tokenspeed/runtime/distributed/comm_ops.py
+++ b/python/tokenspeed/runtime/distributed/comm_ops.py
@@ -410,3 +410,54 @@ def token_reduce_scatter(
     if backend is None:
         backend = get_global_backend()
     return backend.token_reduce_scatter(tensor, group, scattered_num_tokens)
+
+
+def pp_send(
+    tensor: torch.Tensor,
+    dst_group_index: int,
+    group: Group,
+    backend: CommBackend | None = None,
+) -> None:
+    """Send a tensor to another pipeline stage (P2P over the PP group).
+
+    Args:
+        tensor: Contiguous device tensor to send.
+        dst_group_index: Destination position within ``group`` (the PP rank of
+            the receiving stage), not a global rank.
+        group: The PP group (one rank per stage, same intra-stage position).
+        backend: Communication backend; defaults to the global backend.
+    """
+    if backend is None:
+        backend = get_global_backend()
+    backend.send(tensor.contiguous(), dst_group_index, group)
+
+
+def pp_recv(
+    size: torch.Size | tuple[int, ...],
+    dtype: torch.dtype,
+    device: torch.device,
+    src_group_index: int,
+    group: Group,
+    backend: CommBackend | None = None,
+) -> torch.Tensor:
+    """Receive a tensor from another pipeline stage (P2P over the PP group).
+
+    The shape/dtype are supplied by the caller: every PP rank runs the same
+    deterministic scheduler, so the receiver derives the payload geometry from
+    its own forward op without a metadata exchange.
+
+    Args:
+        size: Shape of the incoming tensor.
+        dtype: Element type of the incoming tensor.
+        device: Device to allocate the receive buffer on.
+        src_group_index: Source position within ``group`` (the PP rank of the
+            sending stage), not a global rank.
+        group: The PP group (one rank per stage, same intra-stage position).
+        backend: Communication backend; defaults to the global backend.
+
+    Returns:
+        The received tensor.
+    """
+    if backend is None:
+        backend = get_global_backend()
+    return backend.recv(torch.Size(size), dtype, device, src_group_index, group)

--- a/python/tokenspeed/runtime/distributed/mapping.py
+++ b/python/tokenspeed/runtime/distributed/mapping.py
@@ -329,28 +329,49 @@ class Mapping(MappingBase):
         moe_dp_size: int | None = None,
         vision_tp_size: int | None = None,
         vision_dp_size: int | None = None,
+        pp_size: int = 1,
+        pp_layer_partition: tuple[int, ...] | None = None,
         nprocs_per_node: int | None = None,
         nnodes: int | None = None,
         base_gpu_id: int = 0,
         gpu_id_step: int = 1,
     ):
         super().__init__(rank, world_size)
+        # Pipeline parallelism is the outermost dimension: the world splits
+        # into pp_size contiguous stages and every per-layer-type mapping
+        # resolves inside one stage. Sub-mappings keep the GLOBAL rank — the
+        # stride arithmetic stays correct because a stage base is a multiple
+        # of every intra-stage stride.
+        assert pp_size > 0
+        assert (
+            world_size % pp_size == 0
+        ), f"world_size {world_size} must be divisible by pp_size {pp_size}"
+        self.pp_size = pp_size
+        # Optional explicit per-stage layer counts (front to back); validated
+        # against the model's layer count where the split is resolved
+        # (pp_stage_windows).
+        self.pp_layer_partition = (
+            tuple(int(count) for count in pp_layer_partition)
+            if pp_layer_partition
+            else None
+        )
+        stage_world_size = world_size // pp_size
         self.attn = AttentionLayerMapping(
             rank=rank,
-            world_size=world_size,
+            world_size=stage_world_size,
             tp_size=attn_tp_size,
             cp_size=attn_cp_size,
             dp_size=attn_dp_size,
         )
         self.dense = DenseLayerMapping(
             rank=rank,
-            world_size=world_size,
+            world_size=stage_world_size,
             tp_size=dense_tp_size,
             dp_size=dense_dp_size,
         )
         self.moe = MoeLayerMapping(
             rank=rank,
-            world_size=world_size,
+            world_size=stage_world_size,
             tp_size=moe_tp_size,
             ep_size=moe_ep_size,
             dp_size=moe_dp_size,
@@ -376,6 +397,46 @@ class Mapping(MappingBase):
         self.dense.rank = rank
         self.moe.rank = rank
         self.vision.rank = rank
+
+    @cached_property
+    def has_pp(self) -> bool:
+        return self.pp_size > 1
+
+    @cached_property
+    def stage_world_size(self) -> int:
+        return self.world_size // self.pp_size
+
+    @cached_property
+    def pp_rank(self) -> int:
+        return _make_parallelism_rank(
+            self.rank, self.pp_size, stride=self.stage_world_size
+        )
+
+    @cached_property
+    def pp_group(self) -> Group:
+        return _make_parallelism_group(
+            self.rank, self.pp_size, stride=self.stage_world_size
+        )
+
+    @cached_property
+    def is_first_pp_rank(self) -> bool:
+        return self.pp_rank == 0
+
+    @cached_property
+    def is_last_pp_rank(self) -> bool:
+        return self.pp_rank == self.pp_size - 1
+
+    @cached_property
+    def pp_prev_rank(self) -> int:
+        """Global rank of the same intra-stage position one stage upstream."""
+        assert not self.is_first_pp_rank
+        return self.rank - self.stage_world_size
+
+    @cached_property
+    def pp_next_rank(self) -> int:
+        """Global rank of the same intra-stage position one stage downstream."""
+        assert not self.is_last_pp_rank
+        return self.rank + self.stage_world_size
 
     @cached_property
     def has_attn_tp(self) -> bool:
@@ -406,6 +467,7 @@ class Mapping(MappingBase):
         lines = [
             f"Mapping(rank={rank_str}, world_size={self.world_size})",
             f"  Cluster : {self.nnodes} node(s) x {self.nprocs_per_node} proc(s)",
+            f"  Pipeline: pp={self.pp_size}",
             f"  Attention: tp={self.attn.tp_size}  cp={self.attn.cp_size}  dp={self.attn.dp_size}",
             f"    Vision: tp={self.vision.tp_size}  item_dp={self.vision.dp_size}",
             f"  Dense   : tp={self.dense.tp_size}  dp={self.dense.dp_size}",

--- a/python/tokenspeed/runtime/distributed/pp_stage.py
+++ b/python/tokenspeed/runtime/distributed/pp_stage.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Pipeline-stage boundary state and layer-window helpers.
+
+A pipeline stage's forward either consumes a :class:`PPStageState` received
+from the upstream stage (mid-pipeline) or produces one for the downstream
+stage. The tensor geometry is fully derivable from the token count plus model
+config on both sides — every PP rank runs the same deterministic scheduler —
+so the wire protocol is a fixed-order sequence of raw tensor sends with no
+metadata exchange.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+
+import torch
+
+from tokenspeed.runtime.distributed.mapping import Mapping
+
+
+def pp_stage_windows(
+    num_layers: int,
+    pp_size: int,
+    partition: tuple[int, ...] | None = None,
+) -> list[tuple[int, int]]:
+    """All stages' [start, end) layer windows.
+
+    The single source of the stage-split arithmetic: the model build, the KV
+    transfer route, and the Decode-side peer planner must all agree on it.
+
+    Args:
+        num_layers: Total model layer count.
+        pp_size: Number of pipeline stages.
+        partition: Optional explicit per-stage layer counts (front to back),
+            e.g. ``(8, 11, 11, 8)``. When omitted, layers split as evenly as
+            possible with the remainder on the front stages.
+
+    Returns:
+        One ``[start, end)`` window per stage, covering ``0..num_layers``.
+
+    Raises:
+        ValueError: the partition length or sum does not match.
+    """
+    if partition is not None:
+        if len(partition) != pp_size:
+            raise ValueError(
+                f"pp layer partition {partition} has {len(partition)} entries "
+                f"for {pp_size} pipeline stages"
+            )
+        if any(count <= 0 for count in partition):
+            raise ValueError(
+                f"pp layer partition {partition} must give every stage at "
+                "least one layer"
+            )
+        if sum(partition) != num_layers:
+            raise ValueError(
+                f"pp layer partition {partition} sums to {sum(partition)} "
+                f"but the model has {num_layers} layers"
+            )
+        counts = partition
+    else:
+        base = num_layers // pp_size
+        remainder = num_layers % pp_size
+        counts = tuple(
+            base + (1 if stage < remainder else 0) for stage in range(pp_size)
+        )
+    windows = []
+    start = 0
+    for length in counts:
+        windows.append((start, start + length))
+        start += length
+    return windows
+
+
+def pp_layer_window(num_hidden_layers: int, mapping: Mapping) -> tuple[int, int]:
+    """Return this stage's [start, end) global layer window.
+
+    Honors ``mapping.pp_layer_partition`` when set (explicit per-stage layer
+    counts, e.g. to lighten the embed/lm_head stages). Otherwise layers split
+    as evenly as possible with the remainder on the EARLIER stages.
+    """
+    pp_size = mapping.pp_size
+    pp_rank = mapping.pp_rank if pp_size > 1 else 0
+    partition = getattr(mapping, "pp_layer_partition", None)
+    return pp_stage_windows(num_hidden_layers, pp_size, partition)[pp_rank]
+
+
+@dataclass
+class PPStageState:
+    """Inter-stage tensor bundle in a fixed wire order.
+
+    Fields are declared in wire order; ``tensors()`` and ``from_tensors``
+    round-trip them so the executor can send/recv without knowing the model.
+    ``None`` fields are skipped on the wire — the spec on the receive side
+    must produce the same skip pattern (both sides derive it from config).
+    """
+
+    hidden_states: torch.Tensor
+    hc_x: torch.Tensor | None = None
+    hc_post: torch.Tensor | None = None
+    hc_comb: torch.Tensor | None = None
+    # K3 AttnRes: the valid prefix of the block-residual snapshot buffer,
+    # [num_valid_blocks, num_tokens, hidden]. The downstream stage seeds its
+    # own (full-size) buffer with these rows; its block-write layers fill the
+    # rest.
+    block_residual: torch.Tensor | None = None
+
+    def tensors(self) -> list[torch.Tensor]:
+        out = []
+        for f in fields(self):
+            value = getattr(self, f.name)
+            if value is not None:
+                out.append(value)
+        return out
+
+    @classmethod
+    def from_tensors(cls, tensors: list[torch.Tensor], field_names: list[str]):
+        kwargs = dict(zip(field_names, tensors, strict=True))
+        return cls(**kwargs)

--- a/python/tokenspeed/runtime/engine/cache_hooks.py
+++ b/python/tokenspeed/runtime/engine/cache_hooks.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""L2 cache-op submission and rank-synchronized completion tracking.
+
+Owns everything between an execution plan's cache ops and the scheduler
+events their completions eventually produce: submit ops to the L2 executor,
+count what is in flight, poll completions, and agree across attn-tp ranks on
+which completions EVERY rank has seen (the C++ scheduler is mirrored, so an
+event may only advance once all ranks hold it). ``poll_ready_events`` returns
+events for the event loop to apply — feedback into the scheduler stays an
+explicit ``advance_scheduler`` call in the loop body.
+
+Standalone by construction: depends only on static parallel-layout config,
+not on live event-loop state. ``executor=None`` (kvstore disabled) makes
+every method a cheap no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+
+import torch
+import torch.distributed as dist
+from tokenspeed_scheduler import Cache
+
+from tokenspeed.runtime.engine.scheduler_utils import (
+    cache_event_from_payload,
+    cache_event_key,
+    cache_event_to_payload,
+    cache_sync_debug_enabled,
+    pop_common_cache_event_payloads,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class L2CacheHooks:
+    """Tracks in-flight L2 cache ops for one scheduler event loop."""
+
+    def __init__(
+        self,
+        executor,
+        *,
+        speculative_algorithm: str | None,
+        attn_tp_rank: int,
+        attn_tp_size: int,
+        attn_tp_cpu_group,
+        global_rank: int,
+    ) -> None:
+        self._executor = executor
+        self._speculative_algorithm = speculative_algorithm
+        self._attn_tp_rank = attn_tp_rank
+        self._attn_tp_size = attn_tp_size
+        self._attn_tp_cpu_group = attn_tp_cpu_group
+        self._global_rank = global_rank
+        self._pending_payloads: OrderedDict[tuple[str, int], dict] = OrderedDict()
+        # All ranks submit identical cache plans (the C++ scheduler is
+        # mirrored), so a local in-flight counter mirrors across ranks: if it's
+        # 0 here, no rank has anything pending. Lets us skip the TP collective
+        # in poll_ready_events entirely when nothing is in flight.
+        self._num_inflight = 0
+
+    def submit(self, execution_plan) -> None:
+        """Hand the plan's cache ops to the L2 executor and count them in flight."""
+        if self._executor is None:
+            return
+        self._executor.submit_plan(execution_plan)
+        for op in execution_plan.cache:
+            if isinstance(op, (Cache.WriteBackOp, Cache.LoadBackOp)):
+                self._num_inflight += len(op.op_ids)
+            else:
+                raise TypeError(f"unsupported cache op kind: {type(op).__name__}")
+
+    def poll_ready_events(self) -> list:
+        """Poll completed L2 cache ops and return their rank-synchronized
+        scheduler events. Returns an empty list when there is nothing ready.
+        """
+        if self._executor is None:
+            return []
+        cache_results = self._executor.poll_results()
+        self._num_inflight -= len(cache_results)
+        for event in cache_results:
+            payload = cache_event_to_payload(event)
+            self._pending_payloads[cache_event_key(payload)] = payload
+
+        # The gather below is a collective, but cache-op completion is async and
+        # not lock-step across ranks, so local state (_num_inflight /
+        # _pending_payloads) diverges transiently. A rank-local skip would let
+        # some ranks gather while others return, deadlocking the group. Agree on
+        # the skip via a cheap single-int all_reduce.
+        # NOTE: For non-DFLASH algorithms, cache ops are deterministic across
+        # ranks, so the local short-circuit is safe and avoids collective overhead.
+        local_has_work = bool(self._num_inflight != 0 or self._pending_payloads)
+        if self._speculative_algorithm in ("DFLASH", "DSPARK"):
+            if not self._group_has_work(local_has_work):
+                return []
+        else:
+            if not local_has_work:
+                return []
+
+        ready_payloads = self._pop_ready_payloads()
+        if not ready_payloads:
+            return []
+        logger.debug(
+            "[cache_poll] got %s synchronized results",
+            len(ready_payloads),
+        )
+        events = []
+        for payload in ready_payloads:
+            e = cache_event_from_payload(payload)
+            logger.debug(
+                "[cache_poll] event: op_id=%s type=%s",
+                e.op_id,
+                type(e).__name__,
+            )
+            events.append(e)
+        return events
+
+    def _group_has_work(self, local_has_work: bool) -> bool:
+        """Whether ANY attn-tp rank has cache work this step (unanimous via a
+        single-int MAX all_reduce, far cheaper than the payload gather it
+        guards). Deciding from rank-local state alone deadlocks the group; see
+        poll_ready_events.
+
+        Args:
+            local_has_work: This rank's view of whether any cache op is in
+                flight or any polled payload awaits commit.
+
+        Returns:
+            ``True`` if any rank has work (all must gather); ``False`` only when
+            every rank is idle.
+        """
+        if self._attn_tp_size == 1:
+            return local_has_work
+        flag = torch.tensor([1 if local_has_work else 0], dtype=torch.int32)
+        dist.all_reduce(flag, op=dist.ReduceOp.MAX, group=self._attn_tp_cpu_group)
+        return bool(flag.item())
+
+    def _pop_ready_payloads(self) -> list[dict]:
+        local_payloads = list(self._pending_payloads.values())
+        if self._attn_tp_size == 1:
+            ready_payloads = local_payloads
+        else:
+            gathered_payloads = [None] * self._attn_tp_size
+            dist.all_gather_object(
+                gathered_payloads,
+                local_payloads,
+                group=self._attn_tp_cpu_group,
+            )
+            ready_payloads = pop_common_cache_event_payloads(gathered_payloads)
+            if self._attn_tp_rank == 0 and cache_sync_debug_enabled():
+                pending_ops = [
+                    [(payload["kind"], payload["op_id"]) for payload in rank_payloads]
+                    for rank_payloads in gathered_payloads
+                ]
+                if len({tuple(rank_ops) for rank_ops in pending_ops}) > 1:
+                    logger.info(
+                        "[cache_sync] rank=%s pending_ops=%s ready_ops=%s",
+                        self._global_rank,
+                        pending_ops,
+                        [
+                            (payload["kind"], payload["op_id"])
+                            for payload in ready_payloads
+                        ],
+                    )
+
+        for payload in ready_payloads:
+            self._pending_payloads.pop(cache_event_key(payload), None)
+        return ready_payloads

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -22,7 +22,7 @@ import faulthandler
 import signal
 import threading
 import time
-from collections import OrderedDict
+from collections import deque
 from dataclasses import dataclass
 
 import psutil
@@ -30,38 +30,35 @@ import setproctitle
 import torch
 import torch.distributed as dist
 import zmq
-from tokenspeed_scheduler import PD, Cache, ExecutionEvent, ForwardEvent, Scheduler
+from tokenspeed_scheduler import Scheduler
 
 from tokenspeed.runtime.cache.l2.executor import L2CacheExecutor
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
+from tokenspeed.runtime.engine.cache_hooks import L2CacheHooks
 from tokenspeed.runtime.engine.generation_output_processor import OutputProcesser
-from tokenspeed.runtime.engine.io_struct import IpcReceiver, IpcSender
+from tokenspeed.runtime.engine.io_struct import IpcReceiver, IpcSender, NullSender
 from tokenspeed.runtime.engine.load_snapshot import (
     DirectLoadSnapshotSink,
     LoadSnapshotPublisher,
     NullLoadSnapshotPublisher,
 )
 from tokenspeed.runtime.engine.memory_occupation import MemoryOccupationController
-from tokenspeed.runtime.engine.pause import PauseController
+from tokenspeed.runtime.engine.pause import PauseController, PauseHooks
 from tokenspeed.runtime.engine.request_handler import RequestHandler
 from tokenspeed.runtime.engine.scheduler_utils import (
-    advance_forward,
+    advance_scheduler,
     aligned_max_scheduled_tokens,
-    cache_event_from_payload,
-    cache_event_key,
-    cache_event_to_payload,
-    cache_sync_debug_enabled,
     log_gpu_memory_summary,
     make_config,
     pool_to_cache_groups,
-    pop_common_cache_event_payloads,
     resolve_dspark_prefix_replay_tokens,
     scheduler_cache_geometry_from_pool,
     should_use_overlap_schedule,
 )
+from tokenspeed.runtime.epd.prefill_hooks import EpdPrefillHooks
 from tokenspeed.runtime.execution.distributed_initializer import (
     DistributedConfig,
     DistributedInitializer,
@@ -76,6 +73,7 @@ from tokenspeed.runtime.execution.types import ModelExecutionResult
 from tokenspeed.runtime.grammar.capturable_grammar import GrammarStepInputs
 from tokenspeed.runtime.layers.attention.registry import create_attn_components
 from tokenspeed.runtime.metrics.collector import EngineMetrics
+from tokenspeed.runtime.multimodal.inputs import multimodal_context_for_forward
 from tokenspeed.runtime.pd.decode_executor import DisaggDecodeExecutor
 from tokenspeed.runtime.pd.factory import (
     create_kv_transfer,
@@ -91,12 +89,14 @@ from tokenspeed.runtime.pd.kv_events import (
 from tokenspeed.runtime.pd.mooncake.entities import KVManagerArgs
 from tokenspeed.runtime.pd.prefill_executor import DisaggPrefillExecutor
 from tokenspeed.runtime.pd.topology import PDParallelTopology
+from tokenspeed.runtime.pd.transfer_hooks import PdTransferHooks
 from tokenspeed.runtime.sampling.sampling_params import SamplingParams
 from tokenspeed.runtime.utils import (
     configure_logger,
     get_colorful_logger,
     get_zmq_socket,
 )
+from tokenspeed.runtime.utils.env import envs
 from tokenspeed.runtime.utils.exceptions import get_exception_traceback
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 from tokenspeed.runtime.utils.process import register_usr_signal
@@ -104,75 +104,6 @@ from tokenspeed.runtime.utils.server_args import PortArgs, ServerArgs
 from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 
 logger = get_colorful_logger(__name__)
-
-
-# Sleep between iterations while frozen (PAUSED_ALL) so the keep-mode pause does
-# not busy-spin a CPU core waiting for /resume.
-_PAUSED_IDLE_SLEEP_S = 0.001
-
-
-def _forward_op_executes_model_forward(forward_op, *, is_disagg_decode: bool) -> bool:
-    """Return whether ``forward_op`` will enter the model forward path.
-
-    On decode-side PD, EXTEND ops only start remote KV receive; the model
-    forward runs after the remote prefill completes and the scheduler advances
-    the request into decode. Treating those EXTEND ops as model work makes
-    idle DP ranks enter dummy collectives that the active rank will not match.
-    """
-    if forward_op is None:
-        return False
-    if sum(forward_op.input_lengths) <= 0:
-        return False
-    if (
-        is_disagg_decode
-        and forward_op.num_extends() > 0
-        and not forward_op.is_local_prefill()
-    ):
-        return False
-    return True
-
-
-class _NullSender:
-    """No-op ZMQ sender for non-rank-0 workers."""
-
-    @staticmethod
-    def send_pyobj(x):
-        return None
-
-
-# SMG decodes the ready response's dtype into a fixed enum of these strings, so
-# map tokenspeed's dtype onto the nearest one.
-_WIRE_DTYPE_MAP = {
-    "bfloat16": "bfloat16",
-    "bf16": "bfloat16",
-    "float16": "float16",
-    "half": "float16",
-    "fp16": "float16",
-    "float32": "float32",
-    "float": "float32",
-    "fp32": "float32",
-}
-
-
-def _wire_dtype(dtype) -> str:
-    key = str(dtype).lower().replace("torch.", "")
-    mapped = _WIRE_DTYPE_MAP.get(key)
-    if mapped is None:
-        # Fail at handshake time: misreporting the dtype to the frontend is
-        # worse than refusing to start.
-        raise ValueError(
-            f"dtype {dtype!r} has no SMG wire mapping; extend _WIRE_DTYPE_MAP"
-        )
-    return mapped
-
-
-def _tokenspeed_version() -> str:
-    try:
-        from tokenspeed.version import __version__
-
-        return __version__
-    except Exception:
-        return "unknown"
 
 
 @dataclass(frozen=True)
@@ -241,6 +172,17 @@ class EventLoop:
             disaggregation_mode=server_args.disaggregation_mode,
         )
         self.overlap_schedule_depth = int(self.use_overlap_schedule)
+        # In-flight depth of the unified event loop: how many dispatched
+        # forwards may await commit at once. 0 = commit in the same iteration
+        # (classic non-overlap); 1 = the overlap schedule (CPU post-processes
+        # step N-1 while the GPU runs step N); pp_size = the prefill chunk
+        # pipeline. Distinct from overlap_schedule_depth: that one sizes
+        # decode KV reservations in the C++ scheduler and recipes, this one
+        # only queues commits.
+        if server_args.mapping.has_pp:
+            self.in_flight_depth = server_args.mapping.pp_size
+        else:
+            self.in_flight_depth = int(self.use_overlap_schedule)
         decode_input_tokens = (
             server_args.speculative_num_draft_tokens
             if server_args.speculative_algorithm is not None
@@ -333,23 +275,12 @@ class EventLoop:
                 draft_kv_pool=draft_token_to_kv_pool,
             )
 
-        self.max_model_len = self.model_config.context_len
-        self.max_single_request_tokens = self.model_config.context_len
-        self.max_req_input_len = self.model_config.context_len - 1
         self.attn_tp_size = server_args.attn_tp_size or mapping.attn.tp_size
         self.world_size = server_args.world_size or mapping.world_size
         self.attn_tp_rank = attn_tp_rank
         self.attn_tp_cpu_group = pg_manager.get_process_group(
             "gloo", server_args.mapping.attn.tp_group
         )
-        self._pending_cache_event_payloads: OrderedDict[tuple[str, int], dict] = (
-            OrderedDict()
-        )
-        # All ranks submit identical cache plans (the C++ scheduler is mirrored),
-        # so a local in-flight counter mirrors across ranks: if it's 0 here, no
-        # rank has anything pending. Lets us skip the TP collective in
-        # _commit_cache_results entirely when nothing is in flight.
-        self._num_inflight_cache_ops = 0
         self.dp_rank = dp_rank
         self.dp_size = mapping.attn.dp_size
         self.has_dp = mapping.has_attn_dp
@@ -365,17 +296,27 @@ class EventLoop:
                     "the cache-group scheduler has no L3 storage tier; unset "
                     "--kvstore-storage-backend"
                 )
-            self.l2_cache_executor = L2CacheExecutor(
+            l2_cache_executor = L2CacheExecutor(
                 device_pool=token_to_kv_pool,
                 draft_pool=draft_token_to_kv_pool,
                 host_ratio=server_args.kvstore_ratio,
                 host_size_gb=server_args.kvstore_size,
                 io_backend=server_args.kvstore_io_backend,
             )
-            num_host_pages = self.l2_cache_executor.num_host_pages
+            num_host_pages = l2_cache_executor.num_host_pages
         else:
-            self.l2_cache_executor = None
+            l2_cache_executor = None
             num_host_pages = 0
+        # L2 cache-op submission + rank-synced completion tracking (see
+        # cache_hooks.py); a no-op shell when kvstore is disabled.
+        self._cache_hooks = L2CacheHooks(
+            l2_cache_executor,
+            speculative_algorithm=server_args.speculative_algorithm,
+            attn_tp_rank=attn_tp_rank,
+            attn_tp_size=self.attn_tp_size,
+            attn_tp_cpu_group=self.attn_tp_cpu_group,
+            global_rank=global_rank,
+        )
 
         self._kv_events_enabled = (
             EventPublisherFactory.is_enabled(server_args.kv_events_config)
@@ -503,7 +444,10 @@ class EventLoop:
 
         # Pause/resume control state. Shared with the request handler, which
         # drives the control-request side; the event loop reads the gate.
+        # PauseHooks is the loop-side integration (see pause.py) — the normal
+        # scheduling paths below only carry single-line hooks into it.
         self._pause = PauseController(self.send_to_tokenizer)
+        self._pause_hooks = PauseHooks(self, self._pause)
 
         # GPU-memory data plane (release/resume_memory_occupation). Reuses the
         # pause controller's drain machinery; frees memory via the memory-saver
@@ -522,8 +466,8 @@ class EventLoop:
                 enable=self.server_args.enable_memory_saver
             ),
             enabled=self.server_args.enable_memory_saver,
-            reset_caches_fn=self._reset_caches_for_release,
-            kv_repair_fn=self._kv_repair_after_wake,
+            reset_caches_fn=self._pause_hooks.reset_caches_for_release,
+            kv_repair_fn=self._pause_hooks.kv_repair_after_wake,
             kv_cache_release_allowed=kv_cache_release_allowed,
         )
 
@@ -572,6 +516,15 @@ class EventLoop:
         )
         if server_args.disaggregation_mode != "null":
             assert pd_topology is not None
+            pp_layer_window = None
+            if server_args.mapping.has_pp:
+                from tokenspeed.runtime.distributed.pp_stage import (
+                    pp_layer_window as resolve_pp_layer_window,
+                )
+
+                pp_layer_window = resolve_pp_layer_window(
+                    self.model_config.num_attention_layers, server_args.mapping
+                )
             kv_args = get_kv_args(
                 global_rank,
                 global_rank,
@@ -579,6 +532,7 @@ class EventLoop:
                 token_to_kv_pool,
                 model_config=self.model_config,
                 draft_model_config=draft_model_config,
+                pp_layer_window=pp_layer_window,
             )
             pd_manager_args = KVManagerArgs(
                 bootstrap_port=server_args.disaggregation_bootstrap_port,
@@ -590,213 +544,70 @@ class EventLoop:
                 metrics_reporters=server_args.metrics_reporters,
                 enable_dp_attention=self.has_dp,
             )
+            # PP: transfer-status consensus must span every stage — all
+            # ranks run the same deterministic scheduler and must agree on
+            # Bootstrapped/Succeeded events, and the KV for one request is
+            # produced by pp*tp ranks together.
+            kv_sync_group = (
+                pg_manager.get_process_group("gloo", server_args.mapping.world_group)
+                if server_args.mapping.has_pp
+                else self.attn_tp_cpu_group
+            )
             self.kv_transfer = create_kv_transfer(
                 mode=server_args.disaggregation_mode,
                 backend=server_args.disaggregation_transfer_backend,
                 args=pd_manager_args,
                 kv_args=kv_args,
-                gloo_group=self.attn_tp_cpu_group,
+                gloo_group=kv_sync_group,
             )
-            self._setup_pd_layerwise_transfer(
-                server_args.disaggregation_layerwise_interval
-            )
+            if isinstance(self.kv_transfer, DisaggPrefillExecutor):
+                # P-side layerwise KV streaming: wire the step counter between
+                # the attn backends and the KV sender (a no-op for interval<=0).
+                self.kv_transfer.setup_layerwise_transfer(
+                    self.model_executor,
+                    self.gpu_id,
+                    server_args.disaggregation_layerwise_interval,
+                )
             # EPD: a multimodal prefill node is also the encode->prefill embedding
             # SINK (independent of kv_transfer, its P->D KV source) -- it receives
             # each image's embedding from encode workers over Mooncake so the
             # prefill skips the vision tower. The admission controller owns the
             # receive jobs, the rank-synced admission drain, and the optional NCCL
             # row-shard reassembly; None for decode/encode/text-only nodes.
+            # EpdPrefillHooks is the loop-side integration (see prefill_hooks.py).
             from tokenspeed.runtime.epd.prefill_admission import (
                 make_epd_prefill_admission,
             )
 
-            self.epd_admission = make_epd_prefill_admission(
-                server_args,
-                global_rank,
-                model_config=self.model_config,
-                model_executor=self.model_executor,
-                mapping=mapping,
-                attn_tp_rank=self.attn_tp_rank,
-                attn_tp_size=self.attn_tp_size,
-                attn_tp_cpu_group=self.attn_tp_cpu_group,
-                pg_manager=pg_manager,
+            self._epd_hooks = EpdPrefillHooks(
+                self,
+                make_epd_prefill_admission(
+                    server_args,
+                    global_rank,
+                    model_config=self.model_config,
+                    model_executor=self.model_executor,
+                    mapping=mapping,
+                    attn_tp_rank=self.attn_tp_rank,
+                    attn_tp_size=self.attn_tp_size,
+                    attn_tp_cpu_group=self.attn_tp_cpu_group,
+                    pg_manager=pg_manager,
+                ),
             )
-            # Staged EPD request payloads (request_id -> (spec, state, bootstrap)),
-            # held here while the controller (rid-keyed, like kv_transfer) runs the
-            # async receive; popped in _drain_ready_epd_embeddings on admit/abort.
-            self._epd_staged: dict = {}
         else:
             self.kv_transfer = None
-            self.epd_admission = None
-            self._epd_staged: dict = {}
-
-    def _setup_pd_layerwise_transfer(self, interval: int) -> None:
-        if not isinstance(self.kv_transfer, DisaggPrefillExecutor):
-            return
-        if interval <= 0:
-            return
-
-        from tokenspeed.runtime.pd.utils import StepCounter
-
-        draft_attn_backend = self.model_executor.draft_attn_backend
-        step_counter = StepCounter(self.model_executor.device, self.gpu_id)
-        self.model_executor.attn_backend.register_step_counter(step_counter)
-        if draft_attn_backend is not None:
-            self.model_executor.register_draft_final_step_counter(step_counter)
-        self.kv_transfer.register_layerwise_step_counter(step_counter, interval)
-
-    def _is_epd_request(self, state) -> bool:
-        """True iff this request's images are encode-routed (smg injected per-image
-        encode handshakes) -- it must wait for its embeddings (staged via the EPD
-        admission controller, polled in _drain_ready_epd_embeddings) before being
-        scheduled. Caller guards on self.epd_admission (only a multimodal prefill
-        node has one); everything else admits immediately.
-        """
-        mm = getattr(state, "multimodal_inputs", None)
-        return mm is not None and any(
-            getattr(it, "encode_handshake", None) for it in mm.mm_items
-        )
-
-    def _assert_epd_embeddings_received(self, multimodal_context) -> None:
-        """EPD invariant: every handshaked item is filled with its embedding by the
-        async EPD admission drain (EpdPrefillAdmission.drain) BEFORE admission, so by
-        it is already encoded. This is a defensive check, not a receive: a handshaked
-        item that reached the forward un-received leaked past async admission (the
-        only EPD admission path) -- fail loud instead of running the tower or
-        publishing shard-only rows. No-op for non-EPD / text-only requests.
-        """
-        if (
-            self.epd_admission is None
-            or multimodal_context is None
-            or not multimodal_context.has_extend_inputs()
-        ):
-            return
-        for mm in multimodal_context.mm_inputs:
-            if mm is None:
-                continue
-            missing = [
-                i
-                for i, item in enumerate(mm.mm_items)
-                if getattr(item, "encode_handshake", None) is not None
-                and item.encoded is None
-            ]
-            if missing:
-                raise RuntimeError(
-                    f"EPD: handshaked items {missing} reached the prefill forward "
-                    "un-received; they must be admitted via the EPD admission drain"
-                )
-
-    def _drain_ready_epd_embeddings(self) -> None:
-        """Admit EPD requests whose async embedding receives completed this cycle.
-
-        The EpdPrefillAdmission controller DECIDES (poll + rank-lockstep MIN
-        all-reduce + reassemble) and returns (admitted, failed); here we ACT on
-        those decisions with the EventLoop's collaborators -- register/abort the
-        P->D sender, submit admitted requests, finish failed ones. No-op (and no
-        collective) on non-EPD nodes.
-        """
-        if self.epd_admission is None:
-            return
-        # Pause gate: withhold EPD admission while paused, mirroring the non-EPD
-        # admit_blocked gate -- else the drain below would submit and RUN reassembled
-        # specs during the pause. Staged receives wait in _pending until resume.
-        # Rank-safe: admit_blocked is rank-identical, so all ranks skip together.
-        if self._pause.admit_blocked:
-            return
-        admitted_ids, failed_ids = self.epd_admission.drain()
-        for rid in failed_ids:
-            spec, state, bootstrap = self._epd_staged.pop(rid)
-            # Signal the dual-dispatched decode that this request failed so its KV
-            # receiver fails (FailedEvent -> _process_kv_transfer_events abort)
-            # instead of waiting forever for KV the prefill will never send. The
-            # prefill never registered a P->D sender (deferred to admission), so the
-            # decode has no other reliable way to learn (heartbeat only trips on a
-            # dead prefill /health). Best-effort: only reaches decodes that already
-            # pre-allocated.
-            if (
-                isinstance(self.kv_transfer, DisaggPrefillExecutor)
-                and bootstrap is not None
-            ):
-                try:
-                    self.kv_transfer.abort(rid, bootstrap)
-                except Exception as exc:  # never let it wedge the loop
-                    logger.warning(
-                        "EPD abort->decode signal failed for rid=%s: %s",
-                        rid,
-                        exc,
-                    )
-            state.set_finish_with_abort("EPD embedding receive failed or timed out")
-            self.output_processor.publish_finished_at_admission(rid, state)
-        admitted_specs = []
-        for rid in admitted_ids:
-            spec, state, bootstrap = self._epd_staged.pop(rid)
-            # Aborted mid-receive (no abort path, so drain still returns it admitted):
-            # don't register the P->D sender or submit -- that runs a wasted forward
-            # and leaks the sender. Stream its finish instead.
-            if state.finished:
-                self.output_processor.publish_finished_at_admission(rid, state)
-                continue
-            # Register the P->D sender now (deferred from admission) -- the request
-            # is about to enter the scheduler.
-            if self.kv_transfer is not None:
-                self.kv_transfer.register(rid, bootstrap)
-            admitted_specs.append(spec)
-        if admitted_specs:
-            self.scheduler.submit_requests(admitted_specs)
-        elif self.epd_admission.has_pending():
-            # Nothing advanced this cycle but requests are still receiving; yield the
-            # GIL so the Python daemon transfer/recv threads run (rank-consistent:
-            # admitted/leftover are rank-identical here).
-            time.sleep(0.0005)
-
-    def _commit_cache_results(self) -> None:
-        if self.l2_cache_executor is None:
-            return
-        cache_results = self.l2_cache_executor.poll_results()
-        self._num_inflight_cache_ops -= len(cache_results)
-        for event in cache_results:
-            payload = cache_event_to_payload(event)
-            self._pending_cache_event_payloads[cache_event_key(payload)] = payload
-
-        # The gather below is a collective, but cache-op completion is async and
-        # not lock-step across ranks, so local state (_num_inflight_cache_ops /
-        # _pending_cache_event_payloads) diverges transiently. A rank-local skip
-        # would let some ranks gather while others return, deadlocking the group.
-        # Agree on the skip via a cheap single-int all_reduce.
-        # NOTE: For non-DFLASH algorithms, cache ops are deterministic across
-        # ranks, so the local short-circuit is safe and avoids collective overhead.
-        local_has_work = bool(
-            self._num_inflight_cache_ops != 0 or self._pending_cache_event_payloads
-        )
-        if self.server_args.speculative_algorithm in ("DFLASH", "DSPARK"):
-            if not self._cache_group_has_work(local_has_work):
-                return
-        else:
-            if not local_has_work:
-                return
-
-        ready_payloads = self._pop_ready_cache_event_payloads()
-        if not ready_payloads:
-            return
-        logger.debug(
-            "[cache_poll] got %s synchronized results, advancing scheduler",
-            len(ready_payloads),
-        )
-        ec = ExecutionEvent()
-        for payload in ready_payloads:
-            e = cache_event_from_payload(payload)
-            logger.debug(
-                "[cache_poll] event: op_id=%s type=%s",
-                e.op_id,
-                type(e).__name__,
-            )
-            ec.add_event(e)
-        self.scheduler.advance(ec)
-        self._mark_load_snapshot_dirty()
-        logger.debug("[cache_poll] scheduler.advance() done")
-        self._publish_scheduler_kv_events()
+            self._epd_hooks = EpdPrefillHooks(self, None)
+        # PD transfer-event integration (see pd/transfer_hooks.py); a no-op
+        # when PD is disabled.
+        self._pd_hooks = PdTransferHooks(self)
 
     def _publish_scheduler_kv_events(self) -> None:
+        """Drain the KV events the C++ scheduler accumulated and publish them.
+
+        Drain semantics: events queue up inside the scheduler across any
+        number of mutations (advance / next_execution_plan), so one call at
+        the event-loop tail — its only call site — publishes everything the
+        round produced, in order, as a single batch.
+        """
         raw_events = drain_scheduler_kv_events(
             self.scheduler,
             enabled=self._kv_events_enabled,
@@ -812,63 +623,10 @@ class EventLoop:
             KVEventBatch(ts=time.time(), events=events, attn_dp_rank=self.dp_rank)
         )
 
-    def _cache_group_has_work(self, local_has_work: bool) -> bool:
-        """Whether ANY attn-tp rank has cache work this step (unanimous via a
-        single-int MAX all_reduce, far cheaper than the payload gather it
-        guards). Deciding from rank-local state alone deadlocks the group; see
-        _commit_cache_results.
-
-        Args:
-            local_has_work: This rank's view of whether any cache op is in
-                flight or any polled payload awaits commit.
-
-        Returns:
-            ``True`` if any rank has work (all must gather); ``False`` only when
-            every rank is idle.
-        """
-        if self.attn_tp_size == 1:
-            return local_has_work
-        flag = torch.tensor([1 if local_has_work else 0], dtype=torch.int32)
-        dist.all_reduce(flag, op=dist.ReduceOp.MAX, group=self.attn_tp_cpu_group)
-        return bool(flag.item())
-
-    def _pop_ready_cache_event_payloads(self) -> list[dict]:
-        local_payloads = list(self._pending_cache_event_payloads.values())
-        if self.attn_tp_size == 1:
-            ready_payloads = local_payloads
-        else:
-            gathered_payloads = [None] * self.attn_tp_size
-            dist.all_gather_object(
-                gathered_payloads,
-                local_payloads,
-                group=self.attn_tp_cpu_group,
-            )
-            ready_payloads = pop_common_cache_event_payloads(gathered_payloads)
-            if self.attn_tp_rank == 0 and cache_sync_debug_enabled():
-                pending_ops = [
-                    [(payload["kind"], payload["op_id"]) for payload in rank_payloads]
-                    for rank_payloads in gathered_payloads
-                ]
-                if len({tuple(rank_ops) for rank_ops in pending_ops}) > 1:
-                    logger.info(
-                        "[cache_sync] rank=%s pending_ops=%s ready_ops=%s",
-                        self.global_rank,
-                        pending_ops,
-                        [
-                            (payload["kind"], payload["op_id"])
-                            for payload in ready_payloads
-                        ],
-                    )
-
-        for payload in ready_payloads:
-            self._pending_cache_event_payloads.pop(cache_event_key(payload), None)
-        return ready_payloads
-
     def _dispatch_forward(
         self,
         forward_op,
         sampling_params_list,
-        execution_plan,
         dp_metadata=None,
         stats=None,
         grammar_inputs=None,
@@ -876,9 +634,9 @@ class EventLoop:
     ):
         """Execute one forward step; return (results, on_first_token).
 
-        results is None when the step produces no model output (Path 2/3).
-        Both event_loop and event_loop_overlap call this method; they differ
-        only in *when* they call post_process on the returned results.
+        results is None when the step produces no model output (Path 2/3);
+        otherwise the loop queues (results, on_first_token) in ``in_flight``
+        and commits them later (post_process at the queue head).
 
         Path 1 — no PD:              run forward, return (results, None)
         Path 2 — decode, extend:     trigger RDMA receive, return (None, None)
@@ -897,7 +655,13 @@ class EventLoop:
             dp_metadata.all_decode_or_idle if dp_metadata is not None else False
         )
         dp_all_extend = dp_metadata.all_extend if dp_metadata is not None else False
-        multimodal_context = self._get_multimodal_context_for_forward(forward_op)
+        multimodal_context = (
+            multimodal_context_for_forward(
+                forward_op, self.output_processor.rid_to_state
+            )
+            if self.model_config.is_multimodal_active
+            else None
+        )
 
         if self.kv_transfer is None:
             # Path 1: normal (no disaggregation)
@@ -956,7 +720,8 @@ class EventLoop:
                 )
 
         else:
-            # Prefill node (only reached from event_loop, never event_loop_overlap)
+            # Prefill node (the overlap schedule is disabled for the P role;
+            # under PP the in-flight depth is the chunk-pipeline depth instead)
             if not isinstance(self.kv_transfer, DisaggPrefillExecutor):
                 raise TypeError("kv_transfer must be a DisaggPrefillExecutor.")
             if forward_op.num_extends() == 0:
@@ -970,7 +735,7 @@ class EventLoop:
                 # EPD invariant: handshaked items are filled by the async
                 # EPD admission drain before admission; assert none reached
                 # the forward un-received (no-op for non-EPD / text-only requests).
-                self._assert_epd_embeddings_received(multimodal_context)
+                self._epd_hooks.assert_embeddings_received(multimodal_context)
                 return (
                     self.model_executor.execute_forward_op_with_log(
                         forward_op,
@@ -986,43 +751,6 @@ class EventLoop:
                     ),
                     self.kv_transfer.store_prefill_token,
                 )
-
-    def _get_multimodal_context_for_forward(self, forward_op):
-        if not self.model_config.is_multimodal_active:
-            return None
-
-        num_extends = forward_op.num_extends()
-        mm_inputs = []
-        has_mm = False
-        for index, rid in enumerate(forward_op.request_ids):
-            state = self.output_processor.rid_to_state.get(rid)
-            if state is not None and index < num_extends:
-                state.maybe_extend_multimodal_mrope_positions()
-            item = getattr(state, "multimodal_inputs", None) if state else None
-            mm_inputs.append(item)
-            has_mm = has_mm or item is not None
-        if not has_mm:
-            return None
-
-        from tokenspeed.runtime.multimodal.inputs import MultimodalForwardContext
-
-        return MultimodalForwardContext(
-            mm_inputs=mm_inputs,
-            extend_prefix_lens=list(forward_op.extend_prefix_lens),
-            extend_seq_lens=list(forward_op.input_lengths[:num_extends]),
-        )
-
-    def _submit_cache_ops(self, execution_plan) -> None:
-        if self.l2_cache_executor is None:
-            return
-        self.l2_cache_executor.submit_plan(execution_plan)
-        for op in execution_plan.cache:
-            if isinstance(op, Cache.WriteBackOp):
-                self._num_inflight_cache_ops += len(op.op_ids)
-            elif isinstance(op, Cache.LoadBackOp):
-                self._num_inflight_cache_ops += len(op.op_ids)
-            else:
-                raise ValueError(f"unsupported cache op kind: {type(op).__name__}")
 
     # ------------------------------------------------------------------
     # Helpers
@@ -1070,12 +798,23 @@ class EventLoop:
 
     def _init_interprocess_comm(self):
         context = zmq.Context(2)
-        if self.attn_tp_rank == 0:
+        # Chunk-pipeline: request I/O is owned by GLOBAL rank 0 only —
+        # every stage's tp_rank-0 would otherwise try to open the one
+        # frontend socket pair. recv_reqs broadcasts over the world group.
+        owns_request_io = (
+            self.server_args.mapping.rank == 0
+            if self.server_args.mapping.has_pp
+            else self.attn_tp_rank == 0
+        )
+        if owns_request_io:
             if self.server_args.zmq_msgpack:
                 # SMG drives the scheduler directly: it binds the sockets and
-                # this engine connects in over the msgpack wire (see zmq_msgpack).
+                # this engine connects in over the msgpack wire; the handshake
+                # (engine identity, ready response) lives in zmq_msgpack.
+                from tokenspeed.runtime.engine import zmq_msgpack
+
                 self.recv_from_tokenizer, self.send_to_tokenizer = (
-                    self._init_msgpack_transport(context)
+                    zmq_msgpack.connect_msgpack_engine_for_loop(context, self)
                 )
             else:
                 self.recv_from_tokenizer = IpcReceiver(
@@ -1093,7 +832,7 @@ class EventLoop:
                 )
         else:
             self.recv_from_tokenizer = None
-            self.send_to_tokenizer = _NullSender()
+            self.send_to_tokenizer = NullSender()
 
     def _init_load_snapshot_publisher(self) -> None:
         self._load_snapshot_observed_while_paused = False
@@ -1110,70 +849,9 @@ class EventLoop:
                 self.server_args.load_watch_interval,
             )
 
-    def _init_msgpack_transport(self, context):
-        """Complete the SMG startup handshake and return the wrapped msgpack
-        input/output sockets."""
-        from tokenspeed.runtime.engine import zmq_msgpack, zmq_wire
-
-        # Each DP rank dials SMG with its own engine identity
-        # (zmq_engine_index + dp_rank): the frontend's grouped worker awaits
-        # dp_size engines on one socket set and tells the ranks apart — and
-        # routes inputs back — by this index. The ready response carries the
-        # true dp rank/size alongside.
-        engine_index = self.server_args.zmq_engine_index + self.dp_rank
-        geometry = self._scheduler_cache_geometry
-        ready_response = zmq_wire.WireEngineCoreReadyResponse(
-            max_model_len=self.model_config.context_len,
-            num_gpu_blocks=geometry.num_device_pages,
-            prefix_granularity=geometry.prefix_granularity,
-            dtype=_wire_dtype(self.model_config.dtype),
-            multimodal_encoder_dtype=self.multimodal_encoder_dtype,
-            vllm_version=f"tokenspeed-{_tokenspeed_version()}",
-            world_size=self.world_size,
-            data_parallel_size=self.dp_size,
-            tensor_parallel_size=self.attn_tp_size,
-            data_parallel_rank=self.dp_rank,
-            max_num_seqs=self.server_args.max_num_seqs,
-            # chunked_prefill_size=-1 means "disabled"; the wire field is a
-            # non-negative integer for the frontend, so clamp to 0 (= no cap).
-            max_num_batched_tokens=max(0, self.server_args.chunked_prefill_size),
-            instance_id=self.server_args.served_model_name or self.server_args.model,
-            kv_cache_size_tokens=self.max_total_num_tokens,
-        )
-        return zmq_msgpack.connect_msgpack_engine(
-            context,
-            self.server_args.zmq_handshake_endpoint(),
-            engine_index,
-            ready_response,
-            self.model_config.vocab_size,
-            enable_output_logprobs=self.server_args.enable_output_logprobs,
-        )
-
     # ------------------------------------------------------------------
     # Shared step helpers
     # ------------------------------------------------------------------
-
-    def _reap_or_keep_buffered_spec(self, spec) -> bool:
-        """Resolve a buffered spec on resume; return True if it should be admitted.
-
-        A buffered spec was already registered in ``rid_to_state`` before it was
-        withheld, so if it was aborted while paused it never reached the
-        scheduler and the forward path can never reap it. Handle that here:
-
-        - state missing  -> already published and reaped; drop silently.
-        - state finished -> aborted in place. Stream a terminating finish for
-          pause-initiated aborts (the passive client is still waiting) and drop
-          the registered state so the rid does not leak; client-initiated aborts
-          already tore down their own state, so just reap.
-        - otherwise      -> still live; admit it.
-        """
-        state = self.output_processor.rid_to_state.get(spec.request_id)
-        if state is None:
-            return False
-        if state.finished:
-            self.output_processor.reap_finished_orphan(spec.request_id, state)
-            return False
-        return True
 
     def _request_abort_or_mark(
         self, request_id: str, _reason: str, *, notify_client: bool = False
@@ -1191,10 +869,8 @@ class EventLoop:
             # requests into its Python-side buffers. Re-sample once after that
             # batch instead of heartbeating the pre-mutation tuple forever.
             self._mark_load_snapshot_dirty()
-        # Snapshot the pause state before dispatch: process_requests may flip it
-        # mid-batch. If it was not blocked before but is after, a pause control
-        # message was processed in this very batch — which is what makes the
-        # FIFO edge below detectable (see TODO(pause-fifo)).
+        # Pause-state snapshot for withhold_admissions below: it must be
+        # taken before process_requests, which may flip the state mid-batch.
         pause_blocked_before = self._pause.admit_blocked
         new_req_specs, new_req_states, bootstrap_infos, abort_rids = (
             self.request_handler.process_requests(recv_reqs)
@@ -1214,46 +890,11 @@ class EventLoop:
             self._request_abort_or_mark(rid, "client cancelled request")
             grammar_manager.mark_abort(rid)
 
-        # A pause(mode="abort") cancels every in-flight request through the same
-        # marker path as a client abort; they finish on their next scheduled
-        # step, then the drain check resolves the pause reply.
-        if self._pause.consume_abort_all():
-            for rid in list(self.output_processor.rid_to_state.keys()):
-                # notify_client=True: pause aborts a passive client's request,
-                # so it must receive a terminating finish (unlike a client abort).
-                self._request_abort_or_mark(
-                    rid, "request aborted by pause", notify_client=True
-                )
-                grammar_manager.mark_abort(rid)
-
-        # abort/wait also cancel requests still compiling in the grammar queue:
-        # they are not yet in rid_to_state or the scheduler, so the sweep above
-        # and the drain check both miss them. A finished state makes the next
-        # get_ready_grammar_requests pass publish them instead of admitting, so
-        # they never run under post-resume weights or strand the drain.
-        if self._pause.consume_cancel_grammar():
-            for _, state, _ in grammar_manager.grammar_queue:
-                state.set_finish_with_abort("Aborted by pause", notify_client=True)
-
-        # On resume, flush specs buffered while paused even when no new request
-        # arrives this iteration. This must run before the ``if not ready:
-        # return`` guard below, which would otherwise strand buffered specs
-        # until the next inbound request. Specs aborted while paused are reaped
-        # in place (terminating finish + state cleanup) rather than admitted, so
-        # they don't burn a scheduler slot or leak their rid — see
-        # ``_reap_or_keep_buffered_spec``.
-        if not self._pause.admit_blocked and self._pause.buffered_specs:
-            specs = [
-                spec
-                for spec in self._pause.take_buffered_specs()
-                if self._reap_or_keep_buffered_spec(spec)
-            ]
-            if specs:
-                self.scheduler.submit_requests(specs)
+        self._pause_hooks.apply_transitions(grammar_manager)
 
         # Partition new requests by grammar readiness. Compile-bound requests
         # are queued in GrammarManager and admitted in a later iteration when
-        # their futures resolve (see _drain_ready_grammar_requests below).
+        # their futures resolve (get_ready_grammar_requests below).
         ready = []
         for spec, state, bootstrap in zip(
             new_req_specs, new_req_states, bootstrap_infos
@@ -1292,70 +933,66 @@ class EventLoop:
                 )
                 continue
 
-            if self._pd_cache_enabled:
-                if bootstrap is None:
-                    raise ValueError(
-                        "Paged cache PD request is missing bootstrap information"
-                    )
+            if self._pd_cache_enabled and bootstrap is None:
+                raise ValueError(
+                    "Paged cache PD request is missing bootstrap information"
+                )
             if isinstance(self.kv_transfer, DisaggDecodeExecutor):
                 state.computed_length = state.input_length
             self.output_processor.register(spec.request_id, state)
-            is_epd = self.epd_admission is not None and self._is_epd_request(state)
-            # EPD: DEFER the P->D sender registration to admission (in
-            # EpdPrefillAdmission.drain, just before submit_requests). Registering
-            # it now -- while the request is staged and NOT yet in the C++ scheduler
-            # -- would let DisaggPrefillExecutor.generate_events poll the sender and
-            # emit a BootstrappedEvent that the scheduler's requests_.at(rid) THROWS
-            # on (no such request yet). Non-EPD requests register now (submitted this
-            # same call).
-            if self.kv_transfer is not None and not is_epd:
+            # EPD prefill: an encode-routed request is staged OUT of the
+            # scheduler until its embeddings arrive; its P->D sender
+            # registration and submission are both deferred to the EPD
+            # admission drain (see EpdPrefillHooks.try_stage for why).
+            if self._epd_hooks.try_stage(spec, state, bootstrap):
+                continue
+            if self.kv_transfer is not None:
                 self.kv_transfer.register(spec.request_id, bootstrap)
+            admitted_specs.append(spec)
 
-            # EPD prefill: hold a request whose images are encode-routed OUT of the
-            # scheduler until its per-image embeddings have been received (started
-            # here, polled in EpdPrefillAdmission.drain, which registers the P->D
-            # sender + submits once ready). It is output_processor-registered above;
-            # the sender registration + submission are both deferred. Non-EPD
-            # requests admit immediately as before. Rank-identical because `ready` is
-            # rank-synced (recv_reqs broadcast + grammar gather).
-            if is_epd:
-                self.epd_admission.stage(
-                    spec.request_id, state.multimodal_inputs.mm_items
-                )
-                self._epd_staged[spec.request_id] = (spec, state, bootstrap)
-            else:
-                admitted_specs.append(spec)
-
-        # Pause gate: while paused, withhold new requests from the scheduler
-        # (running requests keep stepping); buffered specs are flushed on resume
-        # above, ahead of any newly-admitted ones, preserving FIFO order.
-        #
-        # TODO(pause-fifo): recv_reqs() drains the socket non-blocking, so a
-        # generate request that arrived *before* a pause control message can be
-        # coalesced into the same batch and reach here after the pause flipped
-        # admit_blocked. Such a pre-pause request is buffered as post-pause work
-        # instead of running (wait) / being aborted (abort). Correct handling
-        # needs the batch processed as an ordered stream that respects the
-        # control request's FIFO position. Tracked as a follow-up; until then we
-        # warn when the coalescing condition is observed so it is not silent.
-        if self._pause.admit_blocked:
-            if admitted_specs and not pause_blocked_before:
-                logger.warning(
-                    "Pause engaged in the same recv batch as %d generate "
-                    "request(s) (rids=%s); their FIFO order relative to the "
-                    "pause is not preserved, so a pre-pause request may be "
-                    "buffered as post-pause work and run only after resume. "
-                    "See TODO(pause-fifo).",
-                    len(admitted_specs),
-                    [spec.request_id for spec in admitted_specs],
-                )
-            self._pause.buffer_specs(admitted_specs)
+        if self._pause_hooks.withhold_admissions(admitted_specs, pause_blocked_before):
             return
 
         if admitted_specs:
             self.scheduler.submit_requests(admitted_specs)
 
     @nvtx_range("loop:commit", color="rapids")
+    def _pp_broadcast_output_tokens(self, forward_op, results) -> None:
+        """Align sampled tokens across pipeline stages before commit.
+
+        Only the last stage samples; the other stages produced placeholder
+        outputs. Every rank's C++ scheduler expects the REAL first token in
+        the final chunk's ExtendResult, and every stage's KV sender needs the
+        bootstrap token, so the last stage broadcasts (output_tokens,
+        output_lengths) over the PP gloo group and the others adopt them.
+        Runs on the commit path (queue head), off the dispatch hot path.
+        """
+        mapping = self.server_args.mapping
+        if not mapping.has_pp:
+            return
+        group = pg_manager.get_process_group("gloo", mapping.pp_group)
+        src_global_rank = mapping.pp_group[-1]
+        results.sync()
+        payload = [None]
+        if mapping.is_last_pp_rank:
+            payload = [
+                (
+                    results.output_tokens.cpu(),
+                    results.output_lengths.cpu(),
+                    (
+                        results.next_input_ids
+                        if results.next_input_ids is None
+                        else results.next_input_ids.cpu()
+                    ),
+                )
+            ]
+        dist.broadcast_object_list(payload, src=src_global_rank, group=group)
+        if not mapping.is_last_pp_rank:
+            tokens, lengths, next_ids = payload[0]
+            results.output_tokens = tokens
+            results.output_lengths = lengths
+            results.next_input_ids = next_ids
+
     def _commit_forward_results(
         self,
         forward_op,
@@ -1368,6 +1005,7 @@ class EventLoop:
             len(forward_op.request_ids),
         )
         self.request_handler._profile_batch_predicate(forward_mode)
+        self._pp_broadcast_output_tokens(forward_op, results)
 
         # post_process_forward_op calls sync() — after this, CPU tensors are ready
         is_prefill_instance = isinstance(self.kv_transfer, DisaggPrefillExecutor)
@@ -1392,70 +1030,6 @@ class EventLoop:
             return None
         return forward_ops[0]
 
-    def _process_kv_transfer_events(self, kv_transfer_events: list) -> list:
-        processed = []
-        for event in kv_transfer_events:
-            processed.append(event)
-            if isinstance(event, PD.SucceededEvent) and isinstance(
-                self.kv_transfer, DisaggPrefillExecutor
-            ):
-                req_id = event.request_id
-                processed.extend(self.output_processor.finish_prefill_request(req_id))
-            elif isinstance(event, PD.RemotePrefillDoneEvent):
-                req_id = event.request_id
-                bootstrap_token = event.bootstrap_token
-                state = self.output_processor.rid_to_state.get(req_id)
-                if state is None or not state.to_abort:
-                    self.output_processor.on_remote_prefill_done(
-                        req_id, bootstrap_token
-                    )
-                if self._pd_cache_enabled:
-                    processed.extend(
-                        self.output_processor.finish_remote_prefill_only_request(req_id)
-                    )
-                if isinstance(self.kv_transfer, DisaggDecodeExecutor):
-                    remote_cache_slot = self.kv_transfer.pop_remote_cache_slot(req_id)
-                    candidate_info = self.kv_transfer.pop_remote_spec_candidate_ids(
-                        req_id
-                    )
-                    if candidate_info is not None:
-                        req_pool_idx, candidate_ids = candidate_info
-                        self.model_executor.write_remote_spec_candidate_ids(
-                            req_pool_idx, candidate_ids
-                        )
-                    remaining_state = self.output_processor.rid_to_state.get(req_id)
-                    if (
-                        remote_cache_slot is not None
-                        and remaining_state is not None
-                        and not remaining_state.to_abort
-                        and not remaining_state.finished
-                    ):
-                        self.model_executor.mark_remote_cache_ready(remote_cache_slot)
-            elif isinstance(event, PD.FailedEvent):
-                # A PD/EPD transfer failed: the decode KV receiver timed out (e.g. the
-                # prefill aborted on embedding timeout so the KV never arrives), or a
-                # transfer errored. Publish the client-visible failure here. An
-                # encode-only EPD flow still needs a following Forward.Abort because
-                # its C++ FailedEvent handler is a no-op; CachePD FailedEvent
-                # atomically terminalizes and fences the leased scheduler resources.
-                req_id = event.request_id
-                state = self.output_processor.rid_to_state.get(req_id)
-                if state is not None:
-                    if state.finished:
-                        self.output_processor.reap_finished_orphan(req_id, state)
-                    else:
-                        state.set_finish_with_abort(
-                            "PD/EPD remote transfer failed or timed out"
-                        )
-                        self.output_processor.publish_finished_at_admission(
-                            req_id, state
-                        )
-                    if not self._pd_cache_enabled:
-                        abort = ForwardEvent.Abort()
-                        abort.request_id = req_id
-                        processed.append(abort)
-        return processed
-
     def _dp_sync_and_check(self, forward_op) -> DpForwardMetadata:
         """Synchronize DP ranks with CPU-only metadata.
 
@@ -1463,11 +1037,21 @@ class EventLoop:
         used for eager token-aware collectives and for choosing a common padded
         CUDA graph shape during decode.
         """
-        import torch.distributed as dist
-
-        executes_model_forward = _forward_op_executes_model_forward(
-            forward_op,
-            is_disagg_decode=isinstance(self.kv_transfer, DisaggDecodeExecutor),
+        # Whether forward_op will enter the model forward path. On decode-side
+        # PD, EXTEND ops only start remote KV receive; the model forward runs
+        # after the remote prefill completes and the scheduler advances the
+        # request into decode. Treating those EXTEND ops as model work makes
+        # idle DP ranks enter dummy collectives that the active rank will not
+        # match.
+        is_disagg_decode = isinstance(self.kv_transfer, DisaggDecodeExecutor)
+        executes_model_forward = (
+            forward_op is not None
+            and sum(forward_op.input_lengths) > 0
+            and not (
+                is_disagg_decode
+                and forward_op.num_extends() > 0
+                and not forward_op.is_local_prefill()
+            )
         )
         num_tokens = sum(forward_op.input_lengths) if executes_model_forward else 0
         batch_size = len(forward_op.request_ids) if executes_model_forward else 0
@@ -1545,6 +1129,19 @@ class EventLoop:
         """Request one fresh scheduler sample on the next paused iteration."""
         self._load_snapshot_observed_while_paused = False
 
+    def _maybe_observe_paused_load(self, had_changes: bool) -> None:
+        """Frozen rounds: sample the load once per pause — and again after any
+        round that changed scheduler state (committed changes, or a dirty mark
+        from new requests / cache-op completions) — instead of on every idle
+        spin. Called at the loop tail, after the advance, so the sample
+        reflects the applied changes.
+        """
+        if self.attn_tp_rank != 0:
+            return
+        if had_changes or not self._load_snapshot_observed_while_paused:
+            self._observe_load_snapshot(self._get_scheduler_stats())
+            self._load_snapshot_observed_while_paused = True
+
     def _record_scheduler_iteration_metrics(
         self, stats: dict, num_iteration_tokens: int
     ) -> None:
@@ -1557,88 +1154,80 @@ class EventLoop:
         )
 
     # ------------------------------------------------------------------
-    # Pause / resume helpers
-    # ------------------------------------------------------------------
-
-    def _reset_caches_for_release(self) -> bool:
-        """Invalidate the prefix/single-table cache before KV is discarded on release.
-
-        KV pages are re-mapped + zeroed on wake, so any retained prefix entry
-        would be stale. The unsafe case (prefix caching on with no reset) is
-        rejected up front in ``MemoryOccupationController.handle_release`` via
-        ``kv_cache_release_allowed``, so by the time we get here either a clear
-        exists or prefix caching is off (nothing to invalidate). Returns False
-        while an asynchronous cache transfer still pins L1 so the release can
-        remain pending and retry on the next event-loop iteration.
-        """
-        clear = getattr(self.scheduler, "clear_l1_cache", None)
-        return not callable(clear) or clear()
-
-    def _kv_pools(self) -> list:
-        """All KV pools whose pages are tagged ``kv_cache`` — the target pool and
-        the draft pool in speculative-decoding runs. Release/repair must walk the
-        SAME set, so both derive it here rather than enumerating pools by hand."""
-        pools = []
-        for attr in ("token_to_kv_pool", "draft_token_to_kv_pool"):
-            pool = getattr(self.model_executor, attr, None)
-            if pool is not None:
-                pools.append(pool)
-        return pools
-
-    def _kv_repair_after_wake(self) -> None:
-        """Zero re-mapped KV buffers (garbage after re-map) for every KV pool,
-        including the draft pool in spec-decode runs — its allocations are tagged
-        ``kv_cache`` too, so a wake that skipped it would feed the draft model
-        stale KV. FP8 KV scales ride with the weights region, so no scale reset
-        is needed here."""
-        for pool in self._kv_pools():
-            if hasattr(pool, "clear_kv_buffers"):
-                pool.clear_kv_buffers()
-
-    def _paused_idle_step(self, prev_forward_op=None, prev_results=None) -> None:
-        """Run one iteration under ``PAUSED_ALL`` (keep mode): no new forward
-        work, but keep DP ranks in lockstep, service the drain check, and yield
-        the CPU so the freeze does not busy-spin a core."""
-        if prev_results is not None:
-            request_changes = self._commit_forward_results(
-                prev_forward_op, prev_results
-            )
-            advance_forward(self.scheduler, request_changes)
-            self._publish_scheduler_kv_events()
-
-        if self.attn_tp_rank == 0 and (
-            prev_results is not None or not self._load_snapshot_observed_while_paused
-        ):
-            stats = self._get_scheduler_stats()
-            self._observe_load_snapshot(stats)
-            self._load_snapshot_observed_while_paused = True
-
-        if self.has_dp:
-            dp_metadata = self._dp_sync_and_check(None)
-            # While memory is released the weights region is unmapped; an idle
-            # forward runs the model and would read freed memory. All DP ranks
-            # release together, so skipping the idle forward stays consistent
-            # across ranks (the small DP sync above still runs to keep lockstep).
-            if dp_metadata.need_idle_forward and not self._pause.released:
-                self.model_executor.execute_idle_forward(
-                    dp_metadata.global_num_tokens,
-                    dp_metadata.global_batch_size,
-                    dp_metadata.all_decode_or_idle,
-                )
-
-        self._pause.maybe_finish_drain(self.scheduler)
-        time.sleep(_PAUSED_IDLE_SLEEP_S)
-
-    # ------------------------------------------------------------------
     # Event loops
     # ------------------------------------------------------------------
 
     def _shutdown_complete(self) -> bool:
         return self.shutdown_event.is_set()
 
+    def _drain_in_flight(self, in_flight) -> list:
+        """Commit every queued forward, oldest first; return their changes."""
+        request_changes = []
+        while in_flight:
+            fo, res, oft = in_flight.popleft()
+            request_changes.extend(self._commit_forward_results(fo, res, oft))
+        return request_changes
+
+    def _dispatch_depends_on_pending_commit(self, forward_op, grammar_inputs) -> bool:
+        """Whether the upcoming dispatch reads state that only a pending
+        commit produces, so the in-flight queue must drain first.
+
+        The single registry of overlap-breaking dependencies — add new rules
+        here, not in ``event_loop``:
+
+        - P-side PD handoff batch: ``kv_transfer.execute`` needs the final
+          chunk's bootstrap token, which only lands at commit.
+        - Eager grammar: ``setup_grammar_step`` reads each matcher's current
+          state to fill the bitmask, and the matcher only advances at the
+          pending step's commit (``accept_token``). Capturable grammar dodges
+          this with an in-graph hostfunc; eager has no equivalent, so trade
+          the overlap away for grammar batches.
+        """
+        if forward_op.num_extends() == 0 and isinstance(
+            self.kv_transfer, DisaggPrefillExecutor
+        ):
+            return True
+        return (
+            grammar_inputs is not None
+            and self.model_executor.eager_grammar_buffers is not None
+        )
+
     def event_loop(self):
-        """Non-overlapping scheduler loop."""
+        """The one scheduler loop, parameterized by in-flight depth.
+
+        ``in_flight_depth`` is how many dispatched forwards may await commit:
+
+        - 0: commit in the same iteration (classic non-overlap behavior).
+        - 1: dispatch the current forward before committing the previous one,
+          so the CPU post-processes step N-1 while the GPU runs step N (the
+          overlap schedule).
+        - pp_size: the prefill chunk pipeline — consecutive chunks occupy
+          different pipeline stages; the head's copy_event sync is the
+          backpressure.
+
+        Correctness never depends on the depth: any dispatch whose inputs
+        depend on a pending commit's side effects drains the queue first
+        (``_dispatch_depends_on_pending_commit`` is the single registry of
+        those rules), and rounds that run no real forward (pause/freeze,
+        DP idle) drain it fully.
+
+        Scheduler feedback is only ever an explicit ``advance_scheduler`` call
+        in this loop body — helpers return events, never advance. Two calls:
+        cache-op completions at the head of the round (so this round's plan
+        sees them) and forward results at the tail (they only exist after
+        dispatch); everything else funnels into ``request_changes``.
+        """
+        in_flight: deque = deque()
+        depth = self.in_flight_depth
         while not self._shutdown_complete():
+            if depth > 0:
+                # Order this iter's default-stream writes (prefix_cache
+                # page-table writes) after the pending forwards on
+                # execution_stream that read the same tensors. Non-blocking
+                # on host; a no-op when nothing is in flight.
+                torch.cuda.default_stream().wait_stream(
+                    self.model_executor.execution_stream
+                )
             num_tracked_reqs = len(self.output_processor.rid_to_state)
             self._process_new_requests()
             if len(self.output_processor.rid_to_state) != num_tracked_reqs:
@@ -1646,76 +1235,132 @@ class EventLoop:
             # EPD prefill: admit requests whose async embedding receives completed
             # this cycle (rank-synced). Fixed position right after
             # _process_new_requests so the drain's TP collective ordering is
-            # rank-identical every cycle.
-            self._drain_ready_epd_embeddings()
-            self._commit_cache_results()
-            if self._pause.forward_blocked:
-                self._paused_idle_step()
-                continue
-            self._load_snapshot_observed_while_paused = False
-            execution_plan = self.scheduler.next_execution_plan()
-            self._publish_scheduler_kv_events()
-            cache_zero_event = self.model_executor.zero_cache_pages(
-                execution_plan.pages_to_zero
-            )
-            self._submit_cache_ops(execution_plan)
+            # rank-identical every cycle. A no-op without an EPD admission
+            # controller (every non-EPD deployment).
+            self._epd_hooks.drain_ready_embeddings()
+            cache_events = self._cache_hooks.poll_ready_events()
+            if cache_events:
+                # Advanced at the HEAD of the round (not funneled into the
+                # tail advance) so completed cache ops are visible to this
+                # round's next_execution_plan — deferring them would delay
+                # cache-gated admissions by a full round.
+                advance_scheduler(self.scheduler, cache_events)
+                self._mark_load_snapshot_dirty()
 
-            forward_op = self._get_forward_op(execution_plan)
-            stats = self._get_scheduler_stats()
-            self._observe_load_snapshot(stats)
-            num_iter_tokens = (
-                sum(forward_op.input_lengths) if forward_op is not None else 0
-            )
-
-            # DP sync: all ranks must participate even when idle.
-            dp_metadata = None
-            if self.has_dp:
-                dp_metadata = self._dp_sync_and_check(forward_op)
-                if dp_metadata.need_idle_forward:
-                    self.model_executor.execute_idle_forward(
-                        dp_metadata.global_num_tokens,
-                        dp_metadata.global_batch_size,
-                        dp_metadata.all_decode_or_idle,
-                    )
-                    self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
-                    continue
-
+            # Every path in this round appends its committed results here;
+            # they feed back into the scheduler through the single
+            # advance_scheduler call at the tail.
             request_changes = []
+            forward_op = None
+            # An idle round (freeze or DP idle) runs no dispatch and — as
+            # before the paths were unified — no kv-transfer event poll.
+            idle_round = False
 
-            if forward_op is not None:
-                sampling_params_list = self._gather_sampling_params(forward_op)
-                grammar_inputs = self._gather_grammar_state(forward_op)
-                self._mark_stats_scheduled(forward_op)
-                results, on_first_token = self._dispatch_forward(
-                    forward_op,
-                    sampling_params_list,
-                    execution_plan,
-                    dp_metadata=dp_metadata,
-                    stats=stats,
-                    grammar_inputs=grammar_inputs,
-                    cache_zero_event=cache_zero_event,
+            if self._pause.forward_blocked:
+                # Freeze: dispatched forwards can't be un-launched; commit them
+                # all before idling.
+                request_changes.extend(self._drain_in_flight(in_flight))
+                self._pause_hooks.paused_idle_step()
+                idle_round = True
+            else:
+                self._load_snapshot_observed_while_paused = False
+                execution_plan = self.scheduler.next_execution_plan()
+                cache_zero_event = self.model_executor.zero_cache_pages(
+                    execution_plan.pages_to_zero
                 )
-                if results is not None:
-                    request_changes.extend(
-                        self._commit_forward_results(
-                            forward_op, results, on_first_token
+                self._cache_hooks.submit(execution_plan)
+
+                forward_op = self._get_forward_op(execution_plan)
+                stats = self._get_scheduler_stats()
+                self._observe_load_snapshot(stats)
+                num_iter_tokens = (
+                    sum(forward_op.input_lengths) if forward_op is not None else 0
+                )
+                # Record once per iteration, from the same pre-dispatch
+                # snapshot as ``stats`` (the running gauge counts requests
+                # admitted but not yet committed-finished this round —
+                # consistent with waiting/pages).
+                self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
+
+                # DP sync: all ranks must participate even when idle. Checked
+                # right after forward_op is derived so an idle round commits
+                # pending steps and skips the per-batch work below (the
+                # gathers are local and read-only, so ordering them after the
+                # collective is rank-safe).
+                dp_metadata = None
+                if self.has_dp:
+                    dp_metadata = self._dp_sync_and_check(forward_op)
+                    if dp_metadata.need_idle_forward:
+                        request_changes.extend(self._drain_in_flight(in_flight))
+                        self.model_executor.execute_idle_forward(
+                            dp_metadata.global_num_tokens,
+                            dp_metadata.global_batch_size,
+                            dp_metadata.all_decode_or_idle,
                         )
+                        idle_round = True
+
+            if not idle_round:
+                grammar_inputs = None
+                sampling_params_list = None
+                if forward_op is not None:
+                    # Gather sampling params and grammar state BEFORE any
+                    # pending commit below — a commit can finish requests and
+                    # pop them from output_processor.rid_to_state, which would
+                    # KeyError on rids still present in the current forward_op.
+                    sampling_params_list = self._gather_sampling_params(forward_op)
+                    grammar_inputs = self._gather_grammar_state(forward_op)
+
+                if (
+                    in_flight
+                    and forward_op is not None
+                    and self._dispatch_depends_on_pending_commit(
+                        forward_op, grammar_inputs
                     )
+                ):
+                    request_changes.extend(self._drain_in_flight(in_flight))
 
-            if self.kv_transfer is not None:
-                kv_transfer_events = self.kv_transfer.generate_events()
-                request_changes.extend(
-                    self._process_kv_transfer_events(kv_transfer_events)
-                )
+                if forward_op is not None:
+                    self._mark_stats_scheduled(forward_op)
+                    results, on_first_token = self._dispatch_forward(
+                        forward_op,
+                        sampling_params_list,
+                        dp_metadata=dp_metadata,
+                        stats=stats,
+                        grammar_inputs=grammar_inputs,
+                        cache_zero_event=cache_zero_event,
+                    )
+                    if results is not None:
+                        in_flight.append((forward_op, results, on_first_token))
 
+                # Commit from the head once the queue exceeds the depth
+                # (immediately at depth 0; one step behind at depth 1; a full
+                # pipeline behind under PP). A round with no new work drains
+                # fully so results never wait on future traffic.
+                effective_depth = depth if forward_op is not None else 0
+                while len(in_flight) > effective_depth:
+                    fo, res, oft = in_flight.popleft()
+                    request_changes.extend(self._commit_forward_results(fo, res, oft))
+
+                request_changes.extend(self._pd_hooks.poll_transfer_events())
+
+            # The forward-result feedback point: everything this round
+            # committed reaches the scheduler here, before the next round
+            # plans. (Cache-op completions advance at the head instead — see
+            # _cache_hooks.poll_ready_events — but through the same advance_scheduler,
+            # the only caller of scheduler.advance.)
             if request_changes:
-                advance_forward(self.scheduler, request_changes)
-                self._publish_scheduler_kv_events()
+                advance_scheduler(self.scheduler, request_changes)
+
+            # Publish KV events once per round, after the last scheduler
+            # mutation: the drain empties everything the round accumulated
+            # (head cache advance, plan, tail advance) in order, as one batch.
+            self._publish_scheduler_kv_events()
+
+            if self._pause.forward_blocked:
+                self._maybe_observe_paused_load(had_changes=bool(request_changes))
 
             # Resolve a deferred abort/wait pause reply once in-flight work drains.
             self._pause.maybe_finish_drain(self.scheduler)
-
-            self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
 
     def _mark_stats_scheduled(self, forward_op) -> None:
         # Stamp the pre-forward "scheduled" time on each request's stats tracker
@@ -1771,158 +1416,6 @@ class EventLoop:
 
         return GrammarStepInputs(grammars=grammars, advance_mask=advance_mask)
 
-    def event_loop_overlap(self):
-        """
-        Overlapping scheduler loop: post-process the previous step's results
-        while the current step's forward pass is in flight.
-        """
-        # EPD invariant: the async embedding drain (EpdPrefillAdmission.drain)
-        # that admits EPD requests runs ONLY in event_loop(), never here. A
-        # prefill node that receives encode embeddings must therefore run the
-        # non-overlap loop -- should_use_overlap_schedule enforces this by forcing
-        # prefill -> non-overlap. Assert it rather than trusting that external
-        # coupling: if a prefill ever reached this loop, every EPD request would
-        # stage into the admission controller and hang forever with no drain.
-        assert self.epd_admission is None, (
-            "EPD prefill must run the non-overlap event_loop(); the embedding "
-            "drain is not wired into event_loop_overlap()"
-        )
-        prev_results: ModelExecutionResult = None
-        prev_forward_op = None
-
-        while not self._shutdown_complete():
-            # Order this iter's default-stream writes (prefix_cache page-table
-            # writes) after the prev iter's forward on execution_stream that
-            # reads the same tensor. Non-blocking on host.
-            torch.cuda.default_stream().wait_stream(
-                self.model_executor.execution_stream
-            )
-            num_tracked_reqs = len(self.output_processor.rid_to_state)
-            self._process_new_requests()
-            if len(self.output_processor.rid_to_state) != num_tracked_reqs:
-                self._mark_load_snapshot_dirty()
-            self._commit_cache_results()
-            if self._pause.forward_blocked:
-                # Freeze: commit any in-flight (overlapped) step — a forward
-                # already on the GPU can't be un-launched — then idle.
-                self._paused_idle_step(prev_forward_op, prev_results)
-                prev_results = None
-                prev_forward_op = None
-                continue
-            self._load_snapshot_observed_while_paused = False
-            execution_plan = self.scheduler.next_execution_plan()
-            self._publish_scheduler_kv_events()
-
-            cache_zero_event = self.model_executor.zero_cache_pages(
-                execution_plan.pages_to_zero
-            )
-            self._submit_cache_ops(execution_plan)
-
-            forward_op = self._get_forward_op(execution_plan)
-            stats = self._get_scheduler_stats()
-            self._observe_load_snapshot(stats)
-            num_iter_tokens = (
-                sum(forward_op.input_lengths) if forward_op is not None else 0
-            )
-
-            grammar_inputs = None
-            if forward_op is not None:
-                # Gather both sampling params and grammar state BEFORE the
-                # prev_results commit below — that commit can finish requests
-                # and pop them from output_processor.rid_to_state, which would
-                # KeyError when we look up rids that are still in the current
-                # forward_op.
-                sampling_params_list = self._gather_sampling_params(forward_op)
-                grammar_inputs = self._gather_grammar_state(forward_op)
-
-            # DP sync: all ranks must participate even when idle.
-            dp_metadata = None
-            if self.has_dp:
-                dp_metadata = self._dp_sync_and_check(forward_op)
-                if dp_metadata.need_idle_forward:
-                    if prev_results is not None:
-                        request_changes = self._commit_forward_results(
-                            prev_forward_op, prev_results
-                        )
-                        advance_forward(self.scheduler, request_changes)
-                        self._publish_scheduler_kv_events()
-                        prev_results = None
-                        prev_forward_op = None
-                    self.model_executor.execute_idle_forward(
-                        dp_metadata.global_num_tokens,
-                        dp_metadata.global_batch_size,
-                        dp_metadata.all_decode_or_idle,
-                    )
-                    self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
-                    continue
-
-            # ---- dispatch current forward first (async GPU launch) ----
-            # Issue curr's forward before committing prev so the GPU runs curr
-            # while the CPU syncs/post-processes prev. Committing prev first
-            # would block the CPU on prev's copy_event and leave the GPU idle
-            # until dispatch — visible as a gap between forwards in the trace.
-            #
-            # Eager grammar exception: setup_grammar_step reads each matcher's
-            # current state to fill the bitmask. Under the overlap pattern the
-            # matcher hasn't been advanced yet by prev's accept_token (commit
-            # below), so the fill would use a one-step-stale state and let the
-            # model sample a token the matcher then rejects. Capturable
-            # grammar dodges this with an in-graph hostfunc that advances
-            # before fill; eager has no equivalent, so we commit prev first
-            # whenever this batch carries grammars. Costs the dispatch/commit
-            # overlap for grammar batches but is correct.
-            request_changes = []
-            curr_has_grammar = grammar_inputs is not None
-            eager_grammar_needs_advance = (
-                curr_has_grammar
-                and prev_results is not None
-                and self.model_executor.eager_grammar_buffers is not None
-            )
-            if eager_grammar_needs_advance:
-                request_changes.extend(
-                    self._commit_forward_results(prev_forward_op, prev_results)
-                )
-                prev_results = None
-                prev_forward_op = None
-
-            curr_results = None
-            if forward_op is not None:
-                self._mark_stats_scheduled(forward_op)
-                curr_results, _ = self._dispatch_forward(
-                    forward_op,
-                    sampling_params_list,
-                    execution_plan,
-                    dp_metadata=dp_metadata,
-                    stats=stats,
-                    grammar_inputs=grammar_inputs,
-                    cache_zero_event=cache_zero_event,
-                )
-
-            # ---- post-process previous step (overlapped with current forward) ----
-            if prev_results is not None:
-                request_changes.extend(
-                    self._commit_forward_results(prev_forward_op, prev_results)
-                )
-
-            # ---- collect KV transfer events ----
-            if self.kv_transfer is not None:
-                kv_transfer_events = self.kv_transfer.generate_events()
-                request_changes.extend(
-                    self._process_kv_transfer_events(kv_transfer_events)
-                )
-
-            if request_changes:
-                advance_forward(self.scheduler, request_changes)
-                self._publish_scheduler_kv_events()
-
-            # Resolve a deferred abort/wait pause reply once in-flight work drains.
-            self._pause.maybe_finish_drain(self.scheduler)
-
-            self._record_scheduler_iteration_metrics(stats, num_iter_tokens)
-
-            prev_results = curr_results
-            prev_forward_op = forward_op
-
     def close(self) -> None:
         self.load_snapshot_publisher.close()
         # Best-effort: tell an attached SMG frontend this engine is going away
@@ -1948,6 +1441,12 @@ def run_event_loop(
     global_rank = mapping.rank
 
     setproctitle.setproctitle(f"tokenspeed::scheduler_{dp_rank}")
+    # Re-assert the NVSHMEM IB traffic class in every inference process:
+    # NVSHMEM reads it from the process environment at bootstrap, and worker
+    # processes may be spawned without inheriting the launcher's setting.
+    if envs.NVSHMEM_IB_TRAFFIC_CLASS.is_set():
+        envs.NVSHMEM_IB_TRAFFIC_CLASS.set(envs.NVSHMEM_IB_TRAFFIC_CLASS.get())
+        logger.info("NVSHMEM_IB_TRAFFIC_CLASS=%d", envs.NVSHMEM_IB_TRAFFIC_CLASS.get())
     faulthandler.enable()
     parent_process = psutil.Process().parent()
     register_usr_signal()
@@ -2006,10 +1505,7 @@ def run_event_loop(
             # the loop and starts the first DP metadata collective.
             dist.barrier(group=event_loop.world_cpu_group)
 
-        if event_loop.use_overlap_schedule:
-            event_loop.event_loop_overlap()
-        else:
-            event_loop.event_loop()
+        event_loop.event_loop()
 
     except Exception:
         traceback = get_exception_traceback()

--- a/python/tokenspeed/runtime/engine/generation_output_processor.py
+++ b/python/tokenspeed/runtime/engine/generation_output_processor.py
@@ -898,7 +898,7 @@ class OutputProcesser:
     def finish_prefill_request(self, req_id: str) -> list:
         """Finish a prefill-instance request when KV transfer succeeds (SucceededEvent).
 
-        Called by event_loop._process_kv_transfer_events at the correct moment — the
+        Called by PdTransferHooks.poll_transfer_events at the correct moment — the
         SucceededEvent itself drives the C++ FSM transition Decoding → Finished,
         so we must NOT emit an additional make_finish_event here.
 

--- a/python/tokenspeed/runtime/engine/io_struct.py
+++ b/python/tokenspeed/runtime/engine/io_struct.py
@@ -1284,6 +1284,16 @@ def ipc_message_union():
     return Union[types]  # noqa: UP007 — dynamic union over a runtime tuple
 
 
+class NullSender:
+    """No-op stand-in for the engine's reply sender on ranks that don't own
+    request I/O (non-rank-0 workers), so control-reply call sites are safe to
+    run on every rank."""
+
+    @staticmethod
+    def send_pyobj(x):
+        return None
+
+
 class IpcSender:
     """Engine-IPC sender wrapping a ZMQ PUSH/DEALER socket.
 

--- a/python/tokenspeed/runtime/engine/pause.py
+++ b/python/tokenspeed/runtime/engine/pause.py
@@ -26,6 +26,12 @@ The pause gate lives in Python: requests are admitted to the scheduler from the
 event loop (``scheduler.submit_requests``), so withholding new work while paused
 is handled here rather than inside the scheduler itself.
 
+Two classes split the work: :class:`PauseController` owns the state machine and
+is driven by the request handler (control plane); :class:`PauseHooks` is the
+EventLoop-side integration — everything the pause/resume API needs from the
+loop lives there, so the loop's normal scheduling paths carry single-line
+hooks only.
+
 Modes (how a pause treats in-flight requests):
 
 - ``abort``: cancel in-flight requests, then drain and reply.
@@ -41,6 +47,8 @@ and replies immediately.
 from __future__ import annotations
 
 import enum
+import logging
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -52,6 +60,12 @@ from tokenspeed.runtime.engine.io_struct import (
     ResumeSchedulerReqInput,
     ResumeSchedulerReqOutput,
 )
+
+logger = logging.getLogger(__name__)
+
+# Sleep between iterations while frozen (PAUSED_ALL) so the keep-mode pause does
+# not busy-spin a CPU core waiting for /resume.
+_PAUSED_IDLE_SLEEP_S = 0.001
 
 
 @dataclass
@@ -108,7 +122,7 @@ class PauseController:
     iteration to resolve a deferred abort/wait reply.
 
     ``send_func`` is the scheduler→tokenizer reply socket (a no-op
-    ``_NullSender`` on non-rank-0 TP ranks, matching the existing control-reply
+    ``NullSender`` on non-rank-0 TP ranks, matching the existing control-reply
     pattern), so the ``handle_*`` methods are safe to call on every rank.
     """
 
@@ -318,3 +332,181 @@ class PauseController:
             return
         self._pending_drain = None
         action.on_drained()
+
+
+class PauseHooks:
+    """EventLoop-side pause/resume integration.
+
+    Stateless glue: all pause state stays in :class:`PauseController` and the
+    loop's collaborators; this class only holds a loop back-reference and acts
+    on them, so the loop's normal scheduling paths carry single-line hooks
+    only. Attribute access on ``loop`` is lazy, so it may be constructed
+    before the loop's collaborators exist.
+    """
+
+    def __init__(self, loop, controller: PauseController) -> None:
+        self._loop = loop
+        self._pause = controller
+
+    # -- admission-path hooks (called from _process_new_requests) -------------
+
+    def apply_transitions(self, grammar_manager) -> None:
+        """Apply one-shot pause/resume edges to in-flight and queued requests.
+
+        Called once per iteration from ``_process_new_requests``, right after
+        control messages were processed (so a fresh edge is acted on in the
+        same iteration) and before the early ``if not ready: return`` (which
+        would otherwise strand buffered specs until the next inbound request).
+
+        - pause(mode="abort"): cancel every in-flight request through the same
+          marker path as a client abort; they finish on their next scheduled
+          step, then the drain check resolves the pause reply. notify_client:
+          a pause aborts a passive client's request, so it must receive a
+          terminating finish (unlike a client abort).
+        - abort/wait: cancel requests still compiling in the grammar queue —
+          they are not yet in ``rid_to_state`` or the scheduler, so the abort
+          sweep and the drain check both miss them. A finished state makes the
+          next ``get_ready_grammar_requests`` pass publish them instead of
+          admitting, so they never run under post-resume weights or strand the
+          drain.
+        - resume: flush specs buffered while paused, even when no new request
+          arrives this iteration. Specs aborted while paused are reaped in
+          place rather than admitted, so they don't burn a scheduler slot or
+          leak their rid — see ``_reap_or_keep_buffered_spec``.
+        """
+        loop = self._loop
+        if self._pause.consume_abort_all():
+            for rid in list(loop.output_processor.rid_to_state.keys()):
+                loop._request_abort_or_mark(
+                    rid, "request aborted by pause", notify_client=True
+                )
+                grammar_manager.mark_abort(rid)
+
+        if self._pause.consume_cancel_grammar():
+            for _, state, _ in grammar_manager.grammar_queue:
+                state.set_finish_with_abort("Aborted by pause", notify_client=True)
+
+        if not self._pause.admit_blocked and self._pause.buffered_specs:
+            specs = [
+                spec
+                for spec in self._pause.take_buffered_specs()
+                if self._reap_or_keep_buffered_spec(spec)
+            ]
+            if specs:
+                loop.scheduler.submit_requests(specs)
+
+    def _reap_or_keep_buffered_spec(self, spec) -> bool:
+        """Resolve a buffered spec on resume; return True if it should be admitted.
+
+        A buffered spec was already registered in ``rid_to_state`` before it was
+        withheld, so if it was aborted while paused it never reached the
+        scheduler and the forward path can never reap it. Handle that here:
+
+        - state missing  -> already published and reaped; drop silently.
+        - state finished -> aborted in place. Stream a terminating finish for
+          pause-initiated aborts (the passive client is still waiting) and drop
+          the registered state so the rid does not leak; client-initiated aborts
+          already tore down their own state, so just reap.
+        - otherwise      -> still live; admit it.
+        """
+        output_processor = self._loop.output_processor
+        state = output_processor.rid_to_state.get(spec.request_id)
+        if state is None:
+            return False
+        if state.finished:
+            output_processor.reap_finished_orphan(spec.request_id, state)
+            return False
+        return True
+
+    def withhold_admissions(
+        self, admitted_specs: list, pause_blocked_before: bool
+    ) -> bool:
+        """Pause admission gate: while paused, buffer ``admitted_specs`` instead
+        of submitting them (running requests keep stepping) and return True so
+        the caller skips submission. Buffered specs are flushed on resume by
+        ``apply_transitions``, ahead of any newly-admitted ones, preserving
+        FIFO order.
+
+        TODO(pause-fifo): recv_reqs() drains the socket non-blocking, so a
+        generate request that arrived *before* a pause control message can be
+        coalesced into the same batch and reach here after the pause flipped
+        admit_blocked. Such a pre-pause request is buffered as post-pause work
+        instead of running (wait) / being aborted (abort). Correct handling
+        needs the batch processed as an ordered stream that respects the
+        control request's FIFO position. Tracked as a follow-up; until then we
+        warn when the coalescing condition is observed so it is not silent.
+        """
+        if not self._pause.admit_blocked:
+            return False
+        if admitted_specs and not pause_blocked_before:
+            logger.warning(
+                "Pause engaged in the same recv batch as %d generate "
+                "request(s) (rids=%s); their FIFO order relative to the "
+                "pause is not preserved, so a pre-pause request may be "
+                "buffered as post-pause work and run only after resume. "
+                "See TODO(pause-fifo).",
+                len(admitted_specs),
+                [spec.request_id for spec in admitted_specs],
+            )
+        self._pause.buffer_specs(admitted_specs)
+        return True
+
+    # -- freeze-loop hook (called from event_loop) -----------------------------
+
+    def paused_idle_step(self) -> None:
+        """Run one iteration under ``PAUSED_ALL`` (keep mode): no new forward
+        work, but keep DP ranks in lockstep and yield the CPU so the freeze
+        does not busy-spin a core. The drain check runs at the event loop's
+        tail (after the round's results advance the scheduler), not here."""
+        loop = self._loop
+        if loop.has_dp:
+            dp_metadata = loop._dp_sync_and_check(None)
+            # While memory is released the weights region is unmapped; an idle
+            # forward runs the model and would read freed memory. All DP ranks
+            # release together, so skipping the idle forward stays consistent
+            # across ranks (the small DP sync above still runs to keep lockstep).
+            if dp_metadata.need_idle_forward and not self._pause.released:
+                loop.model_executor.execute_idle_forward(
+                    dp_metadata.global_num_tokens,
+                    dp_metadata.global_batch_size,
+                    dp_metadata.all_decode_or_idle,
+                )
+
+        time.sleep(_PAUSED_IDLE_SLEEP_S)
+
+    # -- memory release/wake data plane (wired into MemoryOccupationController) -
+
+    def reset_caches_for_release(self) -> bool:
+        """Invalidate the prefix/single-table cache before KV is discarded on release.
+
+        KV pages are re-mapped + zeroed on wake, so any retained prefix entry
+        would be stale. The unsafe case (prefix caching on with no reset) is
+        rejected up front in ``MemoryOccupationController.handle_release`` via
+        ``kv_cache_release_allowed``, so by the time we get here either a clear
+        exists or prefix caching is off (nothing to invalidate). Returns False
+        while an asynchronous cache transfer still pins L1 so the release can
+        remain pending and retry on the next event-loop iteration.
+        """
+        clear = getattr(self._loop.scheduler, "clear_l1_cache", None)
+        return not callable(clear) or clear()
+
+    def _kv_pools(self) -> list:
+        """All KV pools whose pages are tagged ``kv_cache`` — the target pool and
+        the draft pool in speculative-decoding runs. Release/repair must walk the
+        SAME set, so both derive it here rather than enumerating pools by hand."""
+        pools = []
+        for attr in ("token_to_kv_pool", "draft_token_to_kv_pool"):
+            pool = getattr(self._loop.model_executor, attr, None)
+            if pool is not None:
+                pools.append(pool)
+        return pools
+
+    def kv_repair_after_wake(self) -> None:
+        """Zero re-mapped KV buffers (garbage after re-map) for every KV pool,
+        including the draft pool in spec-decode runs — its allocations are tagged
+        ``kv_cache`` too, so a wake that skipped it would feed the draft model
+        stale KV. FP8 KV scales ride with the weights region, so no scale reset
+        is needed here."""
+        for pool in self._kv_pools():
+            if hasattr(pool, "clear_kv_buffers"):
+                pool.clear_kv_buffers()

--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -129,10 +129,22 @@ class RequestHandler:
         self.attn_tp_size = mapping.attn.tp_size
         self.attn_tp_rank = mapping.attn.tp_rank
         self.attn_global_rank = mapping.attn.rank
-        self.attn_tp_cpu_group = pg_manager.get_process_group(
-            "gloo", mapping.attn.tp_group
-        )
-        self.attn_tp_src_rank = mapping.attn.tp_group[0]
+        if mapping.has_pp:
+            # Chunk-pipeline: every stage's scheduler runs the same
+            # deterministic plan, so every rank in the WORLD must see the
+            # same request stream. Only global rank 0 owns the ZMQ input;
+            # the broadcast fans out across stages, not just one TP group.
+            self.attn_tp_size = mapping.world_size
+            self.attn_tp_rank = mapping.rank
+            self.attn_tp_cpu_group = pg_manager.get_process_group(
+                "gloo", mapping.world_group
+            )
+            self.attn_tp_src_rank = mapping.world_group[0]
+        else:
+            self.attn_tp_cpu_group = pg_manager.get_process_group(
+                "gloo", mapping.attn.tp_group
+            )
+            self.attn_tp_src_rank = mapping.attn.tp_group[0]
         self.profile_rank_tag = _profile_rank_tag(mapping.attn)
 
         self.hf_eos_token_id = hf_eos_token_id

--- a/python/tokenspeed/runtime/engine/scheduler_utils.py
+++ b/python/tokenspeed/runtime/engine/scheduler_utils.py
@@ -361,10 +361,18 @@ def make_update_reserve_tokens_event(request_id: str, new_reserve_num_tokens: in
     return fe
 
 
-def advance_forward(scheduler, forward_events: list) -> None:
+def advance_scheduler(scheduler, events: list) -> None:
+    """Feed completion events (forward results or cache-op results) back into
+    the C++ scheduler. The ONLY caller of ``scheduler.advance``.
+
+    Design principle: this is only invoked explicitly and directly from the
+    ``EventLoop.event_loop`` body — never from helpers. Helpers RETURN their
+    events; the loop applies them, so every scheduler state change is visible
+    by reading the loop alone.
+    """
     ec = ExecutionEvent()
-    for fe in forward_events:
-        ec.add_event(fe)
+    for event in events:
+        ec.add_event(event)
     scheduler.advance(ec)
 
 

--- a/python/tokenspeed/runtime/engine/zmq_msgpack.py
+++ b/python/tokenspeed/runtime/engine/zmq_msgpack.py
@@ -289,3 +289,61 @@ def connect_msgpack_engine(
         MsgpackRecvSocket(input_socket, vocab_size, enable_output_logprobs),
         MsgpackSendSocket(output_socket, engine_index=engine_index),
     )
+
+
+def _tokenspeed_version() -> str:
+    try:
+        from tokenspeed.version import __version__
+
+        return __version__
+    except Exception:
+        return "unknown"
+
+
+def connect_msgpack_engine_for_loop(
+    context: zmq.Context, loop
+) -> tuple[MsgpackRecvSocket, MsgpackSendSocket]:
+    """Build the engine's ready response from an event loop's state and run
+    the SMG startup handshake (see ``connect_msgpack_engine``).
+
+    Args:
+        context: The loop's ZMQ context.
+        loop: The scheduler EventLoop; supplies the model/cache geometry and
+            parallel layout the ready response reports to the frontend.
+
+    Returns:
+        The wrapped msgpack (input, output) sockets.
+
+    Each DP rank dials SMG with its own engine identity (zmq_engine_index +
+    dp_rank): the frontend's grouped worker awaits dp_size engines on one
+    socket set and tells the ranks apart — and routes inputs back — by this
+    index. The ready response carries the true dp rank/size alongside.
+    """
+    server_args = loop.server_args
+    geometry = loop._scheduler_cache_geometry
+    ready_response = zmq_wire.WireEngineCoreReadyResponse(
+        max_model_len=loop.model_config.context_len,
+        num_gpu_blocks=geometry.num_device_pages,
+        prefix_granularity=geometry.prefix_granularity,
+        dtype=zmq_wire.wire_dtype(loop.model_config.dtype),
+        multimodal_encoder_dtype=loop.multimodal_encoder_dtype,
+        vllm_version=f"tokenspeed-{_tokenspeed_version()}",
+        world_size=loop.world_size,
+        data_parallel_size=loop.dp_size,
+        tensor_parallel_size=loop.attn_tp_size,
+        data_parallel_rank=loop.dp_rank,
+        max_num_seqs=server_args.max_num_seqs,
+        # chunked_prefill_size=-1 means "disabled"; the wire field is a
+        # non-negative integer for the frontend, so clamp to 0 (= no cap).
+        max_num_batched_tokens=max(0, server_args.chunked_prefill_size),
+        instance_id=server_args.served_model_name or server_args.model,
+        kv_cache_size_tokens=loop.max_total_num_tokens,
+    )
+    return connect_msgpack_engine(
+        context,
+        server_args.zmq_handshake_endpoint(),
+        server_args.zmq_engine_index + loop.dp_rank,
+        ready_response,
+        loop.model_config.vocab_size,
+        enable_output_logprobs=server_args.enable_output_logprobs,
+    )

--- a/python/tokenspeed/runtime/engine/zmq_wire.py
+++ b/python/tokenspeed/runtime/engine/zmq_wire.py
@@ -100,6 +100,43 @@ _DEC_INIT = msgspec.msgpack.Decoder(WireHandshakeInitMessage)
 _DEC_ADD = MsgpackDecoder(TokenizedGenerateReqInput)
 
 
+# SMG decodes the ready response's dtype into a fixed enum of these strings, so
+# map tokenspeed's dtype onto the nearest one.
+_WIRE_DTYPE_MAP = {
+    "bfloat16": "bfloat16",
+    "bf16": "bfloat16",
+    "float16": "float16",
+    "half": "float16",
+    "fp16": "float16",
+    "float32": "float32",
+    "float": "float32",
+    "fp32": "float32",
+}
+
+
+def wire_dtype(dtype) -> str:
+    """Map a tokenspeed/torch dtype onto SMG's wire dtype enum string.
+
+    Args:
+        dtype: A torch dtype or its string form (e.g. ``torch.bfloat16``,
+            ``"bf16"``).
+
+    Returns:
+        The wire enum string (``"bfloat16"`` / ``"float16"`` / ``"float32"``).
+
+    Raises:
+        ValueError: for unmapped dtypes — fail at handshake time: misreporting
+            the dtype to the frontend is worse than refusing to start.
+    """
+    key = str(dtype).lower().replace("torch.", "")
+    mapped = _WIRE_DTYPE_MAP.get(key)
+    if mapped is None:
+        raise ValueError(
+            f"dtype {dtype!r} has no SMG wire mapping; extend _WIRE_DTYPE_MAP"
+        )
+    return mapped
+
+
 def encode(obj: msgspec.Struct) -> bytes:
     """Encode a handshake struct to a msgpack payload."""
     return _ENC.encode(obj)

--- a/python/tokenspeed/runtime/entrypoints/engine.py
+++ b/python/tokenspeed/runtime/entrypoints/engine.py
@@ -648,7 +648,7 @@ def launch_scheduler_headless(server_args: ServerArgs) -> None:
     Headless: no in-process tokenizer_manager and no AsyncLLM detokenizer (SMG
     owns both). This process only spawns and
     supervises the scheduler workers, which connect out to the SMG-bound
-    handshake/input/output sockets (see engine.event_loop._init_msgpack_transport),
+    handshake/input/output sockets (see zmq_msgpack.connect_msgpack_engine_for_loop),
     then blocks until they exit.
 
     Forces ``--zmq-msgpack`` + ``--skip-tokenizer-init`` since SMG passes
@@ -660,7 +660,7 @@ def launch_scheduler_headless(server_args: ServerArgs) -> None:
     server_args.zmq_msgpack = True
     server_args.skip_tokenizer_init = True
     # DP > 1: each rank dials the frontend with its own engine identity
-    # (zmq_engine_index + dp_rank) in event_loop._init_msgpack_transport, the
+    # (zmq_engine_index + dp_rank) in zmq_msgpack.connect_msgpack_engine_for_loop, the
     # choke point shared with the non-headless --zmq-msgpack launch path.
 
     configure_logger(server_args)

--- a/python/tokenspeed/runtime/epd/prefill_hooks.py
+++ b/python/tokenspeed/runtime/epd/prefill_hooks.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""EventLoop-side EPD prefill integration.
+
+Split of responsibilities, mirroring pause.py's PauseController/PauseHooks:
+``EpdPrefillAdmission`` (prefill_admission.py) DECIDES — it owns the receive
+jobs, the rank-synced admission drain, and the optional NCCL row-shard
+reassembly. ``EpdPrefillHooks`` here ACTS on those decisions with the event
+loop's collaborators, so the loop's normal scheduling paths carry single-line
+hooks only.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from tokenspeed.runtime.pd.prefill_executor import DisaggPrefillExecutor
+
+logger = logging.getLogger(__name__)
+
+
+def _is_epd_request(state) -> bool:
+    """True iff this request's images are encode-routed (smg injected per-image
+    encode handshakes) -- it must wait for its embeddings (staged via the EPD
+    admission controller, polled in drain_ready_embeddings) before being
+    scheduled. Everything else admits immediately.
+    """
+    mm = getattr(state, "multimodal_inputs", None)
+    return mm is not None and any(
+        getattr(it, "encode_handshake", None) for it in mm.mm_items
+    )
+
+
+class EpdPrefillHooks:
+    """EventLoop-side EPD prefill hooks.
+
+    Holds a loop back-reference and the admission controller; the only state
+    of its own is the staged request payloads awaiting their embeddings.
+    Constructed with ``admission=None`` on non-EPD nodes (decode / encode /
+    text-only), where every hook is a cheap no-op.
+    """
+
+    def __init__(self, loop, admission) -> None:
+        self._loop = loop
+        self._admission = admission
+        # Staged EPD request payloads (request_id -> (spec, state, bootstrap)),
+        # held here while the controller (rid-keyed, like kv_transfer) runs the
+        # async receive; popped in drain_ready_embeddings on admit/abort.
+        self._staged: dict = {}
+
+    def try_stage(self, spec, state, bootstrap) -> bool:
+        """Stage an encode-routed request OUT of the scheduler until its
+        per-image embeddings have been received; return False for everything
+        else (the caller registers the P->D sender and admits immediately).
+
+        The P->D sender registration is DEFERRED to admission (in
+        ``drain_ready_embeddings``, just before submit_requests). Registering
+        it now -- while the request is staged and NOT yet in the C++ scheduler
+        -- would let DisaggPrefillExecutor.generate_events poll the sender and
+        emit a BootstrappedEvent that the scheduler's requests_.at(rid) THROWS
+        on (no such request yet). Rank-identical because the caller's ready
+        list is rank-synced (recv_reqs broadcast + grammar gather).
+        """
+        if self._admission is None or not _is_epd_request(state):
+            return False
+        self._admission.stage(spec.request_id, state.multimodal_inputs.mm_items)
+        self._staged[spec.request_id] = (spec, state, bootstrap)
+        return True
+
+    def drain_ready_embeddings(self) -> None:
+        """Admit EPD requests whose async embedding receives completed this cycle.
+
+        The EpdPrefillAdmission controller DECIDES (poll + rank-lockstep MIN
+        all-reduce + reassemble) and returns (admitted, failed); here we ACT on
+        those decisions with the EventLoop's collaborators -- register/abort the
+        P->D sender, submit admitted requests, finish failed ones. No-op (and no
+        collective) on non-EPD nodes.
+        """
+        if self._admission is None:
+            return
+        loop = self._loop
+        # Pause gate: withhold EPD admission while paused, mirroring the non-EPD
+        # admit_blocked gate -- else the drain below would submit and RUN reassembled
+        # specs during the pause. Staged receives wait in _pending until resume.
+        # Rank-safe: admit_blocked is rank-identical, so all ranks skip together.
+        if loop._pause.admit_blocked:
+            return
+        admitted_ids, failed_ids = self._admission.drain()
+        for rid in failed_ids:
+            spec, state, bootstrap = self._staged.pop(rid)
+            # Signal the dual-dispatched decode that this request failed so its KV
+            # receiver fails (FailedEvent -> PdTransferHooks abort)
+            # instead of waiting forever for KV the prefill will never send. The
+            # prefill never registered a P->D sender (deferred to admission), so the
+            # decode has no other reliable way to learn (heartbeat only trips on a
+            # dead prefill /health). Best-effort: only reaches decodes that already
+            # pre-allocated.
+            if (
+                isinstance(loop.kv_transfer, DisaggPrefillExecutor)
+                and bootstrap is not None
+            ):
+                try:
+                    loop.kv_transfer.abort(rid, bootstrap)
+                except Exception as exc:  # never let it wedge the loop
+                    logger.warning(
+                        "EPD abort->decode signal failed for rid=%s: %s",
+                        rid,
+                        exc,
+                    )
+            state.set_finish_with_abort("EPD embedding receive failed or timed out")
+            loop.output_processor.publish_finished_at_admission(rid, state)
+        admitted_specs = []
+        for rid in admitted_ids:
+            spec, state, bootstrap = self._staged.pop(rid)
+            # Aborted mid-receive (no abort path, so drain still returns it admitted):
+            # don't register the P->D sender or submit -- that runs a wasted forward
+            # and leaks the sender. Stream its finish instead.
+            if state.finished:
+                loop.output_processor.publish_finished_at_admission(rid, state)
+                continue
+            # Register the P->D sender now (deferred from admission) -- the request
+            # is about to enter the scheduler.
+            if loop.kv_transfer is not None:
+                loop.kv_transfer.register(rid, bootstrap)
+            admitted_specs.append(spec)
+        if admitted_specs:
+            loop.scheduler.submit_requests(admitted_specs)
+        elif self._admission.has_pending():
+            # Nothing advanced this cycle but requests are still receiving; yield the
+            # GIL so the Python daemon transfer/recv threads run (rank-consistent:
+            # admitted/leftover are rank-identical here).
+            time.sleep(0.0005)
+
+    def assert_embeddings_received(self, multimodal_context) -> None:
+        """EPD invariant: every handshaked item is filled with its embedding by the
+        async EPD admission drain (EpdPrefillAdmission.drain) BEFORE admission, so by
+        it is already encoded. This is a defensive check, not a receive: a handshaked
+        item that reached the forward un-received leaked past async admission (the
+        only EPD admission path) -- fail loud instead of running the tower or
+        publishing shard-only rows. No-op for non-EPD / text-only requests.
+        """
+        if (
+            self._admission is None
+            or multimodal_context is None
+            or not multimodal_context.has_extend_inputs()
+        ):
+            return
+        for mm in multimodal_context.mm_inputs:
+            if mm is None:
+                continue
+            missing = [
+                i
+                for i, item in enumerate(mm.mm_items)
+                if getattr(item, "encode_handshake", None) is not None
+                and item.encoded is None
+            ]
+            if missing:
+                raise RuntimeError(
+                    f"EPD: handshaked items {missing} reached the prefill forward "
+                    "un-received; they must be admitted via the EPD admission drain"
+                )

--- a/python/tokenspeed/runtime/execution/distributed_initializer.py
+++ b/python/tokenspeed/runtime/execution/distributed_initializer.py
@@ -165,6 +165,10 @@ class DistributedInitializer:
         pg_manager.init_process_group(config.mapping.attn.dp_group)
         pg_manager.init_process_group(config.mapping.dense.tp_group)
         pg_manager.init_process_group(config.mapping.moe.tp_ep_group)
+        if config.mapping.has_pp:
+            # Cross-stage group for hidden-state P2P (nccl) and small control
+            # broadcasts like the sampled first token (gloo).
+            pg_manager.init_process_group(config.mapping.pp_group)
 
         # Register the trtllm one-shot all-reduce workspaces for the TP
         # groups. AutoBackend routes small SUM all-reduces (<= 2 MB payload,

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -178,6 +178,11 @@ class ModelExecutorConfig:
     world_size: int = 1
     world_group: list[int] | None = None
 
+    # ====== PP (prefill chunk pipeline) =========
+    pp_size: int = 1
+    pp_rank: int = 0
+    pp_group: tuple[int, ...] | None = None
+
     # ====== SPEC =========
     spec_algo: str | None = None
     spec_num_steps: int | None = None
@@ -282,6 +287,11 @@ class ModelExecutorConfig:
             data_parallel_size=server_args.mapping.attn.dp_size,
             world_size=server_args.mapping.world_size,
             world_group=server_args.mapping.world_group,
+            pp_size=server_args.mapping.pp_size,
+            pp_rank=(server_args.mapping.pp_rank if server_args.mapping.has_pp else 0),
+            pp_group=(
+                server_args.mapping.pp_group if server_args.mapping.has_pp else None
+            ),
             spec_algo=server_args.speculative_algorithm,
             spec_num_steps=server_args.speculative_num_steps,
             spec_num_tokens=server_args.speculative_num_draft_tokens,
@@ -583,6 +593,17 @@ class ModelExecutor:
         num_tokens = int(self.config.chunked_prefill_size)
         if num_tokens <= 0 or self.model_runner is None:
             return
+        if self.config.pp_size > 1:
+            # The tuning forward drives the model directly (no stage recv/send
+            # threading), which a mid-pipeline stage cannot run. Fall back to
+            # heuristic tactics on every rank so the world-averaged tactic
+            # collective is skipped consistently.
+            set_autotune_max_num_tokens(num_tokens)
+            logger.info(
+                "Kernel tuning skipped under pipeline parallelism; tunable "
+                "kernels use heuristic tactics"
+            )
+            return
 
         # The bucket mapper keys serving-time tactic lookups, so it must match
         # any pre-swept table loaded earlier even when tuning itself is off.
@@ -665,6 +686,62 @@ class ModelExecutor:
             block_tables, bs=bs, padded_bs=self.draft_page_table.shape[0]
         )
 
+    def _pp_recv_stage_state(self, num_tokens: int):
+        """Receive the upstream stage's boundary bundle (mid-pipeline ranks).
+
+        Geometry comes from the model's wire spec — both sides derive it from
+        config + token count, so no metadata crosses the wire. Runs on the
+        current (execution) stream; NCCL P2P ops on one communicator match in
+        issue order against the upstream sends.
+        """
+        from tokenspeed.runtime.distributed.comm_ops import pp_recv
+        from tokenspeed.runtime.distributed.pp_stage import PPStageState
+
+        spec = self.model_runner.model.model.pp_stage_state_spec(
+            num_tokens, torch.device(self.device)
+        )
+        if not getattr(self, "_pp_wire_logged", False):
+            self._pp_wire_logged = True
+            logger.info(
+                "PP stage %d recv wire: %s",
+                self.config.pp_rank,
+                [(tuple(shape), str(dtype)) for _, shape, dtype in spec],
+            )
+        tensors = [
+            pp_recv(
+                shape,
+                dtype,
+                torch.device(self.device),
+                self.config.pp_rank - 1,
+                self.config.pp_group,
+            )
+            for _, shape, dtype in spec
+        ]
+        return PPStageState.from_tensors(tensors, [name for name, _, _ in spec])
+
+    def _pp_send_stage_state(self, state) -> None:
+        """Send this stage's boundary bundle downstream (non-last ranks)."""
+        from tokenspeed.runtime.distributed.comm_ops import pp_send
+
+        tensors = state.tensors()
+        if not getattr(self, "_pp_wire_logged", False):
+            self._pp_wire_logged = True
+            logger.info(
+                "PP stage %d send wire: %s",
+                self.config.pp_rank,
+                [(tuple(t.shape), str(t.dtype)) for t in tensors],
+            )
+        for tensor in tensors:
+            pp_send(tensor, self.config.pp_rank + 1, self.config.pp_group)
+
+    @property
+    def _pp_is_last_stage(self) -> bool:
+        return self.config.pp_rank == self.config.pp_size - 1
+
+    @property
+    def _pp_is_first_stage(self) -> bool:
+        return self.config.pp_rank == 0
+
     @nvtx_range("target_forward", color="red")
     def _run_target_forward(self, bs: int, ctx: ForwardContext, req_pool_indices):
         positions = self._active_positions_override
@@ -675,6 +752,24 @@ class ModelExecutor:
                 ]
             else:
                 positions = self.input_buffers.positions_buf[: ctx.input_num_tokens]
+        # PP mid-pipeline: receive the upstream boundary state and thread it
+        # through the model's pp_inbound channel. The P role forces eager, so
+        # neither graph path below can be active alongside PP.
+        if self.config.pp_size > 1 and not self._pp_is_first_stage:
+            pp_inbound = self._pp_recv_stage_state(ctx.input_num_tokens)
+            output = self.model_runner.forward(
+                ctx,
+                self.input_buffers.input_ids_buf[: ctx.input_num_tokens],
+                positions,
+                self.input_buffers.out_cache_loc_buf[: ctx.input_num_tokens],
+                req_pool_indices=req_pool_indices,
+                seq_lens=self.input_buffers.seq_lens_buf[:bs],
+                extend_prefix_lens=self.input_buffers.extend_prefix_lens_buf[
+                    : ctx.num_extends
+                ],
+                pp_inbound=pp_inbound,
+            )
+            return output
         # Prefill-graph replay when captured for this forward (the decode graph
         # replays one level up: it captures the whole _forward_step).
         mode = ctx.forward_mode
@@ -837,6 +932,15 @@ class ModelExecutor:
             )
 
         logits_output = self._run_target_forward(bs, ctx, req_pool_indices)
+
+        if self.config.pp_size > 1 and not self._pp_is_last_stage:
+            # Mid-pipeline stage: the model returned the boundary bundle, not
+            # logits. Ship it downstream and return placeholder outputs — the
+            # commit path recognizes a PP placeholder and emits no tokens.
+            self._pp_send_stage_state(logits_output)
+            output_tokens = torch.zeros(bs, dtype=torch.int32, device=self.device)
+            accept_lengths = torch.ones(bs, dtype=torch.int32, device=self.device)
+            return output_tokens, accept_lengths, None
 
         if self.drafter is not None and getattr(
             self.drafter, "_incremental_proj_enabled", False

--- a/python/tokenspeed/runtime/execution/model_runner.py
+++ b/python/tokenspeed/runtime/execution/model_runner.py
@@ -197,8 +197,11 @@ class ModelRunner:
         multimodal_context: MultimodalForwardContext | None = None,
         spec_step_idx: int | None = None,
         kv_sync_event: "torch.cuda.Event | None" = None,
+        pp_inbound=None,
     ) -> LogitsProcessorOutput:
         kwargs = {}
+        if pp_inbound is not None:
+            kwargs["pp_inbound"] = pp_inbound
         if req_pool_indices is not None:
             kwargs["req_pool_indices"] = req_pool_indices
         if seq_lens is not None:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
@@ -553,9 +553,13 @@ class HybridDeepseekV4TokenToKVPool(CachePool):
         mapping shared across layers. Returns 0 when no SWA buffers exist;
         callers must then mask all slots rather than skip the bounds check.
         """
-        if not self.swa_kv_buffer:
-            return 0
-        return int(self.swa_kv_buffer[0].shape[0]) * int(self.swa_block_size)
+        # Under a pipeline-parallel layer window only this stage's layers'
+        # buffers are bound (the rest stay None), so probe the first bound
+        # one — every layer's SWA plane shares the same page count.
+        for buffer in self.swa_kv_buffer or ():
+            if buffer is not None:
+                return int(buffer.shape[0]) * int(self.swa_block_size)
+        return 0
 
     def get_compressed_kv_buffer_2d(self, layer_id: int) -> torch.Tensor:
         return self._require(self.compressed_kv_buffer, layer_id, "compressed KV")

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
@@ -74,10 +74,13 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
         if self.quant_method == "per_token_head":
             raise ValueError("KDA cache does not support per-token-head KV")
         super()._bind_layer_planes()
+        # A state layer with no planned planes belongs to another pipeline
+        # stage (the PP-narrowed plan drops its fields); this view never
+        # executes it, so it gets no entry.
         self._state_buffers_by_layer = {
             layer_id: (self._conv_state[layer_id], self._recurrent_state[layer_id])
             for layer_id, label in enumerate(self._layer_types)
-            if label in STATE_LAYER_TYPES
+            if label in STATE_LAYER_TYPES and self._conv_state[layer_id] is not None
         }
 
     @property

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
@@ -190,9 +190,66 @@ class CacheMemoryPlan:
     planes: tuple[CachePlaneLayout, ...] = ()
     fields: tuple[CacheFieldLayout, ...] = ()
 
+    # Sum of the RETAINED planes' per-parent bytes. Equals lcm_block_bytes
+    # unless the plan was narrowed to a layer window (pipeline parallelism),
+    # where dropped layers' planes are physically excluded from the arena
+    # while the logical geometry (lcm_block_bytes, packing, parent count)
+    # stays the full model's so every rank's scheduler plans identically.
+    resident_block_bytes: int | None = None
+
     @property
     def arena_bytes(self) -> int:
-        return (self.num_lcm_blocks + 1) * self.lcm_block_bytes
+        per_parent = (
+            self.resident_block_bytes
+            if self.resident_block_bytes is not None
+            else self.lcm_block_bytes
+        )
+        return (self.num_lcm_blocks + 1) * per_parent
+
+    def narrow_to_layers(self, first_layer: int, last_layer: int) -> "CacheMemoryPlan":
+        """Physically drop layers outside ``[first_layer, last_layer)``.
+
+        For pipeline parallelism: a stage only writes/reads its own layers'
+        KV, so the other layers' planes need no memory. The logical geometry
+        (prefix_granularity, lcm_block_bytes, num_lcm_blocks, groups) is kept
+        untouched — the scheduler's page math must agree across ranks — while
+        the plane list is filtered to the window's fields and re-packed onto
+        fresh arena offsets. Fields without a ``layer.<id>.`` prefix (none
+        today) are retained.
+        """
+
+        def owned(field: CacheFieldLayout) -> bool:
+            try:
+                layer_id = cache_field_layer_id(field.field_id)
+            except ValueError:
+                return True
+            return first_layer <= layer_id < last_layer
+
+        kept_fields = tuple(field for field in self.fields if owned(field))
+        kept_plane_ids = {field.plane_id for field in kept_fields}
+        planes = []
+        arena_offset = 0
+        for plane in self.planes:
+            if plane.plane_id not in kept_plane_ids:
+                continue
+            planes.append(
+                CachePlaneLayout(
+                    plane_id=plane.plane_id,
+                    bytes_per_lcm_block=plane.bytes_per_lcm_block,
+                    arena_offset_bytes=arena_offset,
+                )
+            )
+            arena_offset += (self.num_lcm_blocks + 1) * plane.bytes_per_lcm_block
+        resident = sum(plane.bytes_per_lcm_block for plane in planes)
+        return CacheMemoryPlan(
+            prefix_granularity=self.prefix_granularity,
+            lcm_block_bytes=self.lcm_block_bytes,
+            num_lcm_blocks=self.num_lcm_blocks,
+            groups=self.groups,
+            planes=tuple(planes),
+            fields=kept_fields,
+            resident_block_bytes=resident,
+        )
 
     def group(self, group_id: str) -> CacheGroupLayout:
         for group in self.groups:

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -917,11 +917,33 @@ def create_attn_components(
 
     # One model, one arena: the merged plan's single allocation, which every
     # compute view below (target, draft) is a layer window onto.
+    pp_logical_plan = None
+    if server_args.mapping.has_pp:
+        # Chunk-pipeline stage: physically allocate only this stage's layers'
+        # planes. The logical geometry (parents, packing, page math) stays
+        # the full model's so every rank's scheduler plans identically; keep
+        # the full plan for the PD wire contract (every stage registers the
+        # same logical layout, Decode plans stage windows against it).
+        from dataclasses import replace as _dc_replace
+
+        from tokenspeed.runtime.distributed.pp_stage import pp_layer_window
+
+        stage_start, stage_end = pp_layer_window(
+            len(spec.layer_types), server_args.mapping
+        )
+        pp_logical_plan = spec.memory_plan
+        spec = _dc_replace(
+            spec,
+            memory_plan=spec.memory_plan.narrow_to_layers(stage_start, stage_end),
+        )
+        target_spec = spec
     arena = create_cache_arena(
         spec,
         device=config.device,
         enable_memory_saver=enable_memory_saver,
     )
+    if pp_logical_plan is not None:
+        arena.pp_logical_plan = pp_logical_plan
     backend, pool = _create_target_components(
         server_args=server_args,
         model_config=model_config,

--- a/python/tokenspeed/runtime/models/base/causal_lm.py
+++ b/python/tokenspeed/runtime/models/base/causal_lm.py
@@ -70,8 +70,13 @@ class BaseCausalLM(nn.Module):
             self.logits_processor = None
         else:
             self.model = self.resolve_model(config, mapping, quant_config, prefix)
-            self.lm_head = self.resolve_lm_head(config, quant_config, prefix)
-            self.logits_processor = self.resolve_logits_processor(config)
+            if mapping.is_last_pp_rank:
+                self.lm_head = self.resolve_lm_head(config, quant_config, prefix)
+                self.logits_processor = self.resolve_logits_processor(config)
+            else:
+                # Mid-pipeline stages emit hidden states, never logits.
+                self.lm_head = None
+                self.logits_processor = None
         self.post_init()
 
     def resolve_model(
@@ -195,6 +200,10 @@ class BaseCausalLM(nn.Module):
             out_cache_loc,
             **model_kwargs,
         )
+        if not self.mapping.is_last_pp_rank:
+            # Mid-pipeline stage: the executor sends this boundary state to
+            # the next stage; there are no logits here.
+            return hidden_states
         logits_metadata = LogitsMetadata.from_forward_context(ctx)
 
         return self.logits_processor(
@@ -210,7 +219,7 @@ class BaseCausalLM(nn.Module):
     ) -> dict:
         """Hook for subclasses to pass model-specific tensors."""
         model_kwargs = {}
-        for key in ("input_embeds", "inputs_embeds"):
+        for key in ("input_embeds", "inputs_embeds", "pp_inbound"):
             if kwargs.get(key) is not None:
                 model_kwargs[key] = kwargs[key]
         return model_kwargs

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -69,6 +69,7 @@ from transformers import PretrainedConfig
 
 from tokenspeed.runtime.distributed import Mapping
 from tokenspeed.runtime.distributed.comm_manager import CommManager
+from tokenspeed.runtime.distributed.pp_stage import PPStageState, pp_layer_window
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
@@ -145,6 +146,7 @@ from tokenspeed.runtime.utils import (
     get_colorful_logger,
     set_weight_attrs,
 )
+from tokenspeed.runtime.utils.common import PPMissingLayer
 from tokenspeed.runtime.utils.cuda_stream import StreamFork
 from tokenspeed.runtime.utils.custom_ops import direct_register_custom_op
 from tokenspeed.runtime.utils.env import global_server_args_dict, pdl_enabled
@@ -4133,29 +4135,45 @@ class DeepseekV4Model(nn.Module):
         self.rms_norm_eps = config.rms_norm_eps
         self.aux_stream = torch.cuda.Stream() if torch.cuda.is_available() else None
         self.topk_indices_buffer = _DeepseekV4TopKBuffer(int(config.index_topk))
-        self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size,
-            config.hidden_size,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
-            prefix=add_prefix("embed_tokens", prefix),
+        # Pipeline stage layer window: [pp_start_layer, pp_end_layer). Global
+        # layer numbering everywhere; other stages' slots hold PPMissingLayer.
+        self.pp_start_layer, self.pp_end_layer = pp_layer_window(
+            config.num_hidden_layers, mapping
         )
+        if mapping.is_first_pp_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                tp_rank=mapping.attn.tp_rank,
+                tp_size=mapping.attn.tp_size,
+                tp_group=mapping.attn.tp_group,
+                prefix=add_prefix("embed_tokens", prefix),
+            )
+        else:
+            self.embed_tokens = None
         self.layers = nn.ModuleList(
             [
-                DeepseekV4DecoderLayer(
-                    config,
-                    layer_id,
-                    mapping,
-                    quant_config,
-                    add_prefix(f"layers.{layer_id}", prefix),
-                    aux_stream=self.aux_stream,
-                    topk_buffer=self.topk_indices_buffer,
+                (
+                    DeepseekV4DecoderLayer(
+                        config,
+                        layer_id,
+                        mapping,
+                        quant_config,
+                        add_prefix(f"layers.{layer_id}", prefix),
+                        aux_stream=self.aux_stream,
+                        topk_buffer=self.topk_indices_buffer,
+                    )
+                    if self.pp_start_layer <= layer_id < self.pp_end_layer
+                    else PPMissingLayer()
                 )
                 for layer_id in range(config.num_hidden_layers)
             ]
         )
-        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm = (
+            RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if mapping.is_last_pp_rank
+            else None
+        )
         hc_dim = config.hc_mult * config.hidden_size
         self.hc_head_fn = nn.Parameter(
             torch.empty(config.hc_mult, hc_dim, dtype=torch.float32),
@@ -4168,6 +4186,47 @@ class DeepseekV4Model(nn.Module):
             torch.empty(1, dtype=torch.float32), requires_grad=False
         )
         self.dspark_layers_to_capture: tuple[int, ...] = ()
+
+    def pp_stage_state_spec(
+        self, num_tokens: int, device: torch.device
+    ) -> list[tuple[str, tuple[int, ...], torch.dtype]]:
+        """Wire spec (name, shape, dtype) of the inter-stage boundary bundle.
+
+        Matches the PPStageState this model's forward returns on a non-last
+        stage: the raw mHC thread state after the stage's final layer. Both
+        the sender and the receiver derive this from config + token count, so
+        no shape metadata crosses the wire.
+        """
+        del device
+        hc = self.hc_mult
+        hidden = self.config.hidden_size
+        # The activation dtype. get_default_dtype() would be wrong here: the
+        # model-dtype context only wraps weight loading, and the serving-time
+        # default is float32 — a recv sized off it would expect twice the
+        # bytes the sender ships and the NCCL P2P pair would spin forever.
+        dtype = None
+        if self.norm is not None:
+            dtype = self.norm.weight.dtype
+        else:
+            for param in self.parameters():
+                if param.is_floating_point() and param.dtype in (
+                    torch.bfloat16,
+                    torch.float16,
+                ):
+                    dtype = param.dtype
+                    break
+        if dtype is None:
+            dtype = torch.bfloat16
+        # Careful with the thread-state shapes: the model loop's variables are
+        # crosswired relative to the layer's return order — the loop's
+        # ``hidden_states`` carries the residual [t, hc, hidden] while
+        # ``hc_x_prev`` carries the layer's FFN output [t, hidden].
+        return [
+            ("hidden_states", (num_tokens, hc, hidden), dtype),
+            ("hc_x", (num_tokens, hidden), dtype),
+            ("hc_post", (num_tokens, hc, 1), torch.float32),
+            ("hc_comb", (num_tokens, hc, hc), torch.float32),
+        ]
 
     def set_dspark_layers_to_capture(self, layer_ids: list[int]) -> None:
         normalized = tuple(int(layer_id) for layer_id in layer_ids)
@@ -4198,23 +4257,32 @@ class DeepseekV4Model(nn.Module):
         ctx: ForwardContext,
         out_cache_loc: torch.Tensor,
         input_embeds: torch.Tensor | None = None,
-    ) -> tuple[torch.Tensor, list[torch.Tensor] | None]:
-        hidden_states = input_embeds
-        if hidden_states is None:
-            with nvtx_range("embed_tokens"):
-                hidden_states = self.embed_tokens(input_ids)
-        with nvtx_range("hc_repeat"):
-            hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+        pp_inbound: PPStageState | None = None,
+    ) -> tuple[torch.Tensor | PPStageState, list[torch.Tensor] | None]:
         # Layer-invariant DSA memos: computing them HERE (graphed scope) would bake
         # dummy addresses; the first attention break computes them LIVE onto ctx.
         ctx.dsa_swa_slot_mapping = None
         ctx.dsa_compressor_slot_cache = None
-        hc_x_prev = None
-        hc_post_prev = None
-        hc_comb_prev = None
+        if pp_inbound is not None:
+            # Mid-pipeline stage: resume the mHC thread state received from
+            # the upstream stage instead of embedding.
+            hidden_states = pp_inbound.hidden_states
+            hc_x_prev = pp_inbound.hc_x
+            hc_post_prev = pp_inbound.hc_post
+            hc_comb_prev = pp_inbound.hc_comb
+        else:
+            hidden_states = input_embeds
+            if hidden_states is None:
+                with nvtx_range("embed_tokens"):
+                    hidden_states = self.embed_tokens(input_ids)
+            with nvtx_range("hc_repeat"):
+                hidden_states = hidden_states.unsqueeze(1).repeat(1, self.hc_mult, 1)
+            hc_x_prev = None
+            hc_post_prev = None
+            hc_comb_prev = None
         dspark_captures = []
         dspark_capture_set = frozenset(self.dspark_layers_to_capture)
-        for layer in self.layers:
+        for layer in self.layers[self.pp_start_layer : self.pp_end_layer]:
             hidden_states, hc_x_prev, hc_post_prev, hc_comb_prev = layer(
                 positions,
                 hidden_states,
@@ -4235,6 +4303,19 @@ class DeepseekV4Model(nn.Module):
                     hc_comb_prev,
                 )
                 dspark_captures.append(resolved_hidden_states.mean(dim=1))
+        if not self.mapping.is_last_pp_rank:
+            # Hand the raw mHC thread state to the next stage; it resumes the
+            # layer loop exactly where this stage stopped (the deferred
+            # post-mapping folds into the next layer's fused_hc downstream).
+            return (
+                PPStageState(
+                    hidden_states=hidden_states,
+                    hc_x=hc_x_prev,
+                    hc_post=hc_post_prev,
+                    hc_comb=hc_comb_prev,
+                ),
+                None,
+            )
         with nvtx_range("hc_ffn_post_final"):
             hidden_states = mhc_post(
                 hc_x_prev, hidden_states, hc_post_prev, hc_comb_prev
@@ -4345,9 +4426,26 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
             ep_rank=self.mapping.moe.ep_rank,
             ep_size=self.mapping.moe.ep_size,
         )
+        pp_start = self.model.pp_start_layer
+        pp_end = self.model.pp_end_layer
+        pp_windowed = not (pp_start == 0 and pp_end == self.config.num_hidden_layers)
+
+        def _pp_owns(name: str) -> bool:
+            """Skip weights for layers another pipeline stage owns.
+
+            The MoE loader raises on a matched-but-unloadable expert weight,
+            so out-of-window layers must be dropped before it sees them.
+            """
+            if not name.startswith("model.layers."):
+                return True
+            layer_id = int(name.split(".", 3)[2])
+            return pp_start <= layer_id < pp_end
+
         for raw_name, loaded_weight in weights:
             name = self._map_weight_name(raw_name)
             if name.startswith("mtp."):
+                continue
+            if pp_windowed and not _pp_owns(name):
                 continue
             if (
                 name.endswith("attn.wo_a.weight")

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -99,6 +99,7 @@ from tokenspeed.runtime.distributed.comm_ops import (
     token_all_gather,
 )
 from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.distributed.pp_stage import PPStageState, pp_layer_window
 from tokenspeed.runtime.execution.cuda_graph_wrapper import (
     get_is_capture_mode,
 )
@@ -2428,14 +2429,22 @@ class KimiLinearModel(nn.Module):
             torch.cuda.Stream(priority=-1) if torch.cuda.is_available() else None
         )
 
-        self.embed_tokens = VocabParallelEmbedding(
-            config.vocab_size,
-            config.hidden_size,
-            org_num_embeddings=config.vocab_size,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
+        # Pipeline stage layer window: [pp_start_layer, pp_end_layer). Global
+        # layer numbering everywhere; other stages' slots hold PPMissingLayer.
+        self.pp_start_layer, self.pp_end_layer = pp_layer_window(
+            config.num_hidden_layers, mapping
         )
+        if mapping.is_first_pp_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                org_num_embeddings=config.vocab_size,
+                tp_rank=mapping.attn.tp_rank,
+                tp_size=mapping.attn.tp_size,
+                tp_group=mapping.attn.tp_group,
+            )
+        else:
+            self.embed_tokens = None
 
         layers_scope = add_prefix("layers", prefix)
 
@@ -2454,11 +2463,16 @@ class KimiLinearModel(nn.Module):
             config.num_hidden_layers,
             get_layer,
             prefix=layers_scope,
+            pp_start_layer=self.pp_start_layer,
+            pp_end_layer=self.pp_end_layer,
         )
         # Cross-layer attn-side mix precompute: a layer's aux stream computes
         # the NEXT layer's block partial alongside its own mlp-side partial
-        # (one dual sweep under attention; blocks are final by then).
-        for i in range(len(self.layers) - 1):
+        # (one dual sweep under attention; blocks are final by then). Under PP
+        # the pair must live on the same stage — the stage boundary severs the
+        # dual sweep there, and the downstream stage's first layer falls back
+        # to its own (non-split) AttnRes mixing.
+        for i in range(self.pp_start_layer, self.pp_end_layer - 1):
             cur, nxt = self.layers[i], self.layers[i + 1]
             if nxt.prev_valid_blocks > 0:
                 assert (
@@ -2472,16 +2486,22 @@ class KimiLinearModel(nn.Module):
                 cur._hoist_next_mlp = not nxt.is_block_write_layer
                 nxt._mlp_split = cur._hoist_next_mlp
 
-        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-
-        # Model-level AttnRes output mixing.
-        self.output_attn_res_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.output_attn_res_proj = ReplicatedLinear(
-            config.hidden_size,
-            1,
-            bias=False,
-            prefix=add_prefix("output_attn_res_proj", prefix),
-        )
+        if mapping.is_last_pp_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            # Model-level AttnRes output mixing.
+            self.output_attn_res_norm = RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.output_attn_res_proj = ReplicatedLinear(
+                config.hidden_size,
+                1,
+                bias=False,
+                prefix=add_prefix("output_attn_res_proj", prefix),
+            )
+        else:
+            self.norm = None
+            self.output_attn_res_norm = None
+            self.output_attn_res_proj = None
         # One-based completed-layer ids; see set_eagle3_layers_to_capture.
         self.eagle3_layers_to_capture: tuple[int, ...] = ()
 
@@ -2505,6 +2525,39 @@ class KimiLinearModel(nn.Module):
 
     def get_input_embeddings(self) -> nn.Module:
         return self.embed_tokens
+
+    def pp_stage_state_spec(
+        self, num_tokens: int, device: torch.device
+    ) -> list[tuple[str, tuple[int, ...], torch.dtype]]:
+        """Wire spec (name, shape, dtype) of the inter-stage boundary bundle.
+
+        K3's boundary state is the accumulated ``prefix_sum`` stream plus the
+        valid prefix of the AttnRes ``block_residual`` snapshot buffer. The
+        upstream stage ships ``ceil_div(its pp_end_layer, block)`` snapshot
+        rows and this stage expects ``ceil_div(pp_start_layer, block)`` — the
+        two are the same number because the windows abut, so no shape
+        metadata crosses the wire.
+        """
+        del device
+        hidden = self.config.hidden_size
+        valid_blocks = ceil_div(self.pp_start_layer, self.config.attn_res_block_size)
+        # The activation dtype. get_default_dtype() would be wrong here (the
+        # model-dtype context only wraps weight loading); take it from any
+        # floating live parameter — mid-stage ranks have no embed/norm.
+        dtype = None
+        for param in self.parameters():
+            if param.is_floating_point() and param.dtype in (
+                torch.bfloat16,
+                torch.float16,
+            ):
+                dtype = param.dtype
+                break
+        if dtype is None:
+            dtype = torch.bfloat16
+        return [
+            ("hidden_states", (num_tokens, hidden), dtype),
+            ("block_residual", (valid_blocks, num_tokens, hidden), dtype),
+        ]
 
     def _dspark_capture_stream(
         self,
@@ -2539,9 +2592,14 @@ class KimiLinearModel(nn.Module):
         ctx: "ForwardContext",
         out_cache_loc: torch.Tensor,
         input_embeds: torch.Tensor | None = None,
+        pp_inbound: PPStageState | None = None,
         **kwargs,
-    ) -> tuple[torch.Tensor, list | None]:
-        if input_embeds is not None:
+    ) -> tuple[torch.Tensor | PPStageState, list | None]:
+        if pp_inbound is not None:
+            # Mid-pipeline stage: resume the AttnRes stream received from the
+            # upstream stage instead of embedding.
+            hidden_states = pp_inbound.hidden_states
+        elif input_embeds is not None:
             hidden_states = input_embeds
         else:
             hidden_states = self.embed_tokens(input_ids)
@@ -2555,6 +2613,11 @@ class KimiLinearModel(nn.Module):
         block_residual = hidden_states.new_empty(
             num_blocks, hidden_states.size(0), hidden_states.size(1)
         )
+        if pp_inbound is not None:
+            # Seed the upstream stage's snapshot rows; this stage's own
+            # block-write layers fill the rest.
+            inbound_blocks = pp_inbound.block_residual
+            block_residual[: inbound_blocks.size(0)].copy_(inbound_blocks)
 
         capture_layers = self.layers_to_capture
         capture_dflash = bool(capture_layers)
@@ -2564,7 +2627,8 @@ class KimiLinearModel(nn.Module):
         )
 
         prefix_sum = hidden_states
-        for layer_idx, layer in enumerate(self.layers):
+        for layer_idx in range(self.pp_start_layer, self.pp_end_layer):
+            layer = self.layers[layer_idx]
             prefix_sum, block_residual = layer(
                 positions, prefix_sum, ctx, out_cache_loc, block_residual
             )
@@ -2584,6 +2648,20 @@ class KimiLinearModel(nn.Module):
             elif capture_eagle3 and layer_idx + 1 in self.eagle3_layers_to_capture:
                 assert aux_hidden_states is not None
                 aux_hidden_states.append(prefix_sum.clone())
+
+        if not self.mapping.is_last_pp_rank:
+            # Hand the AttnRes thread state to the next stage: the prefix sum
+            # plus the snapshot rows written so far. The wire count matches
+            # the downstream spec because the windows abut on the same block
+            # arithmetic (ceil_div of the shared boundary layer id).
+            valid_blocks = ceil_div(self.pp_end_layer, self.config.attn_res_block_size)
+            return (
+                PPStageState(
+                    hidden_states=prefix_sum,
+                    block_residual=block_residual[:valid_blocks],
+                ),
+                None,
+            )
 
         hidden_states = _apply_attn_res(
             prefix_sum,
@@ -2808,6 +2886,10 @@ class KimiLinearForCausalLM(BaseCausalLM):
             ep_size=self.mapping.moe.ep_size,
         )
 
+        pp_start = self.model.pp_start_layer
+        pp_end = self.model.pp_end_layer
+        pp_windowed = not (pp_start == 0 and pp_end == config.num_hidden_layers)
+
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -2816,6 +2898,15 @@ class KimiLinearForCausalLM(BaseCausalLM):
             if name.startswith("model.layers."):
                 layer_str = name.split(".")[2]
                 if layer_str.isdigit() and int(layer_str) >= config.num_hidden_layers:
+                    continue
+                # Skip layers another pipeline stage owns: the MoE loader
+                # raises on a matched-but-unloadable expert weight, so
+                # out-of-window layers must be dropped before it sees them.
+                if (
+                    pp_windowed
+                    and layer_str.isdigit()
+                    and not pp_start <= int(layer_str) < pp_end
+                ):
                     continue
             # Compressed-tensors MXFP4 routed experts ship the packed weight as
             # ``...w{1,2,3}.weight_packed``; the mxfp4 MoE param is
@@ -2922,7 +3013,9 @@ class KimiLinearForCausalLM(BaseCausalLM):
         ``KimiLinearMLAAttention``) and are skipped.
         """
         for layer in self.model.layers:
-            self_attn = layer.self_attn
+            self_attn = getattr(layer, "self_attn", None)
+            if self_attn is None:
+                continue  # PPMissingLayer: another pipeline stage owns it
             if isinstance(self_attn, KimiLinearMLAAttention):
                 w = self_attn.kv_b_proj.weight
                 if w.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
@@ -2974,6 +3067,8 @@ class KimiLinearForCausalLM(BaseCausalLM):
 
         # Fold the AttnRes rms_w * res_w products once; the split kernels take a single wp pointer.
         for layer in self.model.layers:
+            if not hasattr(layer, "self_attention_res_norm"):
+                continue  # PPMissingLayer
             layer._attn_wp = (
                 layer.self_attention_res_norm.weight.float()
                 * layer.self_attention_res_proj.weight.reshape(-1).float()
@@ -3036,7 +3131,12 @@ class KimiK3ForConditionalGeneration(nn.Module):
             )
             # Normal serving follows the text embedding dtype. Encoder-only
             # construction uses ModelLoader's configured default dtype.
-            if self.language_model is not None:
+            # Non-first pipeline stages own no embedding (and never run the
+            # vision encoder on live inputs); keep the loader dtype there.
+            if (
+                self.language_model is not None
+                and self.language_model.model.embed_tokens is not None
+            ):
                 target_dtype = self.get_input_embeddings().weight.dtype
                 self.vision = self.vision.to(dtype=target_dtype)
             self.vision_embedder = VisionEmbedder(encoder_mapping=mapping.vision)
@@ -3106,6 +3206,17 @@ class KimiK3ForConditionalGeneration(nn.Module):
         return self.language_model.lm_head
 
     @property
+    def model(self):
+        """Expose the text backbone under the ``model`` attribute other
+        registered architectures use (the PP executor resolves the stage wire
+        spec via ``model.pp_stage_state_spec``)."""
+        if self.language_model is None:
+            raise AttributeError(
+                "Kimi-K3 encoder-only mode does not expose a text backbone."
+            )
+        return self.language_model.model
+
+    @property
     def vision_tower(self):
         """Expose the shared MoonViT attribute expected by EPD prefill."""
         return self.vision.vision_tower if self.vision is not None else None
@@ -3147,6 +3258,9 @@ class KimiK3ForConditionalGeneration(nn.Module):
             or self.vision_embedder is None
             or not multimodal_context.has_extend_inputs()
             or ctx.forward_mode.is_decode_or_idle()
+            # Non-first pipeline stages receive the residual stream from
+            # upstream; they own no embedding to splice vision embeds into.
+            or not self.mapping.is_first_pp_rank
         ):
             return None
         input_embeds, model_kwargs = self.vision_embedder.apply(

--- a/python/tokenspeed/runtime/multimodal/inputs.py
+++ b/python/tokenspeed/runtime/multimodal/inputs.py
@@ -289,3 +289,37 @@ class MultimodalForwardContext:
             mm_input is not None and index < len(self.extend_seq_lens)
             for index, mm_input in enumerate(self.mm_inputs)
         )
+
+
+def multimodal_context_for_forward(forward_op, rid_to_state):
+    """Assemble the batch's :class:`MultimodalForwardContext` from per-request
+    state.
+
+    Args:
+        forward_op: The forward op about to dispatch; supplies the batch's
+            request ids and extend geometry.
+        rid_to_state: The output processor's request-id -> state map, whose
+            states carry each request's ``multimodal_inputs``.
+
+    Returns:
+        A ``MultimodalForwardContext`` aligned to the batch order, or ``None``
+        when no request in the batch carries multimodal inputs.
+    """
+    num_extends = forward_op.num_extends()
+    mm_inputs = []
+    has_mm = False
+    for index, rid in enumerate(forward_op.request_ids):
+        state = rid_to_state.get(rid)
+        if state is not None and index < num_extends:
+            state.maybe_extend_multimodal_mrope_positions()
+        item = getattr(state, "multimodal_inputs", None) if state else None
+        mm_inputs.append(item)
+        has_mm = has_mm or item is not None
+    if not has_mm:
+        return None
+
+    return MultimodalForwardContext(
+        mm_inputs=mm_inputs,
+        extend_prefix_lens=list(forward_op.extend_prefix_lens),
+        extend_seq_lens=list(forward_op.input_lengths[:num_extends]),
+    )

--- a/python/tokenspeed/runtime/pd/base/bootstrap.py
+++ b/python/tokenspeed/runtime/pd/base/bootstrap.py
@@ -61,6 +61,11 @@ class DisaggBootstrapServerBase:
         self.world_size = None
         self.dp_size = None
         self.tp_size_per_dp_rank = None
+        # Prefill chunk-pipeline stage count (1 when the source has no PP).
+        self.pp_size = 1
+        # Optional explicit per-stage layer counts; the Decode side must plan
+        # its transfer routes over the SAME stage windows the Prefill used.
+        self.pp_layer_partition: list[int] | None = None
         self.prefill_port_table: dict[int, dict[int, dict[str, str | int]]] = {}
 
         # Initialize every field shared with the server thread before starting
@@ -152,6 +157,15 @@ class DisaggBootstrapServerBase:
         if self.dp_size is None:
             self.dp_size = dp_size
 
+        self.pp_size = int(data.get("pp_size", self.pp_size or 1))
+        if data.get("pp_layer_partition") is not None:
+            self.pp_layer_partition = [
+                int(count) for count in data["pp_layer_partition"]
+            ]
+
+        # With PP the per-dp world spans pp stages; the port table keys by the
+        # dense stage-major rank (pp_rank * tp + tp_rank == global rank at
+        # dp_size == 1, which PP requires).
         tp_size_per_dp_rank = world_size // dp_size
         if self.tp_size_per_dp_rank is None:
             self.tp_size_per_dp_rank = tp_size_per_dp_rank
@@ -189,6 +203,8 @@ class DisaggBootstrapServerBase:
             prefill_parallel_info = {
                 "prefill_tp_size": self.world_size,
                 "prefill_dp_size": self.dp_size,
+                "prefill_pp_size": self.pp_size,
+                "prefill_pp_layer_partition": self.pp_layer_partition,
             }
             prefill_parallel_info.update(self._extra_parallel_info())
             return web.json_response(prefill_parallel_info, status=200)

--- a/python/tokenspeed/runtime/pd/cache_protocol.py
+++ b/python/tokenspeed/runtime/pd/cache_protocol.py
@@ -142,6 +142,7 @@ class CacheTransferContract:
                     )
                     for field in plan_payload["fields"]
                 ),
+                resident_block_bytes=plan_payload.get("resident_block_bytes"),
             )
             schema_payload = payload["transfer_schema"]
             return cls(
@@ -254,8 +255,15 @@ def build_cache_fields_by_producer_step(
     plan: CacheMemoryPlan,
     *,
     num_target_layers: int,
+    pp_layer_window: tuple[int, int] | None = None,
 ) -> CacheProducerSchedule:
-    """Group cache fields by the Prefill barrier that makes them transferable."""
+    """Group cache fields by the Prefill barrier that makes them transferable.
+
+    With prefill chunk-pipeline parallelism, ``pp_layer_window`` narrows the
+    schedule to this stage's [start, end) global layers: the attention backend
+    records one producer step per layer IT executes, so the step axis must be
+    stage-local while the field IDs keep their global layer numbering.
+    """
 
     fields_by_layer: dict[int, list[str]] = {}
     for field in plan.fields:
@@ -268,9 +276,24 @@ def build_cache_fields_by_producer_step(
     if (
         isinstance(num_target_layers, bool)
         or not isinstance(num_target_layers, int)
-        or not 0 < num_target_layers <= merged_layers
+        or num_target_layers < 1
+        or (pp_layer_window is None and num_target_layers > merged_layers)
     ):
         raise ValueError("PD target layer count is outside the cache plan")
+
+    if pp_layer_window is not None:
+        start, end = pp_layer_window
+        if not 0 <= start < end <= num_target_layers:
+            raise ValueError("PP layer window is outside the target layer range")
+        # The plan may already be narrowed to the stage window (v2 physical
+        # narrowing), in which case merged_layers reflects the window's last
+        # layer + 1 rather than the full model — that's expected here.
+        return CacheProducerSchedule(
+            fields_by_step=tuple(
+                tuple(fields_by_layer.get(layer_id, ()))
+                for layer_id in range(start, end)
+            )
+        )
 
     fields_by_step = [
         tuple(fields_by_layer.get(layer_id, ()))

--- a/python/tokenspeed/runtime/pd/factory.py
+++ b/python/tokenspeed/runtime/pd/factory.py
@@ -41,6 +41,7 @@ def get_kv_args(
     *,
     model_config,
     draft_model_config=None,
+    pp_layer_window: tuple[int, int] | None = None,
 ):
     # One big model, one arena: a draft's continuation-layer planes live in
     # the target pool's merged plan, so exactly one typed slab registration is
@@ -53,11 +54,31 @@ def get_kv_args(
     producer_schedule = build_cache_fields_by_producer_step(
         token_to_kv_pool.arena.plan,
         num_target_layers=model_config.num_attention_layers,
+        pp_layer_window=pp_layer_window,
     )
     layout, base_addr = build_arena_cache_transfer_contract(
         token_to_kv_pool.arena,
         transfer_schema=transfer_schema,
     )
+    # Chunk-pipeline: the arena holds only this stage's layers (narrowed
+    # plan), which is what local source addressing must use. The WIRE
+    # contract, however, must be the full logical plan: every stage
+    # registers the same layout, and Decode validates + plans stage windows
+    # against the complete field set.
+    wire_layout = None
+    logical_plan = getattr(token_to_kv_pool.arena, "pp_logical_plan", None)
+    if logical_plan is not None:
+        from tokenspeed.runtime.pd.cache_protocol import CacheTransferContract
+
+        wire_layout = CacheTransferContract(
+            plan=logical_plan,
+            group_specs=token_to_kv_pool.arena.cache_group_specs,
+            transfer_schema=build_cache_transfer_schema(
+                logical_plan,
+                model_config=model_config,
+                draft_model_config=draft_model_config,
+            ),
+        )
     return KVArgs(
         engine_rank=engine_rank,
         kv_data_ptr=base_addr,
@@ -65,6 +86,8 @@ def get_kv_args(
         gpu_id=gpu_id,
         cache_layout=layout,
         cache_producer_schedule=producer_schedule,
+        pp_layer_window=pp_layer_window,
+        wire_cache_layout=wire_layout,
     )
 
 

--- a/python/tokenspeed/runtime/pd/mooncake/decode.py
+++ b/python/tokenspeed/runtime/pd/mooncake/decode.py
@@ -47,10 +47,17 @@ class PrefillParallelInfo:
     tp_size: int
     dp_size: int
     cache_layout: CacheTransferContract | None = None
+    # Prefill chunk-pipeline stage count; each stage sends only its own
+    # layers' KV, so Decode plans per stage and unions the routes.
+    pp_size: int = 1
+    # Optional explicit per-stage layer counts the Prefill split with; None
+    # means the even split. Decode must derive the SAME stage windows.
+    pp_layer_partition: tuple[int, ...] | None = None
 
     @property
     def prefill_tp_size_per_dp_rank(self):
-        return self.tp_size // self.dp_size
+        # Intra-stage TP width: the registered world spans pp stages.
+        return self.tp_size // (self.dp_size * self.pp_size)
 
 
 def parse_prefill_status_message(

--- a/python/tokenspeed/runtime/pd/mooncake/entities.py
+++ b/python/tokenspeed/runtime/pd/mooncake/entities.py
@@ -58,6 +58,20 @@ class KVArgs:
     gpu_id: int
     cache_layout: CacheTransferContract
     cache_producer_schedule: CacheProducerSchedule | None = None
+    # Prefill chunk-pipeline: this rank's [start, end) global layer window.
+    # None when PP is off (the rank owns every layer).
+    pp_layer_window: tuple[int, int] | None = None
+    # Full-model logical contract for the PD wire when the local arena/plan
+    # is narrowed to a stage window; None means cache_layout is already it.
+    wire_cache_layout: CacheTransferContract | None = None
+
+    @property
+    def wire_layout(self) -> CacheTransferContract:
+        return (
+            self.wire_cache_layout
+            if self.wire_cache_layout is not None
+            else self.cache_layout
+        )
 
 
 class KVTransferError(Exception):

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -286,7 +286,11 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         self, registration: KVArgsRegisterInfo
     ) -> KVArgsRegisterInfo:
         """Validate and cache the route owned by this Prefill rank once."""
-        layout = self.kv_args.cache_layout
+        # Plan against the LOGICAL layout (full model): peer validation and
+        # fragment geometry must match what Decode sees on the wire. The
+        # window filter below keeps only fields this stage's physical arena
+        # actually holds, so local addressing never touches a dropped plane.
+        layout = getattr(self.kv_args, "wire_layout", None) or self.kv_args.cache_layout
         peer_layout = registration.peer_cache_layout
         prefill_tp_size = self.topology.tp_size
         local_tp_rank = self.topology.tp_rank
@@ -295,6 +299,10 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             decode_tp_size=registration.decode_tp_size,
             prefill_layout=layout,
             decode_layout=peer_layout,
+            # PP: this stage transfers only its own layers' fields; the other
+            # stages run their own planners over their windows, and the union
+            # covers the whole plan on the Decode side.
+            prefill_layer_window=getattr(self.kv_args, "pp_layer_window", None),
         )
         route = planner.plan_for_decode_rank(registration.decode_tp_rank)
         expected_decode_ranks = planner.decode_ranks_by_prefill_rank[local_tp_rank]
@@ -620,11 +628,26 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 registration.dst_port,
                 req.room,
                 TransferPoll.Success,
-                self.topology.tp_rank,
+                self._status_prefill_rank,
                 bootstrap_token=bootstrap_token,
                 spec_candidate_ids=spec_candidate_ids,
             )
         return True
+
+    @property
+    def _status_prefill_rank(self) -> int:
+        """This rank's identity in Decode's completion-tracking rank space.
+
+        Without PP this is the intra-DP TP rank. With the prefill chunk
+        pipeline every stage sends its own layers' KV, so Decode must count
+        completions from pp*tp distinct sources: stage-major
+        ``pp_rank * tp_size + tp_rank`` keeps the space dense and collision
+        free.
+        """
+        pp_rank = getattr(self.topology, "pp_rank", 0)
+        if pp_rank == 0:
+            return self.topology.tp_rank
+        return pp_rank * self.topology.tp_size + self.topology.tp_rank
 
     def sync_status_to_decode_endpoint(
         self,
@@ -693,7 +716,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                         dst_port,
                         req.room,
                         TransferPoll.Failed,
-                        self.topology.tp_rank,
+                        self._status_prefill_rank,
                     )
                 except Exception:
                     logger.exception(
@@ -796,7 +819,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                         registration.dst_port,
                         req.room,
                         TransferPoll.Success,
-                        self.topology.tp_rank,
+                        self._status_prefill_rank,
                         bootstrap_token=bootstrap_token,
                         spec_candidate_ids=spec_candidate_ids,
                     )
@@ -872,7 +895,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     registration.dst_port,
                     parsed_room,
                     TransferPoll.Failed,
-                    self.topology.tp_rank,
+                    self._status_prefill_rank,
                 )
                 return
             if transfer_info.block_manifest is not None:
@@ -926,7 +949,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     dst_port,
                     parsed_room,
                     TransferPoll.Failed,
-                    self.topology.tp_rank,
+                    self._status_prefill_rank,
                 )
             except Exception:
                 logger.exception(
@@ -946,7 +969,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 registration.dst_port,
                 parsed_room,
                 TransferPoll.Failed,
-                self.topology.tp_rank,
+                self._status_prefill_rank,
             )
             return
         complete = len(candidate_infos) == expected_fanout
@@ -1055,14 +1078,23 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
 
         bootstrap_server_url = f"{ip_address}:{self.bootstrap_port}"
         url = f"http://{bootstrap_server_url}/route"
+        pp_layer_partition = getattr(self.topology, "pp_layer_partition", None)
         payload = {
             "role": "Prefill",
             "world_size": self.topology.world_size,
             "dp_size": self.topology.dp_size,
+            "pp_size": self.topology.pp_size,
+            "pp_layer_partition": (
+                list(pp_layer_partition) if pp_layer_partition else None
+            ),
             "rank_ip": get_local_ip_by_remote(),
             "rank_port": self.rank_port,
             "engine_rank": self.topology.global_rank,
-            "cache_layout": self.kv_args.cache_layout.to_wire_bytes().decode("ascii"),
+            "cache_layout": (
+                getattr(self.kv_args, "wire_layout", None) or self.kv_args.cache_layout
+            )
+            .to_wire_bytes()
+            .decode("ascii"),
         }
 
         try:

--- a/python/tokenspeed/runtime/pd/mooncake/receiver.py
+++ b/python/tokenspeed/runtime/pd/mooncake/receiver.py
@@ -28,6 +28,9 @@ from dataclasses import dataclass
 import requests
 import zmq
 
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+    cache_field_layer_id,
+)
 from tokenspeed.runtime.pd.base.status import TransferPoll
 from tokenspeed.runtime.pd.cache_protocol import (
     CachePDBlockManifest,
@@ -67,10 +70,17 @@ def _get_prefill_parallel_info_from_server(
                 if cache_layout_wire is not None
                 else None
             )
+            raw_partition = prefill_parallel_info.get("prefill_pp_layer_partition")
             return PrefillParallelInfo(
                 tp_size=int(prefill_parallel_info["prefill_tp_size"]),
                 dp_size=int(prefill_parallel_info["prefill_dp_size"]),
                 cache_layout=cache_layout,
+                pp_size=int(prefill_parallel_info.get("prefill_pp_size", 1)),
+                pp_layer_partition=(
+                    tuple(int(count) for count in raw_partition)
+                    if raw_partition
+                    else None
+                ),
             )
         else:
             logger.error(
@@ -128,23 +138,70 @@ def _calc(kv_mgr, prefill_parallel_info: PrefillParallelInfo) -> ReceiverRoutePl
     if prefill_cache_layout is None:
         raise RuntimeError("Paged cache decode connected to a non-Paged cache prefill")
     decode_tp_rank = kv_mgr.topology.tp_rank
-    planner = CacheTransferPlanner(
-        prefill_tp_size=prefill_tp_size_per_dp_rank,
-        decode_tp_size=local_tp_size_per_dp_rank,
-        prefill_layout=prefill_cache_layout,
-        decode_layout=local_cache_layout,
-    )
-    transfer_plan = planner.plan_for_decode_rank(decode_tp_rank)
-    dummy_tp_ranks = ()
-    if decode_tp_rank == 0:
-        dummy_tp_ranks = tuple(
-            rank
-            for rank, decode_ranks in planner.decode_ranks_by_prefill_rank.items()
-            if not decode_ranks
+
+    pp_size = prefill_parallel_info.pp_size
+    if pp_size <= 1:
+        planner = CacheTransferPlanner(
+            prefill_tp_size=prefill_tp_size_per_dp_rank,
+            decode_tp_size=local_tp_size_per_dp_rank,
+            prefill_layout=prefill_cache_layout,
+            decode_layout=local_cache_layout,
         )
+        transfer_plan = planner.plan_for_decode_rank(decode_tp_rank)
+        dummy_tp_ranks = ()
+        if decode_tp_rank == 0:
+            dummy_tp_ranks = tuple(
+                rank
+                for rank, decode_ranks in planner.decode_ranks_by_prefill_rank.items()
+                if not decode_ranks
+            )
+        return ReceiverRoutePlan(
+            transfer_plan=transfer_plan,
+            dummy_tp_ranks=dummy_tp_ranks,
+        )
+
+    # Prefill chunk pipeline: stage s (layers window w_s) sends only its own
+    # layers' fields, from its own tp group. Plan each stage over its window
+    # and union the routes; a stage rank's identity in the union is the dense
+    # stage-major rank pp_rank * tp_size + tp_rank (matching both the
+    # bootstrap port table and the Prefill status messages).
+    from tokenspeed.runtime.distributed.pp_stage import pp_stage_windows
+
+    num_layers = (
+        max(
+            cache_field_layer_id(field.field_id)
+            for field in prefill_cache_layout.plan.fields
+        )
+        + 1
+    )
+    windows = pp_stage_windows(
+        num_layers,
+        pp_size,
+        getattr(prefill_parallel_info, "pp_layer_partition", None),
+    )
+    merged_fragments: dict[int, tuple] = {}
+    dummy_ranks: list[int] = []
+    for stage, window in enumerate(windows):
+        planner = CacheTransferPlanner(
+            prefill_tp_size=prefill_tp_size_per_dp_rank,
+            decode_tp_size=local_tp_size_per_dp_rank,
+            prefill_layout=prefill_cache_layout,
+            decode_layout=local_cache_layout,
+            prefill_layer_window=window,
+        )
+        stage_plan = planner.plan_for_decode_rank(decode_tp_rank)
+        base = stage * prefill_tp_size_per_dp_rank
+        for tp_rank, fragments in stage_plan.fragments_by_prefill_rank.items():
+            merged_fragments[base + tp_rank] = fragments
+        if decode_tp_rank == 0:
+            dummy_ranks.extend(
+                base + rank
+                for rank, decode_ranks in planner.decode_ranks_by_prefill_rank.items()
+                if not decode_ranks
+            )
     return ReceiverRoutePlan(
-        transfer_plan=transfer_plan,
-        dummy_tp_ranks=dummy_tp_ranks,
+        transfer_plan=RankTransferPlan(fragments_by_prefill_rank=merged_fragments),
+        dummy_tp_ranks=tuple(sorted(dummy_ranks)),
     )
 
 

--- a/python/tokenspeed/runtime/pd/prefill_executor.py
+++ b/python/tokenspeed/runtime/pd/prefill_executor.py
@@ -94,6 +94,30 @@ class DisaggPrefillExecutor:
             step_counter, self._layerwise_interval
         )
 
+    def setup_layerwise_transfer(
+        self, model_executor, gpu_id: int, interval: int
+    ) -> None:
+        """Wire a shared step counter between the attention backends and this
+        executor's KV sender so KV pages stream out layer-by-layer during the
+        prefill forward instead of all at once after it.
+
+        Args:
+            model_executor: Owner of the attention backend(s) the counter hooks
+                into (and of the draft backend in spec-decode runs).
+            gpu_id: Device index the counter is created against.
+            interval: Layer interval between sends; ``<= 0`` disables
+                layerwise transfer (this call becomes a no-op).
+        """
+        if interval <= 0:
+            return
+        from tokenspeed.runtime.pd.utils import StepCounter
+
+        step_counter = StepCounter(model_executor.device, gpu_id)
+        model_executor.attn_backend.register_step_counter(step_counter)
+        if model_executor.draft_attn_backend is not None:
+            model_executor.register_draft_final_step_counter(step_counter)
+        self.register_layerwise_step_counter(step_counter, interval)
+
     def _bootstrap(self, request_id, info):
         self.senders[request_id] = MooncakeKVSender(
             mgr=self.kv_manager,

--- a/python/tokenspeed/runtime/pd/topology.py
+++ b/python/tokenspeed/runtime/pd/topology.py
@@ -51,10 +51,17 @@ class PDParallelTopology:
     dp_rank: int
     world_size: int
     global_rank: int
+    # Prefill chunk-pipeline coordinates. tp/cp/dp are INTRA-stage; the world
+    # is pp stages of tp*cp*dp ranks each.
+    pp_size: int = 1
+    pp_rank: int = 0
+    # Optional explicit per-stage layer counts (front to back). Registered
+    # with the bootstrap so the Decode side plans over the same windows.
+    pp_layer_partition: tuple[int, ...] | None = None
 
     def __post_init__(self) -> None:
         """Validate parallel sizes and rank coordinates."""
-        for name in ("tp", "cp", "dp"):
+        for name in ("tp", "cp", "dp", "pp"):
             size = getattr(self, f"{name}_size")
             rank = getattr(self, f"{name}_rank")
             if size <= 0:
@@ -62,10 +69,10 @@ class PDParallelTopology:
             if not 0 <= rank < size:
                 raise ValueError(f"{name}_rank must be in [0, {size}), got {rank}")
 
-        expected_world_size = self.tp_size * self.cp_size * self.dp_size
+        expected_world_size = self.tp_size * self.cp_size * self.dp_size * self.pp_size
         if self.world_size != expected_world_size:
             raise ValueError(
-                "world_size must equal tp_size * cp_size * dp_size: "
+                "world_size must equal tp_size * cp_size * dp_size * pp_size: "
                 f"expected {expected_world_size}, got {self.world_size}"
             )
         if not 0 <= self.global_rank < self.world_size:
@@ -95,6 +102,9 @@ class PDParallelTopology:
             dp_rank=attention.dp_rank,
             world_size=mapping.world_size,
             global_rank=mapping.rank,
+            pp_size=getattr(mapping, "pp_size", 1),
+            pp_rank=(mapping.pp_rank if getattr(mapping, "pp_size", 1) > 1 else 0),
+            pp_layer_partition=getattr(mapping, "pp_layer_partition", None),
         )
 
     def require_cache_pd_supported(self) -> None:

--- a/python/tokenspeed/runtime/pd/transfer_hooks.py
+++ b/python/tokenspeed/runtime/pd/transfer_hooks.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""EventLoop-side PD transfer-event integration.
+
+The KV transfer executors (prefill/decode) DECIDE — they own the senders /
+receivers and surface progress as PD events. ``PdTransferHooks`` here ACTS on
+those events with the event loop's collaborators (output processor, model
+executor) and returns the enriched event list for the loop to advance the
+scheduler with — feedback into the scheduler stays an explicit
+``advance_scheduler`` call in the loop body.
+"""
+
+from __future__ import annotations
+
+from tokenspeed_scheduler import PD, ForwardEvent
+
+from tokenspeed.runtime.pd.decode_executor import DisaggDecodeExecutor
+from tokenspeed.runtime.pd.prefill_executor import DisaggPrefillExecutor
+
+
+class PdTransferHooks:
+    """EventLoop-side PD transfer hooks. Stateless glue: holds only a loop
+    back-reference; a cheap no-op when PD is disabled (``kv_transfer=None``).
+    """
+
+    def __init__(self, loop) -> None:
+        self._loop = loop
+
+    def poll_transfer_events(self) -> list:
+        """Poll the KV transfer executor, act on its events, and return the
+        (possibly enriched) event list for the scheduler advance. Empty when
+        PD is disabled.
+        """
+        loop = self._loop
+        if loop.kv_transfer is None:
+            return []
+
+        processed = []
+        for event in loop.kv_transfer.generate_events():
+            processed.append(event)
+            if isinstance(event, PD.SucceededEvent) and isinstance(
+                loop.kv_transfer, DisaggPrefillExecutor
+            ):
+                req_id = event.request_id
+                processed.extend(loop.output_processor.finish_prefill_request(req_id))
+            elif isinstance(event, PD.RemotePrefillDoneEvent):
+                req_id = event.request_id
+                bootstrap_token = event.bootstrap_token
+                state = loop.output_processor.rid_to_state.get(req_id)
+                if state is None or not state.to_abort:
+                    loop.output_processor.on_remote_prefill_done(
+                        req_id, bootstrap_token
+                    )
+                if loop._pd_cache_enabled:
+                    processed.extend(
+                        loop.output_processor.finish_remote_prefill_only_request(req_id)
+                    )
+                if isinstance(loop.kv_transfer, DisaggDecodeExecutor):
+                    remote_cache_slot = loop.kv_transfer.pop_remote_cache_slot(req_id)
+                    candidate_info = loop.kv_transfer.pop_remote_spec_candidate_ids(
+                        req_id
+                    )
+                    if candidate_info is not None:
+                        req_pool_idx, candidate_ids = candidate_info
+                        loop.model_executor.write_remote_spec_candidate_ids(
+                            req_pool_idx, candidate_ids
+                        )
+                    remaining_state = loop.output_processor.rid_to_state.get(req_id)
+                    if (
+                        remote_cache_slot is not None
+                        and remaining_state is not None
+                        and not remaining_state.to_abort
+                        and not remaining_state.finished
+                    ):
+                        loop.model_executor.mark_remote_cache_ready(remote_cache_slot)
+            elif isinstance(event, PD.FailedEvent):
+                # A PD/EPD transfer failed: the decode KV receiver timed out (e.g. the
+                # prefill aborted on embedding timeout so the KV never arrives), or a
+                # transfer errored. Publish the client-visible failure here. An
+                # encode-only EPD flow still needs a following Forward.Abort because
+                # its C++ FailedEvent handler is a no-op; CachePD FailedEvent
+                # atomically terminalizes and fences the leased scheduler resources.
+                req_id = event.request_id
+                state = loop.output_processor.rid_to_state.get(req_id)
+                if state is not None:
+                    if state.finished:
+                        loop.output_processor.reap_finished_orphan(req_id, state)
+                    else:
+                        state.set_finish_with_abort(
+                            "PD/EPD remote transfer failed or timed out"
+                        )
+                        loop.output_processor.publish_finished_at_admission(
+                            req_id, state
+                        )
+                    if not loop._pd_cache_enabled:
+                        abort = ForwardEvent.Abort()
+                        abort.request_id = req_id
+                        processed.append(abort)
+        return processed

--- a/python/tokenspeed/runtime/pd/transfer_plan.py
+++ b/python/tokenspeed/runtime/pd/transfer_plan.py
@@ -23,6 +23,9 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+    cache_field_layer_id,
+)
 from tokenspeed.runtime.pd.cache_protocol import (
     CacheTransferContract,
     validate_cache_peer_layout,
@@ -99,7 +102,18 @@ class CacheTransferPlanner:
         decode_tp_size: int,
         prefill_layout: CacheTransferContract,
         decode_layout: CacheTransferContract,
+        prefill_layer_window: tuple[int, int] | None = None,
     ):
+        """Plan fragments between one Prefill rank set and one Decode rank set.
+
+        Args:
+            prefill_layer_window: With prefill chunk-pipeline parallelism, the
+                ``[start, end)`` global layer window whose KV THIS planning
+                context transfers. Fields owned by other pipeline stages are
+                excluded from the route (each stage runs its own planner over
+                its own window, and the union of stages covers the plan).
+                None plans every field (no PP).
+        """
         if prefill_tp_size <= 0 or decode_tp_size <= 0:
             raise UnsupportedPDLayoutError("Paged cache TP sizes must be positive")
         if prefill_tp_size > MAX_CACHE_TP_SIZE or decode_tp_size > MAX_CACHE_TP_SIZE:
@@ -108,7 +122,15 @@ class CacheTransferPlanner:
             )
         self.prefill_tp_size = prefill_tp_size
         self.decode_tp_size = decode_tp_size
+        self._layer_window = prefill_layer_window
         validate_cache_peer_layout(prefill_layout, decode_layout)
+
+        def in_window(field_id: str) -> bool:
+            if prefill_layer_window is None:
+                return True
+            layer_id = cache_field_layer_id(field_id)
+            return prefill_layer_window[0] <= layer_id < prefill_layer_window[1]
+
         self._partitions = {
             field.field_id: prefill_layout.transfer_schema.partition_for(field.field_id)
             for field in prefill_layout.plan.fields
@@ -125,6 +147,7 @@ class CacheTransferPlanner:
                 decode_layout.fields_for_group(decode_spec.group_id),
                 strict=True,
             )
+            if in_window(prefill_segment.field_id)
         )
         for _, prefill_segment, decode_segment in self._segment_pairs:
             self._validate_tp_mapping(prefill_segment, decode_segment)
@@ -140,7 +163,10 @@ class CacheTransferPlanner:
             raise UnsupportedPDLayoutError(
                 f"decode_tp_rank={decode_tp_rank} is out of range"
             )
-        if self.prefill_tp_size == self.decode_tp_size:
+        # Equal-TP fast path: empty fragments mean "copy every field whole".
+        # A PP layer window cannot use it — only the window's fields may be
+        # copied, so the explicit fragment route is mandatory.
+        if self.prefill_tp_size == self.decode_tp_size and self._layer_window is None:
             return RankTransferPlan(
                 fragments_by_prefill_rank={decode_tp_rank: ()},
             )

--- a/python/tokenspeed/runtime/sampling/dp_sampling_config.py
+++ b/python/tokenspeed/runtime/sampling/dp_sampling_config.py
@@ -181,6 +181,9 @@ def setup_dp_sampling(
         The resolved runtime config (``enabled=False`` when unsupported).
     """
     processor = model.logits_processor
+    if processor is None:
+        # Mid-pipeline PP stage: no logits, no sampling of any kind here.
+        return DpSamplingRuntimeConfig(enabled=False)
     topology = DpSamplingTopology(
         tp_rank=processor.tp_rank,
         tp_size=processor.tp_size,

--- a/python/tokenspeed/runtime/utils/common.py
+++ b/python/tokenspeed/runtime/utils/common.py
@@ -192,18 +192,45 @@ class LayerFn(Protocol):
     def __call__(self, idx: int, prefix: str) -> torch.nn.Module: ...
 
 
+class PPMissingLayer(torch.nn.Identity):
+    """Placeholder for a layer owned by another pipeline stage.
+
+    Keeps global layer numbering intact (KV field names, weight names, and
+    ``layer_id`` all stay global) while contributing no parameters, so the
+    weight loader's skip-unknown semantics leave it untouched.
+    """
+
+
 def make_layers(
     num_hidden_layers: int,
     layer_fn: LayerFn,
     prefix: str = "",
+    pp_start_layer: int = 0,
+    pp_end_layer: int | None = None,
 ) -> torch.nn.ModuleList:
-    """Make a list of layers with the given layer function"""
-    start_layer = 0
-    end_layer = num_hidden_layers
+    """Make a list of layers with the given layer function.
+
+    Args:
+        num_hidden_layers: Total layer count of the model (all stages).
+        layer_fn: Factory called with the GLOBAL layer index.
+        prefix: Parameter-name prefix.
+        pp_start_layer: First global layer index this pipeline stage owns.
+        pp_end_layer: One past the last owned layer; None means all layers.
+
+    Returns:
+        A ModuleList of length ``num_hidden_layers`` where positions outside
+        [pp_start_layer, pp_end_layer) hold :class:`PPMissingLayer`.
+    """
+    if pp_end_layer is None:
+        pp_end_layer = num_hidden_layers
     modules = torch.nn.ModuleList(
         [
-            layer_fn(idx=idx, prefix=add_prefix(idx, prefix))
-            for idx in range(start_layer, end_layer)
+            (
+                layer_fn(idx=idx, prefix=add_prefix(idx, prefix))
+                if pp_start_layer <= idx < pp_end_layer
+                else PPMissingLayer()
+            )
+            for idx in range(num_hidden_layers)
         ]
     )
     return modules

--- a/python/tokenspeed/runtime/utils/env.py
+++ b/python/tokenspeed/runtime/utils/env.py
@@ -283,6 +283,12 @@ class Envs:
     # EPLB
     TOKENSPEED_EXPERT_DISTRIBUTION_RECORDER_DIR = EnvStr("/tmp")
 
+    # Communication
+    # InfiniBand traffic class for NVSHMEM (DeepEP all-to-all). Read in every
+    # inference process entry so the value reaches NVSHMEM regardless of how
+    # the process was spawned; unset leaves NVSHMEM's own default in place.
+    NVSHMEM_IB_TRAFFIC_CLASS = EnvInt(None)
+
     # Runtime behavior
     TOKENSPEED_WORKSPACE_INITIAL_MB = EnvInt(256)
     TOKENSPEED_WORKSPACE_TRTLLM_MHA_MB = EnvInt(512)

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -51,7 +51,7 @@ ENABLE_CP = os.environ.get("ENABLE_CP", "false").lower() in ("true", "1")
 
 # Spec-decode overshoot spans the physical KV extent must absorb past the
 # logical context_len. The overlap scheduler steps a finished request at most
-# ONE extra iteration (event_loop_overlap commits the previous step every
+# ONE extra iteration (the depth-1 event loop commits the previous step every
 # round, so the Finish event reaches the C++ scheduler before the next plan),
 # and termination is checked CPU-side against max_new_tokens, so verify can
 # commit past context_len for exactly that window:
@@ -183,6 +183,13 @@ class ServerArgs:
 
     # Data parallelism
     data_parallel_size: int | None = None
+    # Pipeline parallelism (prefill-only): number of stages. Only supported on
+    # PD-disaggregated prefill servers; see resolve_disaggregation.
+    pipeline_parallel_size: int = 1
+    # Optional explicit per-stage layer counts, front to back (e.g.
+    # "8,11,11,8"). Default None = even split, remainder to the front. Use to
+    # lighten the embed (first) and lm_head (last) stages.
+    pp_layer_partition: tuple[int, ...] | None = None
     load_balance_method: str = "shortest_queue"
     load_watch_interval: float = 0.02
 
@@ -558,6 +565,7 @@ class ServerArgs:
         world_size = self.world_size
         nprocs_per_node = self.nprocs_per_node
         nnodes = 1 if self.nnodes is None else self.nnodes
+        pp_size = self.pipeline_parallel_size
 
         attn_tp_size = self.attn_tp_size
         attn_dp_size = self.data_parallel_size
@@ -568,7 +576,7 @@ class ServerArgs:
             attn_cp_size, attn_tp_size = attn_tp_size, 1
 
         if world_size is None:
-            world_size = 1
+            world_size = pp_size
             if attn_tp_size is not None:
                 world_size *= attn_tp_size
             if attn_cp_size is not None:
@@ -576,17 +584,27 @@ class ServerArgs:
             if attn_dp_size is not None:
                 world_size *= attn_dp_size
             logger.info(
-                "Inferred world_size (%s) from attn_tp_size (%s) x attn_cp_size (%s) x attn_dp_size (%s)",
+                "Inferred world_size (%s) from attn_tp_size (%s) x attn_cp_size (%s) x attn_dp_size (%s) x pp_size (%s)",
                 world_size,
                 attn_tp_size,
                 attn_cp_size,
                 attn_dp_size,
+                pp_size,
             )
         else:
             logger.info("Specified world_size (%s)", world_size)
 
+        # Pipeline stages are the outermost split: every per-layer-type
+        # parallelism resolves inside one stage's world.
+        if world_size % pp_size != 0:
+            raise ValueError(
+                f"world_size ({world_size}) must be divisible by "
+                f"--pipeline-parallel-size ({pp_size})"
+            )
+        stage_world_size = world_size // pp_size
+
         attn_tp_size, attn_cp_size, attn_dp_size = _resolve_parallelism_sizes(
-            world_size, attn_tp_size, attn_cp_size, attn_dp_size
+            stage_world_size, attn_tp_size, attn_cp_size, attn_dp_size
         )
 
         # Dense layers default to the attention replica's TP width
@@ -600,16 +618,21 @@ class ServerArgs:
             dense_tp_size = attn_tp_size * attn_cp_size
         dense_dp_size = None
 
-        # --enable-expert-parallel auto-sets ep_size = world_size
+        # --enable-expert-parallel auto-sets ep_size = the stage world (the
+        # whole world when PP is off).
         if self.enable_expert_parallel and self.ep_size == 1:
-            self.ep_size = world_size
-            logger.info("--enable-expert-parallel: auto-setting ep_size=%s", world_size)
+            self.ep_size = stage_world_size
+            logger.info(
+                "--enable-expert-parallel: auto-setting ep_size=%s", stage_world_size
+            )
 
-        # MoE parallel sizes default to consuming the full world size unless
+        # MoE parallel sizes default to consuming the full stage world unless
         # the user overrides them explicitly.
         moe_ep_size = 1 if self.ep_size is None else self.ep_size
         moe_tp_size = (
-            world_size // moe_ep_size if self.moe_tp_size is None else self.moe_tp_size
+            stage_world_size // moe_ep_size
+            if self.moe_tp_size is None
+            else self.moe_tp_size
         )
         moe_dp_size = None
 
@@ -641,6 +664,8 @@ class ServerArgs:
             moe_dp_size=moe_dp_size,
             vision_tp_size=vision_tp_size,
             vision_dp_size=vision_dp_size,
+            pp_size=pp_size,
+            pp_layer_partition=self.pp_layer_partition,
             nprocs_per_node=nprocs_per_node,
             nnodes=nnodes,
             base_gpu_id=self.base_gpu_id,
@@ -744,6 +769,50 @@ class ServerArgs:
             )
 
     def resolve_disaggregation(self):
+        # Pipeline parallelism is a prefill-node-only capability: the chunk
+        # pipeline needs the P role's structural guarantees (no decode token
+        # feedback, eager execution, non-overlap loop).
+        if self.pipeline_parallel_size > 1:
+            # Debug escape hatch: run PP without PD to validate the stage
+            # pipeline numerically (prefill + first token only — decode
+            # autoregression is NOT correct with in-flight depth > 0).
+            pp_debug = os.environ.get("TS_PP_DEBUG_ALLOW_NON_PREFILL") == "1"
+            if self.disaggregation_mode != "prefill" and not pp_debug:
+                raise ValueError(
+                    "--pipeline-parallel-size > 1 requires "
+                    "--disaggregation-mode prefill; PP is a prefill-node "
+                    "chunk-pipeline feature"
+                )
+            if pp_debug and self.disaggregation_mode == "null":
+                logger.warning(
+                    "TS_PP_DEBUG_ALLOW_NON_PREFILL=1: running PP without PD "
+                    "for pipeline validation; only prefill/first-token output "
+                    "is meaningful"
+                )
+                self.enforce_eager = True
+            if self.mapping.has_attn_dp:
+                raise ValueError(
+                    "--pipeline-parallel-size > 1 with attention DP is not "
+                    "supported yet"
+                )
+            if self.speculative_algorithm is not None:
+                raise ValueError(
+                    "--pipeline-parallel-size > 1 does not support "
+                    "speculative decoding"
+                )
+            if (
+                self.pp_layer_partition is not None
+                and len(self.pp_layer_partition) != self.pipeline_parallel_size
+            ):
+                raise ValueError(
+                    f"--pp-layer-partition {self.pp_layer_partition} has "
+                    f"{len(self.pp_layer_partition)} entries but "
+                    f"--pipeline-parallel-size is {self.pipeline_parallel_size}"
+                )
+        elif self.pp_layer_partition is not None:
+            raise ValueError(
+                "--pp-layer-partition requires --pipeline-parallel-size > 1"
+            )
         # PD disaggregation
         if self.disaggregation_mode == "prefill":
             self.enforce_eager = True
@@ -1338,6 +1407,24 @@ class ServerArgs:
             type=int,
             default=ServerArgs.data_parallel_size,
             help="The data parallelism size. If not set, inferred from world_size and attn_tp_size.",
+        )
+        parser.add_argument(
+            "--pipeline-parallel-size",
+            metavar="PIPELINE_PARALLEL_SIZE",
+            type=int,
+            default=ServerArgs.pipeline_parallel_size,
+            help="Number of pipeline stages for prefill chunk pipelining. "
+            "Only supported with --disaggregation-mode prefill.",
+        )
+        parser.add_argument(
+            "--pp-layer-partition",
+            metavar="PP_LAYER_PARTITION",
+            type=lambda arg: tuple(int(v) for v in arg.split(",")),
+            default=ServerArgs.pp_layer_partition,
+            help="Explicit per-stage layer counts for pipeline parallelism, "
+            'front to back, e.g. "8,11,11,8". Must have one entry per stage '
+            "and sum to the model's layer count. Default: even split with "
+            "the remainder on the front stages.",
         )
         parser.add_argument(
             "--load-balance-method",

--- a/test/runtime/distributed/test_pd_decode_dp_metadata.py
+++ b/test/runtime/distributed/test_pd_decode_dp_metadata.py
@@ -18,7 +18,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from tokenspeed.runtime.engine.event_loop import _forward_op_executes_model_forward
+"""CPU-only tests for EventLoop._dp_sync_and_check's per-rank metadata.
+
+The all_gather is faked (each fake rank's local row is written into the
+global tensor directly), so the tests pin down what each rank REPORTS and
+how the gathered rows are interpreted — in particular the decode-side PD
+rule: an EXTEND op that only starts remote KV receive is reported as IDLE,
+so idle DP ranks don't enter dummy collectives the active rank won't match.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed
+
+from tokenspeed.runtime.engine.event_loop import EventLoop
+from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+from tokenspeed.runtime.pd.decode_executor import DisaggDecodeExecutor
 
 
 class FakeForwardOp:
@@ -39,33 +55,98 @@ class FakeForwardOp:
         return self._local_prefill
 
 
-def test_pd_decode_extend_only_does_not_require_idle_forward():
+class _FakeLoop:
+    """Only the state read by ``EventLoop._dp_sync_and_check``."""
+
+    def __init__(self, *, world_size=1, disagg_decode=False):
+        self.kv_transfer = (
+            object.__new__(DisaggDecodeExecutor) if disagg_decode else None
+        )
+        self._dp_local_info = torch.zeros(1, 3, dtype=torch.int32)
+        self._dp_global_info = torch.zeros(world_size, 3, dtype=torch.int32)
+        self.world_cpu_group = None
+
+
+def _sync(loop, forward_op, monkeypatch, other_rank_rows=()):
+    """Run _dp_sync_and_check with the collective replaced by direct writes:
+    this rank's row lands in slot 0, ``other_rank_rows`` fill the rest."""
+
+    def fake_gather(global_info, local_info, group=None):
+        global_info[0] = local_info[0]
+        for i, row in enumerate(other_rank_rows, start=1):
+            global_info[i] = torch.tensor(row, dtype=torch.int32)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_into_tensor", fake_gather)
+    return EventLoop._dp_sync_and_check(loop, forward_op)
+
+
+def test_pd_decode_extend_only_is_reported_idle(monkeypatch):
     # Decode-side PD EXTEND starts KV receive only; no model collectives run on
-    # the active DP rank yet, so idle DP ranks must not enter dummy forward.
+    # the active DP rank yet, so it must report IDLE (0 tokens) to its peers.
+    loop = _FakeLoop(disagg_decode=True)
     op = FakeForwardOp(input_lengths=[17], num_extends=1)
 
-    assert not _forward_op_executes_model_forward(op, is_disagg_decode=True)
+    meta = _sync(loop, op, monkeypatch)
+
+    assert meta.global_num_tokens == [0]
+    assert meta.global_forward_mode == [int(ForwardMode.IDLE)]
+    assert not meta.need_idle_forward
 
 
-def test_pd_decode_decode_step_requires_idle_forward():
+def test_pd_decode_decode_step_is_reported_as_decode(monkeypatch):
+    loop = _FakeLoop(disagg_decode=True)
     op = FakeForwardOp(input_lengths=[1], num_extends=0)
 
-    assert _forward_op_executes_model_forward(op, is_disagg_decode=True)
+    meta = _sync(loop, op, monkeypatch)
+
+    assert meta.global_num_tokens == [1]
+    assert meta.global_forward_mode == [int(ForwardMode.DECODE)]
+    assert meta.all_decode_or_idle
 
 
-def test_pd_decode_local_recovery_prefill_executes_model_forward():
+def test_pd_decode_local_recovery_prefill_is_model_work(monkeypatch):
+    loop = _FakeLoop(disagg_decode=True)
     op = FakeForwardOp(input_lengths=[17], num_extends=1, local_prefill=True)
 
-    assert _forward_op_executes_model_forward(op, is_disagg_decode=True)
+    meta = _sync(loop, op, monkeypatch)
+
+    assert meta.global_num_tokens == [17]
+    assert meta.global_forward_mode == [int(ForwardMode.EXTEND)]
+    assert meta.all_extend
 
 
-def test_non_pd_extend_still_executes_model_forward():
+def test_non_pd_extend_is_model_work(monkeypatch):
+    loop = _FakeLoop()
     op = FakeForwardOp(input_lengths=[17], num_extends=1)
 
-    assert _forward_op_executes_model_forward(op, is_disagg_decode=False)
+    meta = _sync(loop, op, monkeypatch)
+
+    assert meta.global_num_tokens == [17]
+    assert meta.global_forward_mode == [int(ForwardMode.EXTEND)]
 
 
-def test_zero_token_forward_op_is_not_model_work():
+def test_zero_token_forward_op_is_not_model_work(monkeypatch):
+    loop = _FakeLoop()
     op = FakeForwardOp(input_lengths=[0], num_extends=1)
 
-    assert not _forward_op_executes_model_forward(op, is_disagg_decode=False)
+    meta = _sync(loop, op, monkeypatch)
+
+    assert meta.global_num_tokens == [0]
+    assert meta.global_forward_mode == [int(ForwardMode.IDLE)]
+
+
+def test_idle_rank_joins_dummy_forward_only_when_a_peer_has_work(monkeypatch):
+    # Two ranks: this one idle, the peer running a 4-token decode batch.
+    loop = _FakeLoop(world_size=2)
+    busy_peer = (4, 4, int(ForwardMode.DECODE))
+
+    meta = _sync(loop, None, monkeypatch, other_rank_rows=[busy_peer])
+
+    assert meta.need_idle_forward
+    assert meta.all_decode_or_idle
+    assert meta.global_num_tokens == [0, 4]
+
+    # Fully idle world: nothing to keep in lockstep with.
+    idle_peer = (0, 0, int(ForwardMode.IDLE))
+    meta = _sync(loop, None, monkeypatch, other_rank_rows=[idle_peer])
+    assert not meta.need_idle_forward

--- a/test/runtime/distributed/test_pd_transfer_plan.py
+++ b/test/runtime/distributed/test_pd_transfer_plan.py
@@ -225,3 +225,114 @@ def test_composite_partition_on_inner_axis_keeps_full_parent_row_stride():
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))
+
+
+# ---- prefill chunk-pipeline (PP) layer-window routing ----
+
+
+def test_pp_layer_window_filters_fragments():
+    """A stage's planner only routes fields inside its layer window."""
+    layout = _paged_layout(
+        local_heads=4, global_heads=4, page_stride=4096, page_zero_offset=128
+    )
+    stage0 = CacheTransferPlanner(
+        prefill_tp_size=1,
+        decode_tp_size=1,
+        prefill_layout=layout,
+        decode_layout=layout,
+        prefill_layer_window=(0, 1),
+    )
+    stage1 = CacheTransferPlanner(
+        prefill_tp_size=1,
+        decode_tp_size=1,
+        prefill_layout=layout,
+        decode_layout=layout,
+        prefill_layer_window=(1, 2),
+    )
+    frags0 = stage0.plan_for_decode_rank(0).fragments_by_prefill_rank[0]
+    frags1 = stage1.plan_for_decode_rank(0).fragments_by_prefill_rank[0]
+    assert {f.field_id for f in frags0} == {"layer.0.k"}
+    assert {f.field_id for f in frags1} == {"layer.1.latent"}
+    # The stage union covers exactly the plan's full field set.
+    all_fields = {field.field_id for field in layout.plan.fields}
+    assert {f.field_id for f in frags0} | {f.field_id for f in frags1} == all_fields
+
+
+def test_pp_receiver_calc_merges_stage_routes():
+    """Decode's route plan spans pp*tp source ranks with disjoint fields."""
+    from types import SimpleNamespace
+
+    from tokenspeed.runtime.pd.mooncake.decode import PrefillParallelInfo
+    from tokenspeed.runtime.pd.mooncake.receiver import _calc
+
+    layout = _paged_layout(
+        local_heads=4, global_heads=4, page_stride=4096, page_zero_offset=128
+    )
+    kv_mgr = SimpleNamespace(
+        topology=SimpleNamespace(tp_size=1, tp_rank=0),
+        kv_args=SimpleNamespace(cache_layout=layout),
+    )
+    info = PrefillParallelInfo(
+        tp_size=2,  # registered world = pp(2) x tp(1)
+        dp_size=1,
+        cache_layout=layout,
+        pp_size=2,
+    )
+    assert info.prefill_tp_size_per_dp_rank == 1
+    plan = _calc(kv_mgr, info)
+    frags = plan.transfer_plan.fragments_by_prefill_rank
+    # Stage-major dense ranks: stage0 -> rank 0 (layer.0), stage1 -> rank 1 (layer.1).
+    assert set(frags) == {0, 1}
+    assert {f.field_id for f in frags[0]} == {"layer.0.k"}
+    assert {f.field_id for f in frags[1]} == {"layer.1.latent"}
+
+
+def test_pp_receiver_calc_honors_layer_partition():
+    """An explicit prefill layer partition moves fields between stage routes."""
+    from types import SimpleNamespace
+
+    from tokenspeed.runtime.pd.mooncake.decode import PrefillParallelInfo
+    from tokenspeed.runtime.pd.mooncake.receiver import _calc
+
+    # Three layers so partition (1, 2) differs from the even split (2, 1).
+    layout = make_layout(
+        group(
+            "history",
+            segment(
+                "layer.0.latent", dtype="bfloat16", shape=(2, 1), offset=0, stride=16
+            ),
+            segment(
+                "layer.1.latent", dtype="bfloat16", shape=(2, 1), offset=512, stride=16
+            ),
+            segment(
+                "layer.2.latent", dtype="bfloat16", shape=(2, 1), offset=1024, stride=16
+            ),
+        ),
+        page_bytes=128,
+    )
+    kv_mgr = SimpleNamespace(
+        topology=SimpleNamespace(tp_size=1, tp_rank=0),
+        kv_args=SimpleNamespace(cache_layout=layout),
+    )
+
+    def stage_fields(partition):
+        info = PrefillParallelInfo(
+            tp_size=2,
+            dp_size=1,
+            cache_layout=layout,
+            pp_size=2,
+            pp_layer_partition=partition,
+        )
+        frags = _calc(kv_mgr, info).transfer_plan.fragments_by_prefill_rank
+        return {rank: {f.field_id for f in fields} for rank, fields in frags.items()}
+
+    # Even split (partition None): stage0 gets layers 0-1, stage1 layer 2.
+    assert stage_fields(None) == {
+        0: {"layer.0.latent", "layer.1.latent"},
+        1: {"layer.2.latent"},
+    }
+    # Explicit (1, 2): stage0 gets layer 0 only, stage1 layers 1-2.
+    assert stage_fields((1, 2)) == {
+        0: {"layer.0.latent"},
+        1: {"layer.1.latent", "layer.2.latent"},
+    }

--- a/test/runtime/test_cache_pd_shutdown.py
+++ b/test/runtime/test_cache_pd_shutdown.py
@@ -68,6 +68,17 @@ class _EventLoopHarness:
         self.has_dp = False
         self.kv_transfer = None
         self._pd_cache_enabled = False
+        self.in_flight_depth = 0
+        self._epd_hooks = SimpleNamespace(
+            drain_ready_embeddings=lambda: self.trace.append("drain_epd")
+        )
+        self._cache_hooks = SimpleNamespace(
+            poll_ready_events=lambda: (self.trace.append("poll_cache"), [])[1],
+            submit=lambda _plan: self.trace.append("submit_cache"),
+        )
+        self._pd_hooks = SimpleNamespace(
+            poll_transfer_events=lambda: (self.trace.append("poll_pd"), [])[1]
+        )
 
     def _shutdown_complete(self) -> bool:
         return EventLoop._shutdown_complete(self)
@@ -78,17 +89,8 @@ class _EventLoopHarness:
         # iteration: finish this scheduler step, then stop at the next head.
         self.shutdown_event.set()
 
-    def _drain_ready_epd_embeddings(self) -> None:
-        self.trace.append("drain_epd")
-
-    def _commit_cache_results(self) -> None:
-        self.trace.append("commit_cache")
-
     def _publish_scheduler_kv_events(self) -> None:
         self.trace.append("publish_kv")
-
-    def _submit_cache_ops(self, _execution_plan) -> None:
-        self.trace.append("submit_cache")
 
     def _get_forward_op(self, _execution_plan):
         self.trace.append("get_forward")
@@ -123,16 +125,17 @@ def test_event_loop_finishes_current_iteration_then_observes_shutdown() -> None:
     assert loop.trace == [
         "process_requests",
         "drain_epd",
-        "commit_cache",
+        "poll_cache",
         "next_plan",
-        "publish_kv",
         "zero_pages",
         "submit_cache",
         "get_forward",
         "stats",
         "observe_load",
-        "pause_finish",
         "metrics",
+        "poll_pd",
+        "publish_kv",
+        "pause_finish",
     ]
 
 

--- a/test/runtime/test_epd_prefill_hooks.py
+++ b/test/runtime/test_epd_prefill_hooks.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""CPU-only tests for EpdPrefillHooks, the event loop side of EPD prefill
+admission. The receive/reassembly controller itself (EpdPrefillAdmission) is
+exercised elsewhere; these drive the hooks against fakes, so no Mooncake, ZMQ,
+or CUDA context is created.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+# CPU-only tests scheduled in runtime-1gpu because they import the full runtime.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.epd.prefill_hooks import EpdPrefillHooks  # noqa: E402
+
+
+class _State:
+    def __init__(self, mm_items=None, *, finished: bool = False) -> None:
+        if mm_items is not None:
+            self.multimodal_inputs = SimpleNamespace(mm_items=mm_items)
+        self.finished = finished
+        self.finish_calls: list[str] = []
+
+    def set_finish_with_abort(self, message: str) -> None:
+        self.finish_calls.append(message)
+
+
+def _handshaked_item():
+    return SimpleNamespace(encode_handshake=object(), encoded=None)
+
+
+def _plain_item():
+    return SimpleNamespace(encode_handshake=None, encoded=None)
+
+
+class _Admission:
+    def __init__(self) -> None:
+        self.staged: list[str] = []
+        self.drain_result: tuple[list, list] = ([], [])
+        self.pending = False
+
+    def stage(self, request_id, mm_items) -> None:
+        self.staged.append(request_id)
+
+    def drain(self):
+        return self.drain_result
+
+    def has_pending(self) -> bool:
+        return self.pending
+
+
+class _OutputProcessor:
+    def __init__(self) -> None:
+        self.published: list[str] = []
+
+    def publish_finished_at_admission(self, request_id, _state) -> None:
+        self.published.append(request_id)
+
+
+class _FakeLoop:
+    """Only the loop state EpdPrefillHooks reads."""
+
+    def __init__(self) -> None:
+        self._pause = SimpleNamespace(admit_blocked=False)
+        self.kv_transfer = None
+        self.output_processor = _OutputProcessor()
+        self.submitted: list[list] = []
+        self.scheduler = SimpleNamespace(
+            submit_requests=lambda specs: self.submitted.append(list(specs))
+        )
+
+
+def _spec(rid: str):
+    return SimpleNamespace(request_id=rid)
+
+
+# --- try_stage ------------------------------------------------------------------
+
+
+def test_try_stage_is_a_no_op_on_non_epd_nodes() -> None:
+    hooks = EpdPrefillHooks(_FakeLoop(), None)
+    state = _State(mm_items=[_handshaked_item()])
+
+    assert not hooks.try_stage(_spec("r0"), state, None)
+    assert hooks._staged == {}
+
+
+def test_try_stage_passes_through_non_encode_routed_requests() -> None:
+    admission = _Admission()
+    hooks = EpdPrefillHooks(_FakeLoop(), admission)
+
+    # Text-only (no multimodal_inputs at all) and plain multimodal (no
+    # per-image encode handshake) both admit immediately.
+    assert not hooks.try_stage(_spec("text"), _State(), None)
+    assert not hooks.try_stage(_spec("mm"), _State(mm_items=[_plain_item()]), None)
+    assert admission.staged == []
+
+
+def test_try_stage_stages_encode_routed_requests() -> None:
+    admission = _Admission()
+    hooks = EpdPrefillHooks(_FakeLoop(), admission)
+    spec, state = _spec("r0"), _State(mm_items=[_handshaked_item()])
+
+    assert hooks.try_stage(spec, state, "bootstrap")
+
+    assert admission.staged == ["r0"]
+    assert hooks._staged == {"r0": (spec, state, "bootstrap")}
+
+
+# --- drain_ready_embeddings -----------------------------------------------------
+
+
+def test_drain_submits_admitted_and_registers_deferred_sender() -> None:
+    admission = _Admission()
+    loop = _FakeLoop()
+    registered: list[tuple[str, object]] = []
+    loop.kv_transfer = SimpleNamespace(
+        register=lambda rid, bootstrap: registered.append((rid, bootstrap))
+    )
+    hooks = EpdPrefillHooks(loop, admission)
+    spec, state = _spec("r0"), _State(mm_items=[_handshaked_item()])
+    hooks.try_stage(spec, state, "bootstrap")
+    admission.drain_result = (["r0"], [])
+
+    hooks.drain_ready_embeddings()
+
+    assert registered == [("r0", "bootstrap")]
+    assert loop.submitted == [[spec]]
+    assert hooks._staged == {}
+
+
+def test_drain_finishes_failed_requests_without_submitting() -> None:
+    admission = _Admission()
+    loop = _FakeLoop()
+    hooks = EpdPrefillHooks(loop, admission)
+    spec, state = _spec("r0"), _State(mm_items=[_handshaked_item()])
+    hooks.try_stage(spec, state, None)
+    admission.drain_result = ([], ["r0"])
+
+    hooks.drain_ready_embeddings()
+
+    assert state.finish_calls == ["EPD embedding receive failed or timed out"]
+    assert loop.output_processor.published == ["r0"]
+    assert loop.submitted == []
+    assert hooks._staged == {}
+
+
+def test_drain_reaps_requests_aborted_mid_receive() -> None:
+    admission = _Admission()
+    loop = _FakeLoop()
+    loop.kv_transfer = SimpleNamespace(
+        register=lambda rid, bootstrap: pytest.fail("must not register the sender")
+    )
+    hooks = EpdPrefillHooks(loop, admission)
+    spec = _spec("r0")
+    state = _State(mm_items=[_handshaked_item()], finished=True)
+    hooks.try_stage(spec, state, "bootstrap")
+    admission.drain_result = (["r0"], [])
+
+    hooks.drain_ready_embeddings()
+
+    assert loop.output_processor.published == ["r0"]
+    assert loop.submitted == []
+
+
+def test_drain_withholds_admission_while_paused() -> None:
+    admission = _Admission()
+    loop = _FakeLoop()
+    loop._pause.admit_blocked = True
+    hooks = EpdPrefillHooks(loop, admission)
+    hooks.try_stage(_spec("r0"), _State(mm_items=[_handshaked_item()]), None)
+    admission.drain_result = (["r0"], [])
+
+    hooks.drain_ready_embeddings()
+
+    assert loop.submitted == []
+    assert "r0" in hooks._staged
+
+
+# --- assert_embeddings_received --------------------------------------------------
+
+
+def test_assert_embeddings_received_raises_on_unreceived_handshaked_item() -> None:
+    hooks = EpdPrefillHooks(_FakeLoop(), _Admission())
+    context = SimpleNamespace(
+        has_extend_inputs=lambda: True,
+        mm_inputs=[SimpleNamespace(mm_items=[_handshaked_item()])],
+    )
+
+    with pytest.raises(RuntimeError, match="un-received"):
+        hooks.assert_embeddings_received(context)
+
+
+def test_assert_embeddings_received_accepts_filled_items_and_non_epd() -> None:
+    filled = SimpleNamespace(encode_handshake=object(), encoded=object())
+    context = SimpleNamespace(
+        has_extend_inputs=lambda: True,
+        mm_inputs=[SimpleNamespace(mm_items=[filled, _plain_item()])],
+    )
+    EpdPrefillHooks(_FakeLoop(), _Admission()).assert_embeddings_received(context)
+    # Non-EPD node: no-op even with an un-received item.
+    bad = SimpleNamespace(
+        has_extend_inputs=lambda: True,
+        mm_inputs=[SimpleNamespace(mm_items=[_handshaked_item()])],
+    )
+    EpdPrefillHooks(_FakeLoop(), None).assert_embeddings_received(bad)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_event_loop_in_flight.py
+++ b/test/runtime/test_event_loop_in_flight.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""CPU-only tests for the event loop's in-flight commit queue helpers.
+
+These exercise ``_dispatch_depends_on_pending_commit`` (the single registry
+of overlap-breaking dependencies) and ``_drain_in_flight`` with fakes, so no
+model, CUDA context, or transfer backend is created.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections import deque
+from types import SimpleNamespace
+
+import pytest
+
+# CPU-only tests scheduled in runtime-1gpu because they import the full runtime.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.engine.event_loop import EventLoop  # noqa: E402
+from tokenspeed.runtime.pd.prefill_executor import DisaggPrefillExecutor  # noqa: E402
+
+
+def _predicate_loop(*, kv_transfer=None, eager_grammar_buffers=None):
+    return SimpleNamespace(
+        kv_transfer=kv_transfer,
+        model_executor=SimpleNamespace(eager_grammar_buffers=eager_grammar_buffers),
+    )
+
+
+def test_pd_handoff_batch_depends_on_pending_commit() -> None:
+    # kv_transfer.execute needs the final chunk's bootstrap token, which only
+    # lands at commit — but only for the P-side handoff batch (no extends).
+    prefill_executor = object.__new__(DisaggPrefillExecutor)
+    loop = _predicate_loop(kv_transfer=prefill_executor)
+    handoff_op = SimpleNamespace(num_extends=lambda: 0)
+    extend_op = SimpleNamespace(num_extends=lambda: 1)
+
+    assert EventLoop._dispatch_depends_on_pending_commit(loop, handoff_op, None)
+    assert not EventLoop._dispatch_depends_on_pending_commit(loop, extend_op, None)
+
+
+def test_handoff_shaped_batch_without_pd_keeps_overlap() -> None:
+    loop = _predicate_loop(kv_transfer=None)
+    op = SimpleNamespace(num_extends=lambda: 0)
+
+    assert not EventLoop._dispatch_depends_on_pending_commit(loop, op, None)
+
+
+def test_eager_grammar_batch_depends_on_pending_commit() -> None:
+    op = SimpleNamespace(num_extends=lambda: 1)
+    grammar_inputs = object()
+
+    # Eager grammar reads matcher state that only advances at commit.
+    eager = _predicate_loop(eager_grammar_buffers=object())
+    assert EventLoop._dispatch_depends_on_pending_commit(eager, op, grammar_inputs)
+    # No grammar in the batch: overlap kept.
+    assert not EventLoop._dispatch_depends_on_pending_commit(eager, op, None)
+    # Capturable grammar (no eager buffers) advances in-graph: overlap kept.
+    capturable = _predicate_loop(eager_grammar_buffers=None)
+    assert not EventLoop._dispatch_depends_on_pending_commit(
+        capturable, op, grammar_inputs
+    )
+
+
+class _DrainHarness:
+    """Only the state read by ``EventLoop._drain_in_flight``."""
+
+    def __init__(self) -> None:
+        self.committed: list[object] = []
+
+    def _commit_forward_results(self, forward_op, results, on_first_token):
+        self.committed.append(forward_op)
+        return [f"change-{forward_op}"]
+
+
+def test_drain_in_flight_commits_oldest_first() -> None:
+    loop = _DrainHarness()
+    in_flight = deque([("op0", None, None), ("op1", None, None)])
+
+    request_changes = EventLoop._drain_in_flight(loop, in_flight)
+
+    assert not in_flight
+    assert loop.committed == ["op0", "op1"]
+    assert request_changes == ["change-op0", "change-op1"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_event_loop_pause_hooks.py
+++ b/test/runtime/test_event_loop_pause_hooks.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""CPU-only tests for PauseHooks, the event loop side of pause/resume.
+
+The PauseController state machine is covered in test_pause_controller.py;
+these exercise PauseHooks against a fake event loop, so no model, CUDA
+context, or scheduler is created.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+# CPU-only tests scheduled in runtime-1gpu because they import the full runtime.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.engine.event_loop import EventLoop  # noqa: E402
+from tokenspeed.runtime.engine.io_struct import NullSender  # noqa: E402
+from tokenspeed.runtime.engine.pause import (  # noqa: E402
+    PauseController,
+    PauseHooks,
+    PauseState,
+)
+
+
+class _State:
+    def __init__(self, *, finished: bool = False) -> None:
+        self.finished = finished
+        self.finish_calls: list[tuple[str, bool]] = []
+
+    def set_finish_with_abort(self, message: str, notify_client: bool = False) -> None:
+        self.finish_calls.append((message, notify_client))
+
+
+class _OutputProcessor:
+    def __init__(self, rid_to_state: dict) -> None:
+        self.rid_to_state = rid_to_state
+        self.aborted: list[tuple[str, bool]] = []
+        self.reaped: list[str] = []
+
+    def mark_abort(self, request_id: str, notify_client: bool = False) -> None:
+        self.aborted.append((request_id, notify_client))
+
+    def reap_finished_orphan(self, request_id: str, _state) -> None:
+        self.reaped.append(request_id)
+
+
+class _GrammarManager:
+    def __init__(self, queued_states=()) -> None:
+        self.grammar_queue = [(None, state, None) for state in queued_states]
+        self.aborted: list[str] = []
+
+    def mark_abort(self, rid: str) -> None:
+        self.aborted.append(rid)
+
+
+class _Scheduler:
+    """Drained live-state accessors + the submit sink the hooks act on."""
+
+    def __init__(self) -> None:
+        self.submitted: list[list] = []
+
+    def submit_requests(self, specs: list) -> None:
+        self.submitted.append(list(specs))
+
+    def waiting_size(self) -> int:
+        return 0
+
+    def decoding_size(self) -> int:
+        return 0
+
+    def prefilling_size(self) -> int:
+        return 0
+
+
+class _FakeLoop:
+    """Only the loop state PauseHooks reads."""
+
+    # The real abort marker so the notify_client contract stays honest.
+    _request_abort_or_mark = EventLoop._request_abort_or_mark
+
+    def __init__(self, rid_to_state: dict | None = None) -> None:
+        self.output_processor = _OutputProcessor(rid_to_state or {})
+        self.scheduler = _Scheduler()
+        self.has_dp = False
+
+
+def _hooks(rid_to_state: dict | None = None) -> tuple[PauseHooks, _FakeLoop]:
+    loop = _FakeLoop(rid_to_state)
+    return PauseHooks(loop, PauseController(NullSender())), loop
+
+
+def _spec(rid: str):
+    return SimpleNamespace(request_id=rid)
+
+
+# --- apply_transitions --------------------------------------------------------
+
+
+def test_abort_pause_edge_cancels_inflight_and_grammar_queue() -> None:
+    hooks, loop = _hooks(rid_to_state={"r0": _State(), "r1": _State()})
+    hooks._pause.request_drain(
+        abort_inflight=True, on_drained=lambda: None, on_cancelled=lambda: None
+    )
+    queued = _State()
+    grammar_manager = _GrammarManager(queued_states=[queued])
+
+    hooks.apply_transitions(grammar_manager)
+
+    # In-flight requests aborted with a terminating finish for the passive client.
+    assert loop.output_processor.aborted == [("r0", True), ("r1", True)]
+    assert grammar_manager.aborted == ["r0", "r1"]
+    # Still-compiling requests finished so they are published, not admitted.
+    assert queued.finish_calls == [("Aborted by pause", True)]
+
+    # Edges are one-shot: a second pass in the same pause does nothing.
+    hooks.apply_transitions(grammar_manager)
+    assert loop.output_processor.aborted == [("r0", True), ("r1", True)]
+    assert queued.finish_calls == [("Aborted by pause", True)]
+
+
+def test_wait_pause_edge_cancels_grammar_queue_but_not_inflight() -> None:
+    hooks, loop = _hooks(rid_to_state={"r0": _State()})
+    hooks._pause.request_drain(
+        abort_inflight=False, on_drained=lambda: None, on_cancelled=lambda: None
+    )
+    queued = _State()
+    grammar_manager = _GrammarManager(queued_states=[queued])
+
+    hooks.apply_transitions(grammar_manager)
+
+    assert loop.output_processor.aborted == []
+    assert queued.finish_calls == [("Aborted by pause", True)]
+
+
+def test_resume_flushes_live_buffered_specs_and_reaps_finished() -> None:
+    live_state = _State()
+    done_state = _State(finished=True)
+    hooks, loop = _hooks(rid_to_state={"live": live_state, "done": done_state})
+    hooks._pause.state = PauseState.PAUSED_NEW
+    live, done, gone = _spec("live"), _spec("done"), _spec("gone")
+    hooks._pause.buffer_specs([live, done, gone])
+
+    # Still paused: nothing flushed.
+    hooks.apply_transitions(_GrammarManager())
+    assert loop.scheduler.submitted == []
+
+    # Resumed: live specs re-admitted; aborted-while-paused ones reaped in
+    # place; already-reaped ones dropped silently.
+    hooks._pause.state = PauseState.UNPAUSED
+    hooks.apply_transitions(_GrammarManager())
+    assert loop.scheduler.submitted == [[live]]
+    assert loop.output_processor.reaped == ["done"]
+    assert hooks._pause.buffered_specs == []
+
+
+# --- withhold_admissions ------------------------------------------------------
+
+
+def test_admission_gate_passes_through_when_unpaused() -> None:
+    hooks, _ = _hooks()
+    specs = [_spec("r0")]
+
+    assert not hooks.withhold_admissions(specs, True)
+    assert hooks._pause.buffered_specs == []
+
+
+def test_admission_gate_buffers_specs_while_paused() -> None:
+    hooks, _ = _hooks()
+    hooks._pause.state = PauseState.PAUSED_NEW
+    specs = [_spec("r0"), _spec("r1")]
+
+    assert hooks.withhold_admissions(specs, True)
+    assert hooks._pause.buffered_specs == specs
+
+
+def test_admission_gate_warns_when_pause_coalesced_with_requests(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    hooks, _ = _hooks()
+    hooks._pause.state = PauseState.PAUSED_NEW
+
+    # pause_blocked_before=False: the pause flipped in this very recv batch,
+    # so the FIFO-order caveat must be surfaced (see TODO(pause-fifo)).
+    with caplog.at_level(logging.WARNING):
+        assert hooks.withhold_admissions([_spec("r0")], False)
+    assert "TODO(pause-fifo)" in caplog.text
+
+
+# --- paused_idle_step ---------------------------------------------------------
+
+
+def test_paused_idle_step_leaves_the_drain_check_to_the_loop_tail() -> None:
+    # The event loop resolves the drain at its tail, after the round's results
+    # have advanced the scheduler; paused_idle_step must not consume it early.
+    hooks, _ = _hooks()
+    hooks._pause.request_drain(
+        abort_inflight=False,
+        on_drained=lambda: pytest.fail("drain must resolve at the loop tail"),
+        on_cancelled=lambda: None,
+    )
+
+    hooks.paused_idle_step()
+
+    assert hooks._pause.is_drain_pending
+
+
+# --- memory release/wake data plane -------------------------------------------
+
+
+def test_reset_caches_for_release_uses_scheduler_clear_when_present() -> None:
+    hooks, loop = _hooks()
+    # No clear_l1_cache on the scheduler: nothing to invalidate, release allowed.
+    assert hooks.reset_caches_for_release()
+
+    loop.scheduler.clear_l1_cache = lambda: False
+    assert not hooks.reset_caches_for_release()
+    loop.scheduler.clear_l1_cache = lambda: True
+    assert hooks.reset_caches_for_release()
+
+
+def test_kv_repair_after_wake_clears_target_and_draft_pools() -> None:
+    hooks, loop = _hooks()
+    cleared: list[str] = []
+    loop.model_executor = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(
+            clear_kv_buffers=lambda: cleared.append("target")
+        ),
+        draft_token_to_kv_pool=SimpleNamespace(
+            clear_kv_buffers=lambda: cleared.append("draft")
+        ),
+    )
+
+    hooks.kv_repair_after_wake()
+
+    assert cleared == ["target", "draft"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_kimi_k3_eagle3.py
+++ b/test/runtime/test_kimi_k3_eagle3.py
@@ -44,6 +44,12 @@ def test_capture_tensor_matches_post_layer_attnres_reference():
     model = SimpleNamespace(
         embed_tokens=lambda input_ids: input_ids.to(torch.bfloat16).unsqueeze(-1),
         config=SimpleNamespace(num_hidden_layers=4, attn_res_block_size=2),
+        # Single-stage pipeline window: the forward walks
+        # [pp_start_layer, pp_end_layer) and only the last stage applies
+        # the output AttnRes fold.
+        pp_start_layer=0,
+        pp_end_layer=4,
+        mapping=SimpleNamespace(is_last_pp_rank=True),
         layers=[
             FakeLayer(torch.tensor([[1.0], [2.0]], dtype=torch.bfloat16)),
             FakeLayer(torch.tensor([[3.0], [4.0]], dtype=torch.bfloat16)),

--- a/test/runtime/test_l2_cache_hooks.py
+++ b/test/runtime/test_l2_cache_hooks.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""CPU-only, single-rank tests for L2CacheHooks (attn_tp_size == 1, so no
+collectives run). The cross-rank payload agreement itself is covered by the
+pop_common_cache_event_payloads tests; these drive submit/poll bookkeeping
+with a fake executor.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+# CPU-only tests scheduled in runtime-1gpu because they import the full runtime.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed_scheduler import Cache  # noqa: E402
+
+from tokenspeed.runtime.engine import cache_hooks as cache_hooks_module  # noqa: E402
+from tokenspeed.runtime.engine.cache_hooks import L2CacheHooks  # noqa: E402
+
+
+class _FakeWriteBackOp:
+    def __init__(self, op_ids) -> None:
+        self.op_ids = op_ids
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.submitted_plans: list = []
+        self.results: list = []
+
+    def submit_plan(self, plan) -> None:
+        self.submitted_plans.append(plan)
+
+    def poll_results(self) -> list:
+        results, self.results = self.results, []
+        return results
+
+
+def _hooks(executor, speculative_algorithm=None) -> L2CacheHooks:
+    return L2CacheHooks(
+        executor,
+        speculative_algorithm=speculative_algorithm,
+        attn_tp_rank=0,
+        attn_tp_size=1,
+        attn_tp_cpu_group=None,
+        global_rank=0,
+    )
+
+
+def _writeback_done_event(op_id: int):
+    event = Cache.WriteBackDoneEvent()
+    event.op_id = op_id
+    return event
+
+
+@pytest.fixture()
+def fake_cache_ops(monkeypatch: pytest.MonkeyPatch):
+    # The C++ op bindings (Cache.WriteBackOp) expose no Python constructor, so
+    # substitute the type the isinstance check dispatches on.
+    monkeypatch.setattr(
+        cache_hooks_module,
+        "Cache",
+        SimpleNamespace(WriteBackOp=_FakeWriteBackOp, LoadBackOp=()),
+    )
+
+
+def test_disabled_kvstore_is_a_no_op() -> None:
+    hooks = _hooks(None)
+    hooks.submit(SimpleNamespace(cache=[SimpleNamespace()]))
+    assert hooks.poll_ready_events() == []
+
+
+def test_submit_counts_in_flight_and_rejects_unknown_ops(fake_cache_ops) -> None:
+    executor = _Executor()
+    hooks = _hooks(executor)
+    plan = SimpleNamespace(cache=[_FakeWriteBackOp(op_ids=[1, 2])])
+
+    hooks.submit(plan)
+
+    assert executor.submitted_plans == [plan]
+    assert hooks._num_inflight == 2
+
+    with pytest.raises(TypeError, match="unsupported cache op kind"):
+        hooks.submit(SimpleNamespace(cache=[object()]))
+
+
+def test_poll_returns_completed_events_and_settles_inflight(fake_cache_ops) -> None:
+    executor = _Executor()
+    hooks = _hooks(executor)
+    hooks.submit(SimpleNamespace(cache=[_FakeWriteBackOp(op_ids=[7])]))
+
+    # Nothing completed yet: in flight, but no ready payloads.
+    assert hooks.poll_ready_events() == []
+
+    executor.results = [_writeback_done_event(7)]
+    events = hooks.poll_ready_events()
+
+    assert [type(e).__name__ for e in events] == ["WriteBackDoneEvent"]
+    assert events[0].op_id == 7
+    assert hooks._num_inflight == 0
+    # Settled: the idle short-circuit now skips polling work entirely.
+    assert hooks.poll_ready_events() == []
+    assert hooks._pending_payloads == {}
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_load_snapshot.py
+++ b/test/runtime/test_load_snapshot.py
@@ -395,20 +395,11 @@ def test_event_loop_observation_projects_the_sampled_scheduler_values():
     ]
 
 
-@pytest.mark.parametrize(
-    "has_overlap_result",
-    [False, True],
-    ids=["non_overlap_post_finish", "overlap_commit"],
-)
-def test_paused_idle_step_refreshes_load_after_optional_overlap_commit(
-    monkeypatch, has_overlap_result
-):
-    """The first paused step observes post-finish CPU scheduler state once."""
+def _paused_observation_loop(trace, scheduler_state):
+    """An EventLoop shell with just the state _maybe_observe_paused_load reads."""
     pytest.importorskip("tokenspeed_scheduler")
     from tokenspeed.runtime.engine import event_loop as event_loop_module
 
-    trace = []
-    scheduler_state = {"available": 20, "active": 0, "waiting": 0}
     loop = event_loop_module.EventLoop.__new__(event_loop_module.EventLoop)
     loop.scheduler = SimpleNamespace(
         available_kv_pages=lambda: (
@@ -431,62 +422,56 @@ def test_paused_idle_step_refreshes_load_after_optional_overlap_commit(
     loop.load_snapshot_publisher = SimpleNamespace(
         observe=lambda values: trace.append(("observe", values))
     )
-    loop.has_dp = False
-    loop._pause = SimpleNamespace(
-        maybe_finish_drain=lambda scheduler: trace.append("drain")
-    )
-    loop._publish_scheduler_kv_events = lambda: trace.append("kv_events")
-    monkeypatch.setattr(
-        event_loop_module,
-        "advance_forward",
-        lambda scheduler, changes: trace.append(("advance", changes)),
-    )
-    monkeypatch.setattr(
-        event_loop_module.time, "sleep", lambda seconds: trace.append("sleep")
-    )
+    return loop
 
-    prev_forward_op = None
-    prev_results = None
-    if has_overlap_result:
-        loop.output_processor.rid_to_state["finished"] = object()
-        scheduler_state.update(available=16, active=4, waiting=1)
 
-        def commit_results(forward_op, results):
-            trace.append("commit")
-            loop.output_processor.rid_to_state.clear()
-            scheduler_state.update(available=20, active=0, waiting=0)
-            return ["finished"]
+def test_paused_load_observation_samples_once_until_marked_dirty():
+    """While frozen, the loop tail samples the load once per pause — and again
+    only after a round that changed scheduler state: committed request changes
+    or a dirty mark (new requests / cache-op completions). The sample is taken
+    at the tail, after the round's advance, so it reflects applied changes."""
+    trace = []
+    scheduler_state = {"available": 20, "active": 0, "waiting": 0}
+    loop = _paused_observation_loop(trace, scheduler_state)
 
-        loop._commit_forward_results = commit_results
-        prev_forward_op = object()
-        prev_results = object()
+    # First paused round observes; the latch suppresses the idle spin after it.
+    loop._maybe_observe_paused_load(had_changes=False)
+    loop._maybe_observe_paused_load(had_changes=False)
 
-    loop._paused_idle_step(prev_forward_op, prev_results)
-    loop._paused_idle_step()
+    # A dirty mark (e.g. control traffic or a cache-op advance) forces one
+    # fresh sample of the mutated scheduler state.
     scheduler_state.update(available=18, active=2, waiting=1)
     loop._mark_load_snapshot_dirty()
-    loop._paused_idle_step()
+    loop._maybe_observe_paused_load(had_changes=False)
 
-    expected_prefix = (
-        ["commit", ("advance", ["finished"]), "kv_events"] if has_overlap_result else []
-    )
+    # A round that committed request changes re-samples even while latched.
+    scheduler_state.update(available=17, active=3, waiting=2)
+    loop._maybe_observe_paused_load(had_changes=True)
+
     assert trace == [
-        *expected_prefix,
         "available",
         "active",
         "waiting",
         ("observe", (0, 0, 0, 0, 20)),
-        "drain",
-        "sleep",
-        "drain",
-        "sleep",
         "available",
         "active",
         "waiting",
         ("observe", (0, 1, 2, 2, 20)),
-        "drain",
-        "sleep",
+        "available",
+        "active",
+        "waiting",
+        ("observe", (0, 2, 3, 3, 20)),
     ]
+
+
+def test_paused_load_observation_is_rank0_only():
+    trace = []
+    loop = _paused_observation_loop(trace, {"available": 20, "active": 0, "waiting": 0})
+    loop.attn_tp_rank = 1
+
+    loop._maybe_observe_paused_load(had_changes=True)
+
+    assert trace == []
 
 
 @pytest.mark.parametrize(

--- a/test/runtime/test_nvshmem_env.py
+++ b/test/runtime/test_nvshmem_env.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import os
+
+from tokenspeed.runtime.utils.env import envs
+
+
+def test_nvshmem_ib_traffic_class_unset_by_default():
+    with envs.NVSHMEM_IB_TRAFFIC_CLASS.override(None):
+        assert envs.NVSHMEM_IB_TRAFFIC_CLASS.get() is None
+        assert "NVSHMEM_IB_TRAFFIC_CLASS" not in os.environ
+
+
+def test_nvshmem_ib_traffic_class_reaches_process_environ():
+    with envs.NVSHMEM_IB_TRAFFIC_CLASS.override(100):
+        assert envs.NVSHMEM_IB_TRAFFIC_CLASS.is_set()
+        assert envs.NVSHMEM_IB_TRAFFIC_CLASS.get() == 100
+        # NVSHMEM reads the raw environment at bootstrap; the registry set()
+        # must materialize the value there, not only in Python state.
+        assert os.environ["NVSHMEM_IB_TRAFFIC_CLASS"] == "100"
+
+
+def test_nvshmem_ib_traffic_class_reassert_is_idempotent():
+    # run_event_loop re-asserts the value in each inference process; doing so
+    # must not corrupt or drop the setting.
+    with envs.NVSHMEM_IB_TRAFFIC_CLASS.override(100):
+        envs.NVSHMEM_IB_TRAFFIC_CLASS.set(envs.NVSHMEM_IB_TRAFFIC_CLASS.get())
+        assert envs.NVSHMEM_IB_TRAFFIC_CLASS.get() == 100
+        assert os.environ["NVSHMEM_IB_TRAFFIC_CLASS"] == "100"

--- a/test/runtime/test_pp_mapping.py
+++ b/test/runtime/test_pp_mapping.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import pytest
+
+from tokenspeed.runtime.distributed.mapping import Mapping
+
+
+def _mapping(rank: int, world_size: int, pp_size: int, **kw) -> Mapping:
+    m = Mapping(world_size=world_size, pp_size=pp_size, **kw)
+    m.rank = rank
+    return m
+
+
+def test_pp_disabled_by_default():
+    m = _mapping(0, 8, 1, attn_tp_size=8)
+    assert not m.has_pp
+    assert m.pp_size == 1
+    assert m.pp_rank == 0
+    assert m.is_first_pp_rank and m.is_last_pp_rank
+    assert m.stage_world_size == 8
+    assert m.attn.tp_size == 8
+
+
+def test_pp2_stage_split_and_groups():
+    # world 8 = 2 stages x TP4. Ranks 0-3 stage 0, ranks 4-7 stage 1.
+    for rank in range(8):
+        m = _mapping(rank, 8, 2, attn_tp_size=4)
+        assert m.stage_world_size == 4
+        assert m.attn.tp_size == 4
+        assert m.pp_rank == rank // 4
+        assert m.pp_group == (rank % 4, rank % 4 + 4)
+        assert m.is_first_pp_rank == (rank < 4)
+        assert m.is_last_pp_rank == (rank >= 4)
+    # Intra-stage TP group stays inside the stage.
+    m5 = _mapping(5, 8, 2, attn_tp_size=4)
+    assert m5.attn.tp_group == (4, 5, 6, 7)
+    assert m5.attn.tp_rank == 1
+    assert m5.pp_prev_rank == 1
+
+
+def test_pp_next_prev_rank():
+    m0 = _mapping(2, 8, 2, attn_tp_size=4)
+    assert m0.pp_next_rank == 6
+    with pytest.raises(AssertionError):
+        _ = m0.pp_prev_rank
+    m1 = _mapping(6, 8, 2, attn_tp_size=4)
+    assert m1.pp_prev_rank == 2
+    with pytest.raises(AssertionError):
+        _ = m1.pp_next_rank
+
+
+def test_pp_moe_ep_resolves_inside_stage():
+    # EP consumes the stage world, not the whole world.
+    m = _mapping(0, 8, 2, attn_tp_size=4, moe_ep_size=4, moe_tp_size=1)
+    assert m.moe.ep_size == 4
+    assert m.moe.tp_ep_size == 4
+
+
+def test_pp_world_size_divisibility():
+    with pytest.raises(AssertionError):
+        Mapping(world_size=6, pp_size=4, attn_tp_size=1)
+
+
+def test_narrow_to_layers_drops_other_stage_planes():
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
+        CacheFieldLayout,
+        CacheGroupLayout,
+        CacheMemoryPlan,
+        CachePlaneLayout,
+    )
+
+    plan = CacheMemoryPlan(
+        prefix_granularity=64,
+        lcm_block_bytes=1000,
+        num_lcm_blocks=9,
+        groups=(
+            CacheGroupLayout(group_id="g", cache_blocks_per_lcm_block=1, page_count=10),
+        ),
+        planes=(
+            CachePlaneLayout(
+                plane_id="unit.0", bytes_per_lcm_block=600, arena_offset_bytes=0
+            ),
+            CachePlaneLayout(
+                plane_id="unit.1", bytes_per_lcm_block=400, arena_offset_bytes=6000
+            ),
+        ),
+        fields=(
+            CacheFieldLayout(
+                group_id="g",
+                field_id="layer.0.kv",
+                plane_id="unit.0",
+                shape=(600,),
+                dtype="uint8",
+                field_offset_bytes=0,
+                page_stride_bytes=600,
+            ),
+            CacheFieldLayout(
+                group_id="g",
+                field_id="layer.1.kv",
+                plane_id="unit.1",
+                shape=(400,),
+                dtype="uint8",
+                field_offset_bytes=0,
+                page_stride_bytes=400,
+            ),
+        ),
+    )
+    assert plan.arena_bytes == 10 * 1000
+
+    stage1 = plan.narrow_to_layers(1, 2)
+    # Logical geometry unchanged; physical arena holds only layer 1's plane.
+    assert stage1.num_lcm_blocks == 9
+    assert stage1.lcm_block_bytes == 1000
+    assert stage1.arena_bytes == 10 * 400
+    assert [f.field_id for f in stage1.fields] == ["layer.1.kv"]
+    assert [p.plane_id for p in stage1.planes] == ["unit.1"]
+    # The retained plane re-packs to offset 0 of the smaller arena.
+    assert stage1.planes[0].arena_offset_bytes == 0
+    # Field addressing stays within the narrowed arena.
+    top = stage1.field_page_byte_offset("layer.1.kv", 9)
+    assert 0 <= top < stage1.arena_bytes
+
+    stage0 = plan.narrow_to_layers(0, 1)
+    assert stage0.arena_bytes == 10 * 600
+    assert [f.field_id for f in stage0.fields] == ["layer.0.kv"]
+
+
+def test_pp_layer_partition_explicit_windows():
+    from tokenspeed.runtime.distributed.pp_stage import (
+        pp_layer_window,
+        pp_stage_windows,
+    )
+
+    windows = pp_stage_windows(38, 4, (8, 11, 11, 8))
+    assert windows == [(0, 8), (8, 19), (19, 30), (30, 38)]
+
+    # The mapping's partition flows through pp_layer_window.
+    m = _mapping(6, 8, 4, attn_tp_size=2)
+    m.pp_layer_partition = (8, 11, 11, 8)
+    assert m.pp_rank == 3
+    assert pp_layer_window(38, m) == (30, 38)
+
+    # No partition -> the even split with the remainder in front.
+    assert pp_stage_windows(38, 4) == [(0, 10), (10, 20), (20, 29), (29, 38)]
+
+
+def test_pp_layer_partition_validation():
+    from tokenspeed.runtime.distributed.pp_stage import pp_stage_windows
+
+    with pytest.raises(ValueError, match="entries"):
+        pp_stage_windows(38, 4, (8, 30))
+    with pytest.raises(ValueError, match="sums to"):
+        pp_stage_windows(38, 4, (8, 11, 11, 9))
+    with pytest.raises(ValueError, match="at least one layer"):
+        pp_stage_windows(38, 4, (0, 19, 11, 8))
+
+
+def test_mapping_accepts_pp_layer_partition():
+    m = Mapping(
+        world_size=8, pp_size=4, attn_tp_size=2, pp_layer_partition=[8, 11, 11, 8]
+    )
+    assert m.pp_layer_partition == (8, 11, 11, 8)
+    m2 = Mapping(world_size=8, pp_size=4, attn_tp_size=2)
+    assert m2.pp_layer_partition is None
+
+
+def test_k3_attn_res_boundary_blocks_agree():
+    """K3 PP wire contract: the upstream stage ships exactly the snapshot rows
+    the downstream stage expects, at every cut point and block size (the two
+    ceil_divs coincide because the windows abut)."""
+    from tokenspeed.runtime.distributed.pp_stage import pp_stage_windows
+    from tokenspeed.runtime.utils import ceil_div
+
+    for num_layers in (7, 48, 61):
+        for block in (1, 3, 4, 7):
+            for pp_size in (2, 3, 4):
+                windows = pp_stage_windows(num_layers, pp_size)
+                for (_, up_end), (down_start, _) in zip(windows, windows[1:]):
+                    assert up_end == down_start
+                    sent = ceil_div(up_end, block)
+                    expected = ceil_div(down_start, block)
+                    assert sent == expected
+                    # Every snapshot the upstream wrote is included: the last
+                    # block-write layer before the cut has index < sent.
+                    last_written = (up_end - 1) // block
+                    assert last_written < sent
+
+
+def test_pp_stage_state_block_residual_round_trip():
+    import torch
+
+    from tokenspeed.runtime.distributed.pp_stage import PPStageState
+
+    state = PPStageState(
+        hidden_states=torch.zeros(5, 8),
+        block_residual=torch.zeros(3, 5, 8),
+    )
+    tensors = state.tensors()
+    assert len(tensors) == 2
+    rebuilt = PPStageState.from_tensors(tensors, ["hidden_states", "block_residual"])
+    assert rebuilt.block_residual.shape == (3, 5, 8)
+    assert rebuilt.hc_x is None

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/deep_ep.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/deep_ep.py
@@ -710,6 +710,14 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         moe_origin_input: torch.Tensor = None,
     ):
         buffer = self._get_buffer()
+        combine_kwargs = {}
+        if moe_origin_input is not None:
+            # Trees whose low-latency combine carries the identity-expert leg
+            # (routing weight on a -1 id folds moe_origin_input back in) take
+            # the original tokens as ``x_ori`` — and their device kernel
+            # asserts the pointer whenever any routing weight is nonzero, so
+            # it must be forwarded rather than dropped.
+            combine_kwargs["x_ori"] = moe_origin_input
         combined_hidden_states, event, hook = buffer.low_latency_combine(
             hidden_states,
             topk_idx,
@@ -717,6 +725,7 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
             self.handle,
             async_finish=not self.return_recv_hook,
             return_recv_hook=self.return_recv_hook,
+            **combine_kwargs,
         )
         self.handle = None
         return combined_hidden_states, event, hook

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/__init__.py
@@ -18,4 +18,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from tokenspeed_kernel.ops.moe.marlin import mxfp4  # noqa: F401
+from tokenspeed_kernel.ops.moe.marlin import deepep_mxfp4, mxfp4  # noqa: F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/deepep_mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/deepep_mxfp4.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Marlin W4A16 MXFP4 MoE over DeepEP all-to-all (SM90).
+
+The replicated-token Marlin path runs every rank over the full token batch and
+all-reduces; with attention DP that additionally needs a cross-DP all-gather.
+This kernel replaces both collectives with DeepEP's token-level legs: dispatch
+routes each token only to the ranks owning its top-k experts, the local Marlin
+grouped GEMM computes those experts' contributions, and combine reduces the
+per-expert partials back to the token's home rank.
+
+Activations stay bf16 on the wire (Marlin is weight-only quant; there is no
+FP8 activation form to exploit), so dispatch carries a single bf16 tensor.
+
+Both DeepEP modes are supported, and their receive layouts differ:
+
+- Normal (extend-shaped): flat rows with global ``topk_ids`` whose non-local
+  slots arrive as -1; the Marlin apply's global->local remap handles that
+  layout as-is, and the route weights fold into GEMM2 so combine reduces
+  unweighted.
+- Low-latency (decode-shaped): a padded per-expert buffer
+  ``[num_local_experts, recv_m, hidden]`` with ``masked_m`` valid rows per
+  expert and no ids. Each row belongs to exactly one local expert, so the
+  apply flattens the buffer and synthesizes a top-1 routing (weight 1.0);
+  the real route weights are applied by the low-latency combine leg.
+
+Intranode traffic runs the NVLink P2P fast path in both modes; the IBGDA
+requirement only bites for internode low-latency traffic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from types import SimpleNamespace
+
+import torch
+from tokenspeed_kernel.ops.communication.deep_ep import DeepEPDispatcher, DeepEPMode
+from tokenspeed_kernel.ops.moe.marlin.mxfp4 import (
+    MXFP4_BLOCK,
+    marlin_mxfp4_moe_weights,
+    marlin_mxfp4_precomputed_moe_apply,
+)
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+
+
+def _get_dispatcher(
+    plan: dict,
+    w: torch.nn.Module,
+    x: torch.Tensor,
+) -> DeepEPDispatcher:
+    """Build (once per plan) the dispatcher owning this layer's DeepEP legs.
+
+    Sizing comes from the plan rather than the live batch: the DeepEP buffer is
+    allocated on first use and reused for every later forward.
+    """
+    dispatcher = plan.get("_deepep_dispatcher")
+    if dispatcher is not None:
+        return dispatcher
+
+    group = plan.get("deepep_group")
+    if group is None:
+        raise ValueError("DeepEP MoE plan is missing deepep_group")
+    deepep_mode = DeepEPMode(plan.get("deepep_mode") or DeepEPMode.auto.value)
+    capacity = plan.get("deepep_low_latency_max_num_tokens_per_gpu")
+    if deepep_mode.enable_low_latency() and not capacity:
+        raise ValueError(
+            f"DeepEP plan with mode {deepep_mode.value} is missing "
+            "deepep_low_latency_max_num_tokens_per_gpu"
+        )
+    config = SimpleNamespace(
+        top_k=getattr(w, "top_k"),
+        num_experts=getattr(w, "num_experts"),
+        low_latency_max_num_tokens_per_gpu=capacity,
+        hidden_size=x.shape[1],
+        world_size=getattr(w, "ep_size", group.size()),
+        group=group,
+        params_dtype=torch.bfloat16,
+    )
+    dispatcher = DeepEPDispatcher(
+        config,
+        deepep_mode=deepep_mode,
+        async_finish=False,
+        return_recv_hook=True,
+        # bf16 on the wire: Marlin consumes bf16 activations directly, so the
+        # FP8 wire cast of the DeepGEMM path would only add quantization error.
+        use_fp8=False,
+    )
+    plan["_deepep_dispatcher"] = dispatcher
+    return dispatcher
+
+
+def _apply_normal(
+    dispatcher: DeepEPDispatcher,
+    plan: dict,
+    x: torch.Tensor,
+    w: torch.nn.Module,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    enable_pdl: bool,
+    overlap_fn: Callable[[], None] | None,
+) -> torch.Tensor:
+    """Extend-shaped path: flat recv rows, global ids with -1 masking."""
+    dispatcher.dispatch_a(x, topk_ids, topk_weights, low_latency=False)
+    # Normal-mode dispatch finishes asynchronously; work queued here overlaps
+    # the transfer instead of waiting behind it.
+    if overlap_fn is not None:
+        overlap_fn()
+    (
+        recv_x,
+        recv_topk_ids,
+        recv_topk_weights,
+        _,
+        _,
+        _,
+        _,
+    ) = dispatcher.dispatch_b()
+
+    if recv_x.shape[0]:
+        # Local experts' contribution per received token. Non-local ids arrive
+        # as -1 and fall into the Marlin EP mask (zero contribution); the
+        # route weights are folded in by GEMM2, so combine reduces unweighted.
+        expert_out = marlin_mxfp4_precomputed_moe_apply(
+            plan,
+            recv_x,
+            w,
+            None,
+            topk_weights=recv_topk_weights,
+            topk_ids=recv_topk_ids,
+            enable_pdl=enable_pdl,
+        )
+    else:
+        expert_out = torch.zeros_like(recv_x)
+
+    dispatcher.combine_a(
+        expert_out, recv_topk_ids, recv_topk_weights, low_latency=False
+    )
+    return dispatcher.combine_b()
+
+
+def _apply_low_latency(
+    dispatcher: DeepEPDispatcher,
+    plan: dict,
+    x: torch.Tensor,
+    w: torch.nn.Module,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    enable_pdl: bool,
+    overlap_fn: Callable[[], None] | None,
+) -> torch.Tensor:
+    """Decode-shaped path: padded per-expert recv buffer, masked rows.
+
+    The buffer arrives as ``[num_local_experts, recv_m, hidden]`` with
+    ``masked_m`` valid rows per expert and no routing metadata. Every valid row
+    belongs to exactly one known local expert, so the Marlin grouped GEMM runs
+    on the flattened buffer with a synthesized top-1 routing (weight 1.0);
+    padded rows get id -1 and fall into the EP mask instead of computing
+    garbage. The real route weights are applied by the low-latency combine.
+    """
+    dispatcher.dispatch_a(x, topk_ids, topk_weights, low_latency=True)
+    # dispatch_a only launched the send phase; work queued here runs while the
+    # transfer lands instead of leaving the GPU spinning in the recv phase.
+    if overlap_fn is not None:
+        overlap_fn()
+    recv_x, _, _, _, _, _, masked_m = dispatcher.dispatch_b()
+
+    num_local_experts, recv_m, hidden = recv_x.shape
+    ep_rank = int(getattr(w, "ep_rank", 0))
+    expert_start = ep_rank * num_local_experts
+    device = recv_x.device
+
+    # Row r of expert e is valid iff r < masked_m[e]; valid rows route to the
+    # (global) id of their owning expert, padded rows to -1. All device-side,
+    # no sync on masked_m.
+    global_ids = torch.arange(
+        expert_start,
+        expert_start + num_local_experts,
+        dtype=torch.int32,
+        device=device,
+    )
+    valid = torch.arange(recv_m, dtype=torch.int32, device=device).unsqueeze(
+        0
+    ) < masked_m.to(torch.int32).unsqueeze(1)
+    flat_ids = torch.where(valid, global_ids.unsqueeze(1).expand(-1, recv_m), -1)
+    flat_ids = flat_ids.reshape(-1, 1)
+    flat_weights = torch.ones(
+        (num_local_experts * recv_m, 1), dtype=torch.float32, device=device
+    )
+
+    expert_out = marlin_mxfp4_precomputed_moe_apply(
+        plan,
+        recv_x.reshape(num_local_experts * recv_m, hidden),
+        w,
+        None,
+        topk_weights=flat_weights,
+        topk_ids=flat_ids,
+        enable_pdl=enable_pdl,
+    ).view(num_local_experts, recv_m, hidden)
+
+    # The low-latency combine leg applies the routing weights itself. This
+    # deep_ep tree's LL combine carries an identity-expert extension (-1 ids
+    # add x_ori * weight) and device-asserts x_ori whenever any weight is
+    # nonzero; all our ids are valid so x is never actually read, but the
+    # pointer must be supplied.
+    dispatcher.combine_a(
+        expert_out, topk_ids, topk_weights, low_latency=True, moe_origin_input=x
+    )
+    return dispatcher.combine_b()
+
+
+@register_kernel(
+    "moe",
+    "apply",
+    name="marlin_mxfp4_deepep_moe_apply",
+    solution="marlin",
+    weight_preprocessor=marlin_mxfp4_moe_weights,
+    capability=CapabilityRequirement(
+        vendors=frozenset({"nvidia"}),
+        min_arch_version=ArchVersion(9, 0),
+    ),
+    signatures=format_signatures("x", "dense", {torch.bfloat16}),
+    traits={
+        "weight_dtype": frozenset({"mxfp4"}),
+        "activation": frozenset({"silu", "situ", "swiglu"}),
+        "routing_mode": frozenset({"precomputed_topk"}),
+        "supports_deferred_finalize": frozenset({False}),
+        "supports_ep": frozenset({True}),
+        "supports_all_to_all_ep": frozenset({True}),
+        "deepep_modes": frozenset({"normal", "low_latency"}),
+        "ispp_alignment": frozenset({MXFP4_BLOCK}),
+        "internal_activation_dtype": frozenset({"input"}),
+        "supports_bias": frozenset({False}),
+    },
+    priority=Priority.PORTABLE,
+)
+def marlin_mxfp4_deepep_moe_apply(
+    plan: dict,
+    x: torch.Tensor,
+    w: torch.nn.Module,
+    router_logits: torch.Tensor,
+    topk_weights: torch.Tensor | None = None,
+    topk_ids: torch.Tensor | None = None,
+    num_tokens_global: int | None = None,
+    max_num_tokens_per_gpu: int | None = None,
+    do_finalize: bool = True,
+    enable_pdl: bool = False,
+    low_latency: bool | None = None,
+    overlap_fn: Callable[[], None] | None = None,
+) -> torch.Tensor:
+    """Run one Marlin MXFP4 MoE layer over DeepEP all-to-all.
+
+    Args:
+        plan: Execution plan from ``moe_plan``; owns the DeepEP group, mode,
+            low-latency capacity, and the lazily built dispatcher.
+        x: ``[local_tokens, hidden]`` bf16 hidden states of this rank's tokens.
+        w: Module holding Marlin-repacked expert weights plus ``top_k``,
+            ``num_experts``, ``num_local_experts``, ``ep_rank``, ``ep_size``.
+        router_logits: Unused; routing is precomputed.
+        topk_weights: ``[local_tokens, top_k]`` route weights.
+        topk_ids: ``[local_tokens, top_k]`` global expert ids.
+        num_tokens_global: Unused; DeepEP owns the token exchange.
+        max_num_tokens_per_gpu: Unused capacity hint.
+        do_finalize: Must be true (combine is the finalize).
+        enable_pdl: Forwarded to the Marlin apply's activation epilogue.
+        low_latency: Which DeepEP legs to run when the plan mode is "auto".
+            Every rank of the EP group must pass the same value.
+        overlap_fn: Optional work queued inside the dispatch window (e.g. the
+            shared experts); it must not read the dispatch result or write
+            ``x``.
+
+    Returns:
+        ``[local_tokens, hidden]`` bf16 combined MoE output, already reduced
+        across the EP group (no outer all-reduce needed).
+    """
+    del router_logits, num_tokens_global, max_num_tokens_per_gpu
+    if not do_finalize:
+        raise ValueError("Marlin MXFP4 DeepEP MoE cannot defer finalization")
+    if topk_weights is None or topk_ids is None:
+        raise ValueError("Marlin MXFP4 DeepEP MoE requires precomputed top-k")
+
+    dispatcher = _get_dispatcher(plan, w, x)
+    topk_ids = topk_ids.to(torch.int64)
+    topk_weights = topk_weights.to(torch.float32)
+
+    if dispatcher.deepep_mode.resolve(low_latency) == DeepEPMode.normal:
+        return _apply_normal(
+            dispatcher, plan, x, w, topk_weights, topk_ids, enable_pdl, overlap_fn
+        )
+    return _apply_low_latency(
+        dispatcher, plan, x, w, topk_weights, topk_ids, enable_pdl, overlap_fn
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/marlin/mxfp4.py
@@ -218,7 +218,9 @@ def marlin_mxfp4_precomputed_moe_apply(
     if is_ep:
         # Global -> local id remap: [expert_start, +num_local) -> [0, num_local),
         # everything else -> -1 (the align kernel parks these in the extra lane
-        # and the EP GEMM skips those blocks).
+        # and the EP GEMM skips those blocks). Inputs may already carry -1 in
+        # masked slots (DeepEP recv layout); clamp before the gather so the
+        # negative index cannot wrap to the mapping's last entry, then restore.
         expert_start = ep_rank * num_local_experts
         mapping = torch.full(
             (global_num_experts,), -1, dtype=torch.int32, device=topk_ids.device
@@ -226,7 +228,9 @@ def marlin_mxfp4_precomputed_moe_apply(
         mapping[expert_start : expert_start + num_local_experts] = torch.arange(
             num_local_experts, dtype=torch.int32, device=topk_ids.device
         )
-        local_topk_ids = mapping[topk_ids.long()]
+        local_topk_ids = torch.where(
+            topk_ids < 0, topk_ids, mapping[topk_ids.long().clamp_(min=0)]
+        )
         align_num_experts = num_local_experts
     else:
         local_topk_ids = topk_ids

--- a/tokenspeed-kernel/test/ops/moe/test_marlin_deepep_distributed.py
+++ b/tokenspeed-kernel/test/ops/moe/test_marlin_deepep_distributed.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""NVLink smoke test for the Marlin MXFP4 DeepEP MoE (SM90).
+
+Each rank holds a distinct token batch and one shard of the experts; the
+DeepEP apply must return, per rank, the same result as the bf16 dequant
+reference computed over ALL experts for that rank's tokens. Single-node
+DeepEP traffic runs the NVLink P2P path in both modes (no IBGDA / RDMA).
+
+The DeepEP buffer is a process-wide singleton pinned to its first mode, so
+one torchrun invocation exercises one mode. Normal one-GPU pytest runs skip
+this file. Exercise it with:
+
+``torchrun --standalone --nproc-per-node=2 -m pytest -q <this file>``
+``TEST_DEEPEP_MODE=low_latency torchrun --standalone --nproc-per-node=2 \
+  -m pytest -q <this file>``
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+from kimi3_reference import a16w4_mxfp4_moe_reference
+from utils import make_mxfp4_moe_weights
+
+deep_ep = pytest.importorskip("deep_ep", reason="deep_ep is an optional dependency")
+
+
+def _world_size() -> int:
+    return int(os.environ.get("WORLD_SIZE", "1"))
+
+
+def _deepep_mode() -> str:
+    return os.environ.get("TEST_DEEPEP_MODE", "normal")
+
+
+@pytest.mark.skipif(
+    _world_size() not in {2, 4, 8},
+    reason="launch with torchrun world size 2, 4, or 8",
+)
+def test_marlin_deepep_matches_replicated_reference() -> None:
+    import tokenspeed_kernel
+
+    world_size = _world_size()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    if not dist.is_initialized():
+        dist.init_process_group("nccl")
+    rank = dist.get_rank()
+
+    # All ranks share the same weights (same seed); each holds its own tokens.
+    generator = torch.Generator(device="cuda").manual_seed(20260822)
+    num_experts = 4 * world_size
+    num_local = num_experts // world_size
+    top_k = 4
+    # The DeepEP low-latency kernels are compiled for a fixed hidden-size list
+    # (2048 is the smallest, and also K3's routed latent width).
+    hidden_size, intermediate_size = 2048, 256
+    num_tokens = 16
+    beta, linear_beta = 4.0, 25.0
+
+    raw = make_mxfp4_moe_weights(num_experts, hidden_size, intermediate_size, generator)
+    # Distinct per-rank tokens/routing from a rank-seeded generator.
+    rank_gen = torch.Generator(device="cuda").manual_seed(1000 + rank)
+    x = (
+        torch.randn(
+            num_tokens,
+            hidden_size,
+            generator=rank_gen,
+            device="cuda",
+        )
+        * 0.2
+    ).to(torch.bfloat16)
+    topk_ids = torch.stack(
+        [
+            torch.randperm(num_experts, generator=rank_gen, device="cuda")[:top_k]
+            for _ in range(num_tokens)
+        ]
+    ).to(torch.int32)
+    topk_weights = torch.rand(
+        num_tokens, top_k, generator=rank_gen, device="cuda", dtype=torch.float32
+    )
+    topk_weights = topk_weights / topk_weights.sum(-1, keepdim=True)
+
+    expected = a16w4_mxfp4_moe_reference(
+        x,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        topk_ids,
+        topk_weights,
+        situ_beta=beta,
+        situ_linear_beta=linear_beta,
+    )
+
+    lo, hi = rank * num_local, (rank + 1) * num_local
+    module = torch.nn.Module()
+    module.w13_weight = torch.nn.Parameter(raw["w13_weight"][lo:hi].clone(), False)
+    module.w13_weight_scale = torch.nn.Parameter(raw["w13_scale"][lo:hi].clone(), False)
+    module.w2_weight = torch.nn.Parameter(raw["w2_weight"][lo:hi].clone(), False)
+    module.w2_weight_scale = torch.nn.Parameter(raw["w2_scale"][lo:hi].clone(), False)
+    module.top_k = top_k
+    module.num_experts = num_experts
+    module.num_local_experts = num_local
+    module.ep_rank = rank
+    module.ep_size = world_size
+    module.activation = "situ"
+    module.activation_situ_beta = beta
+    module.activation_situ_linear_beta = linear_beta
+
+    mode = _deepep_mode()
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="situ",
+        routing_mode="precomputed_topk",
+        a2a_backend="deepep",
+        ep_size=world_size,
+        ispp=intermediate_size,
+        internal_activation_dtype="input",
+        deepep_group=dist.group.WORLD,
+        deepep_mode=mode,
+        deepep_low_latency_max_num_tokens_per_gpu=(
+            num_tokens if mode == "low_latency" else None
+        ),
+        solution="marlin",
+    )
+    assert plan["apply_kernel_name"] == "marlin_mxfp4_deepep_moe_apply"
+    tokenspeed_kernel.moe_process_weights(plan, module)
+
+    actual = tokenspeed_kernel.moe_apply(
+        plan,
+        x,
+        module,
+        torch.zeros((num_tokens, num_experts), dtype=torch.float32, device="cuda"),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        low_latency=(mode == "low_latency"),
+    )
+
+    torch.testing.assert_close(actual.float(), expected.float(), atol=5e-2, rtol=5e-2)
+    dist.barrier()


### PR DESCRIPTION
## Summary

Two workstreams plus a kernel addition:

### Prefill chunk pipeline (PP)
- Same-request chunk-level pipelining across PP stages on the prefill role: per-stage layer windows (including non-uniform `--pp-layer-partition`), boundary AttnRes handoff, stage-state wire spec, and PD transfer plans narrowed to each stage's layers.
- The unified event loop runs the pipeline as in-flight depth `pp_size`; the last stage broadcasts sampled tokens to peers before commit.
- Validated end-to-end under PD+PP with first-token parity against the non-PP baseline.

### Event-loop cohesion refactor
Principles are documented in `docs/design/event-loop.md` (new):
- **EventLoop is a coordinator only.** Pause/resume (`PauseHooks`), EPD prefill admission (`EpdPrefillHooks`), PD transfer events (`PdTransferHooks`), and L2 cache-op tracking (`L2CacheHooks`) each live in their own module and enter the loop as single-line hooks. The SMG handshake moved to `zmq_msgpack`, multimodal batch-context assembly to `multimodal/inputs`, layerwise-transfer wiring onto `DisaggPrefillExecutor`.
- **Scheduler feedback is centralized.** `advance_scheduler` (renamed from `advance_forward`) is the only caller of `scheduler.advance` and is invoked explicitly in the loop body only — helpers return events. Two call sites: cache-op completions at the head of the round, forward results through the single `request_changes` funnel at the tail.
- `_dispatch_depends_on_pending_commit` is the single registry of overlap-breaking dependencies; KV events publish once per round (drain semantics); iteration metrics record once per round.
- Cleanups: dead params/pre-assignments and redundant local imports removed, stale comments fixed, `NullSender` made public.

`event_loop.py` shrinks from ~2040 to ~1450 lines; the remaining EPD/multimodal/SMG/pause footprint is construction wiring and one-line hooks.

### Kernel
- Marlin W4A16 MXFP4 MoE over DeepEP dispatch (single-node NVLink), with a distributed numeric test.

## Testing
- New CPU-only unit tests for the extracted hooks (pause, EPD, L2 cache, in-flight queue) and for `_dp_sync_and_check`'s per-rank PD-decode metadata; 94 runtime tests in the touched area pass locally.
- `pre-commit run --all-files` clean; CI-equivalent ruff checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)