### PR TITLE
perf(kda): size the batched commit launches from the grid they actual…

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -1697,23 +1697,40 @@ def kda_gate_precompute_kernel(
 _SM_COUNT: dict[int, int] = {}
 
 
-def _gate_tiling(rows: int, num_heads: int, head_dim: int, device):
-    """Rows and gate channels per program, widest grid that still fills the GPU.
-
-    Both knobs only decide which rows a program owns -- every row still
-    reduces over the whole D_FA axis -- so this never moves a result. What it
-    does move is whether the weight-tile load has any parallelism to hide
-    behind: small batches need a narrower tiling to cover the machine, and at
-    large row counts the choices converge.
-    """
+def _sm_count(device) -> int:
+    """Multiprocessor count for the device, memoized per index."""
     index = device.index if device.index is not None else torch.cuda.current_device()
     sms = _SM_COUNT.get(index)
     if sms is None:
         sms = torch.cuda.get_device_properties(index).multi_processor_count
         _SM_COUNT[index] = sms
+    return sms
+
+
+def _gate_tiling(rows: int, num_heads: int, head_dim: int, device, layers: int = 1):
+    """Rows and gate channels per program: the widest tile the grid can afford.
+
+    Both knobs only decide which rows a program owns -- every row still
+    reduces over the whole D_FA axis -- but the tile shape does pick the
+    reduction tree, so two tilings agree to a few ulp rather than bit for bit.
+    What the choice really moves is the ``[BK, D_FA]`` weight traffic, which
+    scales with ``cdiv(rows, block_t)``: a narrower row block buys parallelism
+    by reading that tile again in every program, so taking one the grid did
+    not need is pure amplification.
+
+    ``layers`` is the batched caller's outer grid dimension. Omitting it made
+    the estimate short by that factor and drove the all-layer launch to the
+    narrowest tiling at every batch size.
+    """
+    sms = _sm_count(device)
     for block_t, block_k in ((8, 32), (4, 32), (2, 16), (1, 16)):
+        if block_t > rows:
+            continue
         programs = (
-            num_heads * triton.cdiv(rows, block_t) * triton.cdiv(head_dim, block_k)
+            layers
+            * num_heads
+            * triton.cdiv(rows, block_t)
+            * triton.cdiv(head_dim, block_k)
         )
         if programs >= 4 * sms:
             return block_t, min(block_k, triton.next_power_of_2(head_dim))
@@ -2264,7 +2281,9 @@ def batched_recurrent_kda_replay_commit(
     layers = addresses.shape[0]
     batch = accepted_length.numel()
     rows = batch * draft_token_num
-    block_t, block_k = _gate_tiling(rows, num_heads, head_dim, addresses.device)
+    block_t, block_k = _gate_tiling(
+        rows, num_heads, head_dim, addresses.device, layers=layers
+    )
     batched_kda_gate_precompute_kernel[
         (
             layers * num_heads,
@@ -2307,7 +2326,15 @@ def batched_recurrent_kda_replay_commit(
         num_warps=1,
         num_stages=2,
     )
-    batched_kda_commit_conv_window_kernel[(layers, batch, 1)](
+    # Swept 8192..64 at every batch size: 128 wins from batch 8 up (3x the
+    # whole-row block at 32) and ties the best within noise at batch 1, while
+    # 64 falls off a cliff. A fixed block beats sizing to the grid, which
+    # stopped narrowing while the wins were still there.
+    conv_dim = 3 * num_heads * head_dim
+    conv_block = 128
+    batched_kda_commit_conv_window_kernel[
+        (layers, batch, triton.cdiv(conv_dim, conv_block))
+    ](
         addresses,
         read_indices,
         write_indices,
@@ -2316,10 +2343,10 @@ def batched_recurrent_kda_replay_commit(
         T=draft_token_num,
         STRIDE_QKV=qkv_stride,
         STRIDE_CONV=conv_stride,
-        CONV_DIM=3 * num_heads * head_dim,
+        CONV_DIM=conv_dim,
         LAYERS_PER_GROUP=layers_per_group,
-        BLOCK=triton.next_power_of_2(3 * num_heads * head_dim),
-        num_warps=8,
+        BLOCK=conv_block,
+        num_warps=1,
     )
 
 
@@ -2416,13 +2443,7 @@ def kda_commit_conv_window(
     )
     # Narrow the column block until the grid covers the machine: at one
     # request the widest block leaves 18 programs for 4608 channels.
-    index = write_indices.device.index
-    if index is None:
-        index = torch.cuda.current_device()
-    sms = _SM_COUNT.get(index)
-    if sms is None:
-        sms = torch.cuda.get_device_properties(index).multi_processor_count
-        _SM_COUNT[index] = sms
+    sms = _sm_count(write_indices.device)
     # Narrowing past 64 stops paying: the columns each program owns get too
     # few to amortize its own setup.
     block = 256

--- a/tokenspeed-kernel/test/ops/attention/test_kda_replay_commit.py
+++ b/tokenspeed-kernel/test/ops/attention/test_kda_replay_commit.py
@@ -39,6 +39,8 @@ requires_registered_replay = pytest.mark.skipif(
 )
 
 from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (  # noqa: E402
+    _gate_tiling,
+    batched_kda_commit_conv_window_kernel,
     batched_recurrent_kda_replay_commit,
     fused_recurrent_kda_replay_commit,
     fused_recurrent_kda_verify_megafuse,
@@ -134,6 +136,60 @@ def _batched_static_args(x, layers_per_group):
         layers_per_group=layers_per_group,
         lower_bound=LOWER_BOUND,
     )
+
+
+def test_gate_tiling_counts_every_layer_in_the_grid():
+    """The batched launch tiles for its own grid, which spans all layers."""
+    dev = torch.device(DEV)
+    rows = 8
+    one = _gate_tiling(rows, HV, K, dev)
+    many = _gate_tiling(rows, HV, K, dev, layers=69)
+    # More programs can only let an earlier, wider rung clear the threshold.
+    assert many[0] >= one[0] and many[1] >= one[1]
+    assert _gate_tiling(rows, HV, K, dev, layers=10**6) == (8, 32)
+    # A rung wider than the row count spends most of its lanes on rows that
+    # do not exist, so the ladder skips it however wide the grid looks.
+    for narrow in (1, 2, 4):
+        assert _gate_tiling(narrow, HV, K, dev, layers=10**6)[0] <= narrow
+
+
+@pytest.mark.parametrize("block", [64, 128, 256, 512, 2048])
+def test_batched_conv_window_is_independent_of_its_column_block(block):
+    """Splitting the window publish across columns must not move a byte."""
+    layers, n, t = 3, 4, 4
+    source = [_window(n, t, seed=700 + layer) for layer in range(layers)]
+    reads = torch.stack([source[0]["read_indices"]] * layers).to(torch.int32)
+    writes = torch.stack(
+        [torch.arange(9, 9 + n, device=DEV, dtype=torch.int32)] * layers
+    )
+    accepted = torch.tensor([0, t, 1, 3], device=DEV, dtype=torch.int32)
+    conv_dim = 3 * HV * K
+
+    def publish(block_size):
+        xs = [
+            {k: (v.clone() if torch.is_tensor(v) else v) for k, v in x.items()}
+            for x in source
+        ]
+        batched_kda_commit_conv_window_kernel[
+            (layers, n, (conv_dim + block_size - 1) // block_size)
+        ](
+            _batched_descriptor(xs),
+            reads,
+            writes,
+            accepted,
+            n,
+            T=t,
+            STRIDE_QKV=xs[0]["qkv_raw"].stride(0),
+            STRIDE_CONV=xs[0]["conv_pool"].stride(0),
+            CONV_DIM=conv_dim,
+            LAYERS_PER_GROUP=1,
+            BLOCK=block_size,
+            num_warps=min(8, max(1, block_size // 128)),
+        )
+        return [x["conv_pool"] for x in xs]
+
+    for narrow, wide in zip(publish(block), publish(4096), strict=True):
+        torch.testing.assert_close(narrow, wide, atol=0, rtol=0)
 
 
 def test_batched_replay_is_bit_identical_and_descriptor_sensitive():


### PR DESCRIPTION
…ly have

Two launch-side defects in the descriptor-table KDA commit, both of which made a decision from a program count that did not match the grid.

`_gate_tiling` estimated parallelism as `num_heads * row_blocks * k_blocks`, but the batched launch's first grid dimension is `layers * num_heads`. At 69 layers the estimate was short by that factor, so a one-request step fell through the whole ladder to the narrowest `(1, 16)` rung. That rung reads the `[BK, D_FA]` weight tile once per row block, so it paid 8x the weight traffic it needed. Isolating the two knobs at production geometry, the row block is what matters -- `BT 1 -> 8` is -39% at 8 rows and -67% at 512, while `BK 16 -> 32` is -3% on its own. The ladder also now skips a rung wider than the row count instead of counting programs that own no rows.

`batched_kda_commit_conv_window` launched one whole-row block of `next_power_of_2(4608) = 8192` per (layer, request), masking off 44% of its lanes. Sweeping every column block from 8192 down to 64 at production geometry, 128 wins from batch 8 up -- 3.0x the whole-row block at batch 32 -- and ties the best within noise at batch 1, while 64 falls off a cliff. A fixed block beats sizing to the machine: a first attempt narrowed only until the grid covered the SMs and stopped while 12-17% was still on the table.

Effect on the whole commit, two independent runs on an exclusive GB300: batch 1 -34.0%/-31.5%, batch 8 -0.1%/-3.8%, batch 32 -1.4%/-1.7%, batch 64 -1.3%/-1.3%. Read that shape honestly -- only batch 1 gets a large win, because the gate is a much bigger share of the commit when there are few rows. The conv kernel's isolated 3.0x shows up as ~1.3% end to end, which matches its 1.7% share of KDA GPU time; the isolated ratio is not the serving win. At batch 8 the conv change alone measured +2.5% and -1.8% in the two runs, so that cell is neutral within noise.

One behaviour change worth stating. The batched path and the per-layer loop now pick different gate tilings at production shape, so they agree to about 1.9e-7 relative rather than bit for bit. A request can cross that boundary: `_batched_replay_ready` is false until every layer is bound into the descriptor table. The divergence is four orders of magnitude below the bf16 quantisation of the inputs feeding it, and the existing loop-oracle tests already assert agreement at 1e-6, not equality.

Tests: `test_gate_tiling_counts_every_layer_in_the_grid` pins the layer factor and the too-wide-rung skip;
`test_batched_conv_window_is_independent_of_its_column_block` checks that 64/128/256/512/2048 all publish the same bytes as one whole-row block.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
