### PR TITLE
perf(attn_res): remove Blackwell 16K token limit

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attn_res/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attn_res/__init__.py
@@ -29,8 +29,9 @@ from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 __all__ = ["attn_res_fwd", "attn_res_fwd_available"]
 
 # The Blackwell launcher instantiates aligned hidden sizes in [4096, 8192].
+# Its block-residual source stride is passed to CUDA as a signed 32-bit int.
 # AMD Gluon currently specializes Kimi K3's H=7168 fused-output-norm path.
-_MAX_BLACKWELL_TOKENS = 16384
+_MAX_BLACKWELL_TOKENS = ((1 << 31) - 1) // 7168
 _MAX_AMD_GLUON_TOKENS = 65536
 _MAX_N = 12
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/attn_res.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/attn_res.py
@@ -62,7 +62,7 @@ def attn_res_fwd_packed(
 
     Candidates are ``block_residual[0..num_blocks-1]`` then ``layer_residual``
     (N = num_blocks + 1). All inputs must be contiguous bf16 CUDA tensors;
-    supports B = 1, N in [1, 12], T in [1, 16384], H = 7168.
+    supports B = 1, N in [1, 12], T in [1, 299593], H = 7168.
 
     Args:
         layer_residual: bf16 ``[T, B, H]`` current residual stream; updated in

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/attn_res/attn_res_fwd_online_v2.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/attn_res/attn_res_fwd_online_v2.cu
@@ -50,7 +50,7 @@ __device__ __forceinline__ const bf16_t* residual_addr(
     int token, int block_stride_m, int block_stride_r, int H) {
   if (source < N - 1) {
     return block_res + static_cast<long long>(token) * block_stride_m +
-           source * block_stride_r;
+           static_cast<long long>(source) * block_stride_r;
   }
   return layer_res + static_cast<long long>(token) * H;
 }

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/attn_res_binding.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/attn_res_binding.cu
@@ -26,6 +26,7 @@
  * the final candidate. Caller allocates the output.
  */
 #include <cstdint>
+#include <limits>
 
 #include "attn_res/attn_res.cuh"
 #include "tvm_ffi_utils.h"
@@ -80,19 +81,26 @@ static void attn_res_fwd_impl(TensorView layer_residual, TensorView block_residu
   TVM_FFI_ICHECK_EQ(layer_residual.ndim(), 3) << "attn_res_fwd: layer_residual must be [T, B, H]";
   TVM_FFI_ICHECK_EQ(block_residual.ndim(), 4) << "attn_res_fwd: block_residual must be [K, T, B, H]";
 
-  const int T = static_cast<int>(layer_residual.size(0));
-  const int B = static_cast<int>(layer_residual.size(1));
-  const int H = static_cast<int>(layer_residual.size(2));
+  const int64_t T64 = layer_residual.size(0);
+  const int64_t B64 = layer_residual.size(1);
+  const int64_t H64 = layer_residual.size(2);
   const int N = num_blocks + 1;
 
   TVM_FFI_ICHECK(num_blocks >= 0 && num_blocks <= block_residual.size(0))
       << "attn_res_fwd: num_blocks=" << num_blocks << " must be in [0, "
       << block_residual.size(0) << "]";
 
-  TVM_FFI_ICHECK_EQ(B, 1) << "attn_res_fwd: only B=1 supported, got " << B;
+  TVM_FFI_ICHECK_EQ(B64, 1) << "attn_res_fwd: only B=1 supported, got " << B64;
   TVM_FFI_ICHECK(N >= 1 && N <= 12) << "attn_res_fwd: N=" << N << " must be in [1, 12]";
-  TVM_FFI_ICHECK(T >= 1 && T <= 16384) << "attn_res_fwd: T=" << T << " must be in [1, 16384]";
-  TVM_FFI_ICHECK_EQ(H, 7168) << "attn_res_fwd: H must be 7168";
+  constexpr int64_t kMaxTokens = std::numeric_limits<int>::max() / 7168;
+  TVM_FFI_ICHECK(T64 >= 1 && T64 <= kMaxTokens)
+      << "attn_res_fwd: T=" << T64 << " must be in [1, " << kMaxTokens
+      << "] so the block-residual stride fits in int32";
+  TVM_FFI_ICHECK_EQ(H64, 7168) << "attn_res_fwd: H must be 7168";
+
+  const int T = static_cast<int>(T64);
+  const int B = static_cast<int>(B64);
+  const int H = static_cast<int>(H64);
 
   TVM_FFI_ICHECK_EQ(encode_dlpack_dtype(layer_residual.dtype()), bfloat16_code)
       << "attn_res_fwd: layer_residual must be bf16";

--- a/tokenspeed-kernel/test/thirdparty/test_attn_res_online_v2.py
+++ b/tokenspeed-kernel/test/thirdparty/test_attn_res_online_v2.py
@@ -112,6 +112,53 @@ def test_online_v2_matches_reference(
         torch.testing.assert_close(layer, original_layer, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize(
+    ("tokens", "target_block"),
+    [(16_385, 0), (65_536, 5)],
+)
+def test_online_v2_long_sequence_regression(tokens: int, target_block: int) -> None:
+    """Exercise the post-16K path and the widened source address arithmetic."""
+    hidden_size = 7168
+    block_capacity = target_block + 1
+    layer = torch.zeros(tokens, 1, hidden_size, device="cuda", dtype=torch.bfloat16)
+    blocks = torch.zeros(
+        block_capacity,
+        tokens,
+        1,
+        hidden_size,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    blocks[target_block].fill_(1)
+    res_weight = torch.ones(hidden_size, device="cuda", dtype=torch.bfloat16)
+    rms_weight = torch.ones(hidden_size, device="cuda", dtype=torch.bfloat16)
+
+    expected, _ = _reference(
+        layer[:1],
+        None,
+        blocks[:, :1],
+        res_weight,
+        rms_weight,
+        None,
+        block_capacity,
+        1e-5,
+    )
+    actual = attn_res_fwd_packed(
+        layer,
+        blocks,
+        res_weight,
+        rms_weight,
+        1e-5,
+        num_blocks=block_capacity,
+    )
+
+    # At T=65536, source 5 makes source * (T * H) exceed int32.
+    step = max(1, tokens // 8)
+    actual_sample = actual[::step, :, :16]
+    expected_sample = expected[:, :, :16].expand_as(actual_sample)
+    torch.testing.assert_close(actual_sample, expected_sample, atol=0.05, rtol=0.05)
+
+
 @pytest.mark.parametrize("with_out_norm", [False, True])
 def test_online_v2_cuda_graph_capture(with_out_norm: bool) -> None:
     torch.manual_seed(23)


### PR DESCRIPTION
## Summary

Remove the obsolete 16K Blackwell AttnRes limit so long prefills use the fused CUDA kernel instead of the PyTorch fallback, while keeping long-sequence address handling safe.

## Validation

On 8x B300 with Kimi-K3 NVFP4, attention TP=8, MoE TP=8, and no prefix-cache hits:

- 32K/60K mean TTFT: `5.316s/10.375s -> 1.338s/2.674s` (3.97x/3.88x); throughput: `6.16K/5.78K -> 24.50K/22.44K` tok/s.
- 60K peak memory: `264.9 -> 220.6 GiB/GPU` (44.3 GiB saved).
- 65K single-chunk prefill: baseline OOM; modified kernel completes startup and three requests at `238.3 GiB/GPU` peak.
- Correctness: `max_abs=0` at `T=16,385`, `32,768`, and `65,536`.
