### PR TITLE
perf(gfx1250): skip causal mask on fully visible MLA prefill tiles

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/prefill.py
@@ -484,7 +484,7 @@ class AttentionProgram:
 
 
 @gluon.jit
-def process_query_block(program: AttentionProgram, num_tiles):
+def process_query_block(program: AttentionProgram, num_tiles, main_end):
     cfg = program.cfg
     q = program.load_q_nope()
     q_rope = program.load_q_rope()
@@ -508,12 +508,16 @@ def process_query_block(program: AttentionProgram, num_tiles):
         v = program.shared_load_v(buffer_index)
         kv_start = tile_idx * cfg.BLOCK_N
         qk = program.compute_qk(q, k, q_rope, k_rope)
-        qk = program.apply_mask(qk, kv_start)
+        # Tiles below main_end are visible to every row of this query block, so
+        # they need neither the causal mask nor the out-of-range value guard.
+        if tile_idx >= main_end:
+            qk = program.apply_mask(qk, kv_start)
         p, m_i, l_i, acc = program.softmax(qk, m_i, l_i, acc)
-        v_n = kv_start + gl.arange(
-            0, cfg.BLOCK_N, layout=gl.SliceLayout(1, cfg.v_layout)
-        )
-        v = gl.where((v_n < program.kv_len)[:, None], v, 0.0)
+        if tile_idx >= main_end:
+            v_n = kv_start + gl.arange(
+                0, cfg.BLOCK_N, layout=gl.SliceLayout(1, cfg.v_layout)
+            )
+            v = gl.where((v_n < program.kv_len)[:, None], v, 0.0)
         acc = program.compute_pv(p, v, acc)
 
         if tile_idx + 2 < num_tiles:
@@ -602,11 +606,17 @@ def _mla_prefill_gfx1250_kernel(
             kv_end = program.kv_len - program.q_len + program.q_start + cfg.BLOCK_M
             kv_end = gl.minimum(kv_end, program.kv_len)
             kv_end = gl.maximum(kv_end, 0)
+            # Tiles strictly below the first query row's causal limit are fully
+            # visible, so they can skip masking entirely.
+            main_end = program.kv_len - program.q_len + program.q_start
+            main_end = gl.maximum(main_end, 0) // cfg.BLOCK_N
+            main_end = gl.minimum(main_end, program.kv_len // cfg.BLOCK_N)
         else:
             kv_end = program.kv_len
+            main_end = program.kv_len // cfg.BLOCK_N
         num_tiles = (kv_end + cfg.BLOCK_N - 1) // cfg.BLOCK_N
         if num_tiles > 0:
-            process_query_block(program, num_tiles)
+            process_query_block(program, num_tiles, main_end)
         else:
             store_empty_query_block(program)
 

--- a/tokenspeed-kernel/test/ops/test_attention_mla.py
+++ b/tokenspeed-kernel/test/ops/test_attention_mla.py
@@ -320,6 +320,8 @@ def test_mla_decode_with_kvcache(
     require,
 ) -> None:
     require("attention", "mla_decode_with_kvcache", solution, q_dtype, "q")
+    if q_dtype != kv_dtype and not platform.is_cdna4:
+        pytest.skip("only test mixed query/cache dtypes on gfx950")
 
     q_len = 1
     qk_nope_head_dim = 128
@@ -505,7 +507,7 @@ def test_mla_extend_with_kvcache(device: str, dtype: torch.dtype, require) -> No
             refs.append(torch.matmul(probs, visible_kv[:, :kv_lora_rank]))
         q_start += q_len
 
-    tol = 1e-1 if dtype in _FP8_DTYPES else 8e-2
+    tol = 1.5e-1 if dtype in _FP8_DTYPES else 8e-2
     torch.testing.assert_close(out.float(), torch.stack(refs), rtol=tol, atol=tol)
 
 
@@ -687,6 +689,8 @@ def test_mla_decode_small_batch_fixed_entrypoints_match_reference(
     return_lse: bool,
     require,
 ) -> None:
+    if not platform.is_cdna4:
+        pytest.skip("fixed gfx950 MLA decode entrypoints require CDNA4")
     require(
         "attention",
         "mla_decode_with_kvcache",
@@ -715,6 +719,8 @@ def test_mla_decode_small_batch_fixed_entrypoints_match_each_other(
     cache_seqlens_list: list[int],
     require,
 ) -> None:
+    if not platform.is_cdna4:
+        pytest.skip("fixed gfx950 MLA decode entrypoints require CDNA4")
     require(
         "attention",
         "mla_decode_with_kvcache",
@@ -749,6 +755,8 @@ def test_mla_decode_small_batch_fixed_entrypoints_use_out(
     override: str,
     require,
 ) -> None:
+    if not platform.is_cdna4:
+        pytest.skip("fixed gfx950 MLA decode entrypoints require CDNA4")
     require(
         "attention",
         "mla_decode_with_kvcache",


### PR DESCRIPTION
* Skip the causal mask and value range check on KV tiles that sit fully below the diagonal, which keeps the mask block's scalar pressure off and drops scalar spills.
* Fix pre-existing `test_attention_mla.py` failures on gfx1250: score the mixed bf16-query/fp8-cache cases only on gfx950 where that entrypoint exists, size the extend fp8 bound for e5m2's 2 mantissa bits.

## Prefill performance
MI455X, FP8 Q/K/V, 12 heads, `qk_head_dim=192` (128 NoPE + 64 RoPE), `v_head_dim=128`, causal. Op time, min of 200 GPU-event timings:
| batch | tokens/seq | main | branch | delta |
|---|---|---|---|---|
| 1 | 1024 | 47.4µs | 38.4µs | −19% |
| 1 | 4096 | 150.1µs | 93.4µs | −38% |
| 1 | 8192 | 400.5µs | 225.1µs | −44% |
| 4 | 1024 | 57.5µs | 46.3µs | −19% |
| 4 | 4096 | 365.4µs | 219.7µs | −40% |
| 4 | 8192 | 1277.0µs | 712.5µs | −44% |
| 16 | 1024 | 120.5µs | 91.1µs | −24% |
| 16 | 4096 | 1265.0µs | 742.6µs | −41% |
| 16 | 8192 | 4801.9µs | 2800.0µs | −42% |