### PR TITLE
perf(kda): widen the verify block where the grid cannot fill the machine

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -925,9 +925,14 @@ def _kda_verify_launch_config(
     """Route measured verify launch defaults while preserving overrides."""
     if split_producers and value_dim == 128 and not store_states:
         routed_bv = 8 if batch_size < 16 else 16
+        # Under four requests the grid is only a couple of blocks per SM, so
+        # widening them pays: 8-11% at 1..3, bit-identical, and swept as the
+        # boundary rather than assumed -- four warps loses from four requests
+        # up and is 49% slower by eight.
+        routed_warps = 4 if batch_size < 4 else 1
         return (
             routed_bv if bv is None else bv,
-            1 if num_warps is None else num_warps,
+            routed_warps if num_warps is None else num_warps,
             3 if num_stages is None else num_stages,
         )
     return (

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -113,21 +113,28 @@ def test_kda_verify_bv_routing(batch_size, value_dim, store_states, expected) ->
     assert _kda_verify_bv(batch_size, value_dim, store_states) == expected
 
 
-@pytest.mark.parametrize("batch_size,expected_bv", [(1, 8), (15, 8), (16, 16)])
-def test_kda_verify_split_launch_routing(batch_size, expected_bv) -> None:
+@pytest.mark.parametrize(
+    ("batch_size", "expected"),
+    [(1, (8, 4, 3)), (3, (8, 4, 3)), (4, (8, 1, 3)), (15, (8, 1, 3)), (16, (16, 1, 3))],
+)
+def test_kda_verify_split_launch_routing(batch_size, expected) -> None:
+    """Both routed knobs, including where the wide-block window closes."""
     from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
         _kda_verify_launch_config,
     )
 
-    assert _kda_verify_launch_config(
-        batch_size,
-        128,
-        False,
-        split_producers=True,
-        bv=None,
-        num_warps=None,
-        num_stages=None,
-    ) == (expected_bv, 1, 3)
+    assert (
+        _kda_verify_launch_config(
+            batch_size,
+            128,
+            False,
+            split_producers=True,
+            bv=None,
+            num_warps=None,
+            num_stages=None,
+        )
+        == expected
+    )
 
 
 def test_kda_verify_split_launch_requires_both_hoists_and_honors_overrides() -> None:


### PR DESCRIPTION
The split-producer verify route pins `num_warps` to 1 at every batch size. That is right once the grid is large, but under four requests it is not: at BV=8 the grid is `16 * batch * heads` programs, so one request leaves about 1.3 blocks per SM and three leave four. Four warps per block covers the machine better exactly there.

Swept the spill-free neighbourhood at production geometry rather than assuming a threshold -- batch 1/2/3 gain 9.7%/11.5%/7.9%, batch 4 is a wash, and by batch 8 four warps costs 49% because the grid no longer needs the help and the extra lanes only thin the tile. The window closes at four, so that is where the routing switches back.

Two things worth stating. The win is bit-identical: at these batch sizes the wide block reproduces the narrow one exactly, so nothing downstream shifts. And the compile audit gated the sweep -- BV=64 at one warp spills 248 registers and BV=128 spills 922, so only configurations the compiler kept spill-free were ever timed.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
