### PR TITLE
ci: reduce time for gpt-oss perf workflow

### DIFF
--- a/.github/workflows/k8s-dispatch.yml
+++ b/.github/workflows/k8s-dispatch.yml
@@ -40,7 +40,7 @@ on:
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-pd-1p1d-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
-          - test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi35x.yaml
+          - test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi355.yaml
           - test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml

--- a/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi355.yaml
+++ b/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi355.yaml
@@ -59,7 +59,7 @@ perf:
     --max-tokens 1024
     --parallel 1 2 4 8 16
     --number 5 10 20 40 80
-    --warmup-num 4
+    --warmup-num 0.2
     --rate -1
     --seed 1
     --temperature 0

--- a/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi355.yaml
+++ b/test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi355.yaml
@@ -1,5 +1,5 @@
 api_version: ci.tokenspeed.io/v1
-name: perf-gpt-oss-120b-mxfp4-mi35x
+name: perf-gpt-oss-120b-mxfp4-mi355
 type: perf
 workflow_stage: model-test
 triggers:
@@ -59,7 +59,7 @@ perf:
     --max-tokens 1024
     --parallel 1 2 4 8 16
     --number 5 10 20 40 80
-    --warmup-num 16
+    --warmup-num 4
     --rate -1
     --seed 1
     --temperature 0


### PR DESCRIPTION
## Summary

- Change warmup to ratio
- Rename the ci to add mi355 suffix

## Test Plan

<!-- How was this validated? -->
