### PR TITLE
fix(L2): support L2 cache for qwen3.8-flash-next 

### DIFF
--- a/.github/workflows/k8s-dispatch.yml
+++ b/.github/workflows/k8s-dispatch.yml
@@ -40,6 +40,7 @@ on:
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-pd-1p1d-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-mxfp4-evalscope-aime25.yaml
+          - test/ci/eval/qwen3.8-flash-next-fp8-evalscope-gsm8k.yaml
           - test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi355.yaml
           - test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml

--- a/.github/workflows/slurm-dispatch.yml
+++ b/.github/workflows/slurm-dispatch.yml
@@ -48,6 +48,7 @@ on:
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-dp4ep4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-397b-a17b-nvfp4-pd-1p1d-evalscope-aime25.yaml
+          - test/ci/eval/qwen3.8-flash-next-fp8-evalscope-gsm8k.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -195,6 +195,15 @@ window, state checkpoints) are the norm, not the exception. A backend's
 override, never from `prefix_granularity` as a fallback. The CLI flag is
 `--prefix-granularity` (`--block-size` remains a deprecated alias).
 
+Layerwise L2 load fences guard the first access to every field owned by a
+layer, not just the conventional paged-KV buffers. Model-owned side caches
+(for example QSA raw/compressed keys and positions, or PLE state) must wait on
+the pool's layerwise load tracker before their first read or write. A wait in a
+later attention-buffer accessor is too late: the side-cache kernels would
+already be racing the asynchronous H2D restore. Place the fence immediately
+before the first cache-field access so independent projections can still
+overlap the load.
+
 ## block vs. page
 
 **`block` is the general concept; `page` is its specialization under

--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -443,7 +443,6 @@ tokenspeed serve Qwen/Qwen3.8-2.4T-A95B \
   --attention-backend trtllm \
   --chunked-prefill-size 8192 \
   --gpu-memory-utilization 0.95 --max-num-seqs 128 \
-  --disable-kvstore \
   --speculative-algorithm MTP --speculative-num-steps 3 \
   --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
   --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
@@ -460,7 +459,6 @@ tokenspeed serve Qwen/Qwen3.8-2.4T-A95B \
   --attention-backend trtllm \
   --chunked-prefill-size 8192 \
   --gpu-memory-utilization 0.95 --max-num-seqs 128 \
-  --disable-kvstore \
   --speculative-algorithm MTP --speculative-num-steps 3 \
   --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
   --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
@@ -486,7 +484,6 @@ tokenspeed serve Qwen/Qwen3.8-2.4T-A95B \
   --attention-backend trtllm \
   --chunked-prefill-size 8192 \
   --gpu-memory-utilization 0.95 --max-num-seqs 128 \
-  --disable-kvstore \
   --speculative-algorithm MTP --speculative-num-steps 3 \
   --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
   --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
@@ -505,7 +502,6 @@ tokenspeed serve Qwen/Qwen3.8-2.4T-A95B \
   --attention-backend trtllm \
   --chunked-prefill-size 8192 \
   --gpu-memory-utilization 0.95 --max-num-seqs 128 \
-  --disable-kvstore \
   --speculative-algorithm MTP --speculative-num-steps 3 \
   --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
   --reasoning-parser qwen3_thinking --tool-call-parser qwen_coder \
@@ -548,8 +544,7 @@ tokenspeed serve Qwen/Qwen3.8-27B-FP8 \
   --kv-cache-dtype fp8_e4m3 \
   --speculative-algorithm MTP \
   --speculative-draft-model-path Qwen/Qwen3.8-27B-FP8 \
-  --speculative-num-steps 3 \
-  --disable-kvstore
+  --speculative-num-steps 3
 ```
 
 ## Qwen3.8 Flash Next
@@ -577,7 +572,6 @@ ts serve \
     --tensor-parallel-size 4 \
     --quantization fp8 \
     --moe-backend flashinfer_trtllm \
-    --disable-kvstore \
     --speculative-algorithm MTP \
     --speculative-num-steps 3
 ```

--- a/python/tokenspeed/runtime/layers/attention/backends/qwen4_exp.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/qwen4_exp.py
@@ -33,7 +33,6 @@ from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
 from tokenspeed.runtime.layers.attention.backends.qsa import bind_qsa_indexers
 from tokenspeed.runtime.layers.attention.kv_cache.qwen4_exp import (
     QWEN4_EXP_PLE_CACHE_GROUP,
-    QWEN4_EXP_PLE_CONTEXT_FIELD,
     qwen4_exp_ple_conv_field,
 )
 
@@ -96,10 +95,10 @@ class Qwen4ExpMambaAttnBackend(MambaAttnBackend):
         self._ple_verify_scratch = scratch
 
     def ple_verify_scratch(
-        self, layer_id: int
+        self, context_field_id: str, layer_id: int
     ) -> tuple[torch.Tensor, torch.Tensor] | None:
         """Return shared context and per-layer PLE convolution verify rows."""
-        context = self._ple_verify_scratch.get(QWEN4_EXP_PLE_CONTEXT_FIELD)
+        context = self._ple_verify_scratch.get(context_field_id)
         conv = self._ple_verify_scratch.get(qwen4_exp_ple_conv_field(layer_id))
         if context is None or conv is None:
             return None

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/base.py
@@ -63,6 +63,7 @@ def derive_state_groups_by_layer(
     first_layer: int,
     num_layers: int,
     state_layer_ids: Iterable[int],
+    state_field_suffixes: Iterable[str],
 ) -> dict[int, str]:
     """Map each recurrent layer to the state-family group holding its fields.
 
@@ -75,6 +76,8 @@ def derive_state_groups_by_layer(
         first_layer: This view's first layer in the merged plan.
         num_layers: Number of layers in this view's window.
         state_layer_ids: View-local ids of the recurrent (state) layers.
+        state_field_suffixes: Field ID suffixes that make up the pool's
+            recurrent state.
 
     Returns:
         View-local layer id -> state-family group id, one entry per state
@@ -87,13 +90,16 @@ def derive_state_groups_by_layer(
         spec.group_id for spec in arena.cache_group_specs if spec.family == "state"
     }
     wanted = set(state_layer_ids)
+    wanted_suffixes = set(state_field_suffixes)
     mapping: dict[int, str] = {}
     for field in arena.plan.fields:
         located = _layer_plane(field.field_id, first_layer, num_layers)
         if located is None:
             continue
-        layer_id, _ = located
-        if layer_id not in wanted or field.group_id not in state_groups:
+        layer_id, suffix = located
+        if layer_id not in wanted or suffix not in wanted_suffixes:
+            continue
+        if field.group_id not in state_groups:
             continue
         existing = mapping.setdefault(layer_id, field.group_id)
         if existing != field.group_id:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_kda.py
@@ -103,6 +103,7 @@ class HybridKDATokenToKVPool(MLATokenToKVPool):
                 for layer_id, label in enumerate(self._layer_types)
                 if label in STATE_LAYER_TYPES
             ),
+            state_field_suffixes=("conv_state", "recurrent_state"),
         )
 
     def get_component(self, layer_id: int, component_name: str) -> torch.Tensor:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_mha.py
@@ -92,6 +92,7 @@ class HybridMHATokenToKVPool(MHATokenToKVPool):
             first_layer=self._field_layer_offset,
             num_layers=self.layer_num,
             state_layer_ids=self._state_layer_ids,
+            state_field_suffixes=("conv", "ssm"),
         )
 
     def get_state_buffers(self, layer_id: int) -> tuple[torch.Tensor, torch.Tensor]:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/qwen4_exp.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/qwen4_exp.py
@@ -26,7 +26,6 @@ kernels as a side effect.
 """
 
 QWEN4_EXP_PLE_CACHE_GROUP = "qwen4_exp_ple"
-QWEN4_EXP_PLE_CONTEXT_FIELD = "qwen4_exp.ple.context"
 
 QWEN4_EXP_QSA_CACHE_GROUP = "qwen4_exp_qsa"
 QWEN4_EXP_QSA_RECENT_CACHE_GROUP = "qwen4_exp_qsa_recent"
@@ -34,10 +33,16 @@ QWEN4_EXP_QSA_COMPRESSED_ROWS_PER_PAGE = 64
 QWEN4_EXP_QSA_RECENT_ROWS_PER_PAGE = 64
 
 
+def qwen4_exp_ple_context_field(layer_id: int) -> str:
+    """Return the shared PLE context field owned by its first consumer."""
+
+    return f"layer.{layer_id}.qwen4_exp.ple.context"
+
+
 def qwen4_exp_ple_conv_field(layer_id: int) -> str:
     """Return the cache field id for one PLE short-convolution state."""
 
-    return f"qwen4_exp.ple.layer.{layer_id}.conv"
+    return f"layer.{layer_id}.qwen4_exp.ple.conv"
 
 
 def qsa_raw_key_field(layer_id: int) -> str:
@@ -60,7 +65,6 @@ def qsa_rope_position_field(layer_id: int) -> str:
 
 __all__ = [
     "QWEN4_EXP_PLE_CACHE_GROUP",
-    "QWEN4_EXP_PLE_CONTEXT_FIELD",
     "QWEN4_EXP_QSA_CACHE_GROUP",
     "QWEN4_EXP_QSA_COMPRESSED_ROWS_PER_PAGE",
     "QWEN4_EXP_QSA_RECENT_CACHE_GROUP",
@@ -68,5 +72,6 @@ __all__ = [
     "qsa_compressed_field",
     "qsa_raw_key_field",
     "qsa_rope_position_field",
+    "qwen4_exp_ple_context_field",
     "qwen4_exp_ple_conv_field",
 ]

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen4_exp.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen4_exp.py
@@ -30,7 +30,6 @@ from typing_extensions import override
 
 from tokenspeed.runtime.layers.attention.kv_cache.qwen4_exp import (
     QWEN4_EXP_PLE_CACHE_GROUP,
-    QWEN4_EXP_PLE_CONTEXT_FIELD,
     QWEN4_EXP_QSA_CACHE_GROUP,
     QWEN4_EXP_QSA_COMPRESSED_ROWS_PER_PAGE,
     QWEN4_EXP_QSA_RECENT_CACHE_GROUP,
@@ -38,6 +37,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.qwen4_exp import (
     qsa_compressed_field,
     qsa_raw_key_field,
     qsa_rope_position_field,
+    qwen4_exp_ple_context_field,
     qwen4_exp_ple_conv_field,
 )
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
@@ -83,10 +83,12 @@ class Qwen4ExpRecipe(QwenGDNRecipe):
     def _ple_fields(self) -> tuple[CacheFieldSpec, ...]:
         if not getattr(self._text_config, "ple_layer_ids", None):
             return ()
+        ple_layer_ids = tuple(self._text_config.short_conv_layer_ids)
+        context_field = qwen4_exp_ple_context_field(min(ple_layer_ids))
         fields = (
             CacheFieldSpec(
-                QWEN4_EXP_PLE_CONTEXT_FIELD,
-                QWEN4_EXP_PLE_CONTEXT_FIELD,
+                context_field,
+                context_field,
                 (int(self._text_config.ngram_context_len),),
                 cache_dtype_name(torch.int64),
                 exact_page_stride=False,
@@ -101,7 +103,7 @@ class Qwen4ExpRecipe(QwenGDNRecipe):
                 cache_dtype_name(torch.bfloat16),
                 exact_page_stride=False,
             )
-            for layer_id in self._text_config.short_conv_layer_ids
+            for layer_id in ple_layer_ids
         )
 
     @cached_property

--- a/python/tokenspeed/runtime/layers/attention/qsa/indexer.py
+++ b/python/tokenspeed/runtime/layers/attention/qsa/indexer.py
@@ -677,7 +677,11 @@ class QSAIndexer(nn.Module):
             query_lengths=query_lengths,
         )
         q, token_k = self._project_qk(hidden_states, positions)
-        _, compressed, _ = self._fields(ctx.token_to_kv_pool)
+        pool = ctx.token_to_kv_pool
+        load_tracker = getattr(pool, "layerwise_load_tracker", None)
+        if load_tracker is not None:
+            load_tracker.wait_for_layer(self.layer_id)
+        _, compressed, _ = self._fields(pool)
         full_backend = self._full_backend(ctx)
         verify_bs = ctx.bs - ctx.num_extends
         is_target_verify = (
@@ -750,7 +754,7 @@ class QSAIndexer(nn.Module):
             requests,
             qsa_locs,
             recent_locs,
-            ctx.token_to_kv_pool,
+            pool,
             recent_request_limit=ctx.num_extends if is_target_verify else None,
             write_mask=write_mask,
             draft_scratch=draft_scratch if is_draft_decode_step else None,
@@ -766,7 +770,7 @@ class QSAIndexer(nn.Module):
                 logical[-verify_tokens:],
                 recent_locs[-verify_tokens:],
                 verify_bs,
-                ctx.token_to_kv_pool,
+                pool,
             )
         if self.share_topk_for_mtp_iteration:
             shared_topk = getattr(ctx, "dsa_decode_topk", None)

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -566,8 +566,8 @@ def _create_target_components(
     is_inkling: bool,
 ):
     """The target's compute view onto the shared arena + target backend."""
-    # The merged spec includes the draft's continuation layers; the target
-    # view binds every planned field regardless of which model consumes it.
+    # The arena owns every planned field; this view binds only the target
+    # model's layer window.
     pool = create_cache_pool(
         cache_spec,
         config,
@@ -891,21 +891,19 @@ def create_attn_components(
         overlap_schedule_depth=overlap_schedule_depth,
     )
     spec = cache_setup.spec
-    # The target view binds every planned field, draft continuation layers
-    # included, so the merged plan has one owner. The draft is a second view
-    # over the same arena, offset onto its own layer window.
     target_spec = spec
     draft_view_spec = None
     if cache_setup.num_draft_layers:
+        # Transfer fields need one owner even when target and draft share a
+        # cache family, so both compute views use disjoint layer windows.
+        target_spec = spec.layer_view(
+            first_layer=0,
+            num_layers=cache_setup.num_target_layers,
+        )
         draft_view_spec = spec.layer_view(
             first_layer=cache_setup.num_target_layers,
             num_layers=cache_setup.num_draft_layers,
             family=heterogeneous_draft_family,
-        )
-    if heterogeneous_draft_family is not None:
-        target_spec = spec.layer_view(
-            first_layer=0,
-            num_layers=cache_setup.num_target_layers,
         )
     prefix_granularity = spec.memory_plan.prefix_granularity
     _validate_lcm_page_size(

--- a/python/tokenspeed/runtime/models/qwen4_exp_ple.py
+++ b/python/tokenspeed/runtime/models/qwen4_exp_ple.py
@@ -44,7 +44,7 @@ from tokenspeed.runtime.layers.attention.backends.qwen4_exp import (
 )
 from tokenspeed.runtime.layers.attention.kv_cache.qwen4_exp import (
     QWEN4_EXP_PLE_CACHE_GROUP,
-    QWEN4_EXP_PLE_CONTEXT_FIELD,
+    qwen4_exp_ple_context_field,
     qwen4_exp_ple_conv_field,
 )
 from tokenspeed.runtime.layers.hyperconnection import GroupedGemmaRMSNorm
@@ -781,6 +781,8 @@ class Qwen4ExpPLELayer(nn.Module):
     ) -> None:
         super().__init__()
         self.layer_id = int(layer_id)
+        context_layer_id = min(config.short_conv_layer_ids)
+        self.context_field_id = qwen4_exp_ple_context_field(context_layer_id)
         self.hidden_size = int(config.hidden_size)
         self.hc_count = int(config.hc_count)
         self.hc_hidden_size = self.hidden_size * self.hc_count
@@ -1281,7 +1283,7 @@ class Qwen4ExpPLELayer(nn.Module):
         key = (bs, width)
         self._active_verify_key = key
         rows = bs * (width + 1)
-        external = backend.ple_verify_scratch(self.layer_id)
+        external = backend.ple_verify_scratch(self.context_field_id, self.layer_id)
         if external is None:
             raise RuntimeError("Qwen4-Exp PLE verify workspace was not preallocated")
         if external[0].shape[0] < rows or external[1].shape[0] < rows:
@@ -1317,7 +1319,7 @@ class Qwen4ExpPLELayer(nn.Module):
         accepted = accepted_lengths.to(torch.long).clamp(1, width)
         source = torch.arange(bs, device=accepted.device) * (width + 1) + accepted
         pool = self._last_pool
-        context_field = pool.arena.field(QWEN4_EXP_PLE_CONTEXT_FIELD)
+        context_field = pool.arena.field(self.context_field_id)
         conv_field = pool.arena.field(qwen4_exp_ple_conv_field(self.layer_id))
         self._write_pages(
             context_field, destination_pages, context_scratch.index_select(0, source)
@@ -1456,7 +1458,10 @@ class Qwen4ExpPLELayer(nn.Module):
         output_pages = out_blocks_by_group[QWEN4_EXP_PLE_CACHE_GROUP][: ctx.bs]
         pool = ctx.token_to_kv_pool
         self._last_pool = pool
-        context_field = pool.arena.field(QWEN4_EXP_PLE_CONTEXT_FIELD)
+        load_tracker = getattr(pool, "layerwise_load_tracker", None)
+        if load_tracker is not None:
+            load_tracker.wait_for_layer(self.layer_id)
+        context_field = pool.arena.field(self.context_field_id)
         conv_field = pool.arena.field(qwen4_exp_ple_conv_field(self.layer_id))
         initial_context = self._read_pages(
             context_field, input_pages, self.ple_embedding.eos_token_id
@@ -1528,9 +1533,9 @@ class Qwen4ExpPLELayer(nn.Module):
 
 __all__ = [
     "QWEN4_EXP_PLE_CACHE_GROUP",
-    "QWEN4_EXP_PLE_CONTEXT_FIELD",
     "Qwen4ExpNGramEmbedding",
     "Qwen4ExpPLELayer",
+    "qwen4_exp_ple_context_field",
     "qwen4_exp_ple_conv_field",
     "quantize_ple_embedding_rows",
 ]

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -44,6 +44,11 @@ normal path during prefill and low-latency path during decode, and the task
 uses the bounded non-thinking chat template for CI stability. The task requires
 a score of at least 0.90.
 
+The Qwen3.8 Flash Next FP8 correctness task runs GSM8K on two GB200 GPUs with
+tensor parallelism 2 and three-step MTP. It keeps KVStore enabled and uses the
+bounded non-thinking chat template for CI stability. The task requires a score
+of at least 0.90.
+
 Each task expands into one matrix entry per runner label. Add a top-level
 `priority` to a task YAML to bias dispatch order. GitHub Actions starts matrix
 jobs in include-list order, so `high` entries reach a contended runner pool

--- a/test/ci/eval/qwen3.8-flash-next-fp8-evalscope-gsm8k.yaml
+++ b/test/ci/eval/qwen3.8-flash-next-fp8-evalscope-gsm8k.yaml
@@ -1,0 +1,52 @@
+api_version: ci.tokenspeed.io/v1
+name: eval-qwen3.8-flash-next-fp8-gsm8k
+type: eval
+workflow_stage: model-test
+triggers:
+  - per-commit
+  - manual
+runner:
+  labels:
+    - gb200-2gpu
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps.sh
+server:
+  command: >-
+    ts serve
+    --model Qwen/Qwen3.8-Flash-Next-FP8
+    --trust-remote-code
+    --tensor-parallel-size 2
+    --quantization fp8
+    --moe-backend flashinfer_trtllm
+    --speculative-algorithm MTP
+    --speculative-num-steps 3
+    --max-model-len 8192
+    --max-num-seqs 16
+    --max-cudagraph-capture-size 16
+    --sampling-backend greedy
+    --host 127.0.0.1
+    --port 8000
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model Qwen/Qwen3.8-Flash-Next-FP8
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets gsm8k
+    --dataset-hub huggingface
+    --dataset-args '{"gsm8k":{"dataset_id":"openai/gsm8k"}}'
+    --eval-batch-size 16
+    --stream
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":1024,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'
+report:
+  github_step_summary: true
+score_threshold: 0.90

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -42,7 +42,7 @@ DATASETS = {
         "dataset_args": json.loads(GPQA_HUGGINGFACE_DATASET_ARGS)["gpqa_diamond"],
     },
     "gsm8k": {
-        "count": 4,
+        "count": 7,
         "dataset_args": {"dataset_id": "openai/gsm8k"},
     },
     "mmlu": {
@@ -132,6 +132,29 @@ def test_evalscope_configs_use_expected_dataset_sources():
         len(paths) == expected_total
     ), f"expected {expected_total} EvalScope configs, found {len(paths)}"
     assert counts == expected_counts, f"expected {expected_counts}, found {counts}"
+
+
+def test_qwen38_flash_next_runs_gsm8k_with_kvstore_enabled():
+    path = EVAL_CONFIG_DIR / "qwen3.8-flash-next-fp8-evalscope-gsm8k.yaml"
+    task = yaml.safe_load(path.read_text(encoding="utf-8"))
+    server_tokens = shlex.split(task["server"]["command"])
+    eval_tokens = shlex.split(task["eval"]["command"])
+
+    assert task["type"] == "eval"
+    assert task["workflow_stage"] == "model-test"
+    assert task["triggers"] == ["per-commit", "manual"]
+    assert task["runner"]["labels"] == ["gb200-2gpu"]
+    assert flag_value(server_tokens, "--model") == "Qwen/Qwen3.8-Flash-Next-FP8"
+    assert flag_value(server_tokens, "--tensor-parallel-size") == "2"
+    assert flag_value(server_tokens, "--speculative-algorithm") == "MTP"
+    assert flag_value(server_tokens, "--speculative-num-steps") == "3"
+    assert flag_value(server_tokens, "--max-model-len") == "8192"
+    assert flag_value(server_tokens, "--max-num-seqs") == "16"
+    assert flag_value(server_tokens, "--max-cudagraph-capture-size") == "16"
+    assert "--disable-kvstore" not in server_tokens
+    assert flag_value(eval_tokens, "--model") == "Qwen/Qwen3.8-Flash-Next-FP8"
+    assert flag_value(eval_tokens, "--datasets") == "gsm8k"
+    assert task["score_threshold"] == 0.90
 
 
 def test_kvv_configs_use_pinned_upstream_and_local_api():

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -5,7 +5,10 @@ import pytest
 import torch
 
 import tokenspeed.runtime.layers.attention.kv_cache.mha as mha_cache
-from tokenspeed.runtime.cache.transfer.layout import combine_cache_transfer_layouts
+from tokenspeed.runtime.cache.transfer.layout import (
+    combine_cache_transfer_layouts,
+    select_layer_fields,
+)
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
@@ -648,7 +651,7 @@ def test_deepseek_v4_draft_pd_is_rejected_for_an_ordinary_target(
         )
 
 
-def test_hybrid_draft_layers_share_the_merged_plan() -> None:
+def test_hybrid_draft_layers_share_plan_with_disjoint_views() -> None:
     setup = _hybrid_setup_with_narrow_draft()
 
     # One big model: the draft layer's field is planned as a continuation
@@ -662,6 +665,18 @@ def test_hybrid_draft_layers_share_the_merged_plan() -> None:
         plan.group(draft_field.group_id).page_count
         == plan.group(target_field.group_id).page_count
     )
+    target_fields, _ = select_layer_fields(
+        plan.fields,
+        first_layer=0,
+        num_layers=setup.num_target_layers,
+    )
+    draft_fields, _ = select_layer_fields(
+        plan.fields,
+        first_layer=setup.num_target_layers,
+        num_layers=setup.num_draft_layers,
+    )
+    assert target_fields.isdisjoint(draft_fields)
+    assert target_fields | draft_fields == {field.field_id for field in plan.fields}
 
 
 def test_hybrid_draft_only_sliding_group_packs_by_ratio() -> None:

--- a/test/runtime/test_qwen4_exp.py
+++ b/test/runtime/test_qwen4_exp.py
@@ -462,6 +462,7 @@ def test_qwen4_exp_qsa_publishes_and_reuses_context_topk() -> None:
     rows = torch.tensor([[3, 1, -1], [5, 2, 0]], dtype=torch.int32)
     indexer = QSAIndexer.__new__(QSAIndexer)
     torch.nn.Module.__init__(indexer)
+    indexer.layer_id = 3
     indexer.share_topk_for_mtp_iteration = True
     indexer.compressed_token_page_size = 256
     indexer.recent_page_size = 64
@@ -478,6 +479,12 @@ def test_qwen4_exp_qsa_publishes_and_reuses_context_topk() -> None:
     requests = torch.tensor([0, 1])
     cache_locs = torch.tensor([1, 2], dtype=torch.int32)
     updates = []
+    cache_accesses = []
+    pool = SimpleNamespace(
+        layerwise_load_tracker=SimpleNamespace(
+            wait_for_layer=lambda layer_id: cache_accesses.append(("wait", layer_id))
+        )
+    )
 
     indexer._metadata = lambda ctx: metadata
     indexer._decode_query_lengths = lambda ctx, total_tokens: None
@@ -486,7 +493,13 @@ def test_qwen4_exp_qsa_publishes_and_reuses_context_topk() -> None:
         torch.zeros((2, 1, 1)),
         torch.ones((2, 1, 1)),
     )
-    indexer._fields = lambda pool: (None, torch.empty(0), None)
+
+    def fields(actual_pool):
+        assert actual_pool is pool
+        cache_accesses.append(("fields", indexer.layer_id))
+        return None, torch.empty(0), None
+
+    indexer._fields = fields
     indexer._full_backend = lambda ctx: backend
     indexer._backend_group_page_size = lambda *args: 64
     indexer._page_table_expansion = lambda *args: 1
@@ -506,7 +519,7 @@ def test_qwen4_exp_qsa_publishes_and_reuses_context_topk() -> None:
         num_extends=2,
         forward_mode=ForwardMode.EXTEND,
         attn_backend=backend,
-        token_to_kv_pool=object(),
+        token_to_kv_pool=pool,
         dsa_decode_topk=None,
     )
 
@@ -514,6 +527,7 @@ def test_qwen4_exp_qsa_publishes_and_reuses_context_topk() -> None:
 
     torch.testing.assert_close(actual, rows)
     torch.testing.assert_close(ctx.dsa_decode_topk, rows)
+    assert cache_accesses == [("wait", 3), ("fields", 3)]
     assert len(updates) == 1
     assert len(selections) == 1
 
@@ -524,6 +538,12 @@ def test_qwen4_exp_qsa_publishes_and_reuses_context_topk() -> None:
     actual = indexer(torch.zeros((2, 4)), torch.tensor([9, 10]), ctx)
 
     torch.testing.assert_close(actual, rows)
+    assert cache_accesses == [
+        ("wait", 3),
+        ("fields", 3),
+        ("wait", 3),
+        ("fields", 3),
+    ]
     assert len(updates) == 2
 
 

--- a/test/runtime/test_qwen4_exp.py
+++ b/test/runtime/test_qwen4_exp.py
@@ -25,6 +25,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from tokenspeed.runtime.cache.transfer.layout import select_layer_fields
 from tokenspeed.runtime.configs.model_config import is_qwen4_exp
 from tokenspeed.runtime.configs.qwen4_exp_config import (
     Qwen4ExpConfig,
@@ -69,11 +70,11 @@ from tokenspeed.runtime.models.qwen4_exp import (
 )
 from tokenspeed.runtime.models.qwen4_exp_ple import (
     QWEN4_EXP_PLE_CACHE_GROUP,
-    QWEN4_EXP_PLE_CONTEXT_FIELD,
     Qwen4ExpNGramEmbedding,
     Qwen4ExpPLELayer,
     _nth_prime_after,
     quantize_ple_embedding_rows,
+    qwen4_exp_ple_context_field,
     qwen4_exp_ple_conv_field,
 )
 
@@ -1081,10 +1082,11 @@ def test_qwen4_exp_nextn_reads_nested_mtp_index_sharing_config() -> None:
 
 
 def test_qwen4_exp_ple_verify_workspace_shares_context_rows() -> None:
+    context_field = qwen4_exp_ple_context_field(0)
     fields = (
         SimpleNamespace(
             group_id=QWEN4_EXP_PLE_CACHE_GROUP,
-            field_id=QWEN4_EXP_PLE_CONTEXT_FIELD,
+            field_id=context_field,
             shape=(2,),
         ),
         SimpleNamespace(
@@ -1099,7 +1101,7 @@ def test_qwen4_exp_ple_verify_workspace_shares_context_rows() -> None:
         ),
     )
     cache_fields = {
-        QWEN4_EXP_PLE_CONTEXT_FIELD: torch.empty((3, 2), dtype=torch.int64),
+        context_field: torch.empty((3, 2), dtype=torch.int64),
         qwen4_exp_ple_conv_field(0): torch.empty((3, 16, 9), dtype=torch.bfloat16),
         qwen4_exp_ple_conv_field(2): torch.empty((3, 16, 9), dtype=torch.bfloat16),
     }
@@ -1114,8 +1116,8 @@ def test_qwen4_exp_ple_verify_workspace_shares_context_rows() -> None:
     backend._ple_verify_scratch = {}
 
     backend._ensure_ple_verify_scratch(max_bs=2, draft_token_num=3)
-    first = backend.ple_verify_scratch(0)
-    second = backend.ple_verify_scratch(2)
+    first = backend.ple_verify_scratch(context_field, 0)
+    second = backend.ple_verify_scratch(context_field, 2)
 
     assert first is not None and second is not None
     assert first[0] is second[0]
@@ -1226,6 +1228,7 @@ def _ple_layer_stub(hc_count: int = 1, hidden_size: int = 2, pages: int = 5):
     layer = Qwen4ExpPLELayer.__new__(Qwen4ExpPLELayer)
     torch.nn.Module.__init__(layer)
     layer.layer_id = 0
+    layer.context_field_id = qwen4_exp_ple_context_field(0)
     layer.hidden_size = hidden_size
     layer.hc_count = hc_count
     layer.hc_hidden_size = hidden_size * hc_count
@@ -1260,7 +1263,7 @@ def _ple_layer_stub(hc_count: int = 1, hidden_size: int = 2, pages: int = 5):
 
     layer._conv_sequences = conv_sequences
     fields = {
-        QWEN4_EXP_PLE_CONTEXT_FIELD: torch.zeros((pages, 1), dtype=torch.int64),
+        layer.context_field_id: torch.zeros((pages, 1), dtype=torch.int64),
         qwen4_exp_ple_conv_field(0): torch.zeros(
             (pages, layer.hc_hidden_size, 1), dtype=torch.bfloat16
         ),
@@ -1270,7 +1273,7 @@ def _ple_layer_stub(hc_count: int = 1, hidden_size: int = 2, pages: int = 5):
 
 def test_qwen4_exp_ple_reads_state_block_metadata() -> None:
     layer, fields, folded = _ple_layer_stub(pages=3)
-    context = fields[QWEN4_EXP_PLE_CONTEXT_FIELD]
+    context = fields[layer.context_field_id]
     context[1] = 5
     metadata = SimpleNamespace(
         state_in_blocks_by_group={
@@ -1284,7 +1287,11 @@ def test_qwen4_exp_ple_reads_state_block_metadata() -> None:
     )
     layer._metadata = lambda ctx: metadata
     layer._linear_backend = lambda ctx: SimpleNamespace()
-    pool = SimpleNamespace(arena=SimpleNamespace(field=fields.__getitem__))
+    waited_layers = []
+    pool = SimpleNamespace(
+        arena=SimpleNamespace(field=fields.__getitem__),
+        layerwise_load_tracker=SimpleNamespace(wait_for_layer=waited_layers.append),
+    )
     ctx = SimpleNamespace(
         bs=1,
         forward_mode=ForwardMode.DECODE,
@@ -1299,6 +1306,7 @@ def test_qwen4_exp_ple_reads_state_block_metadata() -> None:
     )
 
     assert output.shape == (1, 2)
+    assert waited_layers == [0]
     # The layer folds the residual into the conv itself, so it hands the conv
     # the incoming hidden states and returns updated states, not a delta.
     assert folded["add_terms"][1] is hidden_states
@@ -1370,7 +1378,7 @@ def test_qwen4_exp_ple_handles_a_ragged_padded_batch() -> None:
     torch.testing.assert_close(req, torch.tensor([0, 0, 0, 1, 1]))
     torch.testing.assert_close(starts, torch.tensor([0, 3]))
     # Each request carries its own last token into its own output page.
-    context = fields[QWEN4_EXP_PLE_CONTEXT_FIELD]
+    context = fields[layer.context_field_id]
     torch.testing.assert_close(context[3], torch.tensor([12]))
     torch.testing.assert_close(context[4], torch.tensor([21]))
 
@@ -1437,7 +1445,8 @@ def test_qwen4_exp_cache_recipe_adds_ple_and_qsa_groups() -> None:
     groups = {group.group_id: group for group in setup.spec.cache_group_specs}
 
     assert setup.spec.family == "qwen4_exp"
-    assert fields[QWEN4_EXP_PLE_CONTEXT_FIELD].shape == (2,)
+    context_field = qwen4_exp_ple_context_field(0)
+    assert fields[context_field].shape == (2,)
     assert fields[qwen4_exp_ple_conv_field(0)].shape == (16, 9)
     assert fields[qsa_raw_key_field(1)].shape == (4, 1, 8)
     assert fields[qsa_compressed_field(1)].shape == (64, 1, 8)
@@ -1469,7 +1478,14 @@ def test_qwen4_exp_cache_recipe_adds_ple_and_qsa_groups() -> None:
         for group in groups.values()
     )
     assert groups[QWEN4_EXP_PLE_CACHE_GROUP].block_granularity == 256
-    assert fields[QWEN4_EXP_PLE_CONTEXT_FIELD].dtype == "int64"
+    assert fields[context_field].dtype == "int64"
+    selected, consumers = select_layer_fields(
+        setup.spec.memory_plan.fields,
+        first_layer=0,
+        num_layers=2,
+    )
+    assert selected == frozenset(fields)
+    assert context_field in consumers[0]
     assert fields[qsa_raw_key_field(1)].dtype == "bfloat16"
     assert fields[qsa_compressed_field(1)].dtype == "bfloat16"
     assert fields[qsa_rope_position_field(1)].dtype == "int64"

--- a/test/runtime/test_unified_kv_slab_pool.py
+++ b/test/runtime/test_unified_kv_slab_pool.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import sys
 import unittest
+from functools import partial
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -650,7 +651,10 @@ class DeriveStateGroupsByLayerTest(unittest.TestCase):
             )
         except (ImportError, ModuleNotFoundError) as exc:
             self.skipTest(f"needs torch + tokenspeed_kernel: {exc}")
-        self.derive = derive_state_groups_by_layer
+        self.derive = partial(
+            derive_state_groups_by_layer,
+            state_field_suffixes=("conv", "ssm"),
+        )
 
     @staticmethod
     def _arena(fields, families):
@@ -674,10 +678,15 @@ class DeriveStateGroupsByLayerTest(unittest.TestCase):
             fields=(
                 ("layer.0.conv", "linear_attention_0"),
                 ("layer.0.ssm", "linear_attention_0"),
+                ("layer.0.qwen4_exp.ple.conv", "qwen4_exp_ple"),
                 ("layer.1.k", "full_attention"),
                 ("layer.1.v", "full_attention"),
             ),
-            families={"linear_attention_0": "state", "full_attention": "history"},
+            families={
+                "linear_attention_0": "state",
+                "qwen4_exp_ple": "state",
+                "full_attention": "history",
+            },
         )
         mapping = self.derive(arena, first_layer=0, num_layers=2, state_layer_ids=(0,))
         self.assertEqual(mapping, {0: "linear_attention_0"})


### PR DESCRIPTION
## Summary

- Enable host L2/KVStore for Qwen3.8 Flash Next with MTP. The merged target/draft cache plan previously could not produce a valid layerwise transfer layout because the two compute views overlapped and the PLE cache fields were not attributed to layer consumers.
- Give the target and draft models disjoint layer views, make the shared PLE context and per-layer convolution state layer-addressable, and synchronize PLE and QSA side-cache access with layerwise L2 restoration. Restrict hybrid recurrent-state discovery to the expected field suffixes so PLE state is not mistaken for the model's ordinary recurrent state.
- Remove `--disable-kvstore` from the Qwen3.8 model recipes and add a two-GB200, TP2, three-step MTP GSM8K correctness task with KVStore enabled and a `0.90` score threshold. Register the task in both Kubernetes and Slurm dispatch workflows.

## Test Plan

- `python3 -m pytest -q test/ci_system/test_eval_configs.py` — 4 passed.
- `PYTHONPATH=python python3 -m pytest -q test/runtime/test_qwen4_exp.py` — 107 passed.
- Targeted cache-setup and recurrent-state group tests — 4 passed.
- `pre-commit run --all-files` — passed.
- Added `eval-qwen3.8-flash-next-fp8-gsm8k` as per-commit and manual model-level CI coverage.
