### PR TITLE
 perf(k3): select grouped moe tiles by expected routes per expert on gfx950

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
@@ -42,8 +42,20 @@ from tokenspeed_kernel_amd.ops.gfx950.moe.fp16.moe_align_fused import (
 
 MXFP4_GROUP_SIZE = 32
 _MXFP4_GROUP_SIZE_GL = gl.constexpr(32)
-GROUPED_BLOCK_M = 64
-GROUPED_FUSED_ALIGN_MAX_ROUTES = 128
+# K3 EP8 full-grid profiling tunes W13 and W2 independently for each row tile.
+# Each stage tuple is (BLOCK_N, BLOCK_K, subgroup count). BM128 retains the
+# original configuration: its larger row tile already amortizes weight traffic,
+# and increasing BLOCK_K loses once many experts execute concurrently.
+_GROUPED_GEMM_CONFIGS = {
+    16: ((32, 128, 4), (128, 128, 4)),
+    32: ((64, 128, 4), (128, 128, 4)),
+    64: ((64, 128, 8), (128, 128, 8)),
+    128: ((64, 64, 8), (128, 64, 4)),
+}
+_GROUPED_SWIGLU_GEMM_CONFIGS = {
+    64: ((64, 64, 4), (128, 64, 4)),
+    128: ((64, 64, 8), (128, 64, 4)),
+}
 # Atomic combine's cost hardly depends on the batch size at all.  The list of
 # (token, expert) pairs is padded out to a full GROUPED_BLOCK_M-row block per
 # expert, so with 112 experts it is ~7168 rows even for a single token.
@@ -717,9 +729,9 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
     *,
     situ_beta: float,
     situ_linear_beta: float | None,
+    block_m: int,
     activation: str = "situ",
     swiglu_limit: float | None = None,
-    block_m: int | None = None,
     expert_start: int = 0,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
@@ -729,6 +741,8 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
     the first expert represented by the local weight tensors; non-local routes
     are discarded by alignment and reduction kernels. ``activation="swiglu"``
     selects standard alpha=1, beta=0 SwiGLU with an optional clamp.
+    ``block_m`` is shared by route alignment, W13, and W2; the two GEMMs
+    independently choose their output-column tiles for that row tile.
     """
     if hidden_states.dtype != torch.bfloat16 or hidden_states.ndim != 2:
         raise ValueError("grouped gfx950 A16W4 requires rank-2 BF16 activations")
@@ -758,10 +772,6 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
         or not out.is_contiguous()
     ):
         raise ValueError("output must match the hidden-state shape, dtype, and device")
-    if block_m is None:
-        # Sparse EP padding dominates until each rank owns roughly 7k routes.
-        # Keep BM64 below M=3584; BM128 then amortizes launch/grid overhead.
-        block_m = 128 if num_tokens >= 3584 else GROUPED_BLOCK_M
     num_experts, two_intermediate, packed_hidden = w13_weight.shape
     intermediate = two_intermediate // 2
     top_k = int(local_topk_ids.shape[1])
@@ -781,16 +791,21 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
         intermediate // MXFP4_GROUP_SIZE,
     ):
         raise ValueError("W2 scale shape mismatch")
-    if hidden_dim % 256 or intermediate % 128 or block_m not in (64, 128):
+    gemm_configs = (
+        _GROUPED_GEMM_CONFIGS if activation == "situ" else _GROUPED_SWIGLU_GEMM_CONFIGS
+    )
+    if hidden_dim % 256 or intermediate % 128 or block_m not in gemm_configs:
+        supported_block_m = ", ".join(str(value) for value in gemm_configs)
         raise ValueError(
             "grouped gfx950 A16W4 requires hidden_dim divisible by 256, "
-            "intermediate divisible by 128, and block_m in {64, 128}"
+            "intermediate divisible by 128, and block_m in "
+            f"{{{supported_block_m}}} for {activation}"
         )
 
     num_routes = num_tokens * top_k
     align = (
         moe_align_block_size_fused
-        if (0 < num_routes <= GROUPED_FUSED_ALIGN_MAX_ROUTES and num_tokens <= block_m)
+        if activation == "swiglu" and 0 < num_routes <= 128 and num_tokens <= block_m
         else moe_align_block_size_device
     )
     sorted_ids, sorted_experts, sorted_weights, num_valid = align(
@@ -807,9 +822,10 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
         device=hidden_states.device,
     )
 
-    s1_block_n = 64
-    s1_block_k = 64
-    s1_warps = {64: 4, 128: 8}[block_m]
+    # W13 and W2 consume the same aligned row list but use independently tuned
+    # output-column, reduction, and subgroup geometry.
+    stage1_config, stage2_config = gemm_configs[block_m]
+    s1_block_n, s1_block_k, s1_warps = stage1_config
     s1_grid = triton.cdiv(em, block_m) * triton.cdiv(intermediate, s1_block_n)
     _grouped_a16w4_situ_stage1_kernel[(s1_grid,)](
         hidden_states,
@@ -862,9 +878,7 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
             device=hidden_states.device,
         )
         stage2_strides = stage2_out.stride()
-    s2_block_n = 128
-    s2_block_k = 64
-    s2_warps = 4
+    s2_block_n, s2_block_k, s2_warps = stage2_config
     s2_grid = triton.cdiv(em, block_m) * triton.cdiv(hidden_dim, s2_block_n)
     _grouped_a16w4_stage2_kernel[(s2_grid,)](
         inter,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_grouped.py
@@ -46,7 +46,7 @@ _MXFP4_GROUP_SIZE_GL = gl.constexpr(32)
 # Each stage tuple is (BLOCK_N, BLOCK_K, subgroup count). BM128 retains the
 # original configuration: its larger row tile already amortizes weight traffic,
 # and increasing BLOCK_K loses once many experts execute concurrently.
-_GROUPED_GEMM_CONFIGS = {
+_GROUPED_SITU_GEMM_CONFIGS = {
     16: ((32, 128, 4), (128, 128, 4)),
     32: ((64, 128, 4), (128, 128, 4)),
     64: ((64, 128, 8), (128, 128, 8)),
@@ -792,7 +792,9 @@ def gluon_a16w4_situ_grouped_ep_gfx950(
     ):
         raise ValueError("W2 scale shape mismatch")
     gemm_configs = (
-        _GROUPED_GEMM_CONFIGS if activation == "situ" else _GROUPED_SWIGLU_GEMM_CONFIGS
+        _GROUPED_SITU_GEMM_CONFIGS
+        if activation == "situ"
+        else _GROUPED_SWIGLU_GEMM_CONFIGS
     )
     if hidden_dim % 256 or intermediate % 128 or block_m not in gemm_configs:
         supported_block_m = ", ".join(str(value) for value in gemm_configs)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -31,7 +31,32 @@ from tokenspeed_kernel.signature import format_signatures
 
 platform = current_platform()
 
+_ROUTE_DIRECT_DECODE_MAX_TOKENS = 16
 _GFX1250_DECODE_MAX_AVERAGE_BPE = 16
+
+
+def _select_gfx950_grouped_block_m(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+) -> int:
+    """Select the MI350X-tuned grouped-MoE row block."""
+
+    if num_tokens < 0:
+        raise ValueError("num_tokens must be non-negative")
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    if num_experts <= 0:
+        raise ValueError("num_experts must be positive")
+
+    routed_rows_x7 = 7 * num_tokens * top_k
+    if routed_rows_x7 < 65 * num_experts:
+        return 16
+    if routed_rows_x7 < 215 * num_experts:
+        return 32
+    if routed_rows_x7 < 425 * num_experts:
+        return 64
+    return 128
 
 
 def _use_gfx1250_moe_decode(num_routed_rows: int, num_experts: int) -> bool:
@@ -144,13 +169,16 @@ if platform.is_amd:
             gluon_a16w4_warp_decode_ep_gfx950,
         )
 
-        if _supports_a16w4_warp_decode_ep_gfx950(
+        use_route_direct_decode = _supports_a16w4_warp_decode_ep_gfx950(
             x,
             w.w13_weight,
             w.w13_weight_scale,
             w.w2_weight,
             w.w2_weight_scale,
-        ):
+        ) and (
+            activation != "situ" or int(x.shape[0]) < _ROUTE_DIRECT_DECODE_MAX_TOKENS
+        )
+        if use_route_direct_decode:
             # Both stages localize global expert IDs while consuming the linear
             # checkpoint layout, avoiding four pointwise localization kernels.
             return gluon_a16w4_warp_decode_ep_gfx950(
@@ -169,6 +197,22 @@ if platform.is_amd:
                 routed_out=output,
                 **activation_kwargs,
             )
+        global_num_experts = int(
+            getattr(
+                w,
+                "num_experts",
+                num_local_experts * int(getattr(w, "ep_size", 1)),
+            )
+        )
+        block_m = (
+            _select_gfx950_grouped_block_m(
+                int(x.shape[0]),
+                int(topk_ids.shape[1]),
+                global_num_experts,
+            )
+            if activation == "situ"
+            else (128 if int(x.shape[0]) >= 3584 else 64)
+        )
         grouped_kernel = (
             gluon_a16w4_situ_grouped_ep_gfx950
             if activation == "situ"
@@ -182,6 +226,7 @@ if platform.is_amd:
             w.w2_weight_scale,
             topk_weights,
             topk_ids,
+            block_m=block_m,
             expert_start=expert_start,
             out=output,
             **activation_kwargs,

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -310,6 +310,7 @@ def test_grouped_atomic_combine_matches_partial_reduction_gfx950(
             topk_ids,
             situ_beta=4.0,
             situ_linear_beta=25.0,
+            block_m=64,
             expert_start=0,
         )
 
@@ -595,7 +596,7 @@ def test_mxfp4_situ_ep_paths_are_cuda_graph_capturable_gfx950(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
     ).clone()
-    assert bool(grouped_calls) == (num_tokens > 16)
+    assert bool(grouped_calls) == (num_tokens >= 16)
     output = torch.empty_like(hidden_states)
     module._situ_output_buffer = output
 


### PR DESCRIPTION
## Summary

On AMD, for Kimi K3 TP8/EP8 config, the MoE grouped gemm kernel policy was:

```
0 < M <= 16
  -> route-direct subgroup GEMV
  -> no route sorting or per-expert row padding

17 <= M < 3584
  -> group routes by expert
  -> pad every nonempty expert's n_e to a multiple of 64
  -> BLOCK_M=64 grouped GEMMs

M >= 3584
  -> group routes by expert
  -> pad every nonempty expert's n_e to a multiple of 128
  -> BLOCK_M=128 grouped GEMMs
```

This patch changes the route direct boundary to M < 16, so M=16 now uses the grouped path. It also selects a common `BLOCK_M` from the average expected number of routes per expert:

`expected n_e = M * top_k / global_num_experts`

 For Kimi K3 `(top_k=16, global_num_experts=896)`, the empirically tuned MI350X policy in this patch is encoded as the following:
```
    Global M    Expected routes/expert, E[n_e]       Selection
  ━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━
        < 16                           < 0.286    route-direct
  ───────────  ────────────────────────────────  ──────────────
      16–519                       0.286–9.268            BM16
  ───────────  ────────────────────────────────  ──────────────
    520–1719                      9.286–30.696            BM32
  ───────────  ────────────────────────────────  ──────────────
   1720–3399                     30.714–60.696            BM64
  ───────────  ────────────────────────────────  ──────────────
     >= 3400                         >= 60.714           BM128
```

The expected value selects one common BLOCK_M. Route sorting then measures each local expert’s actual route count, (n_e), and pads every nonempty expert to (as it is currently):

`ceil(n_e / BLOCK_M) * BLOCK_M`

In addition to reducing per-expert row padding, the patch tunes BLOCK_N, BLOCK_K, and subgroup count independently for W13 and W2 at each selected BLOCK_M. Both GEMMs consume the same aligned route list and therefore share BLOCK_M.


## Test Plan
Micro benchmarks: 

```
      M    BLOCK_M         Candidate       ToM      Reduction
  ━━━━━━  ━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━
     16          16     254.93 µs     338.24 µs       24.63%
  ──────  ──────────  ────────────  ────────────  ───────────
    512          16     835.46 µs    1092.05 µs       23.50%
  ──────  ──────────  ────────────  ────────────  ───────────
    768          32     852.25 µs    1120.43 µs       23.94%
  ──────  ──────────  ────────────  ────────────  ───────────
   1720          64    1179.04 µs    1265.80 µs        6.85%
  ──────  ──────────  ────────────  ────────────  ───────────
   2400          64    1263.79 µs    1382.60 µs        8.59%
  ──────  ──────────  ────────────  ────────────  ───────────
   3400         128    1624.01 µs    1686.90 µs        3.73%
```

e2e:

Kimi K3 4K/1K, 8× MI350X, TP8/EP8, graphs 16/32/64, no DSPARK, prefix caching disabled, median of three: (in toks/s)

```
Concurrency      ToM         Candidate               Output tok/s delta
 16             331.9869     375.7337                    +13.18%
 32             453.4657     549.4179                    +21.16%
 64             691.9603     759.1296                    +9.7071%
```