### PR TITLE
test(kimi-k3): PD-disaggregation simulation bench (pd_sim)

### DIFF
--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/README.md
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/README.md
@@ -1,0 +1,139 @@
+# PD-disaggregation simulation bench
+
+Ranks the parent directory's serve configs (`../configs/*.sh`, reused
+verbatim) by what a PD-disaggregated deployment cares about: prefill-node
+throughput (P-sim, split into fresh and cached) and decode-node throughput
+(D-sim), measured separately. The agentic bench cannot answer this — its
+numbers mix prefill interference into every decode figure.
+
+## Data: the frozen canonical dataset, same as everything else
+
+All three sub-benches replay the frozen agentic artifact
+(`lightseekorg/agentic-dataset`, the file the agentic bench and the CI gates
+use). Synthetic random-token prompts are deliberately NOT used: speculative
+acceptance and MoE expert routing are content-sensitive, and random text
+would misrepresent both (the two subsystems this bench most needs to rank).
+A `random`-plugin variant with parameterized lengths stays a future
+shape-scan, clearly labelled content-unrealistic.
+
+Real-workload anchors (measured): fresh prefill = ~50K tokens, 1 per
+conversation (~8% of requests, ~75% of prefill compute); cached prefill =
+~0.8-1.3K new tokens on a 50K->67K cached prefix (~92% of requests).
+
+## P-sim: prefill-node simulation
+
+Batch contains prefill only (`max_tokens 1` kills the decode phase and
+reproduces a P node's scheduling profile). Sampling needs no pinning at 1
+output token. One boot per config, fresh phase then cached phase.
+
+**P-fresh (compute-bound):** send the 71 unique first turns cold.
+Ladder: parallel 1/2/4/8/16, number = 2 x parallel (62 unique prompts
+consumed, within the 71 budget; no prompt reused).
+Ranking: **prefill tok/s / GPU**; secondary TTFT p50/p99.
+Validity guard: cache hit <= 5%.
+
+**P-cached (bandwidth-bound, distinct prefixes):** per conversation, prime
+turn 1 with `max_tokens 500` (builds a realistic prefix: 50K prompt + 500
+generated tokens; excluded from measurement), then measure turn 2 with
+`max_tokens 1` — a cached prefill of ~50.5K hit + ~800 new tokens, the real
+turn-increment shape. The prime response's reasoning_content AND content are
+passed back verbatim in the replayed assistant turn: K3's chat template
+renders them into the think/response channels, so the re-rendered prefix
+retokenizes onto the cached token stream (content-only passthrough would
+diverge at the <think> tag and silently recompute the ~500 assistant
+tokens). Residual retokenization boundary effects are absorbed by the
+computed-tokens metric, which counts whatever actually recomputed. Distinct per-conversation prefixes stress cache
+capacity and (under DP) rank affinity — deliberately harder than a shared
+prefix.
+Ranking: **computed tok/s / GPU = (prompt_tokens - cached_tokens) / time**
+(a raw prompt-tok/s column would be inflated by cache-hit accounting);
+secondary requests/s and TTFT p50/p99.
+Validity guard: cache hit >= 95%.
+
+## D-sim: decode-node simulation
+
+A D node's defining state: the KV already exists (computed by P, delivered
+by transfer). The prefix cache plays the transfer's role.
+
+1. **Prime at LOW concurrency** (parallel 2, `max_tokens 1`, first turns):
+   the prime wave only needs to park KV in the cache — its concurrency is
+   independent of the measured concurrency, so the prefill workspace peak
+   stays minimal and cannot disturb razor-thin memory envelopes.
+2. **Settle 30s**: async writebacks and allocator churn quiesce.
+3. **Measure**: resend the SAME first turns, `max_tokens 2000` +
+   `ignore_eos`, ladder parallel 1/2/4/8/16 with number = 2 x parallel
+   (rolling admission keeps the decode batch saturated with arrivals and
+   departures — a D node's steady state, not a lockstep wave). The
+   per-request prefill collapses to a ~full cache hit (the KV-load cost
+   stands in for transfer/load; real transfer cost is out of scope).
+4. Ranking: **Output Throughput (tok/s) / GPU** (decode-only regime, so
+   output-only is the honest number); secondary TPOT p50/p99.
+
+Validity guards, both recorded per rung in the collect output:
+- **cache hit >= 95%** on the measure wave — below it the rung is VOID
+  (primed KV evicted: the config cannot hold C x 50K as a D node, itself a
+  reportable capacity result; under DP it may also mean affinity routing
+  failed to return a request to the rank holding its KV — also reportable).
+- **memory ledger**: max-across-GPUs memory sampled before prime, after
+  prime, and at 5s cadence DURING each measure rung (background sampler,
+  peak recorded). collect flags a rung whose measure peak exceeds the
+  post-prime level by more than 4GiB (`mem-climb`), and VOIDs rungs with
+  missing samples. d_bench boots fresh, so the before-prime baseline is
+  clean (no P-phase residue — the standalone split guarantees it).
+
+Memory-isolation rationale: prefill-phase workspace/activations are
+transient (returned to the torch caching allocator and reused by decode's
+far smaller allocations); the KV pool is sized once at boot from the
+profiling pass and cannot be squeezed by runtime allocations. The ledger
+verifies this empirically instead of trusting the argument.
+
+## Knobs
+
+- Input anchor 50K (frozen-file first turns); D output 2000 (decode >= 95%
+  of measured wall clock at observed TPOT).
+- Concurrency ladder 1/2/4/8/16 (32 needs a max-num-seqs bump — future).
+- Sampling: NOT pinned, matching the agentic bench convention (fixed input,
+  default sampling). Consequence, same as the parent README: speculative
+  acceptance drifts between runs, so D-sim differences below the measured
+  noise band need repeated runs before ranking two configs. P-sim is
+  unaffected (max_tokens 1 has no generation to sample).
+- P:D sizing helper in collect: give it the per-conversation token mix
+  (`--mix-fresh-tokens/--mix-cached-tokens/--mix-decode-tokens`, defaults =
+  the agentic anchors) and it converts the measured rates into GPU-seconds
+  per conversation on each side, printing the provisioning ratio:
+  `P gpu-s/conv / D gpu-s/conv = P-GPUs per D-GPU`.
+
+## Implementation notes
+
+- evalscope's swe_smith plugin has no prime/measure phase control, so ALL
+  phases run through pd_client.py (thin stdlib client, rolling admission,
+  one retry per request; a twice-failed request is recorded and the rung is
+  VOIDed by collect instead of aborting the sweep). pd_sim has its OWN
+  collect script — its summaries are deliberately NOT column-compatible
+  with the parent bench's collect.
+- Every summary and collect report carries the boundaries statement: no
+  KV-transfer cost modeled; prime-as-transfer is the core approximation;
+  single machine; TTFT is approximated by full-request latency at
+  max_tokens 1; TPOT (d-measure only, p50/p99) amortizes the cache-hit KV
+  load into per-token time.
+- Each config boot starts with a warmup on spare conversations 62-63
+  (excluded from every metric) so the first measured rung does not absorb
+  first-touch JIT/autotune costs.
+- The dataset is always fetched into pd_sim/ itself (frozen artifact); a
+  parent-directory agentic_dataset.json is deliberately NOT reused — it may
+  be a local non-frozen build.
+
+## Layout
+
+```
+p_bench.sh           # standalone P sweep: boot -> warmup -> P-fresh ladder -> P-cached ladder -> kill
+d_bench.sh           # standalone D sweep: boot -> warmup -> prime -> settle -> measure ladder (+ memory sampler) -> kill
+pd_client.py         # phased client shared by both benches
+collect_outputs.py   # tables + guards + P:D sizing; accepts multiple sweep dirs:
+                     #   python3 collect_outputs.py outputs/p_<ts> outputs/d_<ts>
+outputs/p_<ts>/, outputs/d_<ts>/   # per-sweep artifacts (gitignored)
+```
+
+The two benches are independently runnable — a P sweep and a D sweep each
+own the machine for their duration and can be run on different days; the
+collect script merges any combination of sweep dirs.

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/README.md
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/README.md
@@ -22,13 +22,22 @@ conversation (~8% of requests, ~75% of prefill compute); cached prefill =
 
 ## P-sim: prefill-node simulation
 
+The P sweep covers the TP configs only — DP is a decode-side scaling
+choice, not a P-node candidate (a P node runs few huge prefills, so DP
+ranks would idle while one rank computes); the DP config stays in D-sim.
+
 Batch contains prefill only (`max_tokens 1` kills the decode phase and
 reproduces a P node's scheduling profile). Sampling needs no pinning at 1
 output token. One boot per config, fresh phase then cached phase.
 
-**P-fresh (compute-bound):** send the 71 unique first turns cold.
+**P-fresh (compute-bound):** send unique first turns cold. The frozen
+artifact contains exact duplicate first-turn pairs (7 pairs in the current
+file: 64 unique of 71), so pd_client deduplicates by first-turn content and
+all offsets index into the deduplicated list — a duplicate reaching a later
+rung would score as a cache hit and break this phase's guard.
 Ladder: parallel 1/2/4/8/16, number = 2 x parallel (62 unique prompts
-consumed, within the 71 budget; no prompt reused).
+consumed plus 2 for warmup, exactly the 64-unique budget; no prompt
+reused — the bench scripts assert the unique count at dataset check time).
 Ranking: **prefill tok/s / GPU**; secondary TTFT p50/p99.
 Validity guard: cache hit <= 5%.
 
@@ -111,6 +120,12 @@ verifies this empirically instead of trusting the argument.
   VOIDed by collect instead of aborting the sweep). pd_sim has its OWN
   collect script — its summaries are deliberately NOT column-compatible
   with the parent bench's collect.
+- Summaries record Requested next to Requests: a twice-failed p-cached
+  prime silently drops its conversation before the measured wave, so the
+  two can diverge with zero Failed Requests — collect VOIDs the mismatch
+  (`short`). Retried Requests is informational only: retries keep their
+  full latency (a hiccup is real), so a nonzero Retried column means the
+  latency percentiles carry retry time.
 - Every summary and collect report carries the boundaries statement: no
   KV-transfer cost modeled; prime-as-transfer is the core approximation;
   single machine; TTFT is approximated by full-request latency at

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/collect_outputs.py
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/collect_outputs.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Collect pd_sim sweeps into three tables (P-fresh / P-cached / D-sim).
+
+Applies the validity guards from the README: a rung is VOID if its cache-hit
+guard fails, if any request failed, or (D-sim) if measure-phase memory kept
+climbing past the post-prime level. Accepts multiple sweep dirs (e.g. one P
+sweep and one D sweep); the P:D sizing helper needs one of each.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+MEM_CLIMB_MIB = 4096  # measure-phase peak more than this above post-prime -> flag
+
+METRIC = {
+    "p_fresh": "Prefill Throughput (tok/s)",
+    "p_cached": "Computed Throughput (tok/s)",
+    "d_measure": "Output Throughput (tok/s)",
+}
+
+
+def hit_guard(phase, hit):
+    if hit < 0:
+        return False  # missing data must not masquerade as a reading
+    if phase == "p_fresh":
+        return hit <= 5.0
+    return hit >= 95.0
+
+
+def num_gpus(config: str) -> int:
+    m = re.search(r"attn_(?:tp|dp)(\d+)", config)
+    if not m:
+        raise ValueError(f"Cannot infer GPU count from config name: {config}")
+    return int(m.group(1))
+
+
+def load_ledgers(sweep_dir: Path):
+    ledger = {}
+    for f in sweep_dir.glob("*_memory_ledger.jsonl"):
+        config = f.name.replace("_memory_ledger.jsonl", "")
+        for line in f.read_text().splitlines():
+            try:
+                e = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ledger[(config, e.get("parallel"))] = e
+    return ledger
+
+
+def collect(sweep_dir: Path):
+    rows = []
+    ledger = load_ledgers(sweep_dir)
+    for summary in sorted(sweep_dir.glob("*/parallel_*/benchmark_summary.json")):
+        run_name = summary.parent.parent.name  # <config>_<phase>
+        m = re.match(r"(.+)_(p_fresh|p_cached|d_measure)$", run_name)
+        if not m:
+            continue
+        config, phase = m.group(1), m.group(2)
+        s = json.loads(summary.read_text())
+        hit = s.get("KV Cache Hit Rate (%)", -1.0)
+        failed = s.get("Failed Requests", 0)
+        metric = s.get(METRIC[phase], 0.0)
+        conc = s.get("Concurrency")
+
+        problems = []
+        if not hit_guard(phase, hit):
+            problems.append("hit")
+        if failed:
+            problems.append(f"{failed}failed")
+
+        row = {
+            "phase": phase,
+            "config": config,
+            "Conc.": conc,
+            f"{METRIC[phase]} /gpu": round(metric / num_gpus(config), 2),
+            "Cache Hit (%)": round(hit, 2),
+            "Requests/s": s.get("Requests/s"),
+            "Latency p50 (s)": s.get("Latency p50 (s)"),
+            "Latency p99 (s)": s.get("Latency p99 (s)"),
+        }
+        if phase == "d_measure":
+            row["TPOT p50 (ms)"] = s.get("TPOT p50 (ms)")
+            row["TPOT p99 (ms)"] = s.get("TPOT p99 (ms)")
+            led = ledger.get((config, conc))
+            if led:
+                after = led.get("mem_after_prime", -1)
+                peak = led.get("mem_peak_during_measure", -1)
+                row["Mem after prime (MiB)"] = after
+                row["Mem peak measure (MiB)"] = peak
+                if peak < 0 or after < 0:
+                    problems.append("mem-unsampled")
+                elif peak - after > MEM_CLIMB_MIB:
+                    problems.append("mem-climb")
+            else:
+                problems.append("no-ledger")
+        row["valid"] = "ok" if not problems else "VOID(" + "+".join(problems) + ")"
+        rows.append(row)
+    return rows
+
+
+def print_tables(rows):
+    print("# Boundaries: no KV-transfer cost modeled; prime-as-transfer is the")
+    print("# core approximation; single machine; TTFT ~= full-request latency")
+    print("# at max_tokens 1; TPOT amortizes the cache-hit KV load.")
+    for phase in ("p_fresh", "p_cached", "d_measure"):
+        sub = [r for r in rows if r["phase"] == phase]
+        if not sub:
+            continue
+        print(f"\n== {phase} ==")
+        cols = [c for c in sub[0].keys() if c != "phase"]
+        print(",".join(cols))
+        for r in sorted(sub, key=lambda x: (x["config"], x["Conc."])):
+            print(",".join(str(r.get(c, "")) for c in cols))
+
+
+def sizing_helper(rows, fresh_tok, cached_tok, decode_tok):
+    """P:D node ratio for a target per-conversation token mix."""
+    print(
+        f"\n== P:D sizing (mix per conversation: fresh={fresh_tok} "
+        f"cached={cached_tok} decode={decode_tok} tokens) =="
+    )
+    for config in sorted({r["config"] for r in rows}):
+        picks = {}
+        for phase in ("p_fresh", "p_cached", "d_measure"):
+            valid = [
+                r
+                for r in rows
+                if r["config"] == config and r["phase"] == phase and r["valid"] == "ok"
+            ]
+            if valid:
+                picks[phase] = max(valid, key=lambda r: r["Conc."])
+        if len(picks) < 3:
+            print(f"{config}: insufficient valid rungs")
+            continue
+        fresh = picks["p_fresh"][f"{METRIC['p_fresh']} /gpu"]
+        cached = picks["p_cached"][f"{METRIC['p_cached']} /gpu"]
+        d = picks["d_measure"][f"{METRIC['d_measure']} /gpu"]
+        if not (fresh and cached and d):
+            print(f"{config}: zero rate in a phase, cannot size")
+            continue
+        # GPU-seconds per conversation on each side; their ratio is the
+        # P-GPU : D-GPU provisioning ratio for this workload mix.
+        p_sec = fresh_tok / fresh + cached_tok / cached
+        d_sec = decode_tok / d
+        print(
+            f"{config}: P {p_sec:.2f} gpu-s/conv, D {d_sec:.2f} gpu-s/conv "
+            f"-> {p_sec / d_sec:.2f} P-GPUs per D-GPU"
+        )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "sweep_dirs",
+        type=Path,
+        nargs="+",
+        help="one or more sweep dirs (e.g. outputs/p_<ts> and " "outputs/d_<ts>)",
+    )
+    ap.add_argument(
+        "--mix-fresh-tokens",
+        type=int,
+        default=50000,
+        help="fresh prefill tokens per conversation (agentic "
+        "anchor: the 50K first turn)",
+    )
+    ap.add_argument(
+        "--mix-cached-tokens",
+        type=int,
+        default=15000,
+        help="cached-prefill computed tokens per conversation "
+        "(agentic anchor: ~11-14 increments x ~1.3K)",
+    )
+    ap.add_argument(
+        "--mix-decode-tokens",
+        type=int,
+        default=6000,
+        help="decoded tokens per conversation (agentic anchor: " "~12 turns x 500)",
+    )
+    args = ap.parse_args()
+
+    rows = []
+    for d in args.sweep_dirs:
+        rows.extend(collect(d))
+    if not rows:
+        sys.exit(f"no benchmark_summary.json under {args.sweep_dirs}")
+    print_tables(rows)
+    sizing_helper(
+        rows, args.mix_fresh_tokens, args.mix_cached_tokens, args.mix_decode_tokens
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/collect_outputs.py
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/collect_outputs.py
@@ -70,6 +70,12 @@ def collect(sweep_dir: Path):
             problems.append("hit")
         if failed:
             problems.append(f"{failed}failed")
+        # A rung that measured fewer requests than asked (twice-failed
+        # p-cached primes drop their conversation before the measured wave)
+        # is a shrunken sample with zero Failed Requests — VOID it.
+        requested = s.get("Requested")
+        if requested is not None and s.get("Requests") != requested:
+            problems.append("short")
 
         row = {
             "phase": phase,
@@ -77,6 +83,10 @@ def collect(sweep_dir: Path):
             "Conc.": conc,
             f"{METRIC[phase]} /gpu": round(metric / num_gpus(config), 2),
             "Cache Hit (%)": round(hit, 2),
+            # Informational, not a guard: retries keep their full latency
+            # (a hiccup is real), so nonzero here means the percentile
+            # columns carry retry time.
+            "Retried": s.get("Retried Requests", 0),
             "Requests/s": s.get("Requests/s"),
             "Latency p50 (s)": s.get("Latency p50 (s)"),
             "Latency p99 (s)": s.get("Latency p99 (s)"),

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/d_bench.sh
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/d_bench.sh
@@ -25,7 +25,11 @@ m = d.get("metadata", {})
 assert n >= 70, f"agentic_dataset.json has only {n} conversations; need >= 70"
 recipe = (m.get("first_turn_length"), m.get("subsequent_turn_length"), m.get("min_turns"), m.get("max_turns"))
 assert recipe == (50000, 800, 10, 15), f"unexpected dataset recipe {recipe}; delete agentic_dataset.json"
-print(f"dataset ok: {n} conversations, recipe {recipe}")
+# pd_client dedups by first-turn content (the frozen artifact has duplicate
+# pairs); prime consumes unique conversations 0-31 + 2 for warmup at 62.
+uniq = len({json.dumps(c[0]["messages"], sort_keys=True) for c in d["conversations"]})
+assert uniq >= 64, f"only {uniq} unique first turns; prime + warmup need 64"
+print(f"dataset ok: {n} conversations ({uniq} unique first turns), recipe {recipe}")
 PYEOF
 
 CONFIGS=(

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/d_bench.sh
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/d_bench.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+MODEL=nvidia/Kimi-K3-NVFP4
+URL=http://127.0.0.1:8000/v1/chat/completions
+DATASET="${SCRIPT_DIR}/agentic_dataset.json"
+
+# Same dataset acquisition + guard as the parent bench (one file, reused).
+# pd_sim always fetches the FROZEN artifact into its own directory — it
+# deliberately does not reuse a parent-directory file, which may be a local
+# non-frozen build.
+[ -s "$DATASET" ] || {
+    curl -fsSL "https://huggingface.co/datasets/lightseekorg/agentic-dataset/resolve/main/agentic_dataset.json" \
+        -o "$DATASET.tmp"
+    mv "$DATASET.tmp" "$DATASET"
+}
+DATASET="$DATASET" python3 - <<'PYEOF'
+import json
+d = json.load(open(__import__("os").environ["DATASET"]))
+n = len(d["conversations"])
+m = d.get("metadata", {})
+assert n >= 70, f"agentic_dataset.json has only {n} conversations; need >= 70"
+recipe = (m.get("first_turn_length"), m.get("subsequent_turn_length"), m.get("min_turns"), m.get("max_turns"))
+assert recipe == (50000, 800, 10, 15), f"unexpected dataset recipe {recipe}; delete agentic_dataset.json"
+print(f"dataset ok: {n} conversations, recipe {recipe}")
+PYEOF
+
+CONFIGS=(
+    attn_tp8_moe_ep8
+    attn_tp8_moe_tp8
+    attn_dp8_moe_ep8
+)
+
+SERVER_PID=
+SERVER_LOG=
+
+launch_server() {
+    local config=$1
+    SERVER_LOG=/tmp/tokenspeed_server_pdsim_${config}.log
+    setsid ${PARENT_DIR}/configs/${config}.sh > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+}
+
+wait_for_ready() {
+    local TIMEOUT=7200
+    local START=$SECONDS
+    until curl -sf -o /dev/null http://127.0.0.1:8000/readiness; do
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "Server died early. Last log lines:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if grep -qE "CUDA out of memory|OutOfMemory|Traceback|Killed" "$SERVER_LOG"; then
+            echo "Server hit a fatal error:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if (( SECONDS - START > TIMEOUT )); then
+            echo "Timeout after ${TIMEOUT}s waiting for server" >&2
+            return 1
+        fi
+        sleep 5
+    done
+    echo "Server ready after $((SECONDS - START))s"
+}
+
+stop_server() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Stopping ts serve (pgid $SERVER_PID)..."
+        kill -TERM -"$SERVER_PID" 2>/dev/null || true
+        for _ in {1..20}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL -"$SERVER_PID" 2>/dev/null || true
+    fi
+    SERVER_PID=
+}
+
+wait_for_port_free() {
+    local port=${1:-8000}
+    local timeout=${2:-90}
+    local start=$SECONDS
+    while ! python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', $port)); s.close()" 2>/dev/null; do
+        if (( SECONDS - start > timeout )); then
+            echo "Port ${port} still in use after ${timeout}s" >&2
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+trap stop_server EXIT
+
+wait_for_port_free 8000
+wait_for_port_free 4000
+
+# Ladder: parallel / number = 2x parallel. All rungs replay the primed
+# conversations 0..31 (reuse is the point: the KV must already be resident).
+LADDER=(
+    "1 2"
+    "2 4"
+    "4 8"
+    "8 16"
+    "16 32"
+)
+
+gpu_mem_max() {
+    # Max used memory across ALL GPUs (DP rank skew must be visible).
+    nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null \
+        | sort -n | tail -1 | grep -E '^[0-9]+$' || echo -1
+}
+
+SWEEP_TS=$(date +%Y%m%d_%H%M%S)
+SWEEP_DIR="${SCRIPT_DIR}/outputs/d_${SWEEP_TS}"
+echo "D-sim sweep outputs: ${SWEEP_DIR}"
+
+for CONFIG in "${CONFIGS[@]}"; do
+    echo "=== Running $CONFIG ==="
+    launch_server "$CONFIG"
+    if ! wait_for_ready; then
+        stop_server
+        exit 1
+    fi
+
+    echo "--- warmup (spare conversations, excluded) ---"
+    python3 "${SCRIPT_DIR}/pd_client.py" --url "$URL" --model "$MODEL" \
+        --dataset "$DATASET" --phase d-prime --parallel 2 --number 2 \
+        --offset 62 --max-tokens 16 \
+        --name "${CONFIG}_warmup" --outputs-dir "$SWEEP_DIR"
+
+    echo "--- D prime (low concurrency) ---"
+    MEM_BEFORE_PRIME=$(gpu_mem_max)
+    python3 "${SCRIPT_DIR}/pd_client.py" --url "$URL" --model "$MODEL" \
+        --dataset "$DATASET" --phase d-prime --parallel 2 --number 32 \
+        --offset 0 --max-tokens 1 \
+        --name "${CONFIG}_d_prime" --outputs-dir "$SWEEP_DIR"
+    MEM_AFTER_PRIME=$(gpu_mem_max)
+    echo "settle 30s..."
+    sleep 30
+
+    echo "--- D measure ---"
+    mkdir -p "$SWEEP_DIR"
+    for rung in "${LADDER[@]}"; do
+        read -r P N <<< "$rung"
+        # Background sampler: peak memory DURING the rung (5s cadence).
+        PEAK_FILE=$(mktemp)
+        (
+            peak=-1
+            while true; do
+                m=$(gpu_mem_max)
+                [ "$m" -gt "$peak" ] 2>/dev/null && peak=$m
+                echo "$peak" > "$PEAK_FILE"
+                sleep 5
+            done
+        ) &
+        SAMPLER_PID=$!
+        python3 "${SCRIPT_DIR}/pd_client.py" --url "$URL" --model "$MODEL" \
+            --dataset "$DATASET" --phase d-measure --parallel "$P" --number "$N" \
+            --offset 0 --max-tokens 2000 \
+            --name "${CONFIG}_d_measure" --outputs-dir "$SWEEP_DIR"
+        kill "$SAMPLER_PID" 2>/dev/null || true
+        MEM_PEAK=$(cat "$PEAK_FILE" 2>/dev/null || echo -1)
+        rm -f "$PEAK_FILE"
+        echo "{\"config\": \"$CONFIG\", \"parallel\": $P, \"mem_before_prime\": ${MEM_BEFORE_PRIME:--1}, \"mem_after_prime\": ${MEM_AFTER_PRIME:--1}, \"mem_peak_during_measure\": ${MEM_PEAK:--1}}" \
+            >> "${SWEEP_DIR}/${CONFIG}_memory_ledger.jsonl"
+    done
+
+    stop_server
+    wait_for_port_free 8000
+done
+
+echo "D-sim sweep done: ${SWEEP_DIR}"

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/p_bench.sh
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/p_bench.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+MODEL=nvidia/Kimi-K3-NVFP4
+URL=http://127.0.0.1:8000/v1/chat/completions
+DATASET="${SCRIPT_DIR}/agentic_dataset.json"
+
+# Same dataset acquisition + guard as the parent bench (one file, reused).
+# pd_sim always fetches the FROZEN artifact into its own directory — it
+# deliberately does not reuse a parent-directory file, which may be a local
+# non-frozen build.
+[ -s "$DATASET" ] || {
+    curl -fsSL "https://huggingface.co/datasets/lightseekorg/agentic-dataset/resolve/main/agentic_dataset.json" \
+        -o "$DATASET.tmp"
+    mv "$DATASET.tmp" "$DATASET"
+}
+DATASET="$DATASET" python3 - <<'PYEOF'
+import json
+d = json.load(open(__import__("os").environ["DATASET"]))
+n = len(d["conversations"])
+m = d.get("metadata", {})
+assert n >= 70, f"agentic_dataset.json has only {n} conversations; need >= 70"
+recipe = (m.get("first_turn_length"), m.get("subsequent_turn_length"), m.get("min_turns"), m.get("max_turns"))
+assert recipe == (50000, 800, 10, 15), f"unexpected dataset recipe {recipe}; delete agentic_dataset.json"
+print(f"dataset ok: {n} conversations, recipe {recipe}")
+PYEOF
+
+CONFIGS=(
+    attn_tp8_moe_ep8
+    attn_tp8_moe_tp8
+    attn_dp8_moe_ep8
+)
+
+SERVER_PID=
+SERVER_LOG=
+
+launch_server() {
+    local config=$1
+    SERVER_LOG=/tmp/tokenspeed_server_pdsim_${config}.log
+    setsid ${PARENT_DIR}/configs/${config}.sh > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+}
+
+wait_for_ready() {
+    local TIMEOUT=7200
+    local START=$SECONDS
+    until curl -sf -o /dev/null http://127.0.0.1:8000/readiness; do
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "Server died early. Last log lines:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if grep -qE "CUDA out of memory|OutOfMemory|Traceback|Killed" "$SERVER_LOG"; then
+            echo "Server hit a fatal error:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if (( SECONDS - START > TIMEOUT )); then
+            echo "Timeout after ${TIMEOUT}s waiting for server" >&2
+            return 1
+        fi
+        sleep 5
+    done
+    echo "Server ready after $((SECONDS - START))s"
+}
+
+stop_server() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Stopping ts serve (pgid $SERVER_PID)..."
+        kill -TERM -"$SERVER_PID" 2>/dev/null || true
+        for _ in {1..20}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL -"$SERVER_PID" 2>/dev/null || true
+    fi
+    SERVER_PID=
+}
+
+wait_for_port_free() {
+    local port=${1:-8000}
+    local timeout=${2:-90}
+    local start=$SECONDS
+    while ! python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', $port)); s.close()" 2>/dev/null; do
+        if (( SECONDS - start > timeout )); then
+            echo "Port ${port} still in use after ${timeout}s" >&2
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+trap stop_server EXIT
+
+wait_for_port_free 8000
+wait_for_port_free 4000
+
+# Ladder: parallel / number = 2x parallel / conversation offset.
+# Offsets advance so neither P phase reuses a conversation (62 of 71).
+LADDER=(
+    "1 2 0"
+    "2 4 2"
+    "4 8 6"
+    "8 16 14"
+    "16 32 30"
+)
+
+SWEEP_TS=$(date +%Y%m%d_%H%M%S)
+SWEEP_DIR="${SCRIPT_DIR}/outputs/p_${SWEEP_TS}"
+echo "P-sim sweep outputs: ${SWEEP_DIR}"
+
+for CONFIG in "${CONFIGS[@]}"; do
+    echo "=== Running $CONFIG ==="
+    launch_server "$CONFIG"
+    if ! wait_for_ready; then
+        stop_server
+        exit 1
+    fi
+
+    echo "--- warmup (spare conversations, excluded) ---"
+    python3 "${SCRIPT_DIR}/pd_client.py" --url "$URL" --model "$MODEL" \
+        --dataset "$DATASET" --phase d-prime --parallel 2 --number 2 \
+        --offset 62 --max-tokens 16 \
+        --name "${CONFIG}_warmup" --outputs-dir "$SWEEP_DIR"
+
+    echo "--- P-fresh ---"
+    for rung in "${LADDER[@]}"; do
+        read -r P N OFF <<< "$rung"
+        python3 "${SCRIPT_DIR}/pd_client.py" --url "$URL" --model "$MODEL" \
+            --dataset "$DATASET" --phase p-fresh --parallel "$P" --number "$N" \
+            --offset "$OFF" --max-tokens 1 \
+            --name "${CONFIG}_p_fresh" --outputs-dir "$SWEEP_DIR"
+    done
+
+    echo "--- P-cached ---"
+    for rung in "${LADDER[@]}"; do
+        read -r P N OFF <<< "$rung"
+        python3 "${SCRIPT_DIR}/pd_client.py" --url "$URL" --model "$MODEL" \
+            --dataset "$DATASET" --phase p-cached --parallel "$P" --number "$N" \
+            --offset "$OFF" --max-tokens 1 \
+            --name "${CONFIG}_p_cached" --outputs-dir "$SWEEP_DIR"
+    done
+
+    stop_server
+    wait_for_port_free 8000
+done
+
+echo "P-sim sweep done: ${SWEEP_DIR}"

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/p_bench.sh
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/p_bench.sh
@@ -25,13 +25,16 @@ m = d.get("metadata", {})
 assert n >= 70, f"agentic_dataset.json has only {n} conversations; need >= 70"
 recipe = (m.get("first_turn_length"), m.get("subsequent_turn_length"), m.get("min_turns"), m.get("max_turns"))
 assert recipe == (50000, 800, 10, 15), f"unexpected dataset recipe {recipe}; delete agentic_dataset.json"
-print(f"dataset ok: {n} conversations, recipe {recipe}")
+# pd_client dedups by first-turn content (the frozen artifact has duplicate
+# pairs); the ladder consumes 62 unique conversations + 2 for warmup.
+uniq = len({json.dumps(c[0]["messages"], sort_keys=True) for c in d["conversations"]})
+assert uniq >= 64, f"only {uniq} unique first turns; ladder + warmup need 64"
+print(f"dataset ok: {n} conversations ({uniq} unique first turns), recipe {recipe}")
 PYEOF
 
 CONFIGS=(
     attn_tp8_moe_ep8
     attn_tp8_moe_tp8
-    attn_dp8_moe_ep8
 )
 
 SERVER_PID=

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/pd_client.py
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/pd_client.py
@@ -56,6 +56,24 @@ def first_turn_messages(conv):
     return conv[0]["messages"]
 
 
+def unique_first_turn_conversations(convs):
+    """Drop conversations whose first turn duplicates an earlier one.
+
+    The frozen artifact contains exact duplicate first-turn pairs (7 in the
+    current file, 64 unique of 71). P-fresh's <=5% hit guard assumes every
+    ladder rung prefills content never seen before, so --offset/--number
+    index into this deduplicated, order-preserving list for ALL phases.
+    """
+    seen = set()
+    out = []
+    for conv in convs:
+        key = json.dumps(first_turn_messages(conv), sort_keys=True)
+        if key not in seen:
+            seen.add(key)
+            out.append(conv)
+    return out
+
+
 class Runner:
     def __init__(self, args):
         self.args = args
@@ -75,12 +93,17 @@ class Runner:
             self.args.url, data=body, headers={"Content-Type": "application/json"}
         )
         t0 = time.monotonic()
+        retried = False
         try:
             with urllib.request.urlopen(req, timeout=self.args.timeout) as r:
                 out = json.load(r)
         except Exception:
             # One retry; a request that fails twice is recorded, not fatal —
-            # the rung completes and collect VOIDs it on failures.
+            # the rung completes and collect VOIDs it on failures. The retry
+            # deliberately stays inside the t0..t1 window (a hiccup is part of
+            # the request's real latency); 'Retried Requests' in the summary
+            # flags rungs whose percentiles carry retry time.
+            retried = True
             try:
                 with urllib.request.urlopen(
                     urllib.request.Request(
@@ -99,6 +122,7 @@ class Runner:
         msg = out["choices"][0]["message"]
         return {
             "latency_s": t1 - t0,
+            "retried": retried,
             "prompt_tokens": usage.get("prompt_tokens", 0),
             "completion_tokens": usage.get("completion_tokens", 0),
             "cached_tokens": details.get("cached_tokens") or 0,
@@ -191,8 +215,13 @@ def summarize(args, results, wall_s):
     summary = {
         "Phase": args.phase,
         "Concurrency": args.parallel,
+        # Requested vs Requests: a p-cached prime that fails twice silently
+        # drops its conversation from the measured wave, so the two can
+        # diverge with zero Failed Requests. collect VOIDs the mismatch.
+        "Requested": args.number,
         "Requests": n,
         "Failed Requests": len(failed),
+        "Retried Requests": sum(1 for r in ok if r.get("retried")),
         "Wall (s)": round(wall_s, 3),
         "Prompt Tokens": prompt,
         "Cached Tokens": cached,
@@ -218,8 +247,9 @@ def summarize(args, results, wall_s):
 
 def main():
     args = parse_args()
-    data = json.load(open(args.dataset))
-    convs = data["conversations"]
+    with open(args.dataset) as f:
+        data = json.load(f)
+    convs = unique_first_turn_conversations(data["conversations"])
 
     runner = Runner(args)
     wall = runner.run(convs)

--- a/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/pd_client.py
+++ b/test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/pd_client.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Phased client for the PD-disaggregation simulation bench.
+
+evalscope's swe_smith plugin has no prime/measure phase control, so the
+prime waves, the P-cached turn replay, and the measured waves all run
+through this thin client. It replays the frozen agentic dataset, drives a
+fixed concurrency with rolling admission, and emits a benchmark_summary.json
+consumed by pd_sim's own collect_outputs.py (NOT column-compatible with the
+parent bench's collect — pd_sim has its own).
+
+Phases (--phase):
+  p-fresh   unique first turns, max_tokens 1        -> prefill tok/s
+  p-cached  turn-1 prime (500) then turn-2 measure  -> computed tok/s
+  d-prime   first turns, max_tokens 1, low parallel  (no summary emitted)
+  d-measure resend first turns, max_tokens N        -> output tok/s
+"""
+
+import argparse
+import concurrent.futures as cf
+import json
+import statistics
+import sys
+import threading
+import time
+import urllib.request
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--url", required=True, help="chat/completions endpoint")
+    p.add_argument("--model", required=True, help="served model name")
+    p.add_argument("--dataset", required=True, help="frozen agentic_dataset.json")
+    p.add_argument(
+        "--phase",
+        required=True,
+        choices=["p-fresh", "p-cached", "d-prime", "d-measure"],
+    )
+    p.add_argument("--parallel", type=int, required=True)
+    p.add_argument(
+        "--number",
+        type=int,
+        required=True,
+        help="requests to issue (conversations consumed)",
+    )
+    p.add_argument(
+        "--offset", type=int, default=0, help="first conversation index to use"
+    )
+    p.add_argument("--max-tokens", type=int, default=1)
+    p.add_argument("--timeout", type=int, default=3600)
+    p.add_argument("--name", default="run", help="label for the output dir")
+    p.add_argument("--outputs-dir", default="outputs")
+    return p.parse_args()
+
+
+def first_turn_messages(conv):
+    return conv[0]["messages"]
+
+
+class Runner:
+    def __init__(self, args):
+        self.args = args
+        self.lock = threading.Lock()
+        self.results = []
+
+    def request(self, messages, max_tokens):
+        body = json.dumps(
+            {
+                "model": self.args.model,
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "ignore_eos": True,
+            }
+        ).encode()
+        req = urllib.request.Request(
+            self.args.url, data=body, headers={"Content-Type": "application/json"}
+        )
+        t0 = time.monotonic()
+        try:
+            with urllib.request.urlopen(req, timeout=self.args.timeout) as r:
+                out = json.load(r)
+        except Exception:
+            # One retry; a request that fails twice is recorded, not fatal —
+            # the rung completes and collect VOIDs it on failures.
+            try:
+                with urllib.request.urlopen(
+                    urllib.request.Request(
+                        self.args.url,
+                        data=body,
+                        headers={"Content-Type": "application/json"},
+                    ),
+                    timeout=self.args.timeout,
+                ) as r:
+                    out = json.load(r)
+            except Exception as e:
+                return {"failed": True, "error": str(e)[:200]}
+        t1 = time.monotonic()
+        usage = out.get("usage") or {}
+        details = usage.get("prompt_tokens_details") or {}
+        msg = out["choices"][0]["message"]
+        return {
+            "latency_s": t1 - t0,
+            "prompt_tokens": usage.get("prompt_tokens", 0),
+            "completion_tokens": usage.get("completion_tokens", 0),
+            "cached_tokens": details.get("cached_tokens") or 0,
+            "content": msg.get("content"),
+            "reasoning_content": msg.get("reasoning_content"),
+        }
+
+    def prime_item(self, conv):
+        # P-cached prime: turn 1 with up to 500 generated tokens builds a
+        # realistic prefix (50K prompt + completion). Excluded from timing.
+        # BOTH reasoning_content and content are passed back verbatim: K3's
+        # chat template renders them into the think/response channels, so the
+        # re-rendered assistant turn retokenizes onto the cached token stream
+        # instead of diverging at the <think> open tag.
+        t1_msgs = list(first_turn_messages(conv))
+        prime = self.request(t1_msgs, 500)
+        if prime.get("failed") or len(conv) < 2:
+            return None
+        assistant = {"role": "assistant", "content": prime["content"] or ""}
+        if prime.get("reasoning_content"):
+            assistant["reasoning_content"] = prime["reasoning_content"]
+        return t1_msgs + [assistant] + list(conv[1]["messages"])
+
+    def one_item(self, payload):
+        a = self.args
+        if a.phase == "p-cached":
+            msgs = payload  # pre-assembled turn-2 message list
+        else:
+            msgs = list(first_turn_messages(payload))
+        res = self.request(msgs, a.max_tokens)
+        with self.lock:
+            self.results.append(res)
+        return res
+
+    # NOTE: failed requests carry {'failed': True} and are excluded from the
+    # token/latency aggregates but counted in 'Failed Requests'.
+
+    def run(self, convs):
+        a = self.args
+        picked = convs[a.offset : a.offset + a.number]
+        if len(picked) < a.number:
+            raise SystemExit(
+                f"dataset has only {len(picked)} conversations at offset "
+                f"{a.offset}; need {a.number}"
+            )
+        if a.phase == "p-cached":
+            # Phase 1 (untimed): prime every conversation's turn-1 prefix.
+            with cf.ThreadPoolExecutor(max_workers=a.parallel) as ex:
+                payloads = [m for m in ex.map(self.prime_item, picked) if m]
+            if not payloads:
+                raise SystemExit("no conversation has a second turn")
+        else:
+            payloads = picked
+        # Phase 2 (timed): only the measured requests count toward wall time.
+        t0 = time.monotonic()
+        with cf.ThreadPoolExecutor(max_workers=a.parallel) as ex:
+            list(ex.map(self.one_item, payloads))
+        wall = time.monotonic() - t0
+        return wall
+
+
+BOUNDARIES = (
+    "no KV-transfer cost modeled; prime-as-transfer is the core "
+    "approximation; single machine; TTFT approximated by "
+    "full-request latency at max_tokens 1; TPOT amortizes the "
+    "cache-hit KV load into per-token time"
+)
+
+
+def _nearest_rank(sorted_vals, p):
+    import math
+
+    n = len(sorted_vals)
+    if not n:
+        return 0.0
+    return sorted_vals[max(0, min(n - 1, math.ceil(p * n) - 1))]
+
+
+def summarize(args, results, wall_s):
+    failed = [r for r in results if r.get("failed")]
+    ok = [r for r in results if not r.get("failed")]
+    n = len(ok)
+    prompt = sum(r["prompt_tokens"] for r in ok)
+    cached = sum(r["cached_tokens"] for r in ok)
+    output = sum(r["completion_tokens"] for r in ok)
+    computed = prompt - cached
+    lat = sorted(r["latency_s"] for r in ok)
+    hit = 100.0 * cached / prompt if prompt else 0.0
+
+    summary = {
+        "Phase": args.phase,
+        "Concurrency": args.parallel,
+        "Requests": n,
+        "Failed Requests": len(failed),
+        "Wall (s)": round(wall_s, 3),
+        "Prompt Tokens": prompt,
+        "Cached Tokens": cached,
+        "Computed Prompt Tokens": computed,
+        "Output Tokens": output,
+        "KV Cache Hit Rate (%)": round(hit, 4),
+        "Prefill Throughput (tok/s)": round(prompt / wall_s, 4),
+        "Computed Throughput (tok/s)": round(computed / wall_s, 4),
+        "Output Throughput (tok/s)": round(output / wall_s, 4),
+        "Requests/s": round(n / wall_s, 4),
+        "Latency p50 (s)": round(_nearest_rank(lat, 0.50), 4),
+        "Latency p99 (s)": round(_nearest_rank(lat, 0.99), 4),
+        "Boundaries": BOUNDARIES,
+    }
+    if args.phase == "d-measure" and n:
+        tpots = sorted(
+            1000.0 * r["latency_s"] / max(1, r["completion_tokens"]) for r in ok
+        )
+        summary["TPOT p50 (ms)"] = round(_nearest_rank(tpots, 0.50), 4)
+        summary["TPOT p99 (ms)"] = round(_nearest_rank(tpots, 0.99), 4)
+    return summary
+
+
+def main():
+    args = parse_args()
+    data = json.load(open(args.dataset))
+    convs = data["conversations"]
+
+    runner = Runner(args)
+    wall = runner.run(convs)
+
+    if args.phase == "d-prime":
+        hit = summarize(args, runner.results, wall)["KV Cache Hit Rate (%)"]
+        print(
+            f"primed {len(runner.results)} conversations in {wall:.1f}s "
+            f"(hit during prime: {hit:.1f}%)"
+        )
+        return
+
+    summary = summarize(args, runner.results, wall)
+    outdir = (
+        f"{args.outputs_dir}/{args.name}/"
+        f"parallel_{args.parallel}_number_{args.number}"
+    )
+    import os
+
+    os.makedirs(outdir, exist_ok=True)
+    with open(f"{outdir}/benchmark_summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+    print(json.dumps(summary))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #1187 (merged). Adds `test/agentic_benchmark/kimi_k3/tokenspeed/pd_sim/` — a PD-disaggregation simulation bench that ranks the serve configs by prefill-node and decode-node throughput separately, which the agentic bench cannot answer (its decode numbers mix prefill interference into every decode figure).

## What's in pd_sim

- `p_bench.sh` — P-node sweep over the TP configs (DP is a decode-side scaling choice, not a P-node candidate): P-fresh (cold 50K first turns, compute-bound, cache-hit <=5% guard) then P-cached (primed prefix + turn-2 increment, computed tok/s, hit >=95% guard)
- `d_bench.sh` — D-node sweep over all three configs: prime-as-transfer at low concurrency, 30s settle, rolling-admission decode ladder with cache-hit guard and a memory ledger (VOIDs on >4GiB climb)
- `pd_client.py` — stdlib phased client (evalscope's plugin has no prime/measure phase control); dedups conversations by first-turn content (the frozen artifact has 7 exact duplicate first-turn pairs, 64 unique of 71 — a duplicate reaching a later P-fresh rung scores as a cache hit and breaks the guard)
- `collect_outputs.py` — tables + VOID guards (`hit`, `Nfailed`, `short` on Requested/Requests mismatch, `mem-climb`) + informational `Retried` column + P:D provisioning-ratio helper

## On-machine validation (attn_tp8_moe_ep8, B300x8, 2026-08-23)

Both sweeps + merged collect ran end to end (pre-dedup revision; the dedup fix removes the two P-fresh VOIDs below):

- **D-sim** (all 5 rungs valid): output tok/s/GPU 6.4 / 10.7 / 18.1 / 16.7 / 19.0 at concurrency 1/2/4/8/16 — saturates ~conc 4; memory ledger flat (<=6 MiB climb, confirming the prefill-transient argument)
- **P-fresh**: ~2.3K tok/s/GPU, compute-saturated already at concurrency 1; conc-2/16 rungs VOIDed by the duplicate first turns (guards fired as designed; fixed by the dedup commit)
- **P-cached** (all valid, hit 97.2-97.6%): 404 -> 1143 tok/s/GPU, still climbing at conc 16
- **P:D sizing** (default 50K/15K/6K mix): 0.11 -> ~1 P-GPU per 9 D-GPUs

The duplicate-first-turn finding also concerns the parent agentic bench and CI gates, which share the frozen artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
