### PR TITLE
fix(kimi3): warm the MoE auxiliary stream before graph capture

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -102,6 +102,7 @@ from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.distributed.pp_stage import PPStageState, pp_layer_window
 from tokenspeed.runtime.execution.cuda_graph_wrapper import (
     get_is_capture_mode,
+    get_is_cuda_graph_phase,
 )
 from tokenspeed.runtime.layers.activation import SituAndMul
 from tokenspeed.runtime.layers.layernorm import (
@@ -1846,7 +1847,21 @@ class KimiLinearMoE(nn.Module):
         else:
             self.experts._situ_output_buffer = None
         prepared_shared_shard = None
-        with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
+        # Enable the fork for the whole graph phase, but only overlap during
+        # capture. The pre-capture warmup runs with capture mode off, so gating
+        # ``enable`` on it left the auxiliary stream completely untouched until
+        # capture itself -- the first hipBLASLt call on that stream then did its
+        # lazy handle/workspace setup inside the capturing stream and raised
+        # "operation not permitted when stream is capturing" (900) on every
+        # rank, deadlocking startup. Enabling on the graph phase makes warmup
+        # execute the same branches on the auxiliary stream, serially
+        # (``overlap=False``), so every backend is initialized before capture.
+        # This matches the contract _capture_one documents and the pattern the
+        # other fork-using models already follow.
+        with self.stream_fork.scope(
+            enable=get_is_cuda_graph_phase(),
+            overlap=get_is_capture_mode(),
+        ) as fork:
             with fork.branch():
                 topk_output = self.topk(hidden_states, router_logits)
                 if self._topk_ready is not None and fork._active:

--- a/test/runtime/test_kimi_k3_moe_fork_warmup.py
+++ b/test/runtime/test_kimi_k3_moe_fork_warmup.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""``KimiLinearMoE`` must exercise its auxiliary stream during graph warmup.
+
+``_capture_one`` runs several warmup forwards on the capture stream before
+recording, and documents that "capture-only auxiliary branches use this graph
+phase to warm their own streams serially". Honouring that contract requires
+gating the stream fork on the graph *phase* and gating only the overlap on
+capture mode.
+
+Gating ``enable`` on capture mode instead left the auxiliary stream untouched
+until capture itself. The first hipBLASLt call on that stream then performed its
+lazy handle/workspace setup inside the capturing stream, which HIP rejects with
+"operation not permitted when stream is capturing" (900) on every rank, and
+startup deadlocked with the GPUs idle. It reproduced on gfx950 at TP8/EP1 --
+where the tensor-parallel MoE places a projection on the forked branch -- while
+TP8/EP8 captured cleanly, so the config coverage matters as much as the flag.
+
+CPU-only: no real streams or capture, just the enable/overlap decision.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from tokenspeed.runtime.models.kimi_k3 import KimiLinearMoE
+
+
+class _SpyFork:
+    """Records the ``scope()`` arguments and behaves like an inactive fork."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, bool]] = []
+        self._active = False
+
+    def scope(self, *, enable: bool, overlap: bool = True):
+        self.calls.append({"enable": enable, "overlap": overlap})
+        # Mirror StreamFork: scope() yields the fork itself, and without an aux
+        # stream it stays inactive, so branch() is a passthrough and the fake
+        # collaborators below run inline.
+        return _NullCtx(self)
+
+    def branch(self):
+        return _NullCtx(None)
+
+
+class _NullCtx:
+    def __init__(self, value):
+        self._value = value
+
+    def __enter__(self):
+        return self._value
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _make_moe(fork: _SpyFork) -> SimpleNamespace:
+    """Minimal stand-in exposing only what the fork path of forward() touches."""
+    hidden = torch.zeros(2, 4)
+
+    plan = SimpleNamespace(
+        lane=None,
+        split_shared_rs=False,
+        routed_in_fork=False,
+        defer_finalize=False,
+    )
+    comm = SimpleNamespace(
+        plan=lambda num_tokens, hs: plan,
+        run=lambda *a, **k: hidden,
+        reduce_scatter_shared=lambda x: x,
+        reduce_project_routed=lambda x: x,
+    )
+    return SimpleNamespace(
+        _gather_dp_tokens_for_moe=False,
+        native_latent_moe=None,
+        stream_fork=fork,
+        _topk_ready=None,
+        routed_hidden=4,
+        comm=comm,
+        gate=lambda hs: torch.zeros(2, 2),
+        topk=lambda hs, logits: (torch.zeros(2, 1), torch.zeros(2, 1)),
+        shared_experts=lambda hs, down_out=None: hs,
+        routed_expert_down_proj=lambda hs: (hs, None),
+        experts=SimpleNamespace(_situ_output_buffer=None),
+        _routed_experts=lambda *a, **k: hidden,
+    )
+
+
+def _run(*, graph_phase: bool, capture_mode: bool) -> dict[str, bool]:
+    fork = _SpyFork()
+    moe = _make_moe(fork)
+    with (
+        mock.patch(
+            "tokenspeed.runtime.models.kimi_k3.get_is_cuda_graph_phase",
+            return_value=graph_phase,
+        ),
+        mock.patch(
+            "tokenspeed.runtime.models.kimi_k3.get_is_capture_mode",
+            return_value=capture_mode,
+        ),
+    ):
+        KimiLinearMoE.forward(
+            moe,
+            torch.zeros(2, 4),
+            torch.zeros(2, 4),
+            num_global_tokens=2,
+            max_num_tokens_per_gpu=2,
+        )
+    assert len(fork.calls) == 1
+    return fork.calls[0]
+
+
+def test_warmup_forward_activates_the_auxiliary_stream():
+    """Warmup (graph phase, not yet capturing) must still use the aux stream.
+
+    This is the regression: with ``enable`` gated on capture mode the warmup
+    forwards never touched the aux stream, so hipBLASLt initialized inside the
+    capturing stream and capture died with HIP error 900.
+    """
+    call = _run(graph_phase=True, capture_mode=False)
+    assert call["enable"] is True
+    # Serial during warmup: the point is to initialize the stream, not to
+    # overlap, and overlapping outside capture would race the main stream.
+    assert call["overlap"] is False
+
+
+def test_capture_forward_overlaps():
+    call = _run(graph_phase=True, capture_mode=True)
+    assert call["enable"] is True
+    assert call["overlap"] is True
+
+
+def test_eager_serving_leaves_the_fork_disabled():
+    """Outside the graph phase behaviour is unchanged: no fork, no aux stream."""
+    call = _run(graph_phase=False, capture_mode=False)
+    assert call["enable"] is False


### PR DESCRIPTION
## Problem

`KimiLinearMoE` gates its stream fork on `get_is_capture_mode()`:

```python
with self.stream_fork.scope(enable=get_is_capture_mode()) as fork:
```

`_capture_one` runs several warmup forwards on the capture stream before recording, but those run with capture mode **off**. So `_active` stays `False`, `branch()` is a passthrough, and the auxiliary stream is never touched. Capture then activates that stream for the first time, and the first hipBLASLt call on it performs its lazy handle/workspace setup *inside the capturing stream*:

```
Hip error: 'operation not permitted when stream is capturing'(900)
  at .../hipblaslt/library/src/amd_detail/hipblaslt.cpp:147
```

One error per rank, then startup deadlocks with every GPU at 0% utilization. The server never reports healthy.

Reproduced on 8x gfx950 (MI355X, ROCm 7.2.2, torch 2.13.0+rocm7.2) serving Kimi-K3 MXFP4 at **TP8/EP1**, where the tensor-parallel MoE places a projection on the forked branch. **TP8/EP8 captures cleanly** both before and after this change, which is why it has gone unnoticed.

## Fix

Gate `enable` on the graph phase and `overlap` on capture mode:

```python
with self.stream_fork.scope(
    enable=get_is_cuda_graph_phase(),
    overlap=get_is_capture_mode(),
) as fork:
```

Warmup now runs the same branches on the auxiliary stream serially, so every backend is initialized before capture begins. This matches the contract `_capture_one` already documents —

> Capture-only auxiliary branches use this graph phase to warm their own streams serially.

— and the pattern the other fork-using models follow (`inkling`, `qwen3_5_moe`). `KimiLinearMoE` was the only caller passing the bare `enable=get_is_capture_mode()`.

Behaviour outside the graph phase is unchanged: eager serving still takes no fork.

## Validation

8x gfx950, Kimi-K3 MXFP4, `--tp 8`, MLA, fp8 KV cache, 4k input / 1k output.

| config | capture | probe accuracy | tok/s @ concurrency 1 / 8 / 16 |
|---|---|---|---|
| EP1 before | deadlock | n/a | n/a |
| **EP1 after** | clean | 8/8 | 53.98 / 259.08 / 448.57 |
| EP8 before | clean | 8/8 | 73.84 / 246.55 / 350.70 |
| **EP8 after** | clean | 8/8 | 73.83 / 247.51 / 351.51 |

EP8 is unchanged to three significant figures, so the change is inert where capture already worked. Accuracy is a fixed greedy prompt set (arithmetic, recall, short reasoning) diffed against an EP8 reference.

## Test

`test/runtime/test_kimi_k3_moe_fork_warmup.py` drives the real `KimiLinearMoE.forward` with a spy fork and asserts the enable/overlap decision for all three states: warmup, capture, and eager. CPU-only — no real streams or capture.

Verified the test fails on the previous call site and passes on this one, so it pins the regression rather than just the current behaviour.

`pre-commit run --all-files` passes.