### PR TITLE
feat(gemm): add a bf16 dense-linear form of the ll bf16 gemm

### DIFF
--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -64,6 +64,7 @@ NUM_COPIES = 8
 # 41-round medians repeat within ~1-2%, so 4% clears noise without excluding
 # the consistent 6-11% skinny wins.
 MARGIN = 1.04
+BACKENDS = ("cublas", "rowcta", "skinny", "tgv", "ll_bf16")
 
 
 def timed(fns, iters: int = 96, rounds: int = 41) -> float:
@@ -148,14 +149,23 @@ def candidates(m: int, n: int, k: int):
     except ImportError:
         pass
 
+    from tokenspeed_kernel.ops.gemm.ll_bf16 import ll_bf16_mm, ll_bf16_mm_supported
+
+    if ll_bf16_mm_supported(xs[0], ws[0]):
+
+        def ll(i):
+            return lambda: ll_bf16_mm(xs[i], ws[i], out=o)
+
+        yield "ll_bf16", [ll(i) for i in range(NUM_COPIES)], o, ref
+
 
 route: dict[str, str] = {}
 per_step_gain: dict[int, float] = dict.fromkeys(MS, 0.0)
 print(f"cold-L2 sweep: {NUM_COPIES} weight copies per backend")
 print(f"{'call site':<18}{'NxK':>12} {'M':>2}  ", end="")
-print("  ".join(f"{t:>8}" for t in ("cublas", "rowcta", "skinny", "tgv")), end="")
+print("  ".join(f"{t:>8}" for t in BACKENDS), end="")
 print(f"  {'winner':<8} {'gain':>6}")
-print("-" * 92)
+print("-" * 102)
 for n, k, calls, label in SHAPES:
     for m in MS:
         times: dict[str, float | None] = {}
@@ -174,7 +184,7 @@ for n, k, calls, label in SHAPES:
         best = min(ok, key=ok.get) if ok else None
         cells = "  ".join(
             f"{times.get(t):8.3f}" if isinstance(times.get(t), float) else f"{'-':>8}"
-            for t in ("cublas", "rowcta", "skinny", "tgv")
+            for t in BACKENDS
         )
         # An entry must beat the incumbent selection, not just cuBLAS.
         incumbent = min(

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -18,11 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Measure decode-GEMV backends at Kimi-K3's real serving shapes, cold-cache.
+"""Measure decode-GEMV backends at the served models' real shapes, cold-cache.
 
-The shapes are the exact (N, K) that ``decode_gemv`` receives during TP8
-decode, extracted from an nsys trace of the serving path (rowcta's launch grid
-is ``(N,)``, so gridX identifies each call site). Every measurement cycles
+Run as ``tune_route.py [shape_set] [route.json]``; the set names a key of
+SHAPE_SETS and defaults to K3's TP16 table.
+
+The shapes are the exact (N, K) that the decode path hands the routed GEMV,
+extracted from a trace of the serving path (rowcta's launch grid is ``(N,)``,
+so gridX identifies each call site). Every measurement cycles
 through NUM_COPIES independent weight tensors so the L2 never holds the
 operand between calls -- serving streams a different layer's weight each
 launch, and a single-tensor benchmark distorts the ranking (hot-L2 numbers at
@@ -51,15 +54,34 @@ import torch
 # projection below stays zero rather than quoting a number built on a count
 # carried over from a different parallelism. Labels are the shapes themselves;
 # mapping them to call sites would be a guess until the counts are traced.
-SHAPES = [
-    (3584, 7168, 92, "n3584_k7168"),
-    (2880, 7168, 0, "n2880_k7168"),
-    (1152, 1536, 0, "n1152_k1536"),
-    (7168, 1536, 69, "kda_o_proj_shard"),
-    (1536, 7168, 92, "shared_gate_up_shard"),
-    (7168, 768, 92, "shared_down_shard"),
-]
-MS = [1, 2, 3, 4, 5, 6, 7, 8]  # observed range: the gates admit M <= 8
+SHAPE_SETS = {
+    "k3_tp16": (
+        [
+            (3584, 7168, 92, "n3584_k7168"),
+            (2880, 7168, 0, "n2880_k7168"),
+            (1152, 1536, 0, "n1152_k1536"),
+            (7168, 1536, 69, "kda_o_proj_shard"),
+            (1536, 7168, 92, "shared_gate_up_shard"),
+            (7168, 768, 92, "shared_down_shard"),
+        ],
+        [1, 2, 3, 4, 5, 6, 7, 8],  # observed range: the gates admit M <= 8
+    ),
+    "qwen38_next_tp4": (
+        [
+            (512, 2560, 0, "mlp_gate"),
+            (320, 2560, 0, "shared_gate_up"),
+            (2560, 160, 0, "shared_down"),
+            (2560, 1536, 0, "attn_o_proj"),
+            (4120, 2560, 0, "linear_attn_in_proj"),
+            (3584, 2560, 0, "n3584_k2560"),
+            (640, 2560, 0, "n640_k2560"),
+            (2560, 2560, 0, "n2560_k2560"),
+            (12800, 2560, 0, "n12800_k2560"),
+        ],
+        [1, 2, 4, 8],
+    ),
+}
+SHAPES, MS = SHAPE_SETS[sys.argv[1] if len(sys.argv) > 1 else "k3_tp16"]
 NUM_COPIES = 8
 # 41-round medians repeat within ~1-2%, so 4% clears noise without excluding
 # the consistent 6-11% skinny wins.
@@ -212,5 +234,5 @@ if any(c for _, _, c, _ in SHAPES):
 else:
     print("per-step projection skipped: calls/step not measured")
 print(json.dumps(route, indent=2))
-if len(sys.argv) > 1:
-    json.dump(route, open(sys.argv[1], "w"), indent=2)
+if len(sys.argv) > 2:
+    json.dump(route, open(sys.argv[2], "w"), indent=2)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
@@ -494,10 +494,6 @@ if mm_fp4 is not error_fn:
 
 # ---- FlashInfer BF16 low-latency GEMM, cute-dsl backend ------------------
 
-# The upstreamed form of the kernels vendored under thirdparty/cute_dsl/ll_bf16.
-# No released wheel declares the backend yet, so the probe below reports False
-# everywhere today and callers run the vendored copy; the flashinfer path turns
-# itself on once a release carries it, with no change here.
 _CUTE_DSL_BF16_BACKEND = "cute-dsl"
 _CUTE_DSL_BF16_ARCHS = frozenset({ArchVersion(10, 0), ArchVersion(10, 3)})
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
@@ -495,6 +495,9 @@ if mm_fp4 is not error_fn:
 # ---- FlashInfer BF16 low-latency GEMM, cute-dsl backend ------------------
 
 # The upstreamed form of the kernels vendored under thirdparty/cute_dsl/ll_bf16.
+# No released wheel declares the backend yet, so the probe below reports False
+# everywhere today and callers run the vendored copy; the flashinfer path turns
+# itself on once a release carries it, with no change here.
 _CUTE_DSL_BF16_BACKEND = "cute-dsl"
 _CUTE_DSL_BF16_ARCHS = frozenset({ArchVersion(10, 0), ArchVersion(10, 3)})
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
@@ -20,6 +20,11 @@
 
 from __future__ import annotations
 
+import functools
+import inspect
+from collections.abc import Callable
+from typing import get_args
+
 import torch
 from tokenspeed_kernel.platform import (
     ArchVersion,
@@ -485,3 +490,76 @@ if mm_fp4 is not error_fn:
             out.copy_(output)
             return out
         return output
+
+
+# ---- FlashInfer BF16 low-latency GEMM, cute-dsl backend ------------------
+
+# The upstreamed form of the kernels vendored under thirdparty/cute_dsl/ll_bf16.
+_CUTE_DSL_BF16_BACKEND = "cute-dsl"
+_CUTE_DSL_BF16_ARCHS = frozenset({ArchVersion(10, 0), ArchVersion(10, 3)})
+
+_mm_bf16 = error_fn
+
+if platform.is_nvidia and platform.arch_version in _CUTE_DSL_BF16_ARCHS:
+    try:
+        from flashinfer import mm_bf16 as _mm_bf16
+    except ImportError:
+        pass
+
+
+def _declares_cute_dsl_backend(mm_bf16: Callable[..., object]) -> bool:
+    """Whether this ``mm_bf16`` lists :data:`_CUTE_DSL_BF16_BACKEND`.
+
+    Args:
+        mm_bf16: FlashInfer's entry point, whose ``backend`` annotation is the
+            ``Literal`` of the backends that build it.
+
+    Returns:
+        True on wheels carrying the upstreamed kernels, False on earlier ones,
+        which name every other backend but not this one.
+    """
+    try:
+        # eval_str resolves the Literal even if FlashInfer postpones annotations.
+        backend = inspect.signature(mm_bf16, eval_str=True).parameters["backend"]
+    except (KeyError, NameError, TypeError, ValueError):
+        return False
+    return _CUTE_DSL_BF16_BACKEND in get_args(backend.annotation)
+
+
+@functools.lru_cache(maxsize=1)
+def has_flashinfer_cute_dsl_bf16() -> bool:
+    """Whether the flashinfer cute-dsl BF16 low-latency GEMM is usable here.
+
+    Returns:
+        True when running on an SM100 or SM103 GPU with a flashinfer build
+        whose ``mm_bf16`` declares the backend.
+    """
+    return _mm_bf16 is not error_fn and _declares_cute_dsl_backend(_mm_bf16)
+
+
+def flashinfer_cute_dsl_mm_bf16(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``x @ weight.T (+ bias)`` through the cute-dsl ``mm_bf16`` backend.
+
+    Args:
+        x: ``[M, K]`` contiguous BF16 activation.
+        weight: ``[N, K]`` contiguous BF16 weight; its transpose is the
+            column-major ``(K, N)`` operand the backend wants, with no copy.
+        bias: Optional contiguous ``[N]`` BF16 bias, fused into the epilogue.
+        out: Optional ``[M, N]`` BF16 destination; allocated when omitted.
+
+    Returns:
+        ``[M, N]`` BF16 output, ``out`` when it was given.
+    """
+    return _mm_bf16(
+        x,
+        weight.t(),
+        bias=bias,
+        pdl=pdl_enabled(),
+        out=out,
+        backend=_CUTE_DSL_BF16_BACKEND,
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
@@ -18,12 +18,40 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Registry entry for the vendored CuTe low-latency BF16 router GEMM."""
+"""Registry entry for the vendored CuTe low-latency BF16 router GEMM.
+
+Also exposes :func:`ll_bf16_mm`, the dense-linear form of the same two kernels:
+BF16 output with an optional fused ``[N]`` bias, the shape vLLM reaches through
+``--linear-backend flashinfer_cutedsl``. FlashInfer upstreamed those kernels as
+``mm_bf16``'s ``cute-dsl`` backend, so :func:`ll_bf16_mm` calls FlashInfer when
+the installed wheel declares it and runs the vendored copy otherwise; older
+wheels therefore keep working without pinning a floor.
+
+:func:`ll_bf16_mm` is deliberately *not* registered on ``gemm/decode_gemv``:
+swept on B200 (sm100) against cublas, skinny, and tgv at the six ``(N, K)`` the
+decode path actually dispatches, cold L2, CUDA-graph timed, it clears the
+route's 4% margin at only 4 of the 33 ``(M, N, K)`` points measured and loses by
+up to 3.5x at wide N -- 7168x768 at M = 4 costs 11.84us against cublas 3.39. The
+kernel is bandwidth-optimal only when N is narrow enough that one CTA per column
+still saturates, which the router shape satisfies and these projections do not.
+``test/gemm_tuning/tune_route.py`` carries it as a candidate so a future sweep
+can earn it entries the way skinny and tgv did.
+"""
 
 from __future__ import annotations
 
+import functools
+import inspect
+from collections.abc import Callable
+from typing import get_args
+
 import torch
-from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.platform import (
+    ArchVersion,
+    CapabilityRequirement,
+    current_platform,
+    pdl_enabled,
+)
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 from tokenspeed_kernel.thirdparty.cute_dsl.ll_bf16 import MAX_M, ll_bf16_router
@@ -84,4 +112,148 @@ def ll_bf16_router_supported(
     return ll_bf16_router.supports(hidden_states, weight, m)
 
 
-__all__ = ["MAX_M", "cute_dsl_ll_bf16_router", "ll_bf16_router_supported"]
+# The kernels issue 32-byte vector loads from the base of each operand.
+_PTR_ALIGN = 32
+# Both backends step K in multiples of 128.
+_K_ALIGN = 128
+
+# FlashInfer upstreamed these kernels as this backend, for sm100/sm103 only.
+_FLASHINFER_BACKEND = "cute-dsl"
+_FLASHINFER_ARCHS = frozenset({ArchVersion(10, 0), ArchVersion(10, 3)})
+
+
+def _declares_cute_dsl_backend(mm_bf16: Callable[..., object]) -> bool:
+    """Whether this ``mm_bf16`` lists :data:`_FLASHINFER_BACKEND`.
+
+    Args:
+        mm_bf16: FlashInfer's entry point, whose ``backend`` annotation is the
+            ``Literal`` of the backends that build it.
+
+    Returns:
+        True on wheels carrying the upstreamed kernels, False on earlier ones,
+        which name every other backend but not this one.
+    """
+    try:
+        # eval_str resolves the Literal even if FlashInfer postpones annotations.
+        backend = inspect.signature(mm_bf16, eval_str=True).parameters["backend"]
+    except (KeyError, NameError, TypeError, ValueError):
+        return False
+    return _FLASHINFER_BACKEND in get_args(backend.annotation)
+
+
+@functools.lru_cache(maxsize=1)
+def _flashinfer_mm_bf16() -> Callable[..., torch.Tensor] | None:
+    """FlashInfer's ``mm_bf16`` when it can run these kernels.
+
+    Returns:
+        The callable, or None when the platform is outside
+        :data:`_FLASHINFER_ARCHS` or the wheel predates the backend -- either
+        way the signal to run the vendored copy instead.
+    """
+    if current_platform().arch_version not in _FLASHINFER_ARCHS:
+        return None
+    try:
+        from flashinfer import mm_bf16
+    except ImportError:
+        return None
+    return mm_bf16 if _declares_cute_dsl_backend(mm_bf16) else None
+
+
+def ll_bf16_mm_supported(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> bool:
+    """Whether :func:`ll_bf16_mm` can serve these operands.
+
+    Args:
+        x: ``[..., K]`` BF16 activation; its leading dims flatten to ``M``.
+        weight: ``[N, K]`` BF16 weight.
+        bias: Optional ``[N]`` BF16 bias.
+
+    Returns:
+        True when every guard holds, so the caller can fall back otherwise.
+    """
+    if weight.ndim != 2 or x.ndim < 1:
+        return False
+    k = weight.shape[1]
+    n = weight.shape[0]
+    # Checked before dividing by k, and on the originals: a reshape of a
+    # non-contiguous x would copy, voiding the pointer-alignment check below.
+    if k <= 0 or n <= 0 or x.shape[-1] != k or k % _K_ALIGN:
+        return False
+    if not x.is_contiguous() or not weight.is_contiguous():
+        return False
+    m = x.numel() // k
+    if not 1 <= m <= MAX_M:
+        return False
+    if x.data_ptr() % _PTR_ALIGN or weight.data_ptr() % _PTR_ALIGN:
+        return False
+    if bias is not None and (
+        bias.ndim != 1
+        or bias.shape[0] != n
+        or bias.dtype is not torch.bfloat16
+        or not bias.is_contiguous()
+        or bias.device != x.device
+    ):
+        return False
+    return ll_bf16_router.supports(x.view(m, k), weight, m)
+
+
+def ll_bf16_mm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """``x @ weight.T (+ bias)`` in BF16, the dense-linear form of the router GEMM.
+
+    Runs FlashInfer's ``cute-dsl`` ``mm_bf16`` backend where the wheel declares
+    it, and the vendored copy of the same kernels otherwise. Accumulation stays
+    in FP32 and the bias folds into the epilogue either way, so the result rounds
+    once. Call :func:`ll_bf16_mm_supported` first; operands outside the guard
+    raise.
+
+    Args:
+        x: ``[..., K]`` contiguous BF16 activation; leading dims flatten to
+            ``M``, which must not exceed :data:`MAX_M`.
+        weight: ``[N, K]`` contiguous BF16 weight.
+        bias: Optional contiguous ``[N]`` BF16 bias.
+        out: Optional ``[..., N]`` BF16 destination; allocated when omitted.
+
+    Returns:
+        ``[..., N]`` BF16 tensor carrying ``x``'s leading dims, ``out`` when it
+        was given.
+    """
+    k = weight.shape[1]
+    m = x.numel() // k
+    n = weight.shape[0]
+    # view, not reshape: a reshaped non-contiguous out would take the writes.
+    flat_out = None if out is None else out.view(m, n)
+    mm_bf16 = _flashinfer_mm_bf16()
+    if mm_bf16 is None:
+        result = ll_bf16_router(
+            x.view(m, k),
+            weight,
+            flat_out,
+            bias=bias,
+            out_dtype=torch.bfloat16,
+        )
+    else:
+        # weight.t() is the (K, N) column-major B it wants, at no copy.
+        result = mm_bf16(
+            x.view(m, k),
+            weight.t(),
+            bias=bias,
+            pdl=pdl_enabled(),
+            out=flat_out,
+            backend=_FLASHINFER_BACKEND,
+        )
+    return result.view(*x.shape[:-1], n)
+
+
+__all__ = [
+    "MAX_M",
+    "cute_dsl_ll_bf16_router",
+    "ll_bf16_mm",
+    "ll_bf16_mm_supported",
+    "ll_bf16_router_supported",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
@@ -40,18 +40,12 @@ can earn it entries the way skinny and tgv did.
 
 from __future__ import annotations
 
-import functools
-import inspect
-from collections.abc import Callable
-from typing import get_args
-
 import torch
-from tokenspeed_kernel.platform import (
-    ArchVersion,
-    CapabilityRequirement,
-    current_platform,
-    pdl_enabled,
+from tokenspeed_kernel.ops.gemm.flashinfer import (
+    flashinfer_cute_dsl_mm_bf16,
+    has_flashinfer_cute_dsl_bf16,
 )
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 from tokenspeed_kernel.thirdparty.cute_dsl.ll_bf16 import MAX_M, ll_bf16_router
@@ -116,47 +110,6 @@ def ll_bf16_router_supported(
 _PTR_ALIGN = 32
 # Both backends step K in multiples of 128.
 _K_ALIGN = 128
-
-# FlashInfer upstreamed these kernels as this backend, for sm100/sm103 only.
-_FLASHINFER_BACKEND = "cute-dsl"
-_FLASHINFER_ARCHS = frozenset({ArchVersion(10, 0), ArchVersion(10, 3)})
-
-
-def _declares_cute_dsl_backend(mm_bf16: Callable[..., object]) -> bool:
-    """Whether this ``mm_bf16`` lists :data:`_FLASHINFER_BACKEND`.
-
-    Args:
-        mm_bf16: FlashInfer's entry point, whose ``backend`` annotation is the
-            ``Literal`` of the backends that build it.
-
-    Returns:
-        True on wheels carrying the upstreamed kernels, False on earlier ones,
-        which name every other backend but not this one.
-    """
-    try:
-        # eval_str resolves the Literal even if FlashInfer postpones annotations.
-        backend = inspect.signature(mm_bf16, eval_str=True).parameters["backend"]
-    except (KeyError, NameError, TypeError, ValueError):
-        return False
-    return _FLASHINFER_BACKEND in get_args(backend.annotation)
-
-
-@functools.lru_cache(maxsize=1)
-def _flashinfer_mm_bf16() -> Callable[..., torch.Tensor] | None:
-    """FlashInfer's ``mm_bf16`` when it can run these kernels.
-
-    Returns:
-        The callable, or None when the platform is outside
-        :data:`_FLASHINFER_ARCHS` or the wheel predates the backend -- either
-        way the signal to run the vendored copy instead.
-    """
-    if current_platform().arch_version not in _FLASHINFER_ARCHS:
-        return None
-    try:
-        from flashinfer import mm_bf16
-    except ImportError:
-        return None
-    return mm_bf16 if _declares_cute_dsl_backend(mm_bf16) else None
 
 
 def ll_bf16_mm_supported(
@@ -228,24 +181,15 @@ def ll_bf16_mm(
     n = weight.shape[0]
     # view, not reshape: a reshaped non-contiguous out would take the writes.
     flat_out = None if out is None else out.view(m, n)
-    mm_bf16 = _flashinfer_mm_bf16()
-    if mm_bf16 is None:
+    if has_flashinfer_cute_dsl_bf16():
+        result = flashinfer_cute_dsl_mm_bf16(x.view(m, k), weight, bias, flat_out)
+    else:
         result = ll_bf16_router(
             x.view(m, k),
             weight,
             flat_out,
             bias=bias,
             out_dtype=torch.bfloat16,
-        )
-    else:
-        # weight.t() is the (K, N) column-major B it wants, at no copy.
-        result = mm_bf16(
-            x.view(m, k),
-            weight.t(),
-            bias=bias,
-            pdl=pdl_enabled(),
-            out=flat_out,
-            backend=_FLASHINFER_BACKEND,
         )
     return result.view(*x.shape[:-1], n)
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
@@ -109,18 +109,21 @@ def ll_bf16_mm_supported(
     """
     if weight.ndim != 2 or x.ndim < 1:
         return False
-    k = weight.shape[1]
-    n = weight.shape[0]
-    # Checked before dividing by k, and on the originals: a reshape of a
-    # non-contiguous x would copy, voiding the pointer-alignment check below.
-    if k <= 0 or n <= 0 or x.shape[-1] != k or k % _K_ALIGN:
+    n, k = weight.shape
+    # Checked on the originals: a reshape of a non-contiguous x would copy,
+    # voiding the pointer-alignment check below.
+    if x.shape[-1] != k or k % _K_ALIGN:
+        return False
+    if x.dtype is not torch.bfloat16 or weight.dtype is not torch.bfloat16:
         return False
     if not x.is_contiguous() or not weight.is_contiguous():
         return False
-    m = x.numel() // k
-    if not 1 <= m <= MAX_M:
+    if x.device != weight.device:
         return False
     if x.data_ptr() % _PTR_ALIGN or weight.data_ptr() % _PTR_ALIGN:
+        return False
+    m = x.numel() // k
+    if not 1 <= m <= MAX_M:
         return False
     if bias is not None and (
         bias.ndim != 1
@@ -130,7 +133,11 @@ def ll_bf16_mm_supported(
         or bias.device != x.device
     ):
         return False
-    return ll_bf16_router.supports(x.view(m, k), weight, m)
+    # Only the vendored path carries further requirements -- its own toolchain,
+    # and a cluster for the split-K reduce above MAX_M_DOTPROD.
+    return has_flashinfer_cute_dsl_bf16() or ll_bf16_router.supports(
+        x.view(m, k), weight, m
+    )
 
 
 def ll_bf16_mm(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/ll_bf16.py
@@ -18,25 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Registry entry for the vendored CuTe low-latency BF16 router GEMM.
-
-Also exposes :func:`ll_bf16_mm`, the dense-linear form of the same two kernels:
-BF16 output with an optional fused ``[N]`` bias, the shape vLLM reaches through
-``--linear-backend flashinfer_cutedsl``. FlashInfer upstreamed those kernels as
-``mm_bf16``'s ``cute-dsl`` backend, so :func:`ll_bf16_mm` calls FlashInfer when
-the installed wheel declares it and runs the vendored copy otherwise; older
-wheels therefore keep working without pinning a floor.
-
-:func:`ll_bf16_mm` is deliberately *not* registered on ``gemm/decode_gemv``:
-swept on B200 (sm100) against cublas, skinny, and tgv at the six ``(N, K)`` the
-decode path actually dispatches, cold L2, CUDA-graph timed, it clears the
-route's 4% margin at only 4 of the 33 ``(M, N, K)`` points measured and loses by
-up to 3.5x at wide N -- 7168x768 at M = 4 costs 11.84us against cublas 3.39. The
-kernel is bandwidth-optimal only when N is narrow enough that one CTA per column
-still saturates, which the router shape satisfies and these projections do not.
-``test/gemm_tuning/tune_route.py`` carries it as a candidate so a future sweep
-can earn it entries the way skinny and tgv did.
-"""
+"""Registry entry for the vendored CuTe low-latency BF16 router GEMM."""
 
 from __future__ import annotations
 
@@ -158,12 +140,6 @@ def ll_bf16_mm(
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """``x @ weight.T (+ bias)`` in BF16, the dense-linear form of the router GEMM.
-
-    Runs FlashInfer's ``cute-dsl`` ``mm_bf16`` backend where the wheel declares
-    it, and the vendored copy of the same kernels otherwise. Accumulation stays
-    in FP32 and the bias folds into the epilogue either way, so the result rounds
-    once. Call :func:`ll_bf16_mm_supported` first; operands outside the guard
-    raise.
 
     Args:
         x: ``[..., K]`` contiguous BF16 activation; leading dims flatten to

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Measured decode-GEMV routing for Kimi-K3's projection shapes.
+"""Measured decode-GEMV routing for the served models' projection shapes.
 
 Every entry in ``MEASURED_ROUTE`` was measured on GB300 (sm103) at the exact
 (N, K) the TP8 decode path hands ``decode_gemv`` -- extracted from an nsys
@@ -109,6 +109,49 @@ MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
         (7, 1152, 1536): "skinny",  # 2.59 vs 4.45 (1.72x)
         (8, 1152, 1536): "skinny",  # 2.72 vs 4.46 (1.64x)
         # (1, 1152, 1536) stays on rowcta: 1.907 vs 1.943, inside the margin.
+        # TP4 (B200, sm100), bf16 dense linears: the fp8 checkpoint quantizes
+        # only the routed experts. M is the captured decode bucket -- 5 was
+        # swept but never observed.
+        (1, 512, 2560): "skinny",  # mlp.gate; 1.83 vs 4.37 (2.39x)
+        (2, 512, 2560): "skinny",  # 2.05 vs 4.38 (2.13x)
+        (4, 512, 2560): "ll_bf16",  # 2.28 vs 4.43 (1.95x)
+        (8, 512, 2560): "ll_bf16",  # 2.32 vs 4.64 (2.00x)
+        (1, 320, 2560): "skinny",  # shared_expert gate_up; 1.80 vs 4.36 (2.42x)
+        (2, 320, 2560): "skinny",  # 2.00 vs 5.75 (2.88x)
+        (4, 320, 2560): "ll_bf16",  # 2.22 vs 4.74 (2.13x)
+        (8, 320, 2560): "ll_bf16",  # 2.25 vs 4.73 (2.10x)
+        # shared_expert down-proj. K = 160 is not a multiple of 128, so neither
+        # the skinny GEMM nor ll_bf16 admits it and tgv takes every width.
+        (1, 2560, 160): "tgv",  # 1.61 vs 1.88 (1.17x)
+        (2, 2560, 160): "tgv",  # 1.65 vs 3.09 (1.87x)
+        (4, 2560, 160): "tgv",  # 1.66 vs 3.09 (1.86x)
+        (8, 2560, 160): "tgv",  # 1.65 vs 1.92 (1.16x)
+        (1, 2560, 1536): "ll_bf16",  # attn o_proj; 2.55 vs 3.25 (1.27x)
+        (2, 2560, 1536): "ll_bf16",  # 2.54 vs 4.90 (1.92x)
+        (4, 2560, 1536): "ll_bf16",  # 2.58 vs 4.84 (1.88x)
+        (8, 2560, 1536): "ll_bf16",  # 2.67 vs 4.67 (1.75x)
+        (1, 4120, 2560): "ll_bf16",  # linear_attn in_proj; 4.84 vs 9.26 (1.91x)
+        (2, 4120, 2560): "ll_bf16",  # 4.88 vs 8.55 (1.75x)
+        (4, 4120, 2560): "ll_bf16",  # 4.87 vs 8.41 (1.73x)
+        (8, 4120, 2560): "ll_bf16",  # 4.91 vs 8.38 (1.71x)
+        (1, 3584, 2560): "ll_bf16",  # 4.35 vs 5.50 (1.26x)
+        (2, 3584, 2560): "ll_bf16",  # 4.42 vs 7.50 (1.70x)
+        (4, 3584, 2560): "ll_bf16",  # 4.41 vs 7.63 (1.73x)
+        (8, 3584, 2560): "ll_bf16",  # 4.44 vs 7.28 (1.64x)
+        # 640x2560 crosses over: skinny leads to M == 4, ll_bf16 from M == 8.
+        (1, 640, 2560): "skinny",  # 1.88 vs 4.69 (2.49x)
+        (2, 640, 2560): "skinny",  # 2.10 vs 4.62 (2.20x)
+        (4, 640, 2560): "skinny",  # 2.89 vs 4.77 (1.65x)
+        (8, 640, 2560): "ll_bf16",  # 3.01 vs 4.81 (1.60x)
+        (1, 2560, 2560): "ll_bf16",  # 3.27 vs 5.06 (1.55x)
+        (2, 2560, 2560): "ll_bf16",  # 3.36 vs 6.37 (1.90x)
+        (4, 2560, 2560): "ll_bf16",  # 3.40 vs 6.08 (1.79x)
+        (8, 2560, 2560): "ll_bf16",  # 3.40 vs 6.35 (1.87x)
+        # 12800x2560's margins shrink as M grows and invert at 8 (cublas 13.70
+        # vs ll_bf16 13.43, inside the margin), so M == 8 keeps cublas.
+        (1, 12800, 2560): "skinny",  # 11.07 vs 14.62 (1.32x)
+        (2, 12800, 2560): "skinny",  # 11.81 vs 14.38 (1.22x)
+        (4, 12800, 2560): "ll_bf16",  # 13.31 vs 14.43 (1.08x)
     }
 )
 
@@ -260,6 +303,36 @@ def tgv_gemv(
     return result
 
 
+def ll_bf16_gemv(
+    x: torch.Tensor, weight: torch.Tensor, out: torch.Tensor | None = None
+) -> torch.Tensor:
+    """``x @ weight.T`` via the low-latency BF16 GEMM.
+
+    Args:
+        x: ``[M, K]`` contiguous bf16 activations.
+        weight: ``[N, K]`` contiguous bf16 weight.
+        out: optional ``[M, N]`` destination.
+
+    Returns:
+        ``[M, N]`` output in ``x``'s dtype.
+    """
+    from tokenspeed_kernel.ops.gemm.ll_bf16 import ll_bf16_mm, ll_bf16_mm_supported
+
+    m, k = x.shape
+    n = weight.shape[0]
+    dev = x.device.index or 0
+    if (
+        MEASURED_ROUTE.get((m, n, k)) != "ll_bf16"
+        or x.dtype != torch.bfloat16
+        or not _usable_in_capture("ll_bf16", dev, m, n, k)
+        or not ll_bf16_mm_supported(x, weight)
+    ):
+        return _torch_decode_gemv(x, weight, out)
+    result = ll_bf16_mm(x.detach(), weight.detach(), out=out)
+    _mark_warmed("ll_bf16", dev, m, n, k)
+    return result
+
+
 # Fused ``a + x @ W.T + c`` (K3 MoE latent up-proj epilogue): (m, n, k) ->
 # (block_size, outputs_per_block, k_unroll). Cold-L2 vs the incumbent: M == 1
 # 8.86us vs rowcta_gemv_add3 9.42, M == 2 10.05 vs composed 12.81. M == 4 was
@@ -400,13 +473,13 @@ def skinny_gemv_add3(
 
 
 def _register_route() -> None:
-    impls = {"skinny": skinny_gemv, "tgv": tgv_gemv}
+    impls = {"skinny": skinny_gemv, "tgv": tgv_gemv, "ll_bf16": ll_bf16_gemv}
     for (m, n, k), backend in MEASURED_ROUTE.items():
         register_kernel(
             "gemm",
             "decode_gemv",
             name=f"{backend}_gemv_m{m}_n{n}_k{k}",
-            solution="cute_dsl" if backend == "skinny" else "flashinfer",
+            solution="flashinfer" if backend == "tgv" else "cute_dsl",
             capability=_CAPABILITY,
             signatures=_BF16_SIG,
             traits={

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/__init__.py
@@ -19,11 +19,6 @@ a bound vLLM does not apply). ``(split_k, num_stages)`` is tuned here too:
 vLLM's tables cover ``(K, N)`` from ``(4096, 256)`` to ``(7168, 384)`` and never
 ``(7168, 896)``, so they run K3 on a ``(6, 4)`` default that loses at every M
 measured -- 5.75 / 8.74 / 9.19 us at M = 16 / 24 / 32 against the picks below.
-
-Both kernels accumulate in fp32 and convert on store, so the same code serves
-the fp32 router projection and a bf16 dense-linear path, with an optional
-``[N]`` bias folded into the epilogue. Output element type and bias presence are
-compile-time specializations, hence part of the compile-cache key.
 """
 
 from __future__ import annotations

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/__init__.py
@@ -19,6 +19,11 @@ a bound vLLM does not apply). ``(split_k, num_stages)`` is tuned here too:
 vLLM's tables cover ``(K, N)`` from ``(4096, 256)`` to ``(7168, 384)`` and never
 ``(7168, 896)``, so they run K3 on a ``(6, 4)`` default that loses at every M
 measured -- 5.75 / 8.74 / 9.19 us at M = 16 / 24 / 32 against the picks below.
+
+Both kernels accumulate in fp32 and convert on store, so the same code serves
+the fp32 router projection and a bf16 dense-linear path, with an optional
+``[N]`` bias folded into the epilogue. Output element type and bias presence are
+compile-time specializations, hence part of the compile-cache key.
 """
 
 from __future__ import annotations
@@ -40,6 +45,7 @@ _SPLITK_CONFIG_BY_M: tuple[tuple[int, tuple[int, int]], ...] = (
 _SPLITK_TILE_N = 16
 _SPLITK_TILE_K = 256
 _SPLITK_DMA_WARPS = 4
+OUT_DTYPES: tuple[torch.dtype, ...] = (torch.float32, torch.bfloat16)
 
 
 def block_size_for(m: int) -> int:
@@ -65,13 +71,19 @@ def _cutedsl_available() -> bool:
     return True
 
 
+def _cutlass_dtype(out_dtype: torch.dtype):
+    from cutlass import BFloat16, Float32
+
+    return BFloat16 if out_dtype is torch.bfloat16 else Float32
+
+
 class LLBf16Router:
     """Compile-once driver for the two vendored CuTe router GEMM kernels."""
 
     def __init__(self) -> None:
         # Device-keyed: a callable compiled on one GPU must not run on another.
-        self._dotprod: dict[tuple[int, int, int, int], Any] = {}
-        self._splitk: dict[tuple[int, int, int], Any] = {}
+        self._dotprod: dict[tuple[int, int, int, int, torch.dtype, bool], Any] = {}
+        self._splitk: dict[tuple[int, int, int, torch.dtype, bool], Any] = {}
         self._compile_lock = threading.Lock()
         self._available: bool | None = None
 
@@ -116,10 +128,16 @@ class LLBf16Router:
         )
 
     def _compile_dotprod(
-        self, m: int, k: int, block_size: int, device: torch.device
+        self,
+        m: int,
+        k: int,
+        block_size: int,
+        device: torch.device,
+        out_dtype: torch.dtype,
+        has_bias: bool,
     ) -> None:
         import cutlass.cute as cute
-        from cutlass import BFloat16, Float32
+        from cutlass import BFloat16
         from quack.compile_utils import make_fake_tensor
         from tokenspeed_kernel.thirdparty.cute_dsl.ll_bf16._kernel import (
             LLBf16Dotprod as _Kernel,
@@ -127,21 +145,27 @@ class LLBf16Router:
 
         n = cute.sym_int()
         divisibility = 8 if k % 8 == 0 else 1
+        cut_out_dtype = _cutlass_dtype(out_dtype)
         a = make_fake_tensor(BFloat16, (m, k), divisibility=divisibility)
         b = make_fake_tensor(BFloat16, (n, k), divisibility=divisibility)
-        c = make_fake_tensor(Float32, (m, n), divisibility=1)
+        c = make_fake_tensor(cut_out_dtype, (m, n), divisibility=1)
+        bias = make_fake_tensor(cut_out_dtype, (n,), divisibility=1)
         gemm = _Kernel(
             k=k,
             bs=block_size,
             use_pdl=torch.cuda.get_device_capability(device)[0] >= 9 and pdl_enabled(),
+            out_dtype=cut_out_dtype,
+            has_bias=has_bias,
         )
         # cute.compile targets the current device, not the operands'.
         with torch.cuda.device(device):
-            self._dotprod[(device.index or 0, m, k, block_size)] = cute.compile(
+            key = (device.index or 0, m, k, block_size, out_dtype, has_bias)
+            self._dotprod[key] = cute.compile(
                 gemm,
                 a,
                 b,
                 c,
+                bias,
                 m,
                 k,
                 1,  # runtime N placeholder for the fake-tensor compile
@@ -149,9 +173,15 @@ class LLBf16Router:
                 options="--enable-tvm-ffi --ptxas-options -maxrregcount=64",
             )
 
-    def _compile_splitk(self, config: tuple[int, int], device: torch.device) -> None:
+    def _compile_splitk(
+        self,
+        config: tuple[int, int],
+        device: torch.device,
+        out_dtype: torch.dtype,
+        has_bias: bool,
+    ) -> None:
         import cutlass.cute as cute
-        from cutlass import BFloat16, Float32
+        from cutlass import BFloat16
         from quack.compile_utils import make_fake_tensor
         from tokenspeed_kernel.thirdparty.cute_dsl.ll_bf16._splitk_kernel import (
             LLBf16SplitK as _Kernel,
@@ -159,9 +189,11 @@ class LLBf16Router:
 
         split_k, num_stages = config
         m, k, n = cute.sym_int(), cute.sym_int(), cute.sym_int()
+        cut_out_dtype = _cutlass_dtype(out_dtype)
         a = make_fake_tensor(BFloat16, (m, k), divisibility=8)
         b = make_fake_tensor(BFloat16, (n, k), divisibility=8)
-        c = make_fake_tensor(Float32, (m, n), divisibility=1)
+        c = make_fake_tensor(cut_out_dtype, (m, n), divisibility=1)
+        bias = make_fake_tensor(cut_out_dtype, (n,), divisibility=1)
         gemm = _Kernel(
             tile_n=_SPLITK_TILE_N,
             tile_k=_SPLITK_TILE_K,
@@ -169,10 +201,13 @@ class LLBf16Router:
             num_dma_warps=_SPLITK_DMA_WARPS,
             split_k=split_k,
             use_pdl=torch.cuda.get_device_capability(device)[0] >= 9 and pdl_enabled(),
+            out_dtype=cut_out_dtype,
+            has_bias=has_bias,
         )
         with torch.cuda.device(device):
-            self._splitk[(device.index or 0, split_k, num_stages)] = cute.compile(
-                gemm, a, b, c, self._stream(device), options="--enable-tvm-ffi"
+            key = (device.index or 0, split_k, num_stages, out_dtype, has_bias)
+            self._splitk[key] = cute.compile(
+                gemm, a, b, c, bias, self._stream(device), options="--enable-tvm-ffi"
             )
 
     def __call__(
@@ -181,9 +216,11 @@ class LLBf16Router:
         b: torch.Tensor,
         out: torch.Tensor | None = None,
         *,
+        bias: torch.Tensor | None = None,
+        out_dtype: torch.dtype | None = None,
         block_size: int | None = None,
     ) -> torch.Tensor:
-        """Compute ``a @ b.T`` with FP32 accumulation and an FP32 result.
+        """Compute ``a @ b.T (+ bias)`` with FP32 accumulation.
 
         The dot-product kernel serves ``M <= MAX_M_DOTPROD`` and the split-K
         kernel the rest up to ``MAX_M``.
@@ -191,12 +228,17 @@ class LLBf16Router:
         Args:
             a: ``[M, K]`` contiguous BF16 activation.
             b: ``[N, K]`` contiguous BF16 weight.
-            out: Optional ``[M, N]`` FP32 destination; allocated when omitted.
+            out: Optional ``[M, N]`` destination in ``out_dtype``; allocated
+                when omitted.
+            bias: Optional contiguous ``[N]`` bias in ``out_dtype``, added in
+                the epilogue.
+            out_dtype: Output element type, one of :data:`OUT_DTYPES`. Defaults
+                to ``out``'s dtype, or float32 when ``out`` is omitted too.
             block_size: Dot-product threads per output column; the measured
                 pick for ``M`` when omitted. Ignored by split-K.
 
         Returns:
-            ``[M, N]`` FP32 tensor, ``out`` when it was given.
+            ``[M, N]`` tensor in ``out_dtype``, ``out`` when it was given.
         """
         m, k = a.shape
         n = b.shape[0]
@@ -204,32 +246,48 @@ class LLBf16Router:
             raise ValueError(
                 f"ll_bf16 cannot serve M={m} K={k} dtypes={a.dtype}/{b.dtype}"
             )
+        if out_dtype is None:
+            out_dtype = torch.float32 if out is None else out.dtype
+        if out_dtype not in OUT_DTYPES:
+            raise ValueError(f"out_dtype must be one of {OUT_DTYPES}, got {out_dtype}")
         if out is None:
-            out = torch.empty(m, n, dtype=torch.float32, device=a.device)
-        elif out.shape != (m, n) or out.dtype is not torch.float32:
-            raise ValueError(f"out must be a [{m}, {n}] float32 tensor")
+            out = torch.empty(m, n, dtype=out_dtype, device=a.device)
+        elif out.shape != (m, n) or out.dtype is not out_dtype:
+            raise ValueError(f"out must be a [{m}, {n}] {out_dtype} tensor")
+        if bias is not None and (
+            bias.dtype is not out_dtype
+            or bias.shape != (n,)
+            or not bias.is_contiguous()
+            or bias.device != a.device
+        ):
+            raise ValueError(f"bias must be a contiguous [{n}] {out_dtype} tensor")
+        # The kernels always take a bias operand and read it only under has_bias.
+        bias_arg = out[0] if bias is None else bias
+        has_bias = bias is not None
 
         device = a.device
         stream = self._stream(device)
         if m <= MAX_M_DOTPROD:
             if block_size is None:
                 block_size = block_size_for(m)
-            key = (device.index or 0, m, k, block_size)
+            key = (device.index or 0, m, k, block_size, out_dtype, has_bias)
             if key not in self._dotprod:
                 # Double-checked: cute.compile is expensive and not thread-safe.
                 with self._compile_lock:
                     if key not in self._dotprod:
-                        self._compile_dotprod(m, k, block_size, device)
-            self._dotprod[key](a, b, out, n, stream)
+                        self._compile_dotprod(
+                            m, k, block_size, device, out_dtype, has_bias
+                        )
+            self._dotprod[key](a, b, out, bias_arg, n, stream)
             return out
 
         config = splitk_config_for(m)
-        key = (device.index or 0, *config)
+        key = (device.index or 0, *config, out_dtype, has_bias)
         if key not in self._splitk:
             with self._compile_lock:
                 if key not in self._splitk:
-                    self._compile_splitk(config, device)
-        self._splitk[key](a, b, out, stream, 1.0)
+                    self._compile_splitk(config, device, out_dtype, has_bias)
+        self._splitk[key](a, b, out, bias_arg, stream, 1.0)
         return out
 
 
@@ -238,6 +296,7 @@ ll_bf16_router = LLBf16Router()
 __all__ = [
     "MAX_M",
     "MAX_M_DOTPROD",
+    "OUT_DTYPES",
     "LLBf16Router",
     "block_size_for",
     "splitk_config_for",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/_kernel.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/_kernel.py
@@ -12,10 +12,11 @@ from cutlass import const_expr
 class LLBf16Dotprod:
     """BF16 router GEMM kernel based on CTA-local dot products.
 
-    This kernel computes C[M, N] = A[M, K] @ B[N, K]^T for bf16 inputs
-    and fp32 output. It launches one CTA per output column, distributes K
-    across CTA threads with vectorized loads, accumulates one fp32 dot product
-    per token, and reduces through warp shuffles plus shared memory.
+    This kernel computes C[M, N] = A[M, K] @ B[N, K]^T (+ bias[N]) for bf16
+    inputs, accumulating in fp32 and converting to ``out_dtype`` on store. It
+    launches one CTA per output column, distributes K across CTA threads with
+    vectorized loads, accumulates one fp32 dot product per token, and reduces
+    through warp shuffles plus shared memory.
 
     :param k: Compile-time K dimension specialized into the generated kernel.
     :type k: int
@@ -33,14 +34,15 @@ class LLBf16Dotprod:
     :note: Supported accumulator data types:
         - Float32
     :note: Supported C data types:
-        - Float32
+        - Float32/BFloat16
     :note: Constraints:
         - K must preserve 16-byte row alignment for contiguous bf16 inputs.
 
     :note: K is handled as vectorized main/tail loops plus scalar remainder.
 
-    :compile-key: ``(M, K, bs)`` selects the token count, hidden size,
-        and CTA thread/K-stripe width specialization.
+    :compile-key: ``(M, K, bs, out_dtype, has_bias)`` selects the token count,
+        hidden size, CTA thread/K-stripe width, output element type, and
+        whether the epilogue folds in a bias.
     """
 
     def __init__(
@@ -50,12 +52,14 @@ class LLBf16Dotprod:
         main_vec_width: int = 8,
         tail_vec_width: int = 4,
         use_pdl: bool = False,
+        out_dtype=cutlass.Float32,
+        has_bias: bool = False,
     ):
         """Initialize the dot-product kernel configuration.
 
         This configuration fixes the CTA thread count, reduction warp count,
-        bf16 vector widths, and K-loop decomposition used by the generated
-        kernel.
+        bf16 vector widths, K-loop decomposition, and epilogue used by the
+        generated kernel.
 
         :param k: Hidden size K used to specialize the K-loop decomposition.
         :type k: int
@@ -67,11 +71,17 @@ class LLBf16Dotprod:
         :type tail_vec_width: int
         :param use_pdl: Whether to launch with Programmatic Dependent Launch.
         :type use_pdl: bool
+        :param out_dtype: Element type of C; the FP32 accumulator converts to it.
+        :param has_bias: Whether the epilogue adds a ``[N]`` bias before the
+            output conversion.
+        :type has_bias: bool
         """
         self.bs = bs
         self.main_vec_width = main_vec_width
         self.tail_vec_width = tail_vec_width
         self.use_pdl = use_pdl
+        self.out_dtype = out_dtype
+        self.has_bias = has_bias
         self.num_warps = bs // cute.arch.WARP_SIZE
         self._init_k_tiles(k)
 
@@ -158,6 +168,7 @@ class LLBf16Dotprod:
         gA: cute.Tensor,
         gB: cute.Tensor,
         gC: cute.Tensor,
+        gBias: cute.Tensor,
         M: cutlass.Constexpr,
         K_dim: cutlass.Constexpr,
         N_dim: cutlass.Int32,
@@ -169,7 +180,7 @@ class LLBf16Dotprod:
         - Traverse K with vectorized 128-bit, vectorized 64-bit, scalar, and
           ragged-tail loops from the precomputed K decomposition.
         - Reduce each token accumulator first within the warp, then across
-          warps through shared memory, and store ``C[:, n]``.
+          warps through shared memory, add the bias, and store ``C[:, n]``.
 
         :param gA: Input tensor A with shape ``[M, K]``.
         :type gA: cute.Tensor
@@ -177,6 +188,10 @@ class LLBf16Dotprod:
         :type gB: cute.Tensor
         :param gC: Output tensor C with shape ``[M, N]``.
         :type gC: cute.Tensor
+        :param gBias: Bias tensor with shape ``[N]``, read only when the
+            kernel was built with ``has_bias``; otherwise a same-typed
+            placeholder the kernel never touches.
+        :type gBias: cute.Tensor
         :param M: Token count selected by the compile key.
         :type M: cutlass.Constexpr
         :param K_dim: Hidden size selected by the compile key.
@@ -190,6 +205,7 @@ class LLBf16Dotprod:
             gA,
             gB,
             gC,
+            gBias,
             M,
             self.main_vec_width,
             self.tail_vec_width,
@@ -219,6 +235,7 @@ class LLBf16Dotprod:
         gA: cute.Tensor,
         gB: cute.Tensor,
         gC: cute.Tensor,
+        gBias: cute.Tensor,
         M: cutlass.Constexpr,
         main_vec_width: cutlass.Constexpr,
         tail_vec_width: cutlass.Constexpr,
@@ -302,10 +319,15 @@ class LLBf16Dotprod:
         if tidx == 0:
             for m in cutlass.range_constexpr(M):
                 partials = sm[m, None].load()
-                gC[m, n_idx] = partials.reduce(
-                    cute.ReductionOp.ADD,
-                    init_val=cutlass.Float32(0.0),
-                    reduction_profile=0,
+                acc_m = cutlass.Float32(
+                    partials.reduce(
+                        cute.ReductionOp.ADD,
+                        init_val=cutlass.Float32(0.0),
+                        reduction_profile=0,
+                    )
                 )
+                if const_expr(self.has_bias):
+                    acc_m = acc_m + gBias[n_idx].to(cutlass.Float32)
+                gC[m, n_idx] = acc_m.to(self.out_dtype)
         if const_expr(self.use_pdl):
             cute.arch.griddepcontrol_launch_dependents()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/_splitk_kernel.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/ll_bf16/_splitk_kernel.py
@@ -42,14 +42,15 @@ def st_shared_remote_f32(remote_addr, val, *, loc=None, ip=None):
 class LLBf16SplitK:
     """BF16 router GEMM kernel based on clustered split-K MMA.
 
-    This kernel computes C[M, N] = A[M, K] @ B[N, K]^T for bf16 inputs
-    and fp32 output. It partitions K across a CTA cluster, uses DMA warps to
-    stage A/B tiles with cp.async, uses MMA warps to accumulate fp32 partials,
-    and reduces split-K partials through DSMEM before storing C.
+    This kernel computes C[M, N] = A[M, K] @ B[N, K]^T (+ bias[N]) for bf16
+    inputs, accumulating in fp32 and converting to ``out_dtype`` on store. It
+    partitions K across a CTA cluster, uses DMA warps to stage A/B tiles with
+    cp.async, uses MMA warps to accumulate fp32 partials, and reduces split-K
+    partials through DSMEM before storing C.
 
     :param ab_dtype: Element type for A and B operands.
     :param acc_dtype: Accumulator type used by MMA and reductions.
-    :param out_dtype: Output element type. The public wrapper uses fp32.
+    :param out_dtype: Output element type; fp32 and bf16 are supported.
     :param tile_n: CTA tile size in N. M is fixed to 16 for router batches.
     :type tile_n: int
     :param tile_k: K tile size staged through shared memory.
@@ -62,18 +63,22 @@ class LLBf16SplitK:
     :type split_k: int
     :param use_pdl: Whether to launch with Programmatic Dependent Launch.
     :type use_pdl: bool
+    :param has_bias: Whether the epilogue adds a ``[N]`` bias before the
+        output conversion.
+    :type has_bias: bool
 
     :note: Supported A/B data types:
         - BFloat16/BFloat16
     :note: Supported accumulator data types:
         - Float32
     :note: Supported C data types:
-        - Float32
+        - Float32/BFloat16
     :note: Constraints:
         - K must preserve 16-byte row alignment for contiguous bf16 inputs.
 
-    :compile-key: ``(split_k, num_stages)`` selects the cluster split
-        count and cp.async pipeline depth specialization.
+    :compile-key: ``(split_k, num_stages, out_dtype, has_bias)`` selects the
+        cluster split count, cp.async pipeline depth, output element type, and
+        whether the epilogue folds in a bias.
     """
 
     def __init__(
@@ -87,6 +92,7 @@ class LLBf16SplitK:
         num_dma_warps: int = 4,
         split_k: int = 8,
         use_pdl: bool = False,
+        has_bias: bool = False,
     ):
         """Initialize the split-K kernel configuration.
 
@@ -109,10 +115,13 @@ class LLBf16SplitK:
         :type split_k: int
         :param use_pdl: Whether to launch with Programmatic Dependent Launch.
         :type use_pdl: bool
+        :param has_bias: Whether the epilogue adds a ``[N]`` bias.
+        :type has_bias: bool
         """
         self.ab_dtype = ab_dtype
         self.acc_dtype = acc_dtype
         self.out_dtype = out_dtype
+        self.has_bias = has_bias
         self.tile_m = 16
         self.tile_n = tile_n
         self.tile_k = tile_k
@@ -190,6 +199,7 @@ class LLBf16SplitK:
         mA: cute.Tensor,
         mB: cute.Tensor,
         mC: cute.Tensor,
+        mBias: cute.Tensor,
         stream: CUstream,
         scale: float = 1.0,
     ):
@@ -210,6 +220,10 @@ class LLBf16SplitK:
         :type mB: cute.Tensor
         :param mC: Output tensor C with shape ``[M, N]``.
         :type mC: cute.Tensor
+        :param mBias: Bias tensor with shape ``[N]``, read only when the kernel
+            was built with ``has_bias``; otherwise a same-typed placeholder the
+            kernel never touches.
+        :type mBias: cute.Tensor
         :param stream: CUDA stream for asynchronous execution.
         :type stream: CUstream
         :param scale: Epilogue scale applied before storing C.
@@ -265,6 +279,7 @@ class LLBf16SplitK:
             mA,
             mB,
             mC,
+            mBias,
             scale,
             sA_layout,
             sB_layout,
@@ -294,6 +309,7 @@ class LLBf16SplitK:
         mA,
         mB,
         mC,
+        mBias,
         scale: cutlass.Float32,
         sA_layout: cute.ComposedLayout,
         sB_layout: cute.ComposedLayout,
@@ -573,7 +589,7 @@ class LLBf16SplitK:
                 local_coord = cute.select(epilogue_slot_coords[elem_idx], mode=[1, 0])
                 global_coord = cC[local_coord]
                 if cute.elem_less(global_coord, mC.shape):
-                    acc = (
+                    acc = cutlass.Float32(
                         partials[None, elem_idx]
                         .load()
                         .reduce(
@@ -582,6 +598,8 @@ class LLBf16SplitK:
                             reduction_profile=0,
                         )
                     )
-                    gC[local_coord] = acc
+                    if const_expr(self.has_bias):
+                        acc = acc + mBias[global_coord[1]].to(cutlass.Float32)
+                    gC[local_coord] = acc.to(self.out_dtype)
 
         cute.arch.sync_threads()

--- a/tokenspeed-kernel/test/ops/gemm/test_ll_bf16_router.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_ll_bf16_router.py
@@ -25,7 +25,9 @@ from typing import Literal
 
 import pytest
 import torch
+from tokenspeed_kernel.ops.gemm import flashinfer as flashinfer_ops
 from tokenspeed_kernel.ops.gemm import ll_bf16 as ll_bf16_ops
+from tokenspeed_kernel.ops.gemm.flashinfer import _declares_cute_dsl_backend
 from tokenspeed_kernel.ops.gemm.kimi3 import (
     KIMI3_HIDDEN_SIZE,
     KIMI3_ROUTER_SIZE,
@@ -33,7 +35,6 @@ from tokenspeed_kernel.ops.gemm.kimi3 import (
 )
 from tokenspeed_kernel.ops.gemm.ll_bf16 import (
     MAX_M,
-    _declares_cute_dsl_backend,
     ll_bf16_mm,
     ll_bf16_mm_supported,
     ll_bf16_router_supported,
@@ -172,7 +173,8 @@ def test_flashinfer_branch_meets_its_documented_requirement(monkeypatch) -> None
             a_arg, b_arg.t(), out, bias=bias, out_dtype=torch.bfloat16
         )
 
-    monkeypatch.setattr(ll_bf16_ops, "_flashinfer_mm_bf16", lambda: stub)
+    monkeypatch.setattr(flashinfer_ops, "_mm_bf16", stub)
+    monkeypatch.setattr(ll_bf16_ops, "has_flashinfer_cute_dsl_bf16", lambda: True)
     torch.testing.assert_close(
         ll_bf16_mm(a, b, bias).float(),
         torch.nn.functional.linear(a.float(), b.float(), bias.float()),

--- a/tokenspeed-kernel/test/ops/gemm/test_ll_bf16_router.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_ll_bf16_router.py
@@ -18,16 +18,26 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""The vendored CuTe dot-product router GEMM against the paths it displaces."""
+"""The vendored CuTe router GEMM, and its dense-linear form, against the paths
+they displace."""
+
+from typing import Literal
 
 import pytest
 import torch
+from tokenspeed_kernel.ops.gemm import ll_bf16 as ll_bf16_ops
 from tokenspeed_kernel.ops.gemm.kimi3 import (
     KIMI3_HIDDEN_SIZE,
     KIMI3_ROUTER_SIZE,
     kimi3_router_projection,
 )
-from tokenspeed_kernel.ops.gemm.ll_bf16 import MAX_M, ll_bf16_router_supported
+from tokenspeed_kernel.ops.gemm.ll_bf16 import (
+    MAX_M,
+    _declares_cute_dsl_backend,
+    ll_bf16_mm,
+    ll_bf16_mm_supported,
+    ll_bf16_router_supported,
+)
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.thirdparty.cute_dsl.ll_bf16 import ll_bf16_router
 
@@ -89,3 +99,124 @@ def test_declines_non_contiguous_and_odd_k() -> None:
         KIMI3_ROUTER_SIZE, KIMI3_HIDDEN_SIZE + 1, device="cuda", dtype=torch.bfloat16
     )
     assert not ll_bf16_router_supported(odd, odd_w, 1)
+
+
+# Covers both backends: the dot product at M <= 4, split-K above it.
+_MM_MS = [1, 4, 8, 32]
+
+
+@pytest.mark.parametrize("m", _MM_MS)
+def test_bf16_epilogue_rounds_once(m: int) -> None:
+    """The epilogue converts from its FP32 accumulator, so no double rounding."""
+    a, b = _inputs(m, seed=5)
+    fp32 = ll_bf16_router(a, b)
+    assert torch.equal(
+        ll_bf16_router(a, b, out_dtype=torch.bfloat16), fp32.to(torch.bfloat16)
+    )
+    bias = torch.randn(KIMI3_ROUTER_SIZE, device="cuda", dtype=torch.bfloat16)
+    assert torch.equal(
+        ll_bf16_router(a, b, bias=bias, out_dtype=torch.bfloat16),
+        (fp32 + bias.float()).to(torch.bfloat16),
+    )
+
+
+@pytest.mark.parametrize("m", _MM_MS)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_mm_matches_linear(m: int, with_bias: bool) -> None:
+    """Whichever path serves it: FlashInfer's backend or the vendored copy."""
+    a, b = _inputs(m, seed=7)
+    bias = (
+        torch.randn(KIMI3_ROUTER_SIZE, device="cuda", dtype=torch.bfloat16)
+        if with_bias
+        else None
+    )
+    assert ll_bf16_mm_supported(a, b, bias)
+    got = ll_bf16_mm(a, b, bias)
+    assert got.dtype is torch.bfloat16
+    torch.testing.assert_close(
+        got.float(),
+        torch.nn.functional.linear(
+            a.float(), b.float(), None if bias is None else bias.float()
+        ),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+
+
+def test_flashinfer_probe_reads_the_declared_backends() -> None:
+    """0.6.18 declares the backend; earlier wheels name every other one."""
+
+    def upstreamed(backend: Literal["cudnn", "cute-dsl"] = "cudnn") -> None: ...
+
+    def earlier(backend: Literal["cudnn", "tgv", "tinygemm"] = "cudnn") -> None: ...
+
+    assert _declares_cute_dsl_backend(upstreamed)
+    assert not _declares_cute_dsl_backend(earlier)
+    assert not _declares_cute_dsl_backend(lambda: None)
+
+
+def test_flashinfer_branch_meets_its_documented_requirement(monkeypatch) -> None:
+    """Its guard wants row-major 2-D A, column-major B, and a contiguous [N] bias."""
+    a, b = _inputs(4, seed=19)
+    bias = torch.randn(KIMI3_ROUTER_SIZE, device="cuda", dtype=torch.bfloat16)
+
+    def stub(a_arg, b_arg, *, bias, pdl, out, backend):
+        assert backend == "cute-dsl"
+        assert isinstance(pdl, bool)
+        assert a_arg.ndim == 2 and a_arg.is_contiguous()
+        assert tuple(b_arg.shape) == (KIMI3_HIDDEN_SIZE, KIMI3_ROUTER_SIZE)
+        assert b_arg.T.is_contiguous()
+        assert bias.shape == (KIMI3_ROUTER_SIZE,) and bias.is_contiguous()
+        assert out is None or (out.dtype is torch.bfloat16 and out.is_contiguous())
+        return ll_bf16_router(
+            a_arg, b_arg.t(), out, bias=bias, out_dtype=torch.bfloat16
+        )
+
+    monkeypatch.setattr(ll_bf16_ops, "_flashinfer_mm_bf16", lambda: stub)
+    torch.testing.assert_close(
+        ll_bf16_mm(a, b, bias).float(),
+        torch.nn.functional.linear(a.float(), b.float(), bias.float()),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+
+
+@pytest.mark.parametrize(("lead", "m"), [((2, 2), 4), ((4, 8), 32)])
+def test_flattens_leading_dims_and_honours_out(lead, m: int) -> None:
+    a, b = _inputs(m, seed=11)
+    x = a.view(*lead, KIMI3_HIDDEN_SIZE)
+    out = torch.empty(*lead, KIMI3_ROUTER_SIZE, device="cuda", dtype=torch.bfloat16)
+    returned = ll_bf16_mm(x, b, out=out)
+    assert returned.shape == out.shape
+    assert returned.data_ptr() == out.data_ptr()
+    assert torch.equal(out.view(m, KIMI3_ROUTER_SIZE), ll_bf16_mm(a, b))
+
+
+def test_mm_guard_declines_what_the_kernels_cannot_serve() -> None:
+    a, b = _inputs(1, seed=13)
+    # K must be a multiple of 128: both backends step K in those units.
+    k_odd = KIMI3_HIDDEN_SIZE + 8
+    assert not ll_bf16_mm_supported(
+        torch.randn(1, k_odd, device="cuda", dtype=torch.bfloat16),
+        torch.randn(KIMI3_ROUTER_SIZE, k_odd, device="cuda", dtype=torch.bfloat16),
+    )
+    big, big_w = _inputs(MAX_M + 1, seed=13)
+    assert not ll_bf16_mm_supported(big, big_w)
+    # Contiguous but offset 8 bytes into its storage, so vector loads misalign.
+    buf = torch.randn(KIMI3_HIDDEN_SIZE + 16, device="cuda", dtype=torch.bfloat16)
+    assert not ll_bf16_mm_supported(buf[4 : 4 + KIMI3_HIDDEN_SIZE].view(1, -1), b)
+    assert not ll_bf16_mm_supported(a, b.unsqueeze(0))
+    # Declined on the original tensor: a reshape would copy into something
+    # contiguous and 32-byte aligned, voiding both checks.
+    wide, wide_w = _inputs(2, seed=17)
+    assert not ll_bf16_mm_supported(wide.t().contiguous().t(), wide_w)
+    # Degenerate weight must be declined, not divided by.
+    assert not ll_bf16_mm_supported(
+        a, torch.zeros(KIMI3_ROUTER_SIZE, 0, device="cuda", dtype=torch.bfloat16)
+    )
+    assert not ll_bf16_mm_supported(
+        a, b, torch.zeros(KIMI3_ROUTER_SIZE + 1, device="cuda", dtype=torch.bfloat16)
+    )
+    assert not ll_bf16_mm_supported(
+        a, b, torch.zeros(KIMI3_ROUTER_SIZE, device="cuda", dtype=torch.float32)
+    )

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -98,7 +98,11 @@ def test_routed_backend_matches_torch(shape, backend):
     reason="route is registered for sm100 and up",
 )
 def test_non_bf16_inputs_fall_back_to_torch():
-    from tokenspeed_kernel.ops.gemm.routed_gemv import skinny_gemv, tgv_gemv
+    from tokenspeed_kernel.ops.gemm.routed_gemv import (
+        ll_bf16_gemv,
+        skinny_gemv,
+        tgv_gemv,
+    )
 
     x = torch.randn(1, 7168, device="cuda", dtype=torch.float16)
     w = torch.randn(768, 7168, device="cuda", dtype=torch.float16)
@@ -108,6 +112,11 @@ def test_non_bf16_inputs_fall_back_to_torch():
     x = torch.randn(1, 1536, device="cuda", dtype=torch.float16)
     w = torch.randn(7168, 1536, device="cuda", dtype=torch.float16)
     got = tgv_gemv(x, w)
+    assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)
+
+    x = torch.randn(1, 1536, device="cuda", dtype=torch.float16)
+    w = torch.randn(2560, 1536, device="cuda", dtype=torch.float16)
+    got = ll_bf16_gemv(x, w)
     assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)
 
 


### PR DESCRIPTION
## Summary
Adds a BF16 dense-linear form of the vendored CuTe low-latency BF16 GEMM as `ll_bf16_mm` — same two kernels as the router GEMM, now with BF16 output and a fused `[N]` bias — and prefers FlashInfer's upstreamed `mm_bf16(backend="cute-dsl")` whenever the installed wheel declares that backend, falling back to the vendored copy otherwise, with no version floor pinned. Routes it into decode by adding an `ll_bf16` backend to `routed_gemv` with 35 `MEASURED_ROUTE` entries, swept at  the BF16 dense-linear shapes a TP4 MoE decode was observed to run. 

## Test Plan
Qwen3.8-Flash-Next-FP8 end-to-end A/B test on identical server configurations and batch size (bs=1) using the agentic benchmark (--parallel 1 --number 4), with TP4 on B200—only route entries were toggled.
 
| Metric | Baseline | With route | Delta |
|---|---|---|---|
| Decode toks/s | 226.24 | 242.13 | **+7.0%** |   
| TPOT | 4.4 ms | 4.1 ms | -6.8% |
| First-turn TTFT | 3.36 s | 3.38 s | flat |

<!-- How was this validated? -->
