### PR TITLE
perf(runtime): pipeline request notifications

### DIFF
--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -71,7 +71,7 @@ from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.grammar.grammar_manager import GrammarManager
 from tokenspeed.runtime.multimodal.shm_transport import prepare_shm_features
 from tokenspeed.runtime.pd.base.bootstrap import BootstrapInfo
-from tokenspeed.runtime.utils import broadcast_pyobj
+from tokenspeed.runtime.utils import PipelinedPyobjBroadcaster
 from tokenspeed.runtime.utils.dispatch import TypeBasedDispatcher
 from tokenspeed.runtime.utils.env import envs
 from tokenspeed.runtime.utils.hf_transformers_utils import get_tokenizer
@@ -145,6 +145,15 @@ class RequestHandler:
                 "gloo", mapping.attn.tp_group
             )
             self.attn_tp_src_rank = mapping.attn.tp_group[0]
+        self.req_broadcaster = (
+            PipelinedPyobjBroadcaster(
+                self.attn_global_rank,
+                self.attn_tp_cpu_group,
+                src=self.attn_tp_src_rank,
+            )
+            if self.attn_tp_size != 1
+            else None
+        )
         self.profile_rank_tag = _profile_rank_tag(mapping.attn)
 
         self.hf_eos_token_id = hf_eos_token_id
@@ -173,8 +182,7 @@ class RequestHandler:
 
         self.init_profiler()
 
-    def recv_reqs(self) -> list:
-        """Receive results at attn_tp_rank = 0 and broadcast it to all other TP ranks."""
+    def _drain_reqs(self) -> list | None:
         if self.attn_tp_rank == 0:
             recv_reqs = []
 
@@ -187,16 +195,21 @@ class RequestHandler:
         else:
             recv_reqs = None
 
-        if self.attn_tp_size != 1:
-            recv_reqs = broadcast_pyobj(
-                recv_reqs,
-                self.attn_global_rank,
-                self.attn_tp_cpu_group,
-                src=self.attn_tp_src_rank,
-            )
+        return recv_reqs
+
+    def recv_reqs(self) -> list:
+        if self.attn_tp_size == 1:
+            recv_reqs = self._drain_reqs()
+        else:
+            if not self.req_broadcaster.in_flight:
+                self.req_broadcaster.start(self._drain_reqs())
+            recv_reqs = self.req_broadcaster.finish()
 
         if recv_reqs:
             prepare_shm_features(recv_reqs, self.attn_tp_cpu_group)
+
+        if self.attn_tp_size != 1:
+            self.req_broadcaster.start(self._drain_reqs())
 
         return recv_reqs
 

--- a/python/tokenspeed/runtime/utils/common.py
+++ b/python/tokenspeed/runtime/utils/common.py
@@ -526,6 +526,47 @@ def set_weight_attrs(
         setattr(weight, key, value)
 
 
+class PipelinedPyobjBroadcaster:
+    """Overlap empty Python-object notifications with useful work."""
+
+    def __init__(
+        self,
+        rank: int,
+        dist_group: torch.distributed.ProcessGroup | None = None,
+        src: int = 0,
+    ) -> None:
+        self.rank = rank
+        self.dist_group = dist_group
+        self.src = src
+        self._data = None
+        self._ready = torch.zeros(1, dtype=torch.long)
+        self._work = None
+
+    @property
+    def in_flight(self) -> bool:
+        return self._work is not None
+
+    def start(self, data: list[Any] | None) -> None:
+        self._data = data
+        if self.rank == self.src:
+            self._ready[0] = bool(data)
+        self._work = dist.broadcast(
+            self._ready,
+            src=self.src,
+            group=self.dist_group,
+            async_op=True,
+        )
+
+    def finish(self) -> list[Any]:
+        self._work.wait()
+        data = self._data
+        self._data = None
+        self._work = None
+        if self._ready.item():
+            return broadcast_pyobj(data, self.rank, self.dist_group, src=self.src)
+        return data or []
+
+
 def broadcast_pyobj(
     data: list[Any],
     rank: int,


### PR DESCRIPTION
## Summary

Pipeline request notifications across scheduler iterations to hide the blocking CPU/Gloo collective between consecutive forwards.

## Validation

Kimi-K3 agentic multi-turn `swe_smith` benchmark, TP8, no speculative decoding, `max_tokens=128`. Results are within-platform baseline-to-optimized comparisons using the same tactic cache and serving configuration.

| System | Concurrency | Baseline | Optimized | Speedup |
| --- | ---: | ---: | ---: | ---: |
| 8× B300, single node | C1 | 74.34 tok/s | 76.64 tok/s | +3.1% |
| 8× B300, single node | C4 | 164.10 tok/s | 167.60 tok/s | +2.1% |
| 8× B300, single node | C16 | 275.73 tok/s | 280.85 tok/s | +1.9% |
| 8× GB300, 2 nodes | C1 | 49.03 tok/s | 60.20 tok/s | +22.8% |
| 8× GB300, 2 nodes | C4 | 113.56 tok/s | 126.69 tok/s | +11.6% |
| 8× GB300, 2 nodes | C16 | 178.75 tok/s | 205.95 tok/s | +15.2% |

All 2,040 benchmark turns completed successfully.

On GB300 C1, optimized TPOT is comparable to B300 (10.01 ms vs. 9.80 ms). The remaining end-to-end throughput difference is primarily in TTFT and is outside the request-notification decode gap addressed by this change.