### PR TITLE
perf(sampling): probe NVLS for the distributed argmax and draft throu…

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -21,8 +21,15 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import torch
+from tokenspeed_kernel.ops.sampling.cute_dsl import distributed_argmax as _dist_argmax
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    supports_dist_argmax_shape as _supports_dist_argmax_shape,
+)
 
 from tokenspeed.runtime.distributed.comm_ops import all_gather_into_tensor
+from tokenspeed.runtime.distributed.process_group_manager import (
+    process_group_manager as pg_manager,
+)
 from tokenspeed.runtime.execution.cache_loc_kernel import (
     dflash_prepare_decode,
 )
@@ -36,7 +43,10 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
-from tokenspeed.runtime.layers.logits_processor import LogitsMetadata
+from tokenspeed.runtime.layers.logits_processor import (
+    LogitsMetadata,
+    _force_deterministic_rsag,
+)
 from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 
@@ -101,6 +111,9 @@ def _resolve_block_geometry(cfg, spec_num_tokens: int) -> tuple[int, int]:
 def _resolve_draft_query_width(verify_width: int, sample_from_anchor: bool) -> int:
     """Resolve rows consumed by one native draft forward."""
     return verify_width - 1 if sample_from_anchor else verify_width
+
+
+_UNSET = object()
 
 
 class DFlash(BaseDrafter):
@@ -194,6 +207,8 @@ class DFlash(BaseDrafter):
             dtype=torch.int32,
             device=self.device,
         )
+        # None means probed-and-unavailable; unset means not probed yet.
+        self._dist_argmax_state: object = _UNSET
         self.draft_input_lengths_buf = torch.full(
             (max_bs,),
             self.draft_query_width,
@@ -269,6 +284,35 @@ class DFlash(BaseDrafter):
                 f"{type(target_model).__name__} does not implement "
                 "set_dflash_aux_hidden_stream, so it can only supply 'prefix'."
             )
+
+    def _probe_dist_argmax_state(self, dtype: torch.dtype, device: torch.device):
+        """Ask for a drafting state, once the head's shard is a fit for one."""
+        head = self.lm_head
+        shard = int(head.shard_indices.num_org_elements)
+        tp_size = int(self.logits_processor.tp_size)
+        if (
+            _force_deterministic_rsag()
+            or not 2 <= tp_size <= 32
+            or int(head.num_embeddings) != int(head.org_vocab_size)
+            or shard * tp_size != int(head.org_vocab_size)
+            or not _supports_dist_argmax_shape(shard, dtype, tp_size)
+        ):
+            return None
+        return self.logits_processor.acquire_dist_argmax_state(
+            head,
+            max_M=self.input_buffers.max_bs * max(self.spec_num_tokens - 1, 1),
+            # Back-to-back walk rounds carry no cross-rank sync between them,
+            # which skip_ping_pong would require.
+            skip_ping_pong=False,
+        )
+
+    def _ensure_dist_argmax_state(self, dtype: torch.dtype, device: torch.device):
+        """Probe once, before capture, and reuse the verdict for the process."""
+        if self._dist_argmax_state is _UNSET:
+            if torch.cuda.is_current_stream_capturing():
+                return None  # rendezvous is collective; leave it to warmup
+            self._dist_argmax_state = self._probe_dist_argmax_state(dtype, device)
+        return self._dist_argmax_state
 
     def _greedy_gather_capacity(self) -> int:
         """Max element count for the greedy head's tensor-parallel all-gather
@@ -361,12 +405,22 @@ class DFlash(BaseDrafter):
         added_vocab_start = int(shard.added_vocab_start_index)
 
         chunk_len = int(hidden_states.shape[0])
+        # The collective probe must sit outside every rank-local branch: a rank
+        # with an empty org shard skipping it would strand the rest.
+        dist_state = self._ensure_dist_argmax_state(weight.dtype, weight.device)
         if num_org > 0:
             base_logits = torch.matmul(hidden_states, weight[:num_org].T)
             if bias_fn is not None:
                 base_logits = base_logits + bias_fn(org_vocab_start, num_org).to(
                     base_logits.dtype
                 )
+            if dist_state is not None:
+                # Without padding the rank-major index IS the global id.
+                _, idx = _dist_argmax(dist_state, base_logits)
+                if out is not None:
+                    out.copy_(idx.view_as(out))
+                    return out
+                return idx.to(torch.int32)
             local_max, local_arg = torch.max(base_logits, dim=-1)
         else:
             local_max = torch.full(

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -27,9 +27,6 @@ from tokenspeed_kernel.ops.sampling.cute_dsl import (
 )
 
 from tokenspeed.runtime.distributed.comm_ops import all_gather_into_tensor
-from tokenspeed.runtime.distributed.process_group_manager import (
-    process_group_manager as pg_manager,
-)
 from tokenspeed.runtime.execution.cache_loc_kernel import (
     dflash_prepare_decode,
 )

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -28,11 +28,15 @@ import triton.language as tl
 from tokenspeed_kernel.ops.communication.triton import all_gather_inner, create_state
 from tokenspeed_kernel.ops.sampling import argmax as sampling_argmax
 from tokenspeed_kernel.ops.sampling.cute_dsl import (
-    create_dist_argmax_state,
+    DistArgmaxState,
     distributed_argmax,
 )
 from tokenspeed_kernel.ops.sampling.cute_dsl import (
     is_available as dist_argmax_available,
+)
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    supports_dist_argmax_shape,
+    try_create_dist_argmax_state,
 )
 from tokenspeed_kernel.platform import current_platform
 from torch import nn
@@ -327,41 +331,85 @@ class LogitsProcessor(nn.Module):
             )
         return self._LOGITS_AG_STATES[key]
 
-    def _init_dist_argmax_state(self, lm_head: VocabParallelEmbedding):
-        if not current_platform().is_nvidia or _force_deterministic_rsag():
-            return None
+    def _agree_across_tp(self, ok: bool, group, device: torch.device) -> bool:
+        """Reduce a per-rank verdict so the whole group takes the same path."""
+        vote = torch.tensor([int(ok)], dtype=torch.int32, device=device)
+        torch.distributed.all_reduce(
+            vote, op=torch.distributed.ReduceOp.MIN, group=group
+        )
+        return bool(vote.item())
 
-        # CuTe DSL argmax is unavailable on some SKUs (e.g. H20 lacks TMA
-        # cluster launch). Fall back to the plain all-gather + argmax path.
-        if not dist_argmax_available():
-            return None
+    def acquire_dist_argmax_state(
+        self,
+        lm_head: VocabParallelEmbedding,
+        *,
+        max_M: int,
+        skip_ping_pong: bool,
+    ) -> DistArgmaxState | None:
+        """Build this TP group's distributed-argmax state, or None to fall back.
 
-        if (
-            self.tp_size == 1
-            or self.skip_all_gather
-            or self.dp_sampling_enabled
-            or self._tp_group_spans_nodes()
+        Shared by the sampler and the drafters. Construction rendezvouses and
+        barriers, so a rank deciding alone would strand the others: platform
+        eligibility and the build outcome are both reduced with MIN. Callers
+        apply their own config-uniform gates first, which may return early
+        because those cost no collective work.
+
+        Args:
+            lm_head: The vocab-parallel head whose shard the argmax reduces.
+            max_M: Largest row count the caller will ever pass.
+            skip_ping_pong: Pin the slot band instead of alternating; only
+                when the caller synchronizes across ranks between calls.
+
+        Returns:
+            The state, or None when this group must use the gather path.
+        """
+        key = (self.tp_group, lm_head.weight.size(0), max_M, skip_ping_pong)
+        if key in self._LOGITS_DIST_ARGMAX_STATES:
+            return self._LOGITS_DIST_ARGMAX_STATES[key]
+        if torch.cuda.is_current_stream_capturing():
+            return None  # never rendezvous inside capture; warmup probes first
+
+        device = lm_head.weight.device
+        group = pg_manager.get_process_group("nccl", self.tp_group)
+        if self._agree_across_tp(
+            current_platform().is_nvidia and dist_argmax_available(), group, device
         ):
+            state = try_create_dist_argmax_state(
+                group=group,
+                rank_in_group=self.tp_rank,
+                max_M=max_M,
+                dtype=lm_head.weight.dtype,
+                device=device,
+                skip_ping_pong=skip_ping_pong,
+            )
+            if not self._agree_across_tp(state is not None, group, device):
+                state = None
+        else:
+            state = None
+        self._LOGITS_DIST_ARGMAX_STATES[key] = state
+        return state
+
+    def _init_dist_argmax_state(self, lm_head: VocabParallelEmbedding):
+        if _force_deterministic_rsag():
+            return None
+        if not 2 <= self.tp_size <= 32:
+            return None  # the kernel's cross-rank reduce is a single warp shuffle
+        if self.skip_all_gather or self.dp_sampling_enabled:
             return None
 
         vocab_per_rank = lm_head.weight.size(0)
         if vocab_per_rank * self.tp_size != self.config.vocab_size:
             return None  # padded vocab: sharded argmax could pick a pad column
-        if vocab_per_rank < 4096 or vocab_per_rank % 32 != 0:
-            return None  # below the kernel's vocab floor / alignment
+        if not supports_dist_argmax_shape(
+            vocab_per_rank, lm_head.weight.dtype, self.tp_size
+        ):
+            return None
 
-        key = (self.tp_group, vocab_per_rank)
-        if key not in self._LOGITS_DIST_ARGMAX_STATES:
-            self._LOGITS_DIST_ARGMAX_STATES[key] = create_dist_argmax_state(
-                group=pg_manager.get_process_group("nccl", self.tp_group),
-                rank_in_group=self.tp_rank,
-                max_M=self._LOGITS_DIST_ARGMAX_MAX_TOKENS,
-                dtype=lm_head.weight.dtype,
-                device=lm_head.weight.device,
-                skip_ping_pong=True,
-            )
-
-        return self._LOGITS_DIST_ARGMAX_STATES[key]
+        return self.acquire_dist_argmax_state(
+            lm_head,
+            max_M=self._LOGITS_DIST_ARGMAX_MAX_TOKENS,
+            skip_ping_pong=True,
+        )
 
     def forward(
         self,
@@ -608,11 +656,15 @@ class LogitsProcessor(nn.Module):
 
         elif not dp_sampling and self.tp_size > 1 and not self.skip_all_gather:
             if self.do_argmax:
-                if self._dist_argmax_state is self._LOGITS_DIST_ARGMAX_UNINITIALIZED:
+                if (
+                    self._dist_argmax_state is self._LOGITS_DIST_ARGMAX_UNINITIALIZED
+                    and not torch.cuda.is_current_stream_capturing()
+                ):
                     self._dist_argmax_state = self._init_dist_argmax_state(lm_head)
 
                 if (
-                    self._dist_argmax_state is not None
+                    self._dist_argmax_state
+                    not in (self._LOGITS_DIST_ARGMAX_UNINITIALIZED, None)
                     and not self.final_logit_softcapping
                     and logits.size(0) <= self._LOGITS_DIST_ARGMAX_MAX_TOKENS
                 ):

--- a/test/runtime/test_logits_processor.py
+++ b/test/runtime/test_logits_processor.py
@@ -108,7 +108,7 @@ def test_force_deterministic_rsag_disables_logits_symm_mem(
     )
     monkeypatch.setattr(
         logits_processor_module,
-        "create_dist_argmax_state",
+        "try_create_dist_argmax_state",
         lambda *args, **kwargs: pytest.fail(
             "symmetric-memory state must not initialize"
         ),
@@ -142,16 +142,76 @@ def test_tp_logits_custom_collectives_skip_cross_node_group(monkeypatch):
         "create_state",
         lambda **kwargs: pytest.fail("cross-node TP must not create RSAG state"),
     )
+    # Distributed argmax is no longer topology-gated: cross-node groups probe
+    # for NVLS instead. This shard is below the kernel's vocab floor, so the
+    # state is rejected before any collective work.
     monkeypatch.setattr(
         logits_processor_module,
-        "create_dist_argmax_state",
+        "try_create_dist_argmax_state",
         lambda **kwargs: pytest.fail(
-            "cross-node TP must not create distributed-argmax state"
+            "a shard below the vocab floor must not reach the constructor"
         ),
     )
 
     assert processor._init_all_gather_state(lm_head) is None
     assert processor._init_dist_argmax_state(lm_head) is None
+
+
+def test_dist_argmax_probe_failure_falls_back_and_latches(monkeypatch):
+    """A failed probe falls back, latches its verdict, and skips capture."""
+    monkeypatch.setitem(
+        global_server_args_dict,
+        "mapping",
+        SimpleNamespace(nprocs_per_node=4),
+    )
+    monkeypatch.setattr(logits_processor_module, "dist_argmax_available", lambda: True)
+    monkeypatch.setattr(
+        logits_processor_module,
+        "current_platform",
+        lambda: SimpleNamespace(is_nvidia=True),
+    )
+    capturing = {"on": True}
+    monkeypatch.setattr(
+        logits_processor_module.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: capturing["on"],
+    )
+    monkeypatch.setattr(
+        logits_processor_module.pg_manager,
+        "get_process_group",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        logits_processor_module.torch.distributed,
+        "all_reduce",
+        lambda tensor, **k: None,
+    )
+    calls = []
+
+    def failing_create(**kwargs):
+        calls.append(1)
+        return None  # the group has no NVLS multicast
+
+    monkeypatch.setattr(
+        logits_processor_module, "try_create_dist_argmax_state", failing_create
+    )
+    processor = LogitsProcessor(
+        config=SimpleNamespace(model_type="test", vocab_size=8192),
+        tp_rank=0,
+        tp_size=2,
+        tp_group=(0, 4),
+    )
+    lm_head = SimpleNamespace(weight=torch.ones((4096, 2), dtype=torch.float32))
+
+    # Inside capture: no collective work, and nothing may latch.
+    assert processor._init_dist_argmax_state(lm_head) is None
+    assert len(calls) == 0
+
+    capturing["on"] = False
+    assert processor._init_dist_argmax_state(lm_head) is None
+    # The verdict is cached: the constructor must not be retried.
+    assert processor._init_dist_argmax_state(lm_head) is None
+    assert len(calls) == 1
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -61,6 +61,8 @@ __all__ = [
     "argmax",
     "argmax_pair",
     "create_dist_argmax_state",
+    "supports_dist_argmax_shape",
+    "try_create_dist_argmax_state",
     "cute_dsl_argmax",
     "distributed_argmax",
     "is_available",
@@ -171,6 +173,32 @@ if _ARCH_SUPPORTED and _has_cluster_launch_support():
 def is_available() -> bool:
     """Whether the CuTe DSL argmax kernel can run on this platform."""
     return _CUTE_AVAILABLE
+
+
+def supports_dist_argmax_shape(
+    vocab_per_rank: int, dtype: torch.dtype, world_size: int
+) -> bool:
+    """Whether a shard's width, dtype and group size fit the distributed argmax.
+
+    Deliberately excludes platform and multicast support, which can differ
+    between ranks: this verdict follows from the model config alone, so a
+    caller may reject on it before doing any collective work.
+
+    Args:
+        vocab_per_rank: Column count of one rank's logits shard.
+        dtype: Value dtype of those logits.
+        world_size: Ranks in the group the argmax reduces over.
+
+    Returns:
+        True when the shard is one :func:`distributed_argmax` will accept.
+    """
+    return (
+        dtype in (torch.float16, torch.bfloat16, torch.float32)
+        and 1 <= world_size <= 32
+        and vocab_per_rank >= _MIN_VOCAB_SIZE
+        and vocab_per_rank % _VOCAB_SIZE_ALIGNMENT == 0
+        and world_size * vocab_per_rank < 0x7FFFFFFF
+    )
 
 
 def _supports_cute(N: int, dtype: torch.dtype) -> bool:
@@ -900,14 +928,16 @@ class DistArgmaxState:
     skip_ping_pong: bool = False
 
 
-def create_dist_argmax_state(
+def _build_dist_argmax_state(
     group: _dist.ProcessGroup,
     rank_in_group: int,
     max_M: int,
     dtype: torch.dtype = torch.bfloat16,
     device: torch.device | None = None,
     skip_ping_pong: bool = False,
-) -> DistArgmaxState:
+    *,
+    strict: bool,
+) -> DistArgmaxState | None:
     assert dtype in (
         torch.bfloat16,
         torch.float16,
@@ -942,6 +972,8 @@ def create_dist_argmax_state(
         f"world_size={world_size}"
     )
     if not hdl.multicast_ptr:
+        if not strict:
+            return None
         raise RuntimeError(
             f"distributed_argmax requires CUDA multicast / NVLS, but the "
             f"symm-mem handle on device {device} reports multicast_ptr="
@@ -963,6 +995,70 @@ def create_dist_argmax_state(
         warps_done_gpu=warps_done_gpu,
         use_redux=use_redux,
         skip_ping_pong=skip_ping_pong,
+    )
+
+
+def create_dist_argmax_state(
+    group: _dist.ProcessGroup,
+    rank_in_group: int,
+    max_M: int,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device | None = None,
+    skip_ping_pong: bool = False,
+) -> DistArgmaxState:
+    """Build the cross-rank argmax state, requiring NVLS multicast.
+
+    Args:
+        group: The process group the argmax reduces over.
+        rank_in_group: This process's rank within ``group``.
+        max_M: Largest row count any call will pass.
+        dtype: Value dtype of the logits; bf16, fp16 or fp32.
+        device: CUDA device for the symmetric-memory slots; defaults to the
+            current device.
+        skip_ping_pong: Pin the slot band instead of alternating. Only safe
+            when the caller synchronizes across ranks between calls.
+
+    Returns:
+        The state to pass to :func:`distributed_argmax`.
+
+    Raises:
+        RuntimeError: The group has no CUDA multicast / NVLS support.
+    """
+    return _build_dist_argmax_state(
+        group, rank_in_group, max_M, dtype, device, skip_ping_pong, strict=True
+    )
+
+
+def try_create_dist_argmax_state(
+    group: _dist.ProcessGroup,
+    rank_in_group: int,
+    max_M: int,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device | None = None,
+    skip_ping_pong: bool = False,
+) -> DistArgmaxState | None:
+    """Build the cross-rank argmax state, or report that NVLS is missing.
+
+    Multicast support cannot be queried before the symmetric-memory
+    rendezvous, so callers that would rather fall back than fail ask here
+    instead of catching an exception. Every other precondition still asserts.
+
+    Args:
+        group: The process group the argmax reduces over.
+        rank_in_group: This process's rank within ``group``.
+        max_M: Largest row count any call will pass.
+        dtype: Value dtype of the logits; bf16, fp16 or fp32.
+        device: CUDA device for the symmetric-memory slots; defaults to the
+            current device.
+        skip_ping_pong: Pin the slot band instead of alternating. Only safe
+            when the caller synchronizes across ranks between calls.
+
+    Returns:
+        The state, or ``None`` when the group has no multicast support. The
+        verdict follows from the group's fabric, so every rank agrees on it.
+    """
+    return _build_dist_argmax_state(
+        group, rank_in_group, max_M, dtype, device, skip_ping_pong, strict=False
     )
 
 


### PR DESCRIPTION
…gh it

The CuTe distributed argmax was gated off whenever the TP group spans nodes, but its real requirement is a symm-mem handle with a multicast pointer, which a GB200 NVL72 domain supplies across nodes too (measured 16/16 ranks over four nodes, results bitwise equal to a full-vocab argmax). The gate now asks the hardware: build the state once, reduce the verdict across the group so every rank takes the same path, and fall back to the gather path when any rank cannot. Rank-varying inputs never decide the gate on their own, because the constructor is collective and a rank that skipped it would strand the rest; for the same reason the probe sits outside every rank-local branch, capture never latches a verdict, and a failed probe latches exactly once.

The DSpark/DFlash drafter's vocab-parallel greedy argmax then rides the same kernel: one call replaces the local max plus two tiny all-gathers plus the cross-rank pick, whose cost at tp_size x batch elements was pure collective latency, paid spec_num_tokens - 1 times a step (75us to 5us per call inside the graph). The drafter builds its state in ping-pong mode: its rounds run back to back with no cross-rank sync in between, which skip_ping_pong forbids. Without padding or added vocabulary the kernel's rank-major index is exactly the global token id; configurations with either keep the gather path, as do deterministic-RSAG runs. DFlash2 inherits the primitive unchanged.

Measured on GB200, four-node TP16, same main and prebuilt kernels on both arms: decode goes 458.5/467.1/459.2/477.8 to 472.6/473.5/473.6/496.9 tok/s (+2.9%, every sample moving together) with accepted tokens per round unchanged at 6.813/5.641. Rows containing NaN differ deliberately: the kernel skips NaNs where torch.max propagated them, so a NaN row yields the best finite token instead of garbage.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
