### PR TITLE
feat(mla): serve a block drafter from the CuteDSL MLA backend

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -126,6 +126,9 @@ class CuteDSLMLABackend(AttentionBackend):
         # Set by the registry before graph capture; see mark_cache_contract.
         self._cache_contract_bound = False
 
+        # Block draft: rows expand per block position; see _block_decode_active.
+        self.draft_block_decode = bool(config.draft_block_decode)
+
         self.max_context_len = config.context_len
         self.kernel_page_size = (
             config.kernel_page_size
@@ -526,6 +529,22 @@ class CuteDSLMLABackend(AttentionBackend):
             block_kv_indices = self._create_block_kv_indices(bs, max_blocks, page_table)
             group_out_cache_loc = None
 
+        if self._block_decode_active:
+            block_kv_indices, block_seq_lens = self._expand_block_decode_metadata(
+                block_kv_indices, seq_lens[:bs], bs
+            )
+            self.forward_decode_metadata = CuteDSLMLADecodeMetadata(
+                block_kv_indices=block_kv_indices,
+                max_seq_len_k=self.max_context_len,
+                seq_lens_k=block_seq_lens,
+                # Every row here is a block row, so the drafter's num_extends
+                # would slice the block away.
+                num_extends=0,
+                group_out_cache_loc=None,
+                group_q_len_per_req=1,
+            )
+            return
+
         self.forward_decode_metadata = CuteDSLMLADecodeMetadata(
             block_kv_indices=block_kv_indices,
             max_seq_len_k=self.max_context_len,
@@ -533,6 +552,91 @@ class CuteDSLMLABackend(AttentionBackend):
             num_extends=num_extends,
             group_out_cache_loc=group_out_cache_loc,
             group_q_len_per_req=q_len_per_req,
+        )
+
+    @property
+    def _block_decode_active(self) -> bool:
+        return self.draft_block_decode and self.spec_num_tokens > 1
+
+    def _expand_block_decode_metadata(
+        self,
+        block_kv_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        bs: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """One decode row per block position, all sharing the block-end length.
+
+        The decode kernel derives each row's mask from its cache length, so
+        giving all ``spec_num_tokens`` rows of a request the same length makes
+        every block query attend over the whole block -- including the positions
+        after it -- which is the block draft's semantics.
+        """
+        spec = self.spec_num_tokens
+        expanded_indices = block_kv_indices.repeat_interleave(spec, dim=0)
+        expanded_seq_lens = (
+            seq_lens.clamp(spec, self.max_context_len)
+            .repeat_interleave(spec)
+            .contiguous()
+        )
+        return expanded_indices, expanded_seq_lens
+
+    def _capture_block_decode_graph(self, bs: int, max_blocks: int) -> None:
+        """Record graph metadata over the expanded block rows.
+
+        The block-end lengths are written by the drafter *inside* the captured
+        graph (see ``fill_block_decode_seq_lens``), so they are only seeded here
+        with a value the capture run can safely read.
+        """
+        spec = self.spec_num_tokens
+        rows = bs * spec
+        block_kv_indices = self.decode_cuda_graph_kv_indices[:rows, :max_blocks]
+        block_kv_indices.zero_()
+        seq_lens_k = self.cuda_graph_seq_lens_buf[:rows]
+        seq_lens_k.fill_(spec)
+        metadata = CuteDSLMLADecodeMetadata(
+            block_kv_indices=block_kv_indices,
+            max_seq_len_k=self.max_context_len,
+            seq_lens_k=seq_lens_k,
+            num_extends=0,
+            group_out_cache_loc=None,
+            group_q_len_per_req=1,
+        )
+        self.decode_cuda_graph_metadata[bs] = metadata
+        self.forward_decode_metadata = metadata
+
+    def _replay_block_decode_page_table(
+        self, bs: int, page_table: torch.Tensor | None
+    ) -> None:
+        """Refresh the block rows' page ids, broadcast from one row per request.
+
+        The lengths are re-derived in-graph from the live draft length, so they
+        are deliberately not touched here.
+        """
+        spec = self.spec_num_tokens
+        width = self.decode_cuda_graph_kv_indices.shape[1]
+        rows = self.decode_cuda_graph_kv_indices[: bs * spec].view(bs, spec, width)
+        if page_table is None:
+            rows.zero_()
+            return
+        real_bs = min(int(page_table.shape[0]), bs)
+        cols = min(int(page_table.shape[1]), width)
+        if real_bs > 0:
+            rows[:real_bs, :, :cols].copy_(page_table[:real_bs, None, :cols])
+            if cols < width:
+                rows[:real_bs, :, cols:].zero_()
+        if real_bs < bs:
+            rows[real_bs:].zero_()
+
+    def fill_block_decode_seq_lens(self, bs: int, block_seq_lens: torch.Tensor) -> None:
+        """Broadcast each request's block-end length to its block rows.
+
+        Called by the drafter inside the captured graph, so every replay
+        re-derives the expanded lengths from the live draft length, which is
+        itself recomputed in-graph from the target's accept lengths.
+        """
+        spec = self.spec_num_tokens
+        self.cuda_graph_seq_lens_buf[: bs * spec].view(bs, spec).copy_(
+            block_seq_lens[:bs].clamp(spec, self.max_context_len).unsqueeze(1)
         )
 
     def _init_prefill_metadata(
@@ -629,12 +733,14 @@ class CuteDSLMLABackend(AttentionBackend):
     def init_cuda_graph_state(self, max_bs: int):
         # Own the cache-seqlens buffer; replay copies the live lengths in, so
         # graph state does not depend on the controller mutating a shared tensor.
+        # Block decode records spec_num_tokens rows per request.
+        graph_rows = max_bs * (self.spec_num_tokens if self._block_decode_active else 1)
         self.cuda_graph_seq_lens_buf = torch.zeros(
-            max_bs, dtype=torch.int32, device=self.device
+            graph_rows, dtype=torch.int32, device=self.device
         )
         max_blocks = self._calc_padded_blocks(self.max_context_len)
         self.decode_cuda_graph_kv_indices = torch.zeros(
-            (max_bs, max_blocks), dtype=torch.int32, device=self.device
+            (graph_rows, max_blocks), dtype=torch.int32, device=self.device
         )
         if self._cache_contract_bound:
             # The Paged cache decode graph uses one absolute latent write slot per
@@ -673,6 +779,9 @@ class CuteDSLMLABackend(AttentionBackend):
             )
 
         max_blocks = self._calc_padded_blocks(self.max_context_len)
+        if self._block_decode_active:
+            self._capture_block_decode_graph(bs, max_blocks)
+            return
         block_kv_indices = self.decode_cuda_graph_kv_indices[:bs, :max_blocks]
 
         if uses_cache_groups:
@@ -735,6 +844,11 @@ class CuteDSLMLABackend(AttentionBackend):
             )
 
         metadata = self.decode_cuda_graph_metadata[bs]
+        if self._block_decode_active:
+            # Lengths come from fill_block_decode_seq_lens, inside the graph.
+            self._replay_block_decode_page_table(bs, page_table)
+            self.forward_decode_metadata = metadata
+            return
         # The captured metadata is the source of truth: a cache write-location buffer
         # exists iff this bs was captured on the Paged cache path.
         uses_cache_groups = metadata.group_out_cache_loc is not None
@@ -863,8 +977,12 @@ class CuteDSLMLABackend(AttentionBackend):
 
         metadata = self.forward_decode_metadata
         num_extends = metadata.num_extends
-        q_len_per_req = q.shape[0] // bs
-        query = q.view(bs, q_len_per_req, layer.tp_q_head_num, layer.head_dim)
+        if self._block_decode_active:
+            # Keeping the block on the query axis would re-impose causal order.
+            query = q.view(-1, layer.tp_q_head_num, layer.head_dim).unsqueeze(1)
+        else:
+            q_len_per_req = q.shape[0] // bs
+            query = q.view(bs, q_len_per_req, layer.tp_q_head_num, layer.head_dim)
 
         softmax_scale = layer.scaling
         if self.data_type == torch.float8_e4m3fn:

--- a/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-mmmu-pro-vision-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-mmmu-pro-vision-gb300-slurm.yaml
@@ -23,7 +23,7 @@ server:
     --speculative-algorithm DSPARK
     --speculative-draft-model-path /models/Inferact--Kimi-K3-DSpark/cf6b8244620e7ea4b0651d214f28e89eac75bed6
     --speculative-num-draft-tokens 8
-    --drafter-attention-backend mla
+    --drafter-attention-backend tokenspeed_mla
     --trust-remote-code
     --max-model-len 131072
     --kv-cache-dtype fp8

--- a/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-ocr-bench-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-ocr-bench-gb300-slurm.yaml
@@ -23,7 +23,7 @@ server:
     --speculative-algorithm DSPARK
     --speculative-draft-model-path /models/Inferact--Kimi-K3-DSpark/cf6b8244620e7ea4b0651d214f28e89eac75bed6
     --speculative-num-draft-tokens 8
-    --drafter-attention-backend mla
+    --drafter-attention-backend tokenspeed_mla
     --trust-remote-code
     --max-model-len 65536
     --kv-cache-dtype fp8

--- a/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -1,7 +1,9 @@
 api_version: ci.tokenspeed.io/v1
 # NVFP4 target + DSpark speculative decoding, on the same two-node shape as
 # the speculator-free NVFP4 gate. Speculative flags follow the proven AMD
-# DSpark gate (kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml):
+# DSpark gate (kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml), except
+# the drafter backend: that gate's `mla` is the portable choice, and CuteDSL
+# is faster where it exists.
 # --disable-prefill-graph because prefill graphs add ~40 capture buckets on
 # top of the decode ones the speculator rides on, and the draft weights plus
 # its BF16 cache (kept BF16 automatically when the target KV is FP8) need the
@@ -30,7 +32,7 @@ server:
     --speculative-algorithm DSPARK
     --speculative-draft-model-path /models/Inferact--Kimi-K3-DSpark/cf6b8244620e7ea4b0651d214f28e89eac75bed6
     --speculative-num-draft-tokens 8
-    --drafter-attention-backend mla
+    --drafter-attention-backend tokenspeed_mla
     --trust-remote-code
     --max-model-len 65536
     --kv-cache-dtype fp8

--- a/test/runtime/test_kimi_k3_cudagraph.py
+++ b/test/runtime/test_kimi_k3_cudagraph.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import os
 import sys
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 import torch
@@ -32,6 +33,9 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+from tokenspeed.runtime.layers.attention.backends import (
+    tokenspeed_mla as tokenspeed_mla_module,
+)
 from tokenspeed.runtime.layers.attention.backends.mla import MLAAttnBackend
 from tokenspeed.runtime.layers.attention.backends.mla_cache_groups import (
     MlaCacheGroupMixin,
@@ -45,6 +49,8 @@ from tokenspeed.runtime.layers.attention.page_table import expand_page_table
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 _PAGE_SIZE = 64  # kernel page
+_KV_LORA = 4
+_ROPE = 4
 _LOGICAL_P = 128  # logical block size (ratio 2 kernel pages per logical page)
 _MAX_CTX = 256
 
@@ -54,6 +60,7 @@ def _bare_mla_backend(
     cache_contract: bool,
     is_draft: bool = False,
     spec_num_tokens: int = 1,
+    draft_block_decode: bool = False,
 ) -> CuteDSLMLABackend:
     """A CuteDSLMLABackend with only the attributes the CUDA-graph metadata
     paths touch — the full ctor JIT-compiles CuteDSL kernels (GPU only)."""
@@ -63,6 +70,12 @@ def _bare_mla_backend(
     backend.max_context_len = _MAX_CTX
     backend.is_draft = is_draft
     backend.spec_num_tokens = spec_num_tokens
+    backend.draft_block_decode = draft_block_decode
+    backend.kv_lora_rank = _KV_LORA
+    backend.qk_rope_head_dim = _ROPE
+    backend.kv_cache_dim = _KV_LORA + _ROPE
+    backend.data_type = torch.bfloat16
+    backend.cutedsl_workspace = None
     backend._block_table_aliased = False
     backend._cache_groups_bound = False
     backend._cache_contract_bound = False
@@ -441,3 +454,175 @@ def test_amd_mla_eager_prefill_derives_group_write_locations(monkeypatch) -> Non
         ).tolist()
         == expected.tolist()
     )
+
+
+def test_block_decode_expands_one_row_per_block_position() -> None:
+    """A block draft's rows all carry the block-end length, which is what makes
+    the block non-causal: the kernel masks each row by its own cache length."""
+    spec = 4
+    backend = _bare_mla_backend(
+        cache_contract=False,
+        is_draft=True,
+        spec_num_tokens=spec,
+        draft_block_decode=True,
+    )
+    assert backend._block_decode_active
+    table = torch.tensor([[3, 4], [7, 8]], dtype=torch.int32)
+    seq_lens = torch.tensor([9, 130], dtype=torch.int32)
+
+    rows, lens = backend._expand_block_decode_metadata(table, seq_lens, 2)
+
+    assert rows.tolist() == [[3, 4]] * spec + [[7, 8]] * spec
+    assert lens.tolist() == [9] * spec + [130] * spec
+
+
+def test_block_decode_clamps_a_length_below_the_block() -> None:
+    """A request shorter than the block would ask the kernel for keys it has
+    no page for."""
+    spec = 8
+    backend = _bare_mla_backend(
+        cache_contract=False,
+        is_draft=True,
+        spec_num_tokens=spec,
+        draft_block_decode=True,
+    )
+    _, lens = backend._expand_block_decode_metadata(
+        torch.zeros((2, 2), dtype=torch.int32),
+        torch.tensor([1, _MAX_CTX * 4], dtype=torch.int32),
+        2,
+    )
+    assert lens[:spec].tolist() == [spec] * spec
+    assert lens[spec:].tolist() == [_MAX_CTX] * spec
+
+
+def test_block_decode_graph_buffers_hold_every_block_row() -> None:
+    spec, max_bs = 4, 3
+    backend = _bare_mla_backend(
+        cache_contract=False,
+        is_draft=True,
+        spec_num_tokens=spec,
+        draft_block_decode=True,
+    )
+    backend.init_cuda_graph_state(max_bs)
+    assert backend.cuda_graph_seq_lens_buf.shape[0] == max_bs * spec
+    assert backend.decode_cuda_graph_kv_indices.shape[0] == max_bs * spec
+
+
+def test_block_decode_replay_broadcasts_pages_and_scrubs_padding() -> None:
+    """Padded rows must reach the null page, not another request's pages."""
+    spec, max_bs, bs = 4, 3, 3
+    backend = _bare_mla_backend(
+        cache_contract=False,
+        is_draft=True,
+        spec_num_tokens=spec,
+        draft_block_decode=True,
+    )
+    backend.init_cuda_graph_state(max_bs)
+    backend.decode_cuda_graph_kv_indices.fill_(-9)
+    page_table = torch.tensor([[5, 6], [7, 8]], dtype=torch.int32)
+
+    backend._replay_block_decode_page_table(bs, page_table)
+
+    rows = backend.decode_cuda_graph_kv_indices[: bs * spec]
+    assert rows[:spec, :2].tolist() == [[5, 6]] * spec
+    assert rows[spec : 2 * spec, :2].tolist() == [[7, 8]] * spec
+    assert rows[2 * spec :].eq(0).all(), "padded request kept live pages"
+    assert rows[: 2 * spec, 2:].eq(0).all(), "columns past the table were not scrubbed"
+
+
+def test_block_decode_lengths_are_rewritten_per_replay() -> None:
+    """The drafter calls this inside the captured graph, so two replays with
+    different live draft lengths must not share the first one's rows."""
+    spec, max_bs = 4, 2
+    backend = _bare_mla_backend(
+        cache_contract=False,
+        is_draft=True,
+        spec_num_tokens=spec,
+        draft_block_decode=True,
+    )
+    backend.init_cuda_graph_state(max_bs)
+    buf = backend.cuda_graph_seq_lens_buf
+
+    backend.fill_block_decode_seq_lens(2, torch.tensor([40, 50], dtype=torch.int32))
+    assert buf[: 2 * spec].tolist() == [40] * spec + [50] * spec
+    backend.fill_block_decode_seq_lens(2, torch.tensor([41, 99], dtype=torch.int32))
+    assert buf[: 2 * spec].tolist() == [41] * spec + [99] * spec
+
+
+def test_block_decode_stays_off_for_target_and_single_token_drafts() -> None:
+    """The expansion must be unreachable on every path it was not written for."""
+    target = _bare_mla_backend(cache_contract=False, spec_num_tokens=8)
+    assert not target._block_decode_active
+    one = _bare_mla_backend(
+        cache_contract=False,
+        is_draft=True,
+        spec_num_tokens=1,
+        draft_block_decode=True,
+    )
+    assert not one._block_decode_active
+
+
+def test_block_decode_hands_the_kernel_one_query_per_block_row() -> None:
+    """The expansion is only worth anything if it reaches the kernel: keeping
+    the block on the query axis would restore exactly the causal order the
+    draft must not have, and every other case here would still pass."""
+    spec, bs, heads, dim = 4, 2, 3, 8
+    backend = _bare_mla_backend(
+        cache_contract=False,
+        is_draft=True,
+        spec_num_tokens=spec,
+        draft_block_decode=True,
+    )
+    rows, block_lens = backend._expand_block_decode_metadata(
+        torch.tensor([[1, 2], [3, 4]], dtype=torch.int32),
+        torch.tensor([40, 50], dtype=torch.int32),
+        bs,
+    )
+    backend.forward_decode_metadata = CuteDSLMLADecodeMetadata(
+        block_kv_indices=rows,
+        max_seq_len_k=_MAX_CTX,
+        seq_lens_k=block_lens,
+        num_extends=0,
+        group_out_cache_loc=None,
+        group_q_len_per_req=1,
+    )
+    layer = SimpleNamespace(
+        tp_q_head_num=heads,
+        head_dim=dim,
+        layer_id=0,
+        scaling=1.0,
+        v_head_dim=_KV_LORA,
+        k_scale_float=None,
+    )
+    pool = SimpleNamespace(
+        get_key_buffer=lambda _lid: torch.zeros(
+            4 * backend.kernel_page_size, backend.kv_cache_dim, dtype=torch.bfloat16
+        )
+    )
+
+    seen: dict = {}
+
+    def _spy(**kw):
+        seen.update(kw)
+        return torch.zeros(bs * spec, 1, heads, _KV_LORA)
+
+    # The real workspace sizing wants a CUDA device; the kernel itself is spied.
+    with mock.patch.object(
+        tokenspeed_mla_module, "tokenspeed_mla_decode", _spy
+    ), mock.patch.object(
+        type(backend), "_cutedsl_workspace", lambda _self, _q_len: None
+    ):
+        backend.forward_decode(
+            q=torch.zeros(bs * spec, heads, dim, dtype=torch.bfloat16),
+            k=None,
+            v=None,
+            layer=layer,
+            out_cache_loc=torch.zeros(bs * spec, dtype=torch.int64),
+            token_to_kv_pool=pool,
+            bs=bs,
+            save_kv_cache=False,
+        )
+
+    assert seen["query"].shape == (bs * spec, 1, heads, dim)
+    assert seen["block_tables"].shape[0] == bs * spec
+    assert seen["seq_lens"].tolist() == [40] * spec + [50] * spec


### PR DESCRIPTION
DSpark proposes a whole block in one decode forward, so the attention backend must record spec_num_tokens rows per request and re-derive their lengths on every replay. This backend already named the buffer the drafter reaches for (draft_seq_lens_attr) but allocated one row per request and never implemented the hook, so a DSpark run with --drafter-attention-backend tokenspeed_mla died at startup on a missing fill_block_decode_seq_lens.

Each request now expands into spec_num_tokens single-query rows that share the block-end length, which is how the other backends spell it: the kernel takes each row's mask from its own cache length, so equal lengths let every block query attend over the whole block including the positions after it. The page ids repeat across a request's rows and the lengths are written inside the captured graph from the live draft length.

The three GB300 DSpark gates move onto it. They had inherited `mla` from the AMD gate they were modelled on, where it is the only MLA backend there is; on NVIDIA that costs the draft its split-KV, and the five-layer draft then spends more per layer than the target's tuned kernel does. The AMD gates keep `mla`, which is the portable spelling.

Measured on GB200 with a four-node TP16 serve, decode goes from 324.2 tok/s to 450.8 tok/s, against 436.9 for trtllm_mla. Accepted tokens per round are unchanged from the mla baseline (6.905/5.479 against 6.905/5.453), so the block keeps its non-causal semantics rather than trading draft quality for speed.

The tests cover what would silently change what a block query attends to, and one of them spies on the decode call: the helper-level cases all pass even when the expansion never reaches the kernel, because reshaping the block back onto the query axis restores exactly the causal order the draft must not have.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
