### PR TITLE
perf(comm): one shared fusion workspace per group serves plain all-reduces

### DIFF
--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -199,11 +199,21 @@ staging buffer used for per-step model inputs must therefore have per-step
 lifetime, or use an explicit synchronization before reuse. This applies to
 MTP/GDN mamba state indices as well as token, length, and request-pool inputs.
 
-CUDA IPC and symmetric-memory collectives are node-local. `AutoBackend` routes
-cross-node all-reduce, all-gather, and token all-gather/reduce-scatter groups to
-NCCL. Logits all-gather and distributed argmax use the same cross-node fallback.
-This is required for layouts such as attention DP with dense TP or MoE EP
-spanning nodes.
+CUDA IPC collectives are node-local; the mnnvl fabric workspace spans nodes.
+`AutoBackend` serves single-tensor SUM all-reduces (16-bit, or fp32 where a
+single-node workspace was armed for it; mnnvl serves 16-bit only) on groups
+whose fan-in is 2, 4, 8, or 16 through the armed workspace -- one-shot
+inside its traffic window, two-shot up to the workspace token capacity.
+Cross-node groups arm the full two-shot capacity at startup; single-node
+groups start at the one-shot window and serve larger shapes once
+model-level preparation widens the shared workspace. Other
+fan-ins and dtypes, and any shape the workspace rejects, fall back to NCCL
+(inside the trtllm backend for armed groups; the Triton all-reduce tier
+serves AMD only, where no trtllm workspace exists). Single-node token
+all-gather/reduce-scatter runs on the Triton RSAG backend and uses NCCL
+across nodes. Logits all-gather and distributed argmax use the same
+cross-node fallback. This is required for layouts such as attention DP
+with dense TP or MoE EP spanning nodes.
 
 On ARM systems, [NCCL 2.29.3](https://github.com/NVIDIA/nccl/releases/tag/v2.29.3-1)
 fixes a weak compare-and-swap failure that can hang NCCL when it was compiled

--- a/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/trtllm_allreduce.py
@@ -18,43 +18,40 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Lamport 1-shot all-reduce backend.
+"""TRT-LLM workspace all-reduce backend.
 
-Uses an IPC workspace with Lamport barriers and shared memory for low-latency
-all-reduce on small tensors. Falls back to a provided fallback backend for
-large tensors or unsupported ops.
+Routes plain SUM all-reduces through the group's fusion workspace (IPC
+lamport single-node, mnnvl fabric cross-node) with the strategy resolved by
+size: one-shot inside its traffic window, two-shot up to the workspace's
+token capacity. Falls back to the provided backend for unsupported shapes
+and every other op.
 
-The workspace is created once per group via ``configure_group`` and
-reused for every subsequent ``all_reduce`` on that group.
+The workspace is owned by the kernel package's per-group registry -- the
+same workspace the fused-pattern wrappers use. ``configure_group`` arms it
+once at init; model-level preparation may later grow it in place.
 """
 
 import torch
-from tokenspeed_kernel.ops.communication.trtllm import (
-    AllReduceFusionPattern,
-    trtllm_allreduce_fusion,
-    trtllm_create_ipc_workspace_for_all_reduce_fusion,
-)
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.distributed.comm_backend.base import CommBackend, Group
 
-# Public: dispatch layers (AutoBackend, comm_ops) key size-based routing on
-# the one-shot admission window; tensors past it always take an NCCL path.
+# Public: dispatch layers route tensor COLLECTIONS by this one-shot window.
 MAX_ONESHOT_BYTES = 2 * 1024 * 1024
-_MAX_ONESHOT_BYTES = MAX_ONESHOT_BYTES
 
 
 class TrtllmAllReduceBackend(CommBackend):
-    """Backend using Lamport 1-shot all-reduce.
+    """Backend routing plain SUM all-reduces through the fusion workspace.
 
-    Keyed per-group: each group gets its own IPC workspace so handles
-    are never reused across groups.  Only ``all_reduce`` (SUM) is
-    accelerated; every other op delegates to *fallback*.
+    Keyed per-group: ``configure_group`` arms the kernel package's shared
+    per-group workspace and records the device group here. Only
+    ``all_reduce`` (SUM) is accelerated; every other op delegates to
+    *fallback*.
     """
 
     def __init__(self, fallback: CommBackend):
         self._fallback = fallback
-        self._resources = {}  # group_tuple → {workspace, rank, world_size}
+        self._resources = {}  # group_tuple -> {device_group, rank, ...}
 
     def _load_comm(self):
         return current_platform().is_nvidia
@@ -71,7 +68,7 @@ class TrtllmAllReduceBackend(CommBackend):
         hidden_dim: int,
         use_fp32_lamport: bool = False,
     ) -> bool:
-        """Create IPC workspace for *group*.  Returns True on success."""
+        """Arm the group's shared fusion workspace.  Returns True on success."""
         if group in self._resources:
             return True
 
@@ -79,83 +76,57 @@ class TrtllmAllReduceBackend(CommBackend):
             return False
 
         try:
-
             from tokenspeed.runtime.distributed.process_group_manager import (
                 process_group_manager as pg_manager,
             )
 
-            # No same-node gate here: only the IPC workspace is node-local
-            # (opening a remote rank's IPC handle poisons the CUDA context),
-            # and _skip_ipc_workspace below detects exactly that and skips it.
-            # The mnnvl fabric workspace is the cross-node path -- an early
-            # same-node return would disable it on precisely the groups it
-            # exists to serve.
             device_group = pg_manager.get_process_group("nccl", group)
 
             from tokenspeed_kernel.ops.communication.trtllm import (
-                _skip_ipc_workspace,
+                MNNVL_TWOSHOT_MAX_TOKEN,
+                ensure_workspace_initialized,
+                group_spans_nodes,
             )
 
-            if _skip_ipc_workspace(device_group):
-                ipc_handles, workspace_tensor = None, None
-            else:
-                ipc_handles, workspace_tensor = (
-                    trtllm_create_ipc_workspace_for_all_reduce_fusion(
-                        rank,
-                        len(group),
-                        max_token_num,
-                        hidden_dim,
-                        group=device_group,
-                        use_fp32_lamport=use_fp32_lamport,
-                    )
-                )
+            if group_spans_nodes(device_group):
+                # Cross-node arms mnnvl only; size it for the two-shot range.
+                max_token_num = max(max_token_num, MNNVL_TWOSHOT_MAX_TOKEN)
 
-            # NVLS variant for the plain one-shot path (capability-gated,
-            # collective, symmetric fallback): the fused-pattern wrappers in
-            # the kernel package arm their own copy; this one serves the
-            # backend-level all_reduce (post-restructure attention ARs).
-            from tokenspeed_kernel.ops.communication.trtllm import (
-                _try_create_mnnvl_workspace,
-            )
-
-            mnnvl_workspace = _try_create_mnnvl_workspace(
-                rank,
-                len(group),
-                max_token_num,
-                hidden_dim,
-                device_group,
-            )
-
-            # Nothing usable -> report failure so the backend keeps routing
-            # this group through NCCL.
-            if workspace_tensor is None and mnnvl_workspace is None:
+            # Nothing armed reports False; the group keeps routing through NCCL.
+            if not ensure_workspace_initialized(
+                rank=rank,
+                group=device_group,
+                max_token_num=max_token_num,
+                hidden_dim=hidden_dim,
+                use_fp32_lamport=use_fp32_lamport,
+            ):
                 return False
 
             self._resources[group] = {
-                "ipc_handles": ipc_handles,
-                "workspace": workspace_tensor,
-                "mnnvl": mnnvl_workspace,
                 "rank": rank,
-                "world_size": len(group),
                 "max_token_num": max_token_num,
                 "hidden_dim": hidden_dim,
                 "device_group": device_group,
-                "use_fp32_lamport": use_fp32_lamport,
             }
 
             return True
 
         except Exception:
-
             return False
 
     def has_trtllm_ar(self, group: Group) -> bool:
         return group in self._resources
 
     def oneshot_hidden_dim(self, group: Group) -> int:
-        """Armed one-shot lane width for *group* (0 when unavailable)."""
+        """Hidden lane width the group's workspace is armed for (0 if unarmed)."""
         res = self._resources.get(group)
-        return int(res["hidden_dim"]) if res else 0
+        if res is None:
+            return 0
+        from tokenspeed_kernel.ops.communication.trtllm import (
+            armed_workspace_hidden_dim,
+        )
+
+        return armed_workspace_hidden_dim(res["device_group"])
 
     def ensure_group_lane(self, group: Group, hidden_dim: int) -> bool:
         """Widen *group*'s one-shot lane to at least *hidden_dim*.
@@ -170,30 +141,27 @@ class TrtllmAllReduceBackend(CommBackend):
         if res["hidden_dim"] >= hidden_dim:
             return True
         from tokenspeed_kernel.ops.communication.trtllm import (
-            trtllm_destroy_ipc_workspace_for_all_reduce_fusion,
+            armed_workspace_hidden_dim,
+            ensure_workspace_initialized,
         )
 
         try:
-            # Cross-node groups have no IPC workspace (ipc_handles is None);
-            # destroying it raised, and the except below then popped the group
-            # and permanently disabled the fused path.
-            if res["ipc_handles"] is not None:
-                trtllm_destroy_ipc_workspace_for_all_reduce_fusion(
-                    res["ipc_handles"], group=res["device_group"]
-                )
-            del self._resources[group]
-            return (
-                self.configure_group(
-                    rank=res["rank"],
-                    group=group,
-                    max_token_num=res["max_token_num"],
-                    hidden_dim=hidden_dim,
-                )
-                and self.oneshot_hidden_dim(group) >= hidden_dim
+            ok = ensure_workspace_initialized(
+                rank=res["rank"],
+                group=res["device_group"],
+                max_token_num=res["max_token_num"],
+                hidden_dim=hidden_dim,
             )
         except Exception:
             self._resources.pop(group, None)
             return False
+        if not ok:
+            # A graph-freeze refusal keeps the old lane; a failed grow unarms it.
+            if armed_workspace_hidden_dim(res["device_group"]) == 0:
+                self._resources.pop(group, None)
+            return False
+        res["hidden_dim"] = hidden_dim
+        return True
 
     # ------------------------------------------------------------------
     # CommBackend interface
@@ -213,97 +181,16 @@ class TrtllmAllReduceBackend(CommBackend):
 
         res = self._resources.get(group)
 
-        if (
-            res is not None
-            and op == torch.distributed.ReduceOp.SUM
-            and tensor.numel() * tensor.element_size() <= _MAX_ONESHOT_BYTES
-        ):
+        if res is not None and op == torch.distributed.ReduceOp.SUM:
+            from tokenspeed_kernel.ops.communication.trtllm import (
+                trtllm_workspace_allreduce,
+            )
 
-            result = self._lamport_allreduce(tensor, res)
-
+            result = trtllm_workspace_allreduce(tensor, res["device_group"])
             if result is not None:
                 return result
 
         return self._fallback.all_reduce(tensor, group, op=op)
-
-    def _lamport_allreduce(
-        self, tensor: torch.Tensor, res: dict
-    ) -> torch.Tensor | None:
-        """Run the Lamport 1-shot kernel, return None on failure."""
-        orig_shape = tensor.shape
-
-        # The fused kernel expects 2D [token_num, hidden_dim].
-        if tensor.dim() == 1:
-            tensor_2d = tensor.unsqueeze(0)
-        elif tensor.dim() > 2:
-            tensor_2d = tensor.reshape(-1, tensor.shape[-1])
-        else:
-            tensor_2d = tensor
-
-        token_num, hidden_dim = tensor_2d.shape
-        if hidden_dim > res["hidden_dim"] or token_num > res["max_token_num"]:
-            return None
-        if token_num == 0:
-            return tensor
-        # The Lamport workspace is monomorphic in element type: it was
-        # initialized (and is re-armed after each call) with either fp16/bf16
-        # or fp32 negative-zero sentinels. A payload whose dtype width differs
-        # reads the sentinel pattern as ordinary data and spins forever waiting
-        # for completion flags that never arrive -- e.g. the DSpark Markov
-        # head's fp32 embedding all-reduce during CUDA-graph capture.
-        expected_fp32 = bool(res.get("use_fp32_lamport", False))
-        if (tensor_2d.dtype == torch.float32) != expected_fp32:
-            return None
-
-        from tokenspeed_kernel.ops.communication.trtllm import (
-            MNNVL_PREFER_IPC_BYTES,
-        )
-
-        allreduce_out = torch.empty_like(tensor_2d)
-
-        workspace = res["workspace"]
-        mnnvl = res.get("mnnvl")
-        # Same Tier-2 split as _ar_fusion_workspace: prefer the IPC lamport
-        # workspace (single-node only; cross-node it is None) once the payload
-        # reaches MNNVL_PREFER_IPC_BYTES, mnnvl below it. Unreachable while
-        # _MAX_ONESHOT_BYTES stays under the threshold, but keeps this path
-        # consistent with the kernel-side dispatch if either bound moves.
-        payload_bytes = token_num * hidden_dim * tensor_2d.dtype.itemsize
-        prefer_ipc = workspace is not None and payload_bytes >= MNNVL_PREFER_IPC_BYTES
-        if (
-            not prefer_ipc
-            and mnnvl is not None
-            and mnnvl.supports(
-                token_num,
-                hidden_dim,
-                tensor_2d.dtype,
-                res["world_size"],
-                AllReduceFusionPattern.kAllReduce,
-                use_oneshot=True,
-            )
-        ):
-            workspace = mnnvl
-
-        # Shape not covered by mnnvl and no IPC fallback -> let the caller
-        # fall back to NCCL (this function's None contract).
-        if workspace is None:
-            return None
-
-        trtllm_allreduce_fusion(
-            allreduce_in=tensor_2d,
-            world_size=res["world_size"],
-            world_rank=res["rank"],
-            token_num=token_num,
-            hidden_dim=hidden_dim,
-            workspace_ptrs=workspace,
-            use_oneshot=True,
-            trigger_completion_at_end=True,
-            fp32_acc=False,
-            pattern_code=AllReduceFusionPattern.kAllReduce,
-            allreduce_out=allreduce_out,
-        )
-
-        return allreduce_out.view(orig_shape)
 
     # ---- Delegate everything else to fallback ----
 

--- a/python/tokenspeed/runtime/distributed/comm_ops.py
+++ b/python/tokenspeed/runtime/distributed/comm_ops.py
@@ -52,7 +52,7 @@ from tokenspeed.runtime.distributed.comm_backend import (
 )
 
 # Re-exported for reduce-strategy callers (e.g. kimi3_join_reduce_moe):
-# tensors past the one-shot admission window always take an NCCL path.
+# tensor collections past the one-shot window take an NCCL path.
 from tokenspeed.runtime.distributed.comm_backend.trtllm_allreduce import (  # noqa: F401
     MAX_ONESHOT_BYTES as COMM_ONESHOT_MAX_BYTES,
 )
@@ -324,6 +324,7 @@ def fused_reduce_scatter(
             add_in=fusion_params.add_in,
             fp32_acc=fusion_params.fp32_acc,
             block_quant_fp8=fusion_params.block_quant_fp8,
+            # Shape-derived growth; post-capture grows are refused -- arm before capture.
             max_token_num=fusion_params.max_token_num or tensor.shape[0],
         )
 
@@ -357,6 +358,7 @@ def fused_all_gather(
             rank=rank,
             group=_get_process_group(group),
             total_num_tokens=fusion_params.total_num_tokens,
+            # Shape-derived growth; post-capture grows are refused -- arm before capture.
             max_token_num=fusion_params.max_token_num
             or max(tensor.shape[0], fusion_params.total_num_tokens),
             fp32_acc=fusion_params.fp32_acc,

--- a/python/tokenspeed/runtime/execution/distributed_initializer.py
+++ b/python/tokenspeed/runtime/execution/distributed_initializer.py
@@ -170,14 +170,7 @@ class DistributedInitializer:
             # broadcasts like the sampled first token (gloo).
             pg_manager.init_process_group(config.mapping.pp_group)
 
-        # Register the trtllm one-shot all-reduce workspaces for the TP
-        # groups. AutoBackend routes small SUM all-reduces (<= 2 MB payload,
-        # i.e. the per-step decode reductions) through them; larger payloads
-        # and every other op keep using NCCL. Without this the one-shot
-        # backend is never armed and raw all_reduce callers (e.g. models whose
-        # comm cannot fuse into a norm) pay ring latency per layer.
-        # Unconditional: --force-deterministic-rsag is the escape hatch, and
-        # it overrides at dispatch (auto.py) rather than at registration.
+        # Arm the trtllm AR workspaces; --force-deterministic-rsag overrides at dispatch.
         if config.hidden_size > 0:
             from tokenspeed.runtime.distributed.comm_backend import (
                 get_global_backend,
@@ -186,7 +179,7 @@ class DistributedInitializer:
             backend = get_global_backend()
             trtllm_ar = getattr(backend, "trtllm_ar", None)
             if trtllm_ar is not None:
-                # One-shot serves <= 2 MB only; a small token window bounds the IPC workspace (else NCCL).
+                # One-shot window; configure_group widens cross-node groups.
                 max_oneshot_tokens = max(
                     1, (2 * 1024 * 1024) // max(config.hidden_size * 2, 1)
                 )

--- a/test/runtime/test_deepseek_v4_hopper_fp8.py
+++ b/test/runtime/test_deepseek_v4_hopper_fp8.py
@@ -23,8 +23,8 @@
 Covers the pieces added for running V4-Flash on SM90 without FP4 tensor
 cores: the FP8 indexer query prep + paged gather, the BF16->block-FP8
 weight quantization used when a checkpoint ships ``attn.wo_a`` unquantized,
-and the Lamport all-reduce dtype gate that keeps fp32 payloads off a
-bf16-armed one-shot workspace.
+and the shared-workspace plain all-reduce admission gates (lamport dtype
+sentinel, integer dtypes, hidden alignment, device, and empty inputs).
 """
 
 from __future__ import annotations
@@ -244,38 +244,78 @@ class TestBlockQuantFp8Weight(unittest.TestCase):
         self.assertEqual(scale_inv.shape, (2, 2))
 
 
-class TestLamportAllreduceDtypeGate(unittest.TestCase):
-    def _backend_with_resources(self, use_fp32_lamport: bool):
-        from tokenspeed.runtime.distributed.comm_backend.trtllm_allreduce import (
-            TrtllmAllReduceBackend,
-        )
+def _nvidia_cuda_available() -> bool:
+    from tokenspeed_kernel.platform import current_platform
 
-        backend = TrtllmAllReduceBackend(fallback=None)
-        resources = {
-            "workspace": object(),
-            "mnnvl": None,
-            "rank": 0,
-            "world_size": 8,
-            "max_token_num": 64,
-            "hidden_dim": 4096,
-            "use_fp32_lamport": use_fp32_lamport,
-        }
-        return backend, resources
+    return torch.cuda.is_available() and current_platform().is_nvidia
+
+
+@unittest.skipUnless(_nvidia_cuda_available(), "requires NVIDIA CUDA")
+class TestWorkspaceAllreduceGates(unittest.TestCase):
+    """Admission gates of trtllm_workspace_allreduce + manager failure state."""
+
+    def _reduce(self, tensor, use_fp32_lamport: bool):
+        from unittest import mock
+
+        from tokenspeed_kernel.ops.communication import trtllm as comm
+
+        manager = mock.Mock()
+        manager.initialized = True
+        manager.use_fp32_lamport = use_fp32_lamport
+        manager.max_token_num = 64
+        manager.hidden_dim = 4096
+        manager.world_size = 8
+        with mock.patch.object(
+            comm.dist, "get_process_group_ranks", return_value=[0, 1]
+        ), mock.patch.dict(comm._workspace_managers, {(0, 1): manager}, clear=True):
+            return comm.trtllm_workspace_allreduce(tensor, mock.Mock())
 
     def test_fp32_payload_on_bf16_workspace_falls_back(self):
-        backend, resources = self._backend_with_resources(use_fp32_lamport=False)
-        tensor = torch.zeros(2, 256, dtype=torch.float32)
-        self.assertIsNone(backend._lamport_allreduce(tensor, resources))
+        tensor = torch.zeros(2, 256, dtype=torch.float32, device="cuda")
+        self.assertIsNone(self._reduce(tensor, use_fp32_lamport=False))
 
     def test_bf16_payload_on_fp32_workspace_falls_back(self):
-        backend, resources = self._backend_with_resources(use_fp32_lamport=True)
-        tensor = torch.zeros(2, 256, dtype=torch.bfloat16)
-        self.assertIsNone(backend._lamport_allreduce(tensor, resources))
+        tensor = torch.zeros(2, 256, dtype=torch.bfloat16, device="cuda")
+        self.assertIsNone(self._reduce(tensor, use_fp32_lamport=True))
 
-    def test_zero_token_short_circuits_before_gate(self):
-        backend, resources = self._backend_with_resources(use_fp32_lamport=False)
-        tensor = torch.zeros(0, 256, dtype=torch.float32)
-        self.assertIs(backend._lamport_allreduce(tensor, resources), tensor)
+    def test_zero_token_falls_back(self):
+        tensor = torch.zeros(0, 256, dtype=torch.bfloat16, device="cuda")
+        self.assertIsNone(self._reduce(tensor, use_fp32_lamport=False))
+
+    def test_integer_payload_falls_back(self):
+        tensor = torch.zeros(2, 256, dtype=torch.int64, device="cuda")
+        self.assertIsNone(self._reduce(tensor, use_fp32_lamport=False))
+
+    def test_misaligned_hidden_falls_back(self):
+        tensor = torch.zeros(2, 100, dtype=torch.bfloat16, device="cuda")
+        self.assertIsNone(self._reduce(tensor, use_fp32_lamport=False))
+
+    def test_cpu_payload_falls_back(self):
+        tensor = torch.zeros(2, 256, dtype=torch.bfloat16)
+        self.assertIsNone(self._reduce(tensor, use_fp32_lamport=False))
+
+    def test_group_recorded_before_creation_failure(self):
+        from unittest import mock
+
+        from tokenspeed_kernel.ops.communication import trtllm as comm
+
+        manager = comm.TrtllmFusionWorkspaceManager()
+        sentinel = mock.Mock()
+        with mock.patch.object(
+            comm, "_skip_ipc_workspace", return_value=False
+        ), mock.patch.object(
+            comm,
+            "trtllm_create_ipc_workspace_for_all_reduce_fusion",
+            return_value=(mock.Mock(), mock.Mock()),
+        ), mock.patch.object(
+            comm, "_try_create_mnnvl_workspace", side_effect=RuntimeError("boom")
+        ):
+            with self.assertRaises(RuntimeError):
+                manager.initialize(2, 0, 64, 2048, sentinel)
+        # Cleanup must target this group, not default to WORLD, on the next arm.
+        self.assertIs(manager.group, sentinel)
+        self.assertIsNotNone(manager.ipc_handles)
+        self.assertFalse(manager.initialized)
 
 
 if __name__ == "__main__":

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/trtllm.py
@@ -41,13 +41,24 @@ __all__ = [
     "trtllm_allreduce_fusion",
     "trtllm_create_ipc_workspace_for_all_reduce_fusion",
     "trtllm_create_ipc_workspace_for_minimax",
+    "trtllm_workspace_allreduce",
+    "group_spans_nodes",
+    "armed_workspace_hidden_dim",
+    "ensure_workspace_initialized",
+    "MNNVL_TWOSHOT_MAX_TOKEN",
 ]
 
 platform = current_platform()
 
 AllReduceFusionPattern = ErrorClass
+# Two-shot token capacity of the mnnvl workspace; 0 where the path is absent.
+MNNVL_TWOSHOT_MAX_TOKEN = 0
 allgather_dual_rmsnorm = error_fn
 allreduce_residual_rmsnorm = error_fn
+trtllm_workspace_allreduce = error_fn
+armed_workspace_hidden_dim = error_fn
+ensure_workspace_initialized = error_fn
+group_spans_nodes = error_fn
 allreduce_residual_attnres_combine = error_fn
 allreduce_lane_latent_norm = error_fn
 minimax_allreduce_rms_qk = error_fn
@@ -61,6 +72,7 @@ if current_platform().is_nvidia:
     from tokenspeed_kernel.thirdparty.cuda.trtllm import (
         _MNNVL_SUPPORTED_WORLD_SIZES,
         MNNVL_PREFER_IPC_BYTES,
+        MNNVL_TWOSHOT_MAX_TOKEN,
         AllGatherFusionPattern,
         AllReduceFusionPattern,
         ReduceScatterFusionPattern,
@@ -75,8 +87,6 @@ if current_platform().is_nvidia:
         trtllm_destroy_ipc_workspace_for_all_reduce_fusion,
         trtllm_reducescatter_fusion,
     )
-
-    _workspace_manager = None
 
     def _mnnvl_locally_available(world_size: int) -> bool:
         """Non-collective capability probe for the MNNVL one-shot AR path.
@@ -189,6 +199,17 @@ if current_platform().is_nvidia:
         except Exception:  # noqa: BLE001 -- no distributed context: single node
             return False
 
+    def group_spans_nodes(group: dist.ProcessGroup) -> bool:
+        """Whether the group's ranks live on more than one host.
+
+        Args:
+            group: process group to inspect; collective (hostname gather).
+
+        Returns:
+            True when at least two distinct hosts are present.
+        """
+        return _group_spans_nodes(group)
+
     def _skip_ipc_workspace(group) -> bool:
         """Whether to skip arming the CUDA-IPC workspace for *group*.
 
@@ -211,9 +232,8 @@ if current_platform().is_nvidia:
             self.hidden_dim = None
             self.use_fp32_lamport = None
             self.initialized = False
-            self.group_ranks = (
-                None  # tuple of global ranks this workspace was created for
-            )
+            self.graph_consumed = False
+            self.group = None
 
         def initialize(
             self,
@@ -221,10 +241,17 @@ if current_platform().is_nvidia:
             rank: int,
             max_token_num: int,
             hidden_dim: int,
-            group,
+            group: dist.ProcessGroup,
             use_fp32_lamport: bool = False,
         ):
-            """Initialize workspace"""
+            """(Re)create the workspace at exactly the requested geometry.
+
+            No-op when already armed at it; otherwise the old workspace is
+            destroyed first, so a creation failure (raised from inside
+            ``_create``) leaves the manager unarmed (``initialized`` False);
+            IPC handles already created stay recorded for the next
+            ``cleanup()`` to destroy on the recorded group.
+            """
             if (
                 self.initialized
                 and self.world_size == world_size
@@ -234,12 +261,28 @@ if current_platform().is_nvidia:
             ):
                 return
 
+            # Fail fast: collective recovery here opens rank-desync windows.
             self.cleanup()
+            self._create(
+                world_size, rank, max_token_num, hidden_dim, group, use_fp32_lamport
+            )
+
+        def _create(
+            self,
+            world_size: int,
+            rank: int,
+            max_token_num: int,
+            hidden_dim: int,
+            group: dist.ProcessGroup,
+            use_fp32_lamport: bool,
+        ) -> None:
             # CUDA-IPC handles cannot span nodes -- attempting creation on a
             # cross-node group fails AND leaves a sticky CUDA context error
             # ('invalid resource handle' on the next allocation). Gate it off
             # for cross-node runs; the MNNVL fabric workspace below is the
             # multi-node path.
+            # Recorded first: a failed arm must still destroy on the right group.
+            self.group = group
             _skip_ipc = _skip_ipc_workspace(group)
             if _skip_ipc:
                 self.ipc_handles, self.workspace_tensor = None, None
@@ -280,7 +323,6 @@ if current_platform().is_nvidia:
             self.hidden_dim = hidden_dim
             self.use_fp32_lamport = use_fp32_lamport
             self.initialized = True
-            self.group = group
 
             logger.info(
                 f"TRT-LLM fusion workspace initialized for rank {rank}, "
@@ -319,13 +361,26 @@ if current_platform().is_nvidia:
                     self.max_token_num = None
                     self.hidden_dim = None
                     self.use_fp32_lamport = None
-                    self.group_ranks = None
+                    self.graph_consumed = False
+                    self.group = None
 
-    _workspace_manager = TrtllmFusionWorkspaceManager()
+    _workspace_managers: dict[tuple[int, ...], TrtllmFusionWorkspaceManager] = {}
 
-    #
-    #  # Reduce-scatter now reuses `_workspace_manager` (allreduce-style IPC workspace).
-    # This avoids keeping a second, similarly-sized workspace alive.
+    def _manager_for_group(group: dist.ProcessGroup) -> TrtllmFusionWorkspaceManager:
+        """One fusion-workspace manager per distinct rank set.
+
+        Keyed by global ranks rather than ProcessGroup identity: the runtime
+        AR backend and the fused-pattern wrappers reach the same group through
+        different ProcessGroup objects, and both must land on the same
+        workspace.
+        """
+        key = tuple(dist.get_process_group_ranks(group))
+        manager = _workspace_managers.get(key)
+        if manager is None:
+            manager = _workspace_managers[key] = TrtllmFusionWorkspaceManager()
+        return manager
+
+    # Reduce-scatter reuses the group's fusion workspace (IPC lamport).
 
     def ensure_workspace_initialized(
         rank: int,
@@ -333,34 +388,79 @@ if current_platform().is_nvidia:
         max_token_num: int = 2048,
         hidden_dim: int = 4096,
         use_fp32_lamport: bool = False,
-    ):
+    ) -> bool:
+        """Arm (or grow) the group's shared fusion workspace, collectively.
+
+        Args:
+            rank: this rank within ``group``.
+            group: process group the workspace serves; all ranks must call in
+                lockstep with identical arguments.
+            max_token_num: minimum token capacity to arm; grow-only.
+            hidden_dim: minimum hidden lane width to arm; grow-only.
+            use_fp32_lamport: arm the fp32 lamport sentinel; sticky once set.
+
+        Returns:
+            True when a workspace is armed for the group at (at least) the
+            requested capacity. False for single-rank groups, when nothing
+            could be armed, or when growth was refused because a captured
+            CUDA graph references the current workspace — arm the full
+            geometry every captured graph will use BEFORE capture (capture
+            state is per-rank; keep capture lockstep across ranks). Creation
+            failures propagate (fail fast; a failed grow leaves the group
+            unarmed). Arming fp32 lamport is sticky; a 16-bit plain AR
+            then declines to NCCL regardless of mnnvl, the rmsnorm wrapper
+            degrades to the unfused path and attnres-combine/latent-norm
+            raise where no mnnvl workspace serves the shape, and the
+            reducescatter/allgather wrappers -- IPC-only, no mnnvl
+            implementation -- always raise on the mismatch.
+        """
         world_size = group.size()
         if world_size <= 1:
             return False
 
+        manager = _manager_for_group(group)
         target_max_token_num = max_token_num
         target_hidden_dim = hidden_dim
         target_use_fp32_lamport = use_fp32_lamport
-        if (
-            _workspace_manager.initialized
-            and _workspace_manager.world_size == world_size
-        ):
-            if _workspace_manager.max_token_num is not None:
-                target_max_token_num = max(
-                    _workspace_manager.max_token_num, max_token_num
-                )
-            if _workspace_manager.hidden_dim is not None:
-                target_hidden_dim = max(_workspace_manager.hidden_dim, hidden_dim)
-            if _workspace_manager.use_fp32_lamport:
+        if manager.initialized:
+            if manager.max_token_num is not None:
+                target_max_token_num = max(manager.max_token_num, max_token_num)
+            if manager.hidden_dim is not None:
+                target_hidden_dim = max(manager.hidden_dim, hidden_dim)
+            if manager.use_fp32_lamport:
                 target_use_fp32_lamport = True
 
         if (
-            (not _workspace_manager.initialized)
-            or (_workspace_manager.world_size != world_size)
-            or (_workspace_manager.max_token_num != target_max_token_num)
-            or (_workspace_manager.hidden_dim != target_hidden_dim)
-            or (_workspace_manager.use_fp32_lamport != target_use_fp32_lamport)
+            (not manager.initialized)
+            or (manager.max_token_num != target_max_token_num)
+            or (manager.hidden_dim != target_hidden_dim)
+            or (manager.use_fp32_lamport != target_use_fp32_lamport)
         ):
+            if manager.initialized and manager.graph_consumed:
+                # Recreating would leave captured graphs on freed peer pointers.
+                logger.warning(
+                    "trtllm AR: refusing to grow the fusion workspace "
+                    "(tokens %s->%s hidden %s->%s fp32 %s->%s): a captured "
+                    "CUDA graph references it. Arm the full geometry before "
+                    "graph capture.",
+                    manager.max_token_num,
+                    target_max_token_num,
+                    manager.hidden_dim,
+                    target_hidden_dim,
+                    manager.use_fp32_lamport,
+                    target_use_fp32_lamport,
+                )
+                return False
+            if (
+                manager.initialized
+                and target_use_fp32_lamport
+                and not (manager.use_fp32_lamport)
+            ):
+                # Sticky flip: bf16/fp16 payloads are rejected from here on.
+                logger.warning(
+                    "trtllm AR: workspace sentinel flips to fp32 lamport; "
+                    "16-bit plain all-reduces on this group fall back to NCCL"
+                )
             logger.info(
                 "Re/initializing TRT-LLM fusion IPC workspace: "
                 "world_size=%s rank=%s max_token_num=%s hidden_dim=%s use_fp32_lamport=%s "
@@ -370,11 +470,11 @@ if current_platform().is_nvidia:
                 target_max_token_num,
                 target_hidden_dim,
                 target_use_fp32_lamport,
-                _workspace_manager.max_token_num,
-                _workspace_manager.hidden_dim,
-                _workspace_manager.use_fp32_lamport,
+                manager.max_token_num,
+                manager.hidden_dim,
+                manager.use_fp32_lamport,
             )
-            _workspace_manager.initialize(
+            manager.initialize(
                 world_size=world_size,
                 rank=rank,
                 max_token_num=target_max_token_num,
@@ -383,9 +483,23 @@ if current_platform().is_nvidia:
                 group=group,
             )
 
-        return _workspace_manager.initialized
+        return (
+            manager.initialized
+            and manager.max_token_num == target_max_token_num
+            and manager.hidden_dim == target_hidden_dim
+            and manager.use_fp32_lamport == target_use_fp32_lamport
+        )
+
+    def _mark_captured(
+        manager: TrtllmFusionWorkspaceManager, workspace: torch.Tensor | None
+    ) -> torch.Tensor | None:
+        """Freeze the workspace against growth once a graph captures it."""
+        if torch.cuda.is_current_stream_capturing():
+            manager.graph_consumed = True
+        return workspace
 
     def _ar_fusion_workspace(
+        manager: TrtllmFusionWorkspaceManager,
         token_num: int,
         hidden_dim: int,
         dtype: torch.dtype,
@@ -397,18 +511,20 @@ if current_platform().is_nvidia:
 
         Tier 2 of AR dispatch (Tier 1 chose the trtllm backend in auto.py).
         Decision, first match wins:
-          1. IPC exists (single-node) AND (payload >= MNNVL_PREFER_IPC_BYTES
+          1. compatible IPC workspace exists (single-node, lamport sentinel
+             width matches) AND (payload >= MNNVL_PREFER_IPC_BYTES
              OR pattern == kAllReduceLatentNorm) ....... IPC lamport/twoshot
           2. mnnvl supports this shape ................. mnnvl (the caller's
              ``use_oneshot`` parameter selects its strategy)
-          3. no IPC fallback (cross-node) ............. None (caller degrades:
+          3. no usable IPC (cross-node, or lamport sentinel width mismatch)
+             ............................................ None (caller degrades:
              the rmsnorm family runs unfused NCCL + torch epilogue, the rest
              raise loudly -- never a null workspace into the kernel)
           4. otherwise ................................ IPC
         Cross-node, workspace_tensor is None so only 2/3 apply -- mnnvl serves
         the whole range (it beats NCCL everywhere there).
         """
-        mnnvl = _workspace_manager.mnnvl_workspace
+        mnnvl = manager.mnnvl_workspace
         # Byte-based split between the two fused workspaces: multicast (mnnvl)
         # for small payloads, IPC lamport once bandwidth dominates. Only bites
         # single-node -- cross-node workspace_tensor is None and mnnvl is the
@@ -422,27 +538,32 @@ if current_platform().is_nvidia:
         prefer_ipc = payload_bytes >= MNNVL_PREFER_IPC_BYTES or (
             pattern_code == AllReduceFusionPattern.kAllReduceLatentNorm
         )
-        if _workspace_manager.workspace_tensor is not None and prefer_ipc:
-            return _workspace_manager.workspace_tensor
+        # A sentinel-width mismatch corrupts the lamport neg-zero wait/clear protocol.
+        ipc_ok = manager.workspace_tensor is not None and (
+            (dtype == torch.float32) == manager.use_fp32_lamport
+        )
+        if ipc_ok and prefer_ipc:
+            return _mark_captured(manager, manager.workspace_tensor)
         if mnnvl is not None and mnnvl.supports(
             token_num,
             hidden_dim,
             dtype,
-            _workspace_manager.world_size,
+            manager.world_size,
             pattern_code,
             use_oneshot=use_oneshot,
             residual_reduce_scattered=residual_reduce_scattered,
         ):
-            return mnnvl
+            return _mark_captured(manager, mnnvl)
         # Cross-node there is no IPC workspace, so a shape/pattern mnnvl rejects
         # has no fused home. Return None and let the caller decide: the rmsnorm
         # family degrades to the unfused NCCL path, the rest raise loudly. Never
         # hand the kernel a null workspace.
-        if _workspace_manager.workspace_tensor is None:
+        if not ipc_ok:
             logger.debug(
                 "trtllm AR fusion: shape (tokens=%s, hidden=%s, dtype=%s, "
-                "pattern=%s, oneshot=%s) not supported by mnnvl and no IPC "
-                "workspace; caller falls back unfused",
+                "pattern=%s, oneshot=%s) not supported by mnnvl and no "
+                "compatible IPC workspace (missing or sentinel-width "
+                "mismatch); caller falls back unfused",
                 token_num,
                 hidden_dim,
                 dtype,
@@ -450,7 +571,7 @@ if current_platform().is_nvidia:
                 use_oneshot,
             )
             return None
-        return _workspace_manager.workspace_tensor
+        return _mark_captured(manager, manager.workspace_tensor)
 
     def get_num_tokens_per_rank(world_size: int, total_tokens_in_group: int) -> list:
         token_list_in_group = []
@@ -510,6 +631,113 @@ if current_platform().is_nvidia:
             )
             return quant_out, residual_out, scale_out, partial_norm_out
         return norm_out, residual_out, None, partial_norm_out
+
+    def armed_workspace_hidden_dim(group: dist.ProcessGroup) -> int:
+        """Hidden lane width the group's workspace is armed for.
+
+        Args:
+            group: process group whose shared fusion workspace to inspect.
+
+        Returns:
+            The armed ``hidden_dim`` in elements, or 0 when no workspace is
+            armed for *group*.
+        """
+        manager = _manager_for_group(group)
+        return int(manager.hidden_dim) if manager.initialized else 0
+
+    def trtllm_workspace_allreduce(
+        input_tensor: torch.Tensor,
+        group: dist.ProcessGroup,
+    ) -> torch.Tensor | None:
+        """Plain SUM all-reduce through the group's armed fusion workspace.
+
+        Tier 2 of the plain-AR dispatch (Tier 1 chose the trtllm backend in
+        auto.py). The strategy is resolved by size -- one-shot inside its
+        traffic window, two-shot up to the workspace's token capacity -- over
+        the same IPC-vs-mnnvl split the fused-pattern wrappers use.
+
+        Args:
+            input_tensor: CUDA tensor to sum-reduce; the trailing dimension
+                is treated as the hidden lane. A non-contiguous tensor is
+                served through a contiguous copy and is never mutated.
+            group: process group to reduce over.
+
+        Returns:
+            The reduced tensor (new allocation, same shape), or ``None`` when
+            no workspace is armed for *group* or the shape is not served --
+            the caller keeps its own (NCCL) fallback.
+        """
+        if input_tensor.ndim == 0 or input_tensor.numel() == 0:
+            return None
+        if not input_tensor.is_cuda:
+            return None
+        if input_tensor.dtype not in (
+            torch.bfloat16,
+            torch.float16,
+            torch.float32,
+        ):
+            return None
+        manager = _manager_for_group(group)
+        if not manager.initialized:
+            return None
+
+        tensor_2d = input_tensor.reshape(-1, input_tensor.shape[-1])
+        token_num, hidden_dim = tensor_2d.shape
+        # A sentinel-width mismatch corrupts the lamport neg-zero wait/clear protocol.
+        if (tensor_2d.dtype == torch.float32) != manager.use_fp32_lamport:
+            return None
+        # The device kernels read 16-byte vectors along the hidden lane.
+        if hidden_dim % (16 // tensor_2d.dtype.itemsize) != 0:
+            return None
+        if hidden_dim > manager.hidden_dim or token_num > manager.max_token_num:
+            return None
+
+        world_size = manager.world_size
+        # The device kernels support exactly these fan-ins at every size.
+        if world_size not in _MNNVL_SUPPORTED_WORLD_SIZES:
+            return None
+        requested_oneshot = _ar_should_use_oneshot(
+            token_num, hidden_dim, tensor_2d.dtype, world_size
+        )
+        resolved_oneshot = requested_oneshot
+        if manager.mnnvl_workspace is not None:
+            resolved_oneshot = manager.mnnvl_workspace.resolve_use_oneshot(
+                token_num, None
+            )
+        workspace = _ar_fusion_workspace(
+            manager,
+            token_num,
+            hidden_dim,
+            tensor_2d.dtype,
+            AllReduceFusionPattern.kAllReduce,
+            resolved_oneshot,
+        )
+        if workspace is None:
+            return None
+        # IPC has its own heuristic; only MNNVL uses the workspace's frozen cap.
+        if workspace is not manager.mnnvl_workspace:
+            resolved_oneshot = requested_oneshot
+            # The IPC two-shot kernel asserts token_num > world_size.
+            if not resolved_oneshot and token_num <= world_size:
+                return None
+        if not tensor_2d.is_contiguous():
+            tensor_2d = tensor_2d.contiguous()
+
+        allreduce_out = torch.empty_like(tensor_2d)
+        trtllm_allreduce_fusion(
+            allreduce_in=tensor_2d,
+            world_size=world_size,
+            world_rank=manager.rank,
+            token_num=token_num,
+            hidden_dim=hidden_dim,
+            workspace_ptrs=workspace,
+            use_oneshot=resolved_oneshot,
+            trigger_completion_at_end=True,
+            fp32_acc=False,
+            pattern_code=AllReduceFusionPattern.kAllReduce,
+            allreduce_out=allreduce_out,
+        )
+        return allreduce_out.view(input_tensor.shape)
 
     def allreduce_residual_rmsnorm(
         input_tensor: torch.Tensor,
@@ -600,12 +828,14 @@ if current_platform().is_nvidia:
                 token_num, hidden_dim, input_tensor.dtype, world_size
             )
         )
+        manager = _manager_for_group(group)
         resolved_oneshot = requested_oneshot
-        if _workspace_manager.mnnvl_workspace is not None:
-            resolved_oneshot = _workspace_manager.mnnvl_workspace.resolve_use_oneshot(
+        if manager.mnnvl_workspace is not None:
+            resolved_oneshot = manager.mnnvl_workspace.resolve_use_oneshot(
                 token_num, use_oneshot
             )
         workspace = _ar_fusion_workspace(
+            manager,
             token_num,
             hidden_dim,
             input_tensor.dtype,
@@ -614,7 +844,7 @@ if current_platform().is_nvidia:
             residual_reduce_scattered,
         )
         # IPC has its own heuristic; only MNNVL uses the workspace's frozen cap.
-        if workspace is not _workspace_manager.mnnvl_workspace:
+        if workspace is not manager.mnnvl_workspace:
             resolved_oneshot = requested_oneshot
         if workspace is None:
             # Cross-node group, pattern/shape the mnnvl kernel cannot serve
@@ -715,6 +945,7 @@ if current_platform().is_nvidia:
         norm_out = torch.empty_like(input_tensor)
         m, s_, acc = scratch
         workspace = _ar_fusion_workspace(
+            _manager_for_group(group),
             token_num,
             hidden_dim,
             input_tensor.dtype,
@@ -722,9 +953,9 @@ if current_platform().is_nvidia:
             use_oneshot=True,
         )
         if workspace is None:
-            # mnnvl serves this pattern in-range; only out-of-range shapes land
-            # here cross-node. No unfused equivalent of the combine epilogue --
-            # fail loudly rather than skip the reduce.
+            # Lands here cross-node out-of-mnnvl-range, or single-node on a
+            # sentinel-width mismatch. No unfused equivalent of the combine
+            # epilogue -- fail loudly rather than skip the reduce.
             raise RuntimeError(
                 "trtllm AR fusion: kARResidualAttnResCombine has no fused "
                 f"workspace for this call (tokens={token_num}, "
@@ -797,6 +1028,7 @@ if current_platform().is_nvidia:
             raise RuntimeError("TRT-LLM fusion workspace not available")
 
         workspace = _ar_fusion_workspace(
+            _manager_for_group(group),
             token_num,
             lane_dim,
             lane.dtype,
@@ -804,8 +1036,8 @@ if current_platform().is_nvidia:
             use_oneshot=True,
         )
         if workspace is None:
-            # mnnvl serves this pattern in-range; only out-of-range shapes land
-            # here cross-node. Fail loudly rather than skip the reduce.
+            # Lands here cross-node out-of-mnnvl-range, or single-node on a
+            # sentinel-width mismatch. Fail loudly rather than skip the reduce.
             raise RuntimeError(
                 "trtllm AR fusion: kAllReduceLatentNorm has no fused workspace "
                 f"for this call (tokens={token_num}, lane={lane_dim}, "
@@ -921,11 +1153,18 @@ if current_platform().is_nvidia:
         # the IPC lamport workspace only. Since IPC is skipped on cross-node
         # groups, `initialized` can be True (mnnvl armed) while this workspace
         # is None; without this check a null pointer reaches the FFI.
-        if _workspace_manager.workspace_tensor is None:
+        manager = _manager_for_group(group)
+        if manager.workspace_tensor is None:
             raise RuntimeError(
                 "trtllm reducescatter fusion requires the IPC lamport workspace, which is "
                 "unavailable on this group (cross-node, or IPC explicitly "
                 "skipped). Use the unfused path for this collective."
+            )
+        # A sentinel-width mismatch corrupts the lamport neg-zero wait/clear protocol.
+        if (input_tensor.dtype == torch.float32) != manager.use_fp32_lamport:
+            raise RuntimeError(
+                "trtllm reducescatter fusion: payload width does not match "
+                "the armed lamport sentinel"
             )
 
         trtllm_reducescatter_fusion(
@@ -934,7 +1173,7 @@ if current_platform().is_nvidia:
             world_rank=rank,
             token_num=token_num,
             hidden_dim=hidden_dim,
-            workspace_ptrs=_workspace_manager.workspace_tensor,
+            workspace_ptrs=_mark_captured(manager, manager.workspace_tensor),
             launch_with_pdl=launch_with_pdl,
             trigger_completion_at_end=trigger_completion_at_end,
             num_token_current_rank=token_count,
@@ -1048,11 +1287,18 @@ if current_platform().is_nvidia:
         # the IPC lamport workspace only. Since IPC is skipped on cross-node
         # groups, `initialized` can be True (mnnvl armed) while this workspace
         # is None; without this check a null pointer reaches the FFI.
-        if _workspace_manager.workspace_tensor is None:
+        manager = _manager_for_group(group)
+        if manager.workspace_tensor is None:
             raise RuntimeError(
                 "trtllm allgather fusion requires the IPC lamport workspace, which is "
                 "unavailable on this group (cross-node, or IPC explicitly "
                 "skipped). Use the unfused path for this collective."
+            )
+        # A sentinel-width mismatch corrupts the lamport neg-zero wait/clear protocol.
+        if (qkv.dtype == torch.float32) != manager.use_fp32_lamport:
+            raise RuntimeError(
+                "trtllm allgather fusion: payload width does not match "
+                "the armed lamport sentinel"
             )
 
         trtllm_allgather_fusion(
@@ -1060,7 +1306,7 @@ if current_platform().is_nvidia:
             world_size=world_size,
             world_rank=rank,
             hidden_dim=hidden_dim,
-            workspace_ptrs=_workspace_manager.workspace_tensor,
+            workspace_ptrs=_mark_captured(manager, manager.workspace_tensor),
             launch_with_pdl=launch_with_pdl,
             trigger_completion_at_end=trigger_completion_at_end,
             num_token_current_rank=num_token_current_rank,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/trtllm.py
@@ -561,13 +561,10 @@ def trtllm_create_ipc_workspace_for_all_reduce_fusion(
     Tuple[List[List[int]], torch.Tensor],
     Tuple[List[List[int]], torch.Tensor, dict],
 ]:
-    buffer_size = tp_size * max_token_num * hidden_dim * 2
+    elem_size = 4 if use_fp32_lamport else 2
+    buffer_size = tp_size * max_token_num * hidden_dim * elem_size
     flag_size = tp_size * BarrierFlagCount * 4
-    lamport_comm_size = (
-        tp_size * max_token_num * hidden_dim * 2
-        if not use_fp32_lamport
-        else tp_size * max_token_num * hidden_dim * 4
-    )
+    lamport_comm_size = tp_size * max_token_num * hidden_dim * elem_size
 
     ipc_handles, workspace_tensor = _create_ipc_workspace(
         tp_rank,

--- a/tokenspeed-kernel/test/thirdparty/test_trtllm_mnnvl_comm.py
+++ b/tokenspeed-kernel/test/thirdparty/test_trtllm_mnnvl_comm.py
@@ -156,6 +156,57 @@ def test_plain_allreduce_matches_nccl(token_num):
     torch.testing.assert_close(out.float(), ref, atol=3e-2, rtol=3e-2)
 
 
+@pytest.mark.parametrize("token_num", [8, 147, 288, 576])
+def test_trtllm_workspace_allreduce(token_num):
+    """The backend-facing plain AR serves the workspace's full token range.
+
+    8 tokens rides the one-shot window; the larger counts land past it,
+    where the previous behavior was a NCCL ring fallback, and resolve to
+    two-shot inside the same workspace.
+    """
+    from tokenspeed_kernel.ops.communication.trtllm import (
+        ensure_workspace_initialized,
+        trtllm_workspace_allreduce,
+    )
+
+    rank, dev = _setup()
+    try:
+        armed = ensure_workspace_initialized(
+            rank=rank, group=dist.group.WORLD, max_token_num=2048, hidden_dim=H
+        )
+    except RuntimeError as exc:
+        pytest.skip(f"trtllm fusion workspace unavailable: {exc}")
+    if not armed:
+        pytest.skip("trtllm fusion workspace unavailable")
+    torch.manual_seed(300 + rank)
+    x = (torch.randn(token_num, H, dtype=torch.bfloat16, device=dev) * 0.1).contiguous()
+    out = trtllm_workspace_allreduce(x, dist.group.WORLD)
+    if out is None:
+        pytest.skip("no armed workspace serves this shape on this fabric")
+    torch.cuda.synchronize()
+    assert out.shape == x.shape and out.dtype == x.dtype
+    ref = x.float().clone()
+    dist.all_reduce(ref)
+    torch.testing.assert_close(out.float(), ref, atol=3e-2, rtol=3e-2)
+
+    from tokenspeed_kernel.ops.communication import trtllm as comm
+
+    cap = comm._manager_for_group(dist.group.WORLD).max_token_num
+    oversized = torch.randn(cap + 1, H, dtype=torch.bfloat16, device=dev)
+    assert trtllm_workspace_allreduce(oversized, dist.group.WORLD) is None
+
+    # Non-contiguous input is served through a contiguous copy, never mutated.
+    strided = torch.randn(token_num, 2 * H, dtype=torch.bfloat16, device=dev)[:, ::2]
+    keep = strided.clone()
+    out_nc = trtllm_workspace_allreduce(strided, dist.group.WORLD)
+    assert out_nc is not None
+    torch.cuda.synchronize()
+    torch.testing.assert_close(strided, keep, atol=0, rtol=0)
+    ref_nc = strided.float().clone()
+    dist.all_reduce(ref_nc)
+    torch.testing.assert_close(out_nc.float(), ref_nc, atol=3e-2, rtol=3e-2)
+
+
 @pytest.mark.parametrize("token_num", [1, 8])
 def test_residual_rmsnorm_matches_ipc_backend(token_num):
     from tokenspeed_kernel.thirdparty.cuda.trtllm import AllReduceFusionPattern
@@ -342,7 +393,7 @@ def test_rmsnorm_family_unfused_fallback():
     assert comm.ensure_workspace_initialized(
         rank=rank, group=pg, max_token_num=MAXTOK, hidden_dim=H
     )
-    mgr = comm._workspace_manager
+    mgr = comm._manager_for_group(pg)
 
     token_num = 6
     torch.manual_seed(9_000 + rank)
@@ -392,3 +443,177 @@ def test_rmsnorm_family_unfused_fallback():
     g = [torch.empty_like(norm_out) for _ in range(world)]
     dist.all_gather(g, norm_out)
     assert all(torch.equal(g[0], gi) for gi in g)
+
+
+def test_rsag_serve_and_sentinel_guard():
+    """RS/AG wrappers serve matched-width payloads and raise on a mismatch.
+
+    Runs on a [0, 1] subgroup so its sticky fp32 flip cannot poison the
+    WORLD workspace the other tests share. The workspace registry keys on
+    the global rank tuple, so at world size 2 the subgroup IS the WORLD
+    entry -- skip there.
+    """
+    from tokenspeed_kernel.ops.communication import trtllm as comm
+
+    rank, dev = _setup()
+    if dist.get_world_size() < 4:
+        pytest.skip("needs a world larger than the [0, 1] subgroup")
+    sub = dist.new_group(ranks=[0, 1])
+    try:
+        if rank <= 1:
+            _rsag_body(comm, sub, dist.get_rank(group=sub), dev)
+    finally:
+        try:
+            if rank <= 1:
+                # The sticky fp32 flip would poison the (0, 1) registry entry
+                # for any later use of that rank tuple in this process.
+                comm._manager_for_group(sub).cleanup()
+        finally:
+            dist.barrier()
+
+
+def _rsag_body(comm, sub, grank, dev):
+    hid, maxtok, eps, world = 1024, 32, 1e-6, 2
+    try:
+        armed = comm.ensure_workspace_initialized(
+            rank=grank, group=sub, max_token_num=maxtok, hidden_dim=hid
+        )
+    except RuntimeError as exc:
+        pytest.skip(f"trtllm fusion workspace unavailable: {exc}")
+    if not armed:
+        pytest.skip("trtllm fusion workspace unavailable")
+    manager = comm._manager_for_group(sub)
+    if manager.workspace_tensor is None:
+        pytest.skip("no IPC lamport workspace on this group")
+
+    def _rmsnorm(x32, w):
+        return x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + eps) * w.float()
+
+    # Odd token count so the front-loaded remainder branch is exercised.
+    tok = 9
+    tpr, remaining = tok // world, tok % world
+    my_count = tpr + (1 if grank < remaining else 0)
+    my_off = grank * tpr + min(grank, remaining)
+    torch.manual_seed(500 + grank)
+    x = (torch.randn(tok, hid, dtype=torch.bfloat16, device=dev) * 0.1).contiguous()
+    res = (
+        torch.randn(my_count, hid, dtype=torch.bfloat16, device=dev) * 0.1
+    ).contiguous()
+    w = torch.randn(hid, dtype=torch.bfloat16, device=dev).abs().contiguous()
+    dist.broadcast(w, src=0, group=sub)
+    parts = [torch.empty_like(x) for _ in range(world)]
+    dist.all_gather(parts, x, group=sub)
+    ref_resid = torch.stack(parts).float().sum(0)[my_off : my_off + my_count]
+    ref_resid = ref_resid + res.float()
+    ref_norm = _rmsnorm(ref_resid, w)
+    # use_oneshot pinned: the upstream two-shot RS back-loads the remainder.
+    n_out, r_out, _ = comm.reducescatter_residual_rmsnorm(
+        input_tensor=x.clone(),
+        residual=res.clone(),
+        weight=w,
+        rank=grank,
+        group=sub,
+        eps=eps,
+        max_token_num=maxtok,
+        use_oneshot=True,
+    )
+
+    ql, kvl = 512, 256
+    ntok_cur = 4
+    total = ntok_cur * world
+    qkv = (
+        torch.randn(ntok_cur, hid, dtype=torch.bfloat16, device=dev) * 0.1
+    ).contiguous()
+    wq = torch.nn.Parameter(
+        torch.randn(ql, dtype=torch.bfloat16, device=dev).abs().contiguous(),
+        requires_grad=False,
+    )
+    wkv = torch.nn.Parameter(
+        torch.randn(kvl, dtype=torch.bfloat16, device=dev).abs().contiguous(),
+        requires_grad=False,
+    )
+    dist.broadcast(wq.data, src=0, group=sub)
+    dist.broadcast(wkv.data, src=0, group=sub)
+    gparts = [torch.empty_like(qkv) for _ in range(world)]
+    dist.all_gather(gparts, qkv, group=sub)
+    gathered = torch.cat(gparts, dim=0).float()
+    ref_q = _rmsnorm(gathered[:, :ql], wq.data)
+    ref_kv = _rmsnorm(gathered[:, ql : ql + kvl], wkv.data)
+    ag_out, qn, kvn, _ = comm.allgather_dual_rmsnorm(
+        qkv=qkv.clone(),
+        total_num_tokens=total,
+        weight_q_a=wq,
+        weight_kv_a=wkv,
+        rank=grank,
+        group=sub,
+        eps_q=eps,
+        eps_kv=eps,
+        max_token_num=maxtok,
+    )
+    # Asserts only after every subgroup collective, and on subgroup-MAX
+    # errors, so a one-rank numeric failure cannot desync a peer inside a
+    # later collective (NCCL-watchdog hang instead of a clean FAIL).
+    # Thresholds join the reduce: ref_norm is a per-rank slice, so its scale
+    # is rank-varying; ref_q/ref_kv follow for uniformity.
+    errs = torch.tensor(
+        [
+            (r_out.float() - ref_resid).abs().max().item(),
+            (n_out.float() - ref_norm).abs().max().item(),
+            (qn.float() - ref_q).abs().max().item(),
+            (kvn.float() - ref_kv).abs().max().item(),
+            (ag_out[:, ql + kvl :].float() - gathered[:, ql + kvl :])
+            .abs()
+            .max()
+            .item(),
+            ref_norm.abs().max().item(),
+            ref_q.abs().max().item(),
+            ref_kv.abs().max().item(),
+        ],
+        device=dev,
+    )
+    dist.all_reduce(errs, op=dist.ReduceOp.MAX, group=sub)
+    scale = errs[5].item() or 1.0
+    sq = errs[6].item() or 1.0
+    skv = errs[7].item() or 1.0
+    assert errs[0].item() <= 5e-2, f"RS residual: {errs[0].item():.4g}"
+    assert errs[1].item() <= 0.03 * scale + 0.02, f"RS norm: {errs[1].item():.4g}"
+    assert errs[2].item() <= 0.03 * sq + 0.02, f"AG q: {errs[2].item():.4g}"
+    assert errs[3].item() <= 0.03 * skv + 0.02, f"AG kv: {errs[3].item():.4g}"
+    assert errs[4].item() <= 5e-2, f"AG rope passthrough: {errs[4].item():.4g}"
+
+    # Sticky fp32 flip; 16-bit payloads must now be refused loudly, pre-FFI.
+    assert comm.ensure_workspace_initialized(
+        rank=grank,
+        group=sub,
+        max_token_num=maxtok,
+        hidden_dim=hid,
+        use_fp32_lamport=True,
+    )
+    assert manager.use_fp32_lamport is True
+    ws_before = manager.workspace_tensor
+    with pytest.raises(RuntimeError, match="payload width does not match"):
+        comm.reducescatter_residual_rmsnorm(
+            input_tensor=x.clone(),
+            residual=res.clone(),
+            weight=w,
+            rank=grank,
+            group=sub,
+            eps=eps,
+            max_token_num=maxtok,
+            use_oneshot=True,
+        )
+    with pytest.raises(RuntimeError, match="payload width does not match"):
+        comm.allgather_dual_rmsnorm(
+            qkv=qkv.clone(),
+            total_num_tokens=total,
+            weight_q_a=wq,
+            weight_kv_a=wkv,
+            rank=grank,
+            group=sub,
+            eps_q=eps,
+            eps_kv=eps,
+            max_token_num=maxtok,
+        )
+    # Refusals must not mutate the armed workspace.
+    assert manager.initialized and manager.use_fp32_lamport is True
+    assert manager.workspace_tensor is ws_before


### PR DESCRIPTION
Cross-node, the trtllm AR backend served only payloads inside its 2 MB one-shot window through a private 146-token workspace; anything larger fell to a NCCL ring. At bs=32 spec decode that was 107 attention all-reduces per step of [288, 7168] bf16 at 69 us each -- 7.4 ms/step -- while the model's own 2048-token fusion workspace sat idle for them. Measured on Kimi-K3-NVFP4 (DSpark8, 2x GB300): bs=32 TPOT 40.03 -> 35.38 ms and bs=64 52.94 -> 48.07, with bs=1/8 unchanged.

Rather than growing the backend's private copy, unify ownership: the kernel package keeps one fusion-workspace manager per rank set (keyed by global ranks, since the backend and the fused-pattern wrappers reach the same group through different ProcessGroup objects), and the backend's configure_group/ensure_group_lane arm and grow that shared workspace instead of creating their own IPC + mnnvl duplicates. Plain SUM all-reduces go through the new trtllm_workspace_allreduce: the same IPC-vs-mnnvl split the fused wrappers use, with the strategy resolved by size -- one-shot inside its traffic window, two-shot up to the workspace's token capacity -- and None (NCCL fallback) for anything the workspace cannot serve. The backend's 2 MB admission wall is gone; the constant remains only for routing tensor collections.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
