### PR TITLE
refactor(scheduler): key PD behavior on the role; PD-state and vocabulary cleanups

### DIFF
--- a/docs/design/scheduler.md
+++ b/docs/design/scheduler.md
@@ -46,6 +46,26 @@ The cost is one round of queue latency; the alternative risks a retraction
 cycle. One full chunk already saturates the GPU, so interleaving a newcomer
 into the same round buys no throughput to offset that risk.
 
+**Holding is a property of the *incomplete*, decided at plan-build time.** A
+chunk that reaches the end of its prompt moves the request to `PrefillDone`
+inside the same plan build (`SchedulePrefillEvent` picks the successor state
+by whether the window reaches `PrefillSize()`), so a prompt scheduled in full
+never holds the line. A round can therefore carry **several prefills that
+complete this round plus at most one truncated one — and the truncated one is
+necessarily last**, because `holdsHeadOfLine` seals the phase the moment it
+appears. With 6K of budget left and prompts of 2K / 1K / 10K waiting, the
+round schedules the 2K and the 1K in full and the first 3K chunk of the 10K
+prompt, then stops. The same rule makes the finishing round of a chunked
+prefill cheap: its final chunk releases the line *within* the round, so the
+prompts queued behind it start in that round, not the next.
+
+**Decodes are not part of the line.** In mixed mode the decode batch is built
+before the prefill phases and takes its token budget first (§3.3), so a round
+is *all decodes + the completing prefills + at most one truncated prefill*.
+Outside mixed mode, prefill and decode never share a round at all — decodes
+get the round only when no prefill scheduled — so head-of-line only ever
+orders prefills against each other, never a decode behind a prefill.
+
 ### 1.2 The one lookahead: the state-checkpoint tail
 
 The single place capacity is reserved beyond the current chunk. For mamba /

--- a/docs/design/scheduler.md
+++ b/docs/design/scheduler.md
@@ -114,12 +114,12 @@ a stalled prefill exactly as stuck as an empty one.
 
 **Retract-and-grant, in one round.** The retraction serves a specific request —
 the first candidate whose admission failed for capacity
-(`context.capacity_blocker`). Victims are retracted and the blocked admission
-is **retried in the same plan build**, looping (retract → retry → retract)
-until it fits or the victims run out. The freed capacity therefore reaches the
-request it was freed for within the round; there is never a free page waiting
-for whoever asks first next round, which is what previously required a
-cross-round capacity barrier. Two edges of the loop:
+(`AdmissionFeedback::capacity_blocker`). Victims are retracted and the blocked
+admission is **retried in the same plan build**, looping (retract → retry →
+retract) until it fits or the victims run out. The freed capacity therefore
+reaches the request it was freed for within the round; there is never a free
+page waiting for whoever asks first next round, which is what previously
+required a cross-round capacity barrier. Two edges of the loop:
 
 - **The victim may BE the blocker** (a resident request blocked on its own
   next page is the preferred victim). It comes back through the readmission
@@ -182,6 +182,15 @@ what used to be a rank in a ladder is now the position of a phase in its
 builder, readable top to bottom. A round schedules each request at most once
 (`PlanBuild::Scheduled`), whatever states it moves through while the phases
 run.
+
+A pass's mutable state is split in two on a layer boundary. `PlanBuild` — the
+output plan, the batch under construction, budgets, and the composition flags —
+is held by the role grammars alone, and every operation enters the batch
+through one gate, `pushOperation`, where budget and flag accounting live. The
+per-request admission layer (`admit`, `schedulePrefill*`, `scheduleDecode`)
+sees none of that: it receives only the output plan (to record fresh pages to
+zero) and an `AdmissionFeedback` (`admission_failed`, `capacity_blocker`), so
+it can report outcomes but never compose the batch.
 
 ### 3.1 P — prefill worker
 

--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -223,7 +223,7 @@ pip install flash-linear-attention
 
 Notes:
 
-- K3 uses the grouped paged-cache scheduler and KDA state groups.
+- K3 uses the cache-group scheduler and KDA state groups.
 - KDA dispatch is vendor-neutral at the runtime boundary. The kernel registry
   selects the existing FLA-derived NVIDIA implementation or the native AMD
   implementation, including each backend's preferred recurrent-state layout.

--- a/python/tokenspeed/runtime/configs/inkling_config.py
+++ b/python/tokenspeed/runtime/configs/inkling_config.py
@@ -110,7 +110,7 @@ def inkling_mtp_text_config(
     patterns: the checkpoint records the head's depth-local ids in top-level
     ``mtp_config.local_layer_ids`` (copied here as ``mtp_local_layer_ids``).
     The returned config drives draft layer construction, attention metadata,
-    and paged-cache layout, so its ``local_layer_ids`` are the DEPTH-local
+    and cache-group layout, so its ``local_layer_ids`` are the DEPTH-local
     ids and its ``num_hidden_layers`` is the depth count.
 
     With ``num_steps`` set, depths beyond it are pruned: an MTP chain only
@@ -355,7 +355,7 @@ class InklingModelConfig(PretrainedConfig):
         group (Inkling: 55 sliding + 11 full -> 5 sub-groups of 11 -> 11
         six-way-bound slabs). All sub-groups share the one window, so
         eviction semantics per layer are unchanged vs a single sliding
-        group. Consumed by the paged-cache path (cache-group
+        group. Consumed by the cache-group path (cache-group
         publication and the hybrid slab layout); inert on a single-table-built
         scheduler ext, so the scheduler-blind contract above still holds
         there.

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -431,7 +431,7 @@ class ModelConfig:
             # pattern (mtp_config.local_layer_ids) and only depths
             # 0..steps-1 ever run; swap in the depth-specialized (and
             # steps-pruned) text config so layer construction, attention
-            # metadata, and paged-cache layout all derive from it.
+            # metadata, and cache-group layout all derive from it.
             from tokenspeed.runtime.configs.inkling_config import (
                 inkling_mtp_text_config,
             )

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -280,7 +280,6 @@ class EventLoop:
             cache_groups=cache_groups,
             enable_mixed_prefill_decode=server_args.enable_mixed_batch,
         )
-        scheduler_cfg.enable_pd_cache = pd_enabled
         logger.info(
             "Scheduler config: prefix_granularity=%s num_device_pages=%s "
             "max_scheduled_tokens=%s decode_input_tokens=%s "

--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -223,7 +223,7 @@ class EventLoop:
         )
 
         # Encode nodes never build an EventLoop (they run the LM-free encode
-        # loop), so here "disaggregation is on" means the paged-cache PD
+        # loop), so here "disaggregation is on" means the cache-transfer PD
         # protocol: this engine is a P or D role.
         pd_enabled = server_args.disaggregation_mode != "null"
         if pd_enabled:
@@ -257,7 +257,7 @@ class EventLoop:
                 unsupported.append("non-Mooncake transfer backend")
             if unsupported:
                 raise NotImplementedError(
-                    "Paged-cache PD currently does not support: "
+                    "Cache-transfer PD currently does not support: "
                     + ", ".join(unsupported)
                 )
         # Backend/pool compatibility is validated inside ModelExecutor
@@ -327,7 +327,7 @@ class EventLoop:
         self.max_req_input_len = self.max_model_len - input_reserve
         if self.max_req_input_len < 1:
             raise RuntimeError(
-                "Paged cache cannot admit one request with the configured "
+                "The cache cannot admit one request with the configured "
                 f"decode reserve: max_single_request_tokens="
                 f"{self.max_single_request_tokens}, reserve={input_reserve}"
             )
@@ -660,7 +660,7 @@ class EventLoop:
 
             if self.kv_transfer is not None and bootstrap is None:
                 raise ValueError(
-                    "Paged cache PD request is missing bootstrap information"
+                    "Cache-transfer PD request is missing bootstrap information"
                 )
             if self._device.role is DeviceRole.PD_DECODE:
                 # The prompt was computed on the prefill node.

--- a/python/tokenspeed/runtime/engine/generation_output_processor.py
+++ b/python/tokenspeed/runtime/engine/generation_output_processor.py
@@ -947,7 +947,7 @@ class OutputProcesser:
     def finish_remote_prefill_only_request(self, req_id: str) -> list:
         """Finish after remote prefill when no decode step is needed.
 
-        Paged cache Prefill computes the first real output token.  A one-token
+        A PD Prefill computes the first real output token.  A one-token
         request is therefore already complete when Decode receives
         ``RemotePrefillDoneEvent`` and must not be scheduled for an additional
         decode forward. An aborted request follows the same transport fence

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -1259,7 +1259,7 @@ class ModelExecutor:
         A PD decode destination never executes the prompt locally, so no
         forward of its own can establish these lengths — they come from the
         complete remotely-computed prompt instead, before the first local
-        decode. Paged cache additionally selects the transferred
+        decode. The cache-transfer path additionally selects the transferred
         recurrent-state snapshot block from the resulting sequence length.
         """
         num_extends = forward_op.num_extends()

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -482,8 +482,8 @@ class PrefillGraph:
         The prefill analogue of decode's ``_init_capture_metadata``. KV writes
         go to the reserved dummy slot. Per-group tables use page 0 when a
         backend permits the null page for capture and page 1 when active
-        metadata requires a real writable page. Backends with extra paged
-        caches (DeepSeek-V4 DSA: SWA + compressor + indexer state) need every
+        metadata requires a real writable page. Backends with extra cache
+        groups (DeepSeek-V4 DSA: SWA + compressor + indexer state) need every
         group table, or their extend metadata is incomplete.
         """
         ib = self.input_buffers

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -135,7 +135,7 @@ class AttentionBackend(ABC):
 
     def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
         """Per-group write-location hook for out-of-backend KV writers
-        (fused RoPE prewrite); identity for backends without paged cache
+        (fused RoPE prewrite); identity for backends without cache
         groups (see uses_cache_groups). ``forward_mode`` picks the
         metadata slot for backends that prewrite on extend as well."""
         return out_cache_loc

--- a/python/tokenspeed/runtime/layers/attention/backends/cache_metadata.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/cache_metadata.py
@@ -182,7 +182,7 @@ class CacheBatchMetadata:
     def _validate_active_forward_op(self, active_forward_op: Any) -> None:
         if active_forward_op is not self._forward_op:
             raise RuntimeError(
-                "stale paged cache metadata does not match the active forward operation"
+                "stale cache metadata does not match the active forward operation"
             )
 
     def tables(self, *, active_forward_op: Any) -> Mapping[str, torch.Tensor]:

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -68,7 +68,7 @@ class FlashMLADecodeMetadata:
     flashmla_metadata: object | None = None
     page_table: torch.Tensor | None = None
     seq_lens_k: torch.Tensor | None = None
-    # Paged cache only: absolute latent write locations, request-major, with
+    # Cache-group path only: absolute latent write locations, request-major, with
     # ``group_q_len_per_req`` entries per batch row (1 outside target verify).
     # None on the classic page_table path.
     group_out_cache_loc: torch.Tensor | None = None
@@ -79,7 +79,7 @@ class FlashMLADecodeMetadata:
 class _PrefillMetadata:
     prefill_wrapper: BatchMLAPagedAttentionWrapper
     use_ragged: bool
-    # Paged cache only: packed absolute latent write locations for the extend
+    # Cache-group path only: packed absolute latent write locations for the extend
     # tokens (query order). None on the classic page_table path.
     group_out_cache_loc: torch.Tensor | None = None
 
@@ -110,7 +110,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
     Uses the FlashMLA kernel for decode (any q_len); uses FlashInfer's MLA
     prefill wrappers for the EXTEND path.
 
-    Decode consumes the LCM full-history table when bound to a paged-cache
+    Decode consumes the LCM full-history table when bound to a cache-group
     contract (see :class:`MlaCacheGroupMixin`); otherwise it reads the classic
     ``page_table`` table. The FlashMLA kernel walks pages at a fixed
     ``PAGE_SIZE`` stride, so that is the backend's kernel page size.
@@ -126,7 +126,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         self.kv_cache_quant_method = config.kv_cache_quant_method
         self.cache_dtype = config.kv_cache_dtype
 
-        # Cache-group (LCM) state. Latched on the first paged-cache metadata;
+        # Cache-group (LCM) state. Latched on the first cache metadata;
         # the FlashMLA kernel's page stride is PAGE_SIZE, so that is the kernel
         # page size the group-table expansion targets.
         self._cache_groups_bound = False
@@ -252,8 +252,8 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
             group_table = page_table[:bs]
         elif self._cache_groups_bound and bs > 0 and not forward_mode.is_idle():
             raise RuntimeError(
-                "FlashMLABackend is bound to Paged cache but received no paged "
-                "cache metadata; refusing the legacy page_table path"
+                "FlashMLABackend is bound to cache groups but received no cache "
+                "metadata; refusing the legacy page_table path"
             )
 
         if forward_mode.is_extend_or_mixed():
@@ -363,7 +363,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         )
 
     def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
-        """Group-derived latent write location on the paged-cache path.
+        """Group-derived latent write location on the cache-group path.
 
         Identity when not cache-group bound (classic page_table path) or when
         idle. Decode writes one location per request (position seq-1); extend
@@ -428,7 +428,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
             not global_server_args_dict["mla_disable_ragged"] and extend_no_prefix
         )
 
-        # Paged cache path needs two differently-shaped views of the kernel
+        # The cache-group path needs two differently-shaped views of the kernel
         # full-history table:
         #   * flashinfer paged prefill (plan page_size=1) walks a PER-TOKEN slot
         #     table, so expand each token to its absolute latent slot.
@@ -585,7 +585,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         if self._cache_contract_bound:
             if self.cuda_graph_group_out_cache_loc is None:
                 raise RuntimeError(
-                    "FlashMLA Paged cache graph capture buffer was not "
+                    "FlashMLA cache-group graph capture buffer was not "
                     "allocated; mark_cache_contract must run before "
                     "init_cuda_graph_state"
                 )
@@ -639,7 +639,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         ) and cache_metadata is not None:
             self._cache_groups_bound = True
             # Refresh the block table and per-request write locations in place
-            # from the live full-history table (paged-cache path).
+            # from the live full-history table (cache-group path).
             table = self._resolve_full_history_table(
                 cache_metadata, kwargs.get("forward_batch"), 0
             )

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -82,7 +82,7 @@ def _mask_fresh_initial_state(
 ) -> torch.Tensor:
     """Zero the initial recurrent state of sequences that have no history.
 
-    On the paged cache path a fresh sequence's ``state_in`` page is freshly
+    On the cache-group path a fresh sequence's ``state_in`` block is freshly
     allocated from the shared BlockPool and may carry a previous tenant's
     bytes (the slabs alias every cache group, so those bytes can be fp8 MLA
     latents that reinterpret as huge/NaN fp32) — the recurrent kernels have

--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -77,7 +77,7 @@ class MLAPrefillMetadata:
     chunked_seq_len: torch.Tensor
     cu_chunked_seq_len: torch.Tensor
     max_chunk_len_per_loop: list[int]
-    # Paged cache only: absolute latent locations for model-owned extend writes.
+    # Cache-group path only: absolute latent locations for model-owned extend writes.
     group_out_cache_loc: torch.Tensor | None = None
 
 
@@ -87,7 +87,7 @@ class MLADecodeMetadata:
     num_extends: int
     page_table: torch.Tensor
     seq_lens: torch.Tensor
-    # Paged cache only: absolute latent write locations, request-major, with
+    # Cache-group path only: absolute latent write locations, request-major, with
     # ``group_q_len_per_req`` entries per batch row (1 outside target verify).
     group_out_cache_loc: torch.Tensor | None = None
     group_q_len_per_req: int = 1
@@ -211,7 +211,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             published_draft_page_table = True
         elif self._cache_groups_bound and bs > 0 and not forward_mode.is_idle():
             raise RuntimeError(
-                "MLAAttnBackend is bound to Paged cache but received no paged cache "
+                "MLAAttnBackend is bound to cache groups but received no cache "
                 "metadata; refusing the legacy page_table path"
             )
 
@@ -552,7 +552,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             return
         if uses_cache_groups and self.is_draft:
             raise NotImplementedError(
-                "MLA draft worker does not take the Paged cache path"
+                "MLA draft worker does not take the cache-group path"
             )
         page_table = self.cuda_graph_page_table[:bs, :]
         capture_q_len = self._graph_verify_q_len()
@@ -560,7 +560,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             self._cache_groups_bound = True
             if self.decode_cuda_graph_group_out_cache_loc is None:
                 raise RuntimeError(
-                    "MLA Paged cache graph capture buffer was not allocated; "
+                    "MLA cache-group graph capture buffer was not allocated; "
                     "mark_cache_contract must run before init_cuda_graph_state"
                 )
             page_table.zero_()

--- a/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla_cache_groups.py
@@ -20,7 +20,7 @@
 
 """Shared cache-group (LCM full-history) helpers for MLA backends.
 
-Every MLA backend that consumes the paged-cache full-attention table needs the
+Every MLA backend that consumes the cache-group full-attention table needs the
 same primitives: resolve the scheduler's full-history table in this backend's
 KERNEL pages, and turn per-request sequence lengths into absolute latent write
 locations. The logical->kernel page expansion happens once upstream
@@ -139,7 +139,7 @@ class MlaCacheGroupMixin:
         out: torch.Tensor | None = None,
         q_len_per_req: int = 1,
     ) -> torch.Tensor:
-        """Absolute latent write locations for decoded tokens in Paged cache.
+        """Absolute latent write locations for decoded tokens in the full-attention group.
 
         Plain decode writes one location per request (position ``seq-1``).
         Speculative target verify decodes ``q_len_per_req`` tokens per request
@@ -200,7 +200,7 @@ class MlaCacheGroupMixin:
         *,
         validate_pages: bool = False,
     ) -> torch.Tensor:
-        """Return packed Paged cache extend-write locations in query order."""
+        """Return packed cache-group extend-write locations in query order."""
         page_size = self.kernel_page_size
         chunks: list[torch.Tensor] = []
         pages_for_validation: list[torch.Tensor] = []

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -83,7 +83,7 @@ class CuteDSLMLAPrefillMetadata:
     max_seq_len: int
     cum_seq_lens: torch.Tensor
     seq_lens: torch.Tensor
-    # Paged cache only: absolute latent write locations for the extend tokens,
+    # Cache-group path only: absolute latent write locations for the extend tokens,
     # flattened in q/k/v token order (positions [prefix, seq) per request).
     group_out_cache_loc: torch.Tensor | None = None
 
@@ -94,7 +94,7 @@ class CuteDSLMLADecodeMetadata:
     block_kv_indices: torch.Tensor | None = None
     max_seq_len_k: int | None = None
     seq_lens_k: torch.Tensor | None = None
-    # Paged cache only: absolute latent write locations, group_q_len_per_req
+    # Cache-group path only: absolute latent write locations, group_q_len_per_req
     # entries per batch row. Mixed-batch decode skips whole prefill windows.
     group_out_cache_loc: torch.Tensor | None = None
     group_q_len_per_req: int = 1
@@ -118,7 +118,7 @@ class CuteDSLMLABackend(AttentionBackend):
     def __init__(self, config: MLAConfig):
         super().__init__(config)
 
-        # Latched the first time paged cache metadata arrives. Once bound, a
+        # Latched the first time cache metadata arrives. Once bound, a
         # forward without cache metadata is a hard error: the cache contract
         # forbids falling back to legacy page_table metadata.
         self._cache_groups_bound = False
@@ -259,7 +259,7 @@ class CuteDSLMLABackend(AttentionBackend):
 
         return block_kv_indices
 
-    # ---- Paged cache full-attention-table metadata ----
+    # ---- Cache-group full-attention-table metadata ----
 
     def _resolve_full_history_table(
         self, cache_metadata, forward_batch, bs: int
@@ -403,11 +403,11 @@ class CuteDSLMLABackend(AttentionBackend):
                     seq_lens[:bs], active_forward_op=forward_batch
                 )
         elif self._cache_groups_bound and bs > 0 and not forward_mode.is_idle():
-            # Missing Paged cache metadata must never select the legacy page_table
+            # Missing cache metadata must never select the legacy page_table
             # path after the backend is bound to the contract.
             raise RuntimeError(
                 "tokenspeed_mla is bound to the Cache contract but received "
-                "no paged cache metadata; refusing the legacy page_table path"
+                "no cache metadata; refusing the legacy page_table path"
             )
 
         if forward_mode.is_extend_or_mixed():
@@ -463,7 +463,7 @@ class CuteDSLMLABackend(AttentionBackend):
             self.forward_decode_metadata.num_extends = prev
 
     def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
-        """Paged cache write-location hook for model-owned latent KV writes.
+        """Cache-group write-location hook for model-owned latent KV writes.
 
         Forwards without grouped cache metadata return caller locations untouched;
         byte-for-byte the base-class behavior, so DeepSeek-style MLA models
@@ -480,7 +480,7 @@ class CuteDSLMLABackend(AttentionBackend):
             if metadata is None or metadata.group_out_cache_loc is None:
                 raise RuntimeError(
                     "MLA decode write locations are missing; "
-                    "init_forward_metadata must run with paged cache metadata"
+                    "init_forward_metadata must run with cache metadata"
                 )
             locs = metadata.group_out_cache_loc[
                 metadata.num_extends * metadata.group_q_len_per_req :
@@ -490,7 +490,7 @@ class CuteDSLMLABackend(AttentionBackend):
             if metadata is None or metadata.group_out_cache_loc is None:
                 raise RuntimeError(
                     "MLA prefill write locations are missing; "
-                    "init_forward_metadata must run with paged cache metadata"
+                    "init_forward_metadata must run with cache metadata"
                 )
             locs = metadata.group_out_cache_loc
         if out_cache_loc is not None and locs.shape[0] != out_cache_loc.shape[0]:
@@ -512,7 +512,7 @@ class CuteDSLMLABackend(AttentionBackend):
     ):
         max_blocks = self._calc_padded_blocks(self.max_context_len)
         if group_table is not None:
-            # Paged cache path: kernel pages and write locations both derive from
+            # Cache-group path: kernel pages and write locations both derive from
             # the full-attention table; page_table is never consulted.
             block_kv_indices = self._create_block_kv_indices(
                 bs, max_blocks, group_table
@@ -682,7 +682,7 @@ class CuteDSLMLABackend(AttentionBackend):
         torch.cumsum(extend_seq_lens, dim=0, out=cum_extend_seq_lens[1:])
         max_extend_seq_len = extend_seq_lens_cpu.max().item()
         if group_table is not None:
-            # Paged cache path: chunked history reads gather from the
+            # Cache-group path: chunked history reads gather from the
             # full-attention table (rows are batch-ordered, prefill rows
             # first) in kernel pages.
             chunk_page_table = group_table[:num_extends]
@@ -741,7 +741,7 @@ class CuteDSLMLABackend(AttentionBackend):
             (graph_rows, max_blocks), dtype=torch.int32, device=self.device
         )
         if self._cache_contract_bound:
-            # The Paged cache decode graph uses one absolute latent write slot per
+            # The cache-group decode graph uses one absolute latent write slot per
             # row, refreshed in place from the current full-attention table.
             # Allocate the stable-address buffer outside the graph pool, like
             # the KV indices.
@@ -763,13 +763,13 @@ class CuteDSLMLABackend(AttentionBackend):
         **kwargs,
     ):
         # Structural gate: the target (contract always marked by the registry)
-        # takes the Paged cache capture path; the MTP draft, whose
+        # takes the cache-group capture path; the MTP draft, whose
         # mark_cache_contract deliberately early-returns, keeps the
         # batch-ordered non-cache path.
         uses_cache_groups = bool(cache_group_ids) or self._cache_contract_bound
         if uses_cache_groups and self.is_draft:
             raise NotImplementedError(
-                "tokenspeed_mla draft worker does not take the Paged cache path"
+                "tokenspeed_mla draft worker does not take the cache-group path"
             )
         if forward_mode.is_extend_or_mixed():
             raise NotImplementedError(
@@ -783,7 +783,7 @@ class CuteDSLMLABackend(AttentionBackend):
         block_kv_indices = self.decode_cuda_graph_kv_indices[:bs, :max_blocks]
 
         if uses_cache_groups:
-            # The captured Paged cache graph reads the kernel page table and latent
+            # The captured cache-group graph reads the kernel page table and latent
             # write locations from persistent buffers; replay refreshes both
             # in place from the current full-attention table. Latch _cache_groups_bound
             # so the recorded forward_decode takes the cache write-location
@@ -791,7 +791,7 @@ class CuteDSLMLABackend(AttentionBackend):
             self._cache_groups_bound = True
             if self.decode_cuda_graph_group_out_cache_loc is None:
                 raise RuntimeError(
-                    "tokenspeed_mla Paged cache graph capture: the cache write-location "
+                    "tokenspeed_mla cache-group graph capture: the cache write-location "
                     "buffer is not allocated; init_cuda_graph_state ran before "
                     "the backend was marked as the Cache contract sub-backend"
                 )
@@ -848,11 +848,11 @@ class CuteDSLMLABackend(AttentionBackend):
             self.forward_decode_metadata = metadata
             return
         # The captured metadata is the source of truth: a cache write-location buffer
-        # exists iff this bs was captured on the Paged cache path.
+        # exists iff this bs was captured on the cache-group path.
         uses_cache_groups = metadata.group_out_cache_loc is not None
         if uses_cache_groups and self.is_draft:
             raise NotImplementedError(
-                "tokenspeed_mla draft worker does not take the Paged cache path"
+                "tokenspeed_mla draft worker does not take the cache-group path"
             )
 
         # Copy the live cache lengths into our own buffer (metadata.seq_lens_k
@@ -903,7 +903,7 @@ class CuteDSLMLABackend(AttentionBackend):
         """
         if metadata.group_out_cache_loc is None:
             raise RuntimeError(
-                "tokenspeed_mla Paged cache graph replay: captured decode metadata "
+                "tokenspeed_mla cache-group graph replay: captured decode metadata "
                 "has no cache write-location buffer"
             )
         # Target verify graphs are captured with q_len write locations per
@@ -961,7 +961,7 @@ class CuteDSLMLABackend(AttentionBackend):
         if save_kv_cache:
             assert k is not None
             if self._cache_groups_bound:
-                # Paged cache: write locations derive from the full-attention
+                # Cache-group path: write locations derive from the full-attention
                 # table, never from the caller's page_table-derived locs.
                 out_cache_loc = self.select_out_cache_loc(
                     layer, out_cache_loc, ForwardMode.DECODE

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -120,7 +120,7 @@ class TRTLLMMLADecodeMetadata:
     block_kv_indices: torch.Tensor | None = None
     max_seq_len_k: int | None = None
     seq_lens_k: torch.Tensor | None = None
-    # Paged cache only: absolute latent write locations, request-major, with
+    # Cache-group path only: absolute latent write locations, request-major, with
     # ``group_q_len_per_req`` entries per row (1 outside target verify).
     group_out_cache_loc: torch.Tensor | None = None
     group_q_len_per_req: int = 1
@@ -328,7 +328,7 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
         )
 
     def select_out_cache_loc(self, layer, out_cache_loc, forward_mode=None):
-        """Group-derived latent write location on the paged-cache path.
+        """Group-derived latent write location on the cache-group path.
 
         Identity when not cache-group bound or idle. A draft owns its per-step
         locations (it passes ``num_extends == bs`` by its own convention), so it
@@ -469,7 +469,7 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
         if self._cache_contract_bound:
             if self.decode_cuda_graph_group_out_cache_loc is None:
                 raise RuntimeError(
-                    "trtllm_mla Paged cache graph capture buffer was not "
+                    "trtllm_mla cache-group graph capture buffer was not "
                     "allocated; mark_cache_contract must run before "
                     "init_cuda_graph_state"
                 )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/hybrid_deepseek_v4.py
@@ -46,7 +46,7 @@ def _split_block_tables_into_v4_metadata(
     dict[int, torch.Tensor],
     torch.Tensor | None,
 ]:
-    """Split paged-cache dict into V4-named tables + per-sliding-group offsets.
+    """Split the cache-group dict into V4-named tables + per-sliding-group offsets.
 
     Returns (swa, {ratio: compressor_state}, indexer_state, swa_base,
     {ratio: compressor_state_base}, indexer_state_base). Unknown group ids
@@ -209,7 +209,7 @@ class DeepseekV4CacheMetadata:
         table = self.block_tables.get(v4_compressed_kv_group_id(compress_ratio))
         if table is None:
             raise RuntimeError(
-                "DeepSeek V4 missing paged-cache block table for compressed "
+                "DeepSeek V4 missing cache-group block table for compressed "
                 f"KV group {v4_compressed_kv_group_id(compress_ratio)!r}"
             )
         return table

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/msa.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 LightSeek Foundation
 # SPDX-License-Identifier: MIT
 
-"""Paged cache storage for MiniMax sparse attention."""
+"""Paged KV storage for MiniMax sparse attention."""
 
 from __future__ import annotations
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/cache_runtime.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/cache_runtime.py
@@ -31,7 +31,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
 
 
 def cache_debug_enabled() -> bool:
-    """Whether expensive, GPU-synchronizing Paged cache validation is enabled."""
+    """Whether expensive, GPU-synchronizing cache validation is enabled."""
     return os.environ.get("TOKENSPEED_CACHE_DEBUG") == "1"
 
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/spec.py
@@ -333,7 +333,7 @@ _SLIDING_SUBGROUP_PREFIX = "sliding_attention_"
 
 
 def _retention_for_label(label: str) -> Retention | None:
-    """Retention for a paged-cache layer_type label, or None if unknown.
+    """Retention for a cache-group layer_type label, or None if unknown.
 
     Args:
         label: A layer_type label — one of the exact vocabulary in

--- a/python/tokenspeed/runtime/layers/paged_attention.py
+++ b/python/tokenspeed/runtime/layers/paged_attention.py
@@ -101,7 +101,7 @@ def validate_cache_group_ids(
     model: nn.Module,
     cache_group_specs: Sequence,
 ) -> None:
-    """Fail fast (ValueError) when a pool publishing more than one paged-cache
+    """Fail fast (ValueError) when a pool publishing more than one cache
     group meets a PagedAttention layer whose group_id is empty or unknown --
     instead of a KeyError deep in the backend, possibly during graph capture.
     """

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -850,7 +850,7 @@ class DeepseekV3AttentionMLA(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         # Model-owned KV writes route their locations through the backend:
         # identity on the legacy path (base AttentionBackend hook), the
-        # group-derived locations on the Paged cache path.
+        # group-derived locations on the cache-group path.
         out_cache_loc = ctx.attn_backend.select_out_cache_loc(
             self.attn_mqa, out_cache_loc, ctx.forward_mode
         )
@@ -1078,7 +1078,7 @@ class DeepseekV3AttentionMLA(nn.Module):
         out_cache_loc: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         # See forward_absorb_qkv_proj: backend-selected write locations
-        # (identity off the Paged cache path).
+        # (identity off the cache-group path).
         out_cache_loc = ctx.attn_backend.select_out_cache_loc(
             self.attn_mha, out_cache_loc, ctx.forward_mode
         )

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -2313,7 +2313,7 @@ class DeepseekV4Compressor(nn.Module):
             else:
                 if state_block_table is None:
                     raise RuntimeError(
-                        "DeepSeek V4 missing paged-cache block table for compressor "
+                        "DeepSeek V4 missing cache-group block table for compressor "
                         f"state ratio={self.compress_ratio}"
                     )
                 state_slot_mapping = _group_slot_mapping_from_raw(
@@ -2850,7 +2850,7 @@ class DeepseekV4Indexer(nn.Module):
             )
             if indexer_state_block_table is None:
                 raise RuntimeError(
-                    "DeepSeek V4 missing paged-cache block table for indexer "
+                    "DeepSeek V4 missing cache-group block table for indexer "
                     "compressor state"
                 )
             indexer_state_block_size = pool.get_indexer_state_block_size(layer_index)
@@ -3183,7 +3183,7 @@ class DeepseekV4Attention(nn.Module):
     ) -> torch.Tensor:
         """DSA attention, one COARSE breakable-graph break point.
 
-        Per layer it does multiple paged-cache writes (SWA / compressor /
+        Per layer it does multiple cache-group writes (SWA / compressor /
         indexer), a data/length-dependent indexer -> top-k stage, the FlashMLA
         sparse kernel, AND aux-stream forks -- none capturable into a CUDA
         graph. Under a prefill-graph capture the whole attention runs eager
@@ -3291,7 +3291,7 @@ class DeepseekV4Attention(nn.Module):
 
         # --- Phase 2: state-update + cache-write overlap ---
         # With GEMMs already done, the remaining work per stream is lightweight
-        # state updates and paged cache writes — safe to overlap.
+        # state updates and cache-group writes — safe to overlap.
         topk_indices = None
         if self.indexer is not None:
             if self.compressor is None:

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -763,7 +763,7 @@ class GlmMoeDsaAttention(DeepseekV3AttentionMLA):
     ) -> torch.Tensor:
         """GLM-5 DSA attention, one COARSE breakable-graph break point.
 
-        Like DeepSeek-V4 it does paged-cache writes, a data-dependent indexer
+        Like DeepSeek-V4 it does cache-group writes, a data-dependent indexer
         -> top-k stage and the FlashMLA sparse kernel (plus pre-attn
         collectives), none capturable. Under a prefill-graph capture the whole
         attention runs eager (reading the live ``ctx``) while the layer's

--- a/python/tokenspeed/runtime/models/inkling.py
+++ b/python/tokenspeed/runtime/models/inkling.py
@@ -362,7 +362,7 @@ def _sconv_apply(
     is just a wider ``dim`` with concatenated weights. The paged bridges are
     mandatory and fused: extend chunks tap the checkpoint at their aligned
     start (the prefill kernel never reads the ring), decode rounds tap the
-    ring (the decode kernel never reads the paged cache), and both publish
+    ring (the decode kernel never reads the checkpoint blocks), and both publish
     every covered boundary in-kernel.
     """
     backend = ctx.attn_backend

--- a/python/tokenspeed/runtime/models/kimi_k3_dspark.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_dspark.py
@@ -201,7 +201,7 @@ class K3DSparkDecoderLayer(nn.Module):
             layer_id=layer_id,
             prefix=add_prefix("self_attn", prefix),
         )
-        # The draft's MLA layers join the target's full_attention paged-cache
+        # The draft's MLA layers join the target's full_attention cache
         # group (K3 publishes 4 groups: full_attention + 3 KDA linear). The
         # inherited attn_mqa/attn_mha are built without a group_id; tag them so
         # validate_cache_group_ids binds them to the full_attention table

--- a/python/tokenspeed/runtime/models/qwen4_exp_ple.py
+++ b/python/tokenspeed/runtime/models/qwen4_exp_ple.py
@@ -767,7 +767,7 @@ class Qwen4ExpPLELayer(nn.Module):
     """PLE gating plus dilated depthwise short convolution.
 
     Persistent context and convolution windows live in the model's unified
-    paged cache under :data:`QWEN4_EXP_PLE_CACHE_GROUP`.
+    cache under :data:`QWEN4_EXP_PLE_CACHE_GROUP`.
     """
 
     def __init__(

--- a/python/tokenspeed/runtime/pd/cache_protocol.py
+++ b/python/tokenspeed/runtime/pd/cache_protocol.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Paged cache transfer contract and per-request PD protocol.
+"""Cache transfer contract and per-request PD protocol.
 
 The cache recipe owns semantic group specs and the transfer schema, while the
 memory planner owns physical geometry. PD transports those objects directly
@@ -392,13 +392,11 @@ def validate_cache_peer_layout(
     layout: CacheTransferContract, peer_layout: CacheTransferContract
 ) -> None:
     if layout.plan.prefix_granularity != peer_layout.plan.prefix_granularity:
-        raise CacheContractError(
-            "Paged cache P/D contract mismatch: prefix_granularity"
-        )
+        raise CacheContractError("Cache P/D contract mismatch: prefix_granularity")
     local_group_ids = tuple(spec.group_id for spec in layout.group_specs)
     peer_group_ids = tuple(spec.group_id for spec in peer_layout.group_specs)
     if local_group_ids != peer_group_ids:
-        raise CacheContractError("Paged cache P/D contract mismatch: group order")
+        raise CacheContractError("Cache P/D contract mismatch: group order")
     for local_spec, peer_spec in zip(
         layout.group_specs, peer_layout.group_specs, strict=True
     ):
@@ -412,7 +410,7 @@ def validate_cache_peer_layout(
             or local_spec.transfer_policy != peer_spec.transfer_policy
         ):
             raise CacheContractError(
-                f"Paged cache P/D contract mismatch: group {local_spec.group_id!r} "
+                f"Cache P/D contract mismatch: group {local_spec.group_id!r} "
                 "semantics"
             )
         local_fields = layout.fields_for_group(local_spec.group_id)
@@ -421,7 +419,7 @@ def validate_cache_peer_layout(
         peer_field_ids = tuple(field.field_id for field in peer_fields)
         if local_field_ids != peer_field_ids:
             raise CacheContractError(
-                f"Paged cache P/D contract mismatch: group "
+                f"Cache P/D contract mismatch: group "
                 f"{local_spec.group_id!r} transfer field order"
             )
         for local_field, peer_field in zip(local_fields, peer_fields, strict=True):
@@ -442,7 +440,7 @@ def validate_cache_peer_layout(
                 or tuple(local_global_shape) != tuple(peer_global_shape)
             ):
                 raise CacheContractError(
-                    f"Paged cache P/D contract mismatch: field "
+                    f"Cache P/D contract mismatch: field "
                     f"{local_field.field_id!r} semantics"
                 )
 
@@ -494,16 +492,16 @@ def build_cache_block_manifest(
 ) -> CachePDBlockManifest:
     """Select each group's blocks according to its explicit transfer policy."""
     if prefix_len >= prompt_len:
-        raise CacheContractError("Paged cache PD requires prefix_len < prompt_len")
+        raise CacheContractError("Cache-transfer PD requires prefix_len < prompt_len")
     if prefix_len % layout.plan.prefix_granularity:
         raise CacheContractError(
-            "Paged cache PD prefix_len must be aligned to prefix_granularity"
+            "Cache-transfer PD prefix_len must be aligned to prefix_granularity"
         )
     mapping = forward_op.block_tables_arrays()  # type: ignore[attr-defined]
     expected_ids = {group.group_id for group in layout.group_specs}
     if set(mapping) != expected_ids:
         raise CacheContractError(
-            "scheduler group IDs disagree with the Paged cache layout: "
+            "scheduler group IDs disagree with the cache-transfer layout: "
             f"missing={sorted(expected_ids - set(mapping))}, "
             f"extra={sorted(set(mapping) - expected_ids)}"
         )
@@ -563,7 +561,7 @@ def build_cache_layerwise_block_selection(
     """
     if prefix_len % layout.plan.prefix_granularity:
         raise CacheContractError(
-            "Paged cache PD prefix_len must be aligned to prefix_granularity"
+            "Cache-transfer PD prefix_len must be aligned to prefix_granularity"
         )
     if prefix_len >= prompt_len:
         raise CacheContractError("layerwise selection requires prefix_len < prompt_len")
@@ -577,7 +575,7 @@ def build_cache_layerwise_block_selection(
     expected_ids = {group.group_id for group in layout.group_specs}
     if set(mapping) != expected_ids:
         raise CacheContractError(
-            "scheduler group IDs disagree with the Paged cache layout: "
+            "scheduler group IDs disagree with the cache-transfer layout: "
             f"missing={sorted(expected_ids - set(mapping))}, "
             f"extra={sorted(set(mapping) - expected_ids)}"
         )

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -330,14 +330,14 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         decode_tp_sizes = {reg.decode_tp_size for reg in registrations}
         expected_rank_sets = {reg.expected_decode_ranks for reg in registrations}
         if len(decode_tp_sizes) != 1 or len(expected_rank_sets) != 1:
-            raise ValueError("Paged cache room has inconsistent TP metadata")
+            raise ValueError("Cache-transfer room has inconsistent TP metadata")
         expected_decode_ranks = next(iter(expected_rank_sets))
         actual_decode_ranks = tuple(reg.decode_tp_rank for reg in registrations)
         if len(reqs) != len(expected_decode_ranks) or set(actual_decode_ranks) != set(
             expected_decode_ranks
         ):
             raise ValueError(
-                "Paged cache room destination ranks disagree with the typed route plan"
+                "Cache-transfer room destination ranks disagree with the typed route plan"
             )
 
     def _transfer_data(self, mooncake_session_id, transfer_blocks):
@@ -482,7 +482,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         if self.step_counter is None:
             if room is not None:
                 raise ValueError(
-                    "Paged cache layerwise transfer has no producer step counter"
+                    "Cache-transfer layerwise transfer has no producer step counter"
                 )
             return
         next_session_check = time.monotonic()
@@ -491,7 +491,9 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 None,
                 TransferPoll.Failed,
             ):
-                raise ValueError(f"Paged cache layerwise wait aborted for room {room}")
+                raise ValueError(
+                    f"Cache-transfer layerwise wait aborted for room {room}"
+                )
             now = time.monotonic()
             if session_ids and now >= next_session_check:
                 with self.session_lock:
@@ -501,7 +503,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     )
                 if failed:
                     raise ValueError(
-                        f"Paged cache layerwise peer failed for room {room}"
+                        f"Cache-transfer layerwise peer failed for room {room}"
                     )
                 next_session_check = now + 0.1
             ready_step = self.step_counter.query_ready_cache_step()
@@ -605,7 +607,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                         )
                     self.abort_room(
                         kv_chunk.room,
-                        f"Failed to send Paged cache layer interval of "
+                        f"Failed to send cache layer interval of "
                         f"{kv_chunk.room} to "
                         f"{registration.endpoint}:{registration.dst_port}",
                     )

--- a/python/tokenspeed/runtime/pd/mooncake/receiver.py
+++ b/python/tokenspeed/runtime/pd/mooncake/receiver.py
@@ -136,7 +136,9 @@ def _calc(kv_mgr, prefill_parallel_info: PrefillParallelInfo) -> ReceiverRoutePl
     prefill_cache_layout = prefill_parallel_info.cache_layout
 
     if prefill_cache_layout is None:
-        raise RuntimeError("Paged cache decode connected to a non-Paged cache prefill")
+        raise RuntimeError(
+            "Cache-transfer decode connected to a non-cache-transfer prefill"
+        )
     decode_tp_rank = kv_mgr.topology.tp_rank
 
     pp_size = prefill_parallel_info.pp_size

--- a/python/tokenspeed/runtime/pd/prefill_executor.py
+++ b/python/tokenspeed/runtime/pd/prefill_executor.py
@@ -99,7 +99,7 @@ class DisaggPrefillExecutor:
                 sender.bootstrap_room, {}
             )
             if not transfer_infos:
-                raise RuntimeError("Paged cache destination metadata is unavailable")
+                raise RuntimeError("Cache-transfer destination metadata is unavailable")
             destinations = tuple(
                 info for info in transfer_infos.values() if not info.is_dummy
             )
@@ -109,14 +109,14 @@ class DisaggPrefillExecutor:
                 continue
             first = destinations[0]
             if first.block_manifest is None:
-                raise RuntimeError("Paged cache destination metadata is unavailable")
+                raise RuntimeError("Cache-transfer destination metadata is unavailable")
             prefix_len = first.block_manifest.prefix_len
             prompt_len = first.block_manifest.prompt_len
             chunk_begin = int(op.extend_prefix_lens[index])
             chunk_end = chunk_begin + int(op.input_lengths[index])
             if chunk_end > prompt_len:
                 raise ValueError(
-                    "Paged cache Prefill chunk extends past Decode's prompt manifest"
+                    "Cache-transfer Prefill chunk extends past Decode's prompt manifest"
                 )
             is_last = chunk_end == prompt_len
             # On the first submitted chunk, include blocks that Prefill found in
@@ -138,14 +138,14 @@ class DisaggPrefillExecutor:
             for destination in destinations:
                 if destination.block_manifest is None:
                     raise RuntimeError(
-                        "Paged cache destination metadata is unavailable"
+                        "Cache-transfer destination metadata is unavailable"
                     )
                 if (
                     destination.block_manifest.prefix_len != prefix_len
                     or destination.block_manifest.prompt_len != prompt_len
                 ):
                     raise ValueError(
-                        "Paged cache destinations disagree on the prompt window"
+                        "Cache-transfer destinations disagree on the prompt window"
                     )
             if (
                 not any(group.source_block_ids for group in block_selection.groups)
@@ -188,7 +188,7 @@ class DisaggPrefillExecutor:
                 continue
             token = int(op.decode_input_ids[index])
             if token < 0:
-                raise RuntimeError("Paged cache bootstrap token is unavailable")
+                raise RuntimeError("Cache-transfer bootstrap token is unavailable")
             spec_candidate_ids = list(op.spec_candidate_ids[index]) or None
 
             if self._layerwise_enabled:
@@ -226,7 +226,7 @@ class DisaggPrefillExecutor:
                 sender.bootstrap_room, {}
             )
             if not transfer_infos:
-                raise RuntimeError("Paged cache destination metadata is unavailable")
+                raise RuntimeError("Cache-transfer destination metadata is unavailable")
             destinations = [
                 info for info in transfer_infos.values() if not info.is_dummy
             ]
@@ -239,7 +239,7 @@ class DisaggPrefillExecutor:
                 continue
             destination = destinations[0]
             if destination.block_manifest is None:
-                raise RuntimeError("Paged cache destination metadata is unavailable")
+                raise RuntimeError("Cache-transfer destination metadata is unavailable")
             block_manifest = build_cache_block_manifest(
                 op,
                 layout=self.cache_layout,
@@ -250,7 +250,7 @@ class DisaggPrefillExecutor:
             for destination in destinations:
                 if destination.block_manifest is None:
                     raise RuntimeError(
-                        "Paged cache destination metadata is unavailable"
+                        "Cache-transfer destination metadata is unavailable"
                     )
                 if (
                     destination.block_manifest.prefix_len != block_manifest.prefix_len
@@ -258,7 +258,7 @@ class DisaggPrefillExecutor:
                     != block_manifest.prompt_len
                 ):
                     raise ValueError(
-                        "Paged cache destinations disagree on the prompt window"
+                        "Cache-transfer destinations disagree on the prompt window"
                     )
             pending.append((sender, token, spec_candidate_ids, block_manifest))
 

--- a/python/tokenspeed/runtime/pd/topology.py
+++ b/python/tokenspeed/runtime/pd/topology.py
@@ -108,7 +108,7 @@ class PDParallelTopology:
         )
 
     def require_cache_pd_supported(self) -> None:
-        """Reject attention topologies unsupported by paged-cache PD."""
+        """Reject attention topologies unsupported by cache-transfer PD."""
         if self.cp_size != 1:
             raise ValueError(
                 "CachePD does not support context parallelism: "

--- a/python/tokenspeed/runtime/pd/transfer_plan.py
+++ b/python/tokenspeed/runtime/pd/transfer_plan.py
@@ -93,7 +93,7 @@ class _RankPartition:
 
 
 class CacheTransferPlanner:
-    """Plan model-neutral dense Paged-cache fields across unequal TP sizes."""
+    """Plan model-neutral dense cache fields across unequal TP sizes."""
 
     def __init__(
         self,
@@ -115,10 +115,10 @@ class CacheTransferPlanner:
                 None plans every field (no PP).
         """
         if prefill_tp_size <= 0 or decode_tp_size <= 0:
-            raise UnsupportedPDLayoutError("Paged cache TP sizes must be positive")
+            raise UnsupportedPDLayoutError("Cache TP sizes must be positive")
         if prefill_tp_size > MAX_CACHE_TP_SIZE or decode_tp_size > MAX_CACHE_TP_SIZE:
             raise UnsupportedPDLayoutError(
-                f"Paged cache TP sizes cannot exceed {MAX_CACHE_TP_SIZE}"
+                f"Cache TP sizes cannot exceed {MAX_CACHE_TP_SIZE}"
             )
         self.prefill_tp_size = prefill_tp_size
         self.decode_tp_size = decode_tp_size
@@ -175,7 +175,7 @@ class CacheTransferPlanner:
         target_ranks = tuple(fragments_by_rank)
         if not target_ranks:
             raise UnsupportedPDLayoutError(
-                f"Paged cache decode TP rank {decode_tp_rank} has no source fragments"
+                f"Cache-transfer decode TP rank {decode_tp_rank} has no source fragments"
             )
         return RankTransferPlan(
             fragments_by_prefill_rank=fragments_by_rank,
@@ -188,7 +188,7 @@ class CacheTransferPlanner:
             or prefill_segment.payload_bytes != decode_segment.payload_bytes
         ):
             raise UnsupportedPDLayoutError(
-                f"equal-TP Paged cache field {field!r} rank-local geometry differs"
+                f"equal-TP cache field {field!r} rank-local geometry differs"
             )
         partition = self._partitions[prefill_segment.field_id]
         if partition is None:
@@ -330,7 +330,7 @@ class CacheTransferPlanner:
         distinct_shards = global_extent // local_extent
         if distinct_shards > tp_size or tp_size % distinct_shards:
             raise UnsupportedPDLayoutError(
-                f"Paged cache field {segment.field_id!r} cannot map global "
+                f"Cache field {segment.field_id!r} cannot map global "
                 f"extent {global_extent} and local extent {local_extent} to TP={tp_size}"
             )
         replica_group_size = tp_size // distinct_shards

--- a/test/runtime/conftest.py
+++ b/test/runtime/conftest.py
@@ -1,4 +1,4 @@
-"""Shared helpers for Kimi-K3 paged cache runtime tests."""
+"""Shared helpers for Kimi-K3 cache-group runtime tests."""
 
 from __future__ import annotations
 

--- a/test/runtime/distributed/test_cache_pd_manifest.py
+++ b/test/runtime/distributed/test_cache_pd_manifest.py
@@ -584,7 +584,7 @@ def test_peer_layout_reports_prefix_granularity_mismatch() -> None:
 
     with pytest.raises(
         CacheContractError,
-        match="^Paged cache P/D contract mismatch: prefix_granularity$",
+        match="^Cache P/D contract mismatch: prefix_granularity$",
     ):
         validate_cache_peer_layout(local, peer)
 

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -3721,7 +3721,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             RuntimeError,
-            "missing paged-cache block table",
+            "missing cache-group block table",
         ):
             metadata.cache.compressed_page_table(128)
 

--- a/test/runtime/test_kimi_k3_cudagraph.py
+++ b/test/runtime/test_kimi_k3_cudagraph.py
@@ -1,4 +1,4 @@
-"""Kimi-K3 paged-cache CUDA-graph capture/replay core logic.
+"""Kimi-K3 cache-group CUDA-graph capture/replay core logic.
 
 CPU-only (plain tensors, no real graph capture): exercises the metadata-buffer
 capture/replay LOGIC that the decode CUDA graph depends on. The real
@@ -352,7 +352,7 @@ def test_amd_mla_eager_decode_uses_group_table_and_refuses_fallback() -> None:
     )
     assert torch.equal(selected, decode.group_out_cache_loc)
 
-    with pytest.raises(RuntimeError, match="no paged cache metadata"):
+    with pytest.raises(RuntimeError, match="no cache metadata"):
         backend.init_forward_metadata(
             bs=2,
             num_extends=0,

--- a/test/runtime/test_kimi_k3_kda.py
+++ b/test/runtime/test_kimi_k3_kda.py
@@ -839,7 +839,7 @@ def test_kda_prefix_resume_copy_on_write_and_isolation() -> None:
 @requires_fla
 @pytest.mark.skipif(
     not current_platform().is_amd,
-    reason="indexed paged cache KDA decode is an AMD-specific contract",
+    reason="indexed cache-group KDA decode is an AMD-specific contract",
 )
 def test_kda_cache_pool_component_views_end_to_end(
     monkeypatch: pytest.MonkeyPatch,
@@ -875,7 +875,7 @@ def test_kda_cache_pool_component_views_end_to_end(
     from tokenspeed_kernel.thirdparty.triton import fla_kda_recurrent
 
     def _unexpected_megafuse(*args, **kwargs):
-        raise AssertionError("AMD paged cache decode must bypass the FLA KDA megafuse")
+        raise AssertionError("AMD cache-group decode must bypass the FLA KDA megafuse")
 
     indexed_decode_calls = 0
     indexed_decode = hybrid_kda.kda_paged_decode

--- a/test/runtime/test_kimi_k3_mla.py
+++ b/test/runtime/test_kimi_k3_mla.py
@@ -1,4 +1,4 @@
-"""Kimi-K3 MLA attention on the paged-cache full-attention table.
+"""Kimi-K3 MLA attention on the cache-group full-attention table.
 
 Coverage:
 

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -146,7 +146,6 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_rw("decode_input_tokens", &tokenspeed::SchedulerConfig::decode_input_tokens)
         .def_rw("overlap_schedule_depth", &tokenspeed::SchedulerConfig::overlap_schedule_depth)
         .def_rw("role", &tokenspeed::SchedulerConfig::role)
-        .def_rw("enable_pd_cache", &tokenspeed::SchedulerConfig::enable_pd_cache)
         .def_prop_rw(
             "num_device_pages", [](const tokenspeed::SchedulerConfig& c) { return c.device_allocator.total_pages; },
             [](tokenspeed::SchedulerConfig& c, std::int32_t v) { c.device_allocator.total_pages = v; })

--- a/tokenspeed-scheduler/csrc/fsm/forward_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_events.h
@@ -31,11 +31,13 @@
 #include "cache/coordinator/cache_coordinator.h"
 #include "fsm/base_event.h"
 #include "fsm/forward_states.h"
+// The D and P role grammars schedule INTO the PD parking states
+// (RemotePrefilling, PrefillAwaitingResult), so the forward events name them
+// in their transition signatures.
+#include "fsm/pd_states.h"
 #include "utils.h"
 
 namespace tokenspeed::fsm {
-
-struct Bootstrapping;
 
 struct SchedulePrefillFirstChunkEvent : InvalidTransitionHandler<SchedulePrefillFirstChunkEvent> {
     using InvalidTransitionHandler<SchedulePrefillFirstChunkEvent>::operator();

--- a/tokenspeed-scheduler/csrc/fsm/forward_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/forward_states.h
@@ -163,15 +163,6 @@ private:
     std::int32_t reserve_num_tokens_in_next_schedule_event_{};
 };
 
-// The peer node is prefilling this prompt: this engine admitted and holds
-// the destination pages, and nothing here is schedulable work -- the state
-// advances only when RemotePrefillDoneEvent lands with the bootstrap token.
-// A state of its own, not Prefilling with a source flag: the two share the
-// data layout (hence the inheritance) but no lifecycle.
-struct RemotePrefilling : public Prefilling {
-    using Prefilling::Prefilling;
-};
-
 struct PrefillDone : public ForwardState {
     PrefillDone(TokenContainer* token_container, std::int32_t prefix_granularity,
                 std::unique_ptr<ReqPoolIndex> req_pool_index, TokenContainer::Window window,
@@ -190,43 +181,6 @@ struct PrefillDone : public ForwardState {
         return PrefillInfo{
             .input_ids = PrefillInputIds(),
             .shifted_input_ids = ShiftedInputIds(),
-            .already_scheduled_len = window.begin,
-            .extend_len = window.size,
-        };
-    }
-    void ExtendResultTokens(const std::vector<std::int32_t>& result_tokens) { token_container_->Extend(result_tokens); }
-
-    TokenContainer::Window window{};
-
-private:
-    std::int32_t reserve_num_tokens_in_next_schedule_event_{};
-};
-
-// P role: every chunk is scheduled, but the FINAL chunk's result has not
-// landed yet -- and the remote decode that hands this prompt to the peer
-// needs the bootstrap token that arrives with it. Nothing is schedulable
-// here; the only event this state accepts is that result, which turns it
-// into PrefillDone.
-//
-// A sibling of PrefillDone, not a subclass: `Is<PrefillDone>()` must mean
-// "schedulable" with no exceptions, and inheritance would make the answer
-// depend on how the caller dispatches (holds_alternative vs derived_from vs
-// an overload set).
-struct PrefillAwaitingResult : public ForwardState {
-    PrefillAwaitingResult(TokenContainer* token_container, std::int32_t prefix_granularity,
-                          std::unique_ptr<ReqPoolIndex> req_pool_index, TokenContainer::Window window,
-                          std::int32_t reserve_num_tokens_in_next_schedule_event, std::vector<BlockTable> block_tables,
-                          CacheProgress cache_progress)
-        : ForwardState(token_container, prefix_granularity, std::move(req_pool_index), std::move(block_tables),
-                       std::move(cache_progress)),
-          window{window},
-          reserve_num_tokens_in_next_schedule_event_{reserve_num_tokens_in_next_schedule_event} {}
-
-    std::int32_t ReserveNumTokensInNextScheduleEvent() const { return reserve_num_tokens_in_next_schedule_event_; }
-    PrefillInfo CurrentPrefillInfo() const {
-        return PrefillInfo{
-            .input_ids = token_container_->TokenSlice(window),
-            .shifted_input_ids = ComputeShiftedInputIds(token_container_, window),
             .already_scheduled_len = window.begin,
             .extend_len = window.size,
         };

--- a/tokenspeed-scheduler/csrc/fsm/pd_events.h
+++ b/tokenspeed-scheduler/csrc/fsm/pd_events.h
@@ -29,6 +29,7 @@ namespace tokenspeed {
 namespace fsm {
 
 struct Bootstrapping;
+struct RemotePrefilling;
 
 struct BootstrappedEvent : InvalidTransitionHandler<BootstrappedEvent> {
     using InvalidTransitionHandler<BootstrappedEvent>::operator();

--- a/tokenspeed-scheduler/csrc/fsm/pd_states.h
+++ b/tokenspeed-scheduler/csrc/fsm/pd_states.h
@@ -21,8 +21,19 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
 
+#include "cache/core/cache_types.h"
 #include "core/token_container.h"
+#include "fsm/forward_states.h"
+#include "resource/allocator/req_pool_allocator.h"
+#include "scheduler/request_spec.h"
+
+// States that exist only under PD disaggregation: a fused engine never
+// enters any of them. The universal lifecycle lives in forward_states.h;
+// these extend it with the P and D roles' parking states.
 
 namespace tokenspeed {
 namespace fsm {
@@ -32,6 +43,52 @@ struct Bootstrapping {
 
     TokenContainer* token_container{};
     std::int32_t prefix_granularity{};
+};
+
+// The peer node is prefilling this prompt: this engine admitted and holds
+// the destination pages, and nothing here is schedulable work -- the state
+// advances only when RemotePrefillDoneEvent lands with the bootstrap token.
+// A state of its own, not Prefilling with a source flag: the two share the
+// data layout (hence the inheritance) but no lifecycle.
+struct RemotePrefilling : public Prefilling {
+    using Prefilling::Prefilling;
+};
+
+// P role: every chunk is scheduled, but the FINAL chunk's result has not
+// landed yet -- and the remote decode that hands this prompt to the peer
+// needs the bootstrap token that arrives with it. Nothing is schedulable
+// here; the only event this state accepts is that result, which turns it
+// into PrefillDone.
+//
+// A sibling of PrefillDone, not a subclass: `Is<PrefillDone>()` must mean
+// "schedulable" with no exceptions, and inheritance would make the answer
+// depend on how the caller dispatches (holds_alternative vs derived_from vs
+// an overload set).
+struct PrefillAwaitingResult : public ForwardState {
+    PrefillAwaitingResult(TokenContainer* token_container, std::int32_t prefix_granularity,
+                          std::unique_ptr<ReqPoolIndex> req_pool_index, TokenContainer::Window window,
+                          std::int32_t reserve_num_tokens_in_next_schedule_event, std::vector<BlockTable> block_tables,
+                          CacheProgress cache_progress)
+        : ForwardState(token_container, prefix_granularity, std::move(req_pool_index), std::move(block_tables),
+                       std::move(cache_progress)),
+          window{window},
+          reserve_num_tokens_in_next_schedule_event_{reserve_num_tokens_in_next_schedule_event} {}
+
+    std::int32_t ReserveNumTokensInNextScheduleEvent() const { return reserve_num_tokens_in_next_schedule_event_; }
+    PrefillInfo CurrentPrefillInfo() const {
+        return PrefillInfo{
+            .input_ids = token_container_->TokenSlice(window),
+            .shifted_input_ids = ComputeShiftedInputIds(token_container_, window),
+            .already_scheduled_len = window.begin,
+            .extend_len = window.size,
+        };
+    }
+    void ExtendResultTokens(const std::vector<std::int32_t>& result_tokens) { token_container_->Extend(result_tokens); }
+
+    TokenContainer::Window window{};
+
+private:
+    std::int32_t reserve_num_tokens_in_next_schedule_event_{};
 };
 
 }  // namespace fsm

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -350,7 +350,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
         makeSnapshotStatePrefillSparse(demands, config_.cache_groups, coordinator_, hit_tokens + tokens_this_round);
     }
 
-    if (config_.enable_pd_cache && source == fsm::PrefillSource::kRemote) {
+    if (source == fsm::PrefillSource::kRemote) {
         for (std::size_t i = 0; i < demands.size(); ++i) {
             const CacheGroupConfig& group = config_.cache_groups[i];
             const std::int32_t block_granularity = coordinator_.GroupBlockGranularity(i);
@@ -744,7 +744,7 @@ void Scheduler::maybeRetractForCapacity(AdmissionFeedback& feedback, PlanBuild& 
                 }
                 // A D-role LOCAL recovery grant must not pin: no PD ACK ever
                 // arrives to erase it (its lifetime is the L2 load ticket).
-                if (config_.enable_pd_cache && (remote_grant || config_.role != Role::kD)) {
+                if (remote_grant) {
                     pd_transfer_pins_.insert(blocker->Id());
                 }
                 return;
@@ -820,7 +820,7 @@ void Scheduler::scheduleLocalPrefillWork(AdmissionFeedback& feedback, PlanBuild&
             if (auto operation = schedulePrefillCandidate(build.plan, feedback, request, build.token_budget,
                                                           decode_reserve, build.load_backs)) {
                 pushOperation(build, *request, std::move(*operation));
-                if (config_.enable_pd_cache) {
+                if (config_.role != Role::kFused) {
                     // Pages stay pinned until the PD transfer completes.
                     pd_transfer_pins_.insert(request->Id());
                 }
@@ -941,9 +941,7 @@ void Scheduler::buildDecodeWorkerPlan(AdmissionFeedback& feedback, PlanBuild& bu
                                                       config_.decode_input_tokens, build.load_backs)) {
             build.scheduled.insert(request);
             build.remote_prefill.emplace_back(std::move(*operation));
-            if (config_.enable_pd_cache) {
-                pd_transfer_pins_.insert(request->Id());
-            }
+            pd_transfer_pins_.insert(request->Id());
             break;
         }
         if (feedback.admission_failed && feedback.capacity_blocker == nullptr) {

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -256,14 +256,14 @@ Scheduler::AdmissionMatch Scheduler::matchPrefixAtAdmission(Request* request) {
     return match;
 }
 
-std::optional<CacheCoordinator::AdmissionResult> Scheduler::admit(PlanBuildContext& context,
+std::optional<CacheCoordinator::AdmissionResult> Scheduler::admit(ExecutionPlan& plan, AdmissionFeedback& feedback,
                                                                   CacheCoordinator::PrefixProbe&& prefix,
                                                                   std::span<const GroupDemand> demands,
                                                                   std::optional<std::uint64_t> request_access_epoch) {
     std::optional<CacheCoordinator::AdmissionResult> result =
         coordinator_.Admit(std::move(prefix), demands, request_access_epoch);
     if (!result) {
-        context.admission_failed = true;
+        feedback.admission_failed = true;
         return std::nullopt;
     }
 
@@ -271,30 +271,31 @@ std::optional<CacheCoordinator::AdmissionResult> Scheduler::admit(PlanBuildConte
             "admission fresh-page groups must match scheduler config");
     for (std::size_t i = 0; i < result->new_page_ids.size(); ++i) {
         auto& page_ids = result->new_page_ids[i];
-        auto& pending = context.plan.pages_to_zero[cache_group_ids_[i]];
+        auto& pending = plan.pages_to_zero[cache_group_ids_[i]];
         pending.insert(pending.end(), page_ids.begin(), page_ids.end());
     }
     return result;
 }
 
-std::optional<CacheCoordinator::AdmissionResult> Scheduler::admit(PlanBuildContext& context,
+std::optional<CacheCoordinator::AdmissionResult> Scheduler::admit(ExecutionPlan& plan, AdmissionFeedback& feedback,
                                                                   std::span<const GroupDemand> demands,
                                                                   std::uint64_t request_access_epoch) {
-    return admit(context, coordinator_.ProbePrefix({}), demands, request_access_epoch);
+    return admit(plan, feedback, coordinator_.ProbePrefix({}), demands, request_access_epoch);
 }
 
-bool Scheduler::admitWithKvEventTracking(PlanBuildContext& context, Request& request,
+bool Scheduler::admitWithKvEventTracking(ExecutionPlan& plan, AdmissionFeedback& feedback, Request& request,
                                          const fsm::CacheProgress& cache_progress, std::int32_t new_prefix_hash_begin,
                                          std::span<const GroupDemand> demands) {
     std::vector<CacheKey> event_keys =
         registerKvEventPrefixPages(request, cache_progress.prefix_hashes, new_prefix_hash_begin);
-    const bool admitted = admit(context, demands, cache_progress.access_epoch).has_value();
+    const bool admitted = admit(plan, feedback, demands, cache_progress.access_epoch).has_value();
     discardUncachedKvEventPages(event_keys);
     return admitted;
 }
 
 std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFirstChunk(
-    PlanBuildContext& context, Request* request, std::int32_t remaining, std::int32_t decode_input_tokens) {
+    ExecutionPlan& plan, AdmissionFeedback& feedback, Request* request, std::int32_t remaining,
+    std::int32_t decode_input_tokens) {
     if (req_pool_allocator_.AvailableSlots() == 0) {
         return std::nullopt;
     }
@@ -367,7 +368,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
     }
     setSnapshotStatePrefillReserve(demands, config_.cache_groups, split_tail_tokens);
     std::vector<CacheKey> event_keys = registerKvEventPrefixPages(*request, match.candidate_prefix_hashes, 0);
-    std::optional<CacheCoordinator::AdmissionResult> admission = admit(context, std::move(match.probe), demands);
+    std::optional<CacheCoordinator::AdmissionResult> admission = admit(plan, feedback, std::move(match.probe), demands);
     if (!admission) {
         discardUncachedKvEventPages(event_keys);
         return std::nullopt;
@@ -402,7 +403,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
 }
 
 std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
-    PlanBuildContext& context, Request* request, std::int32_t remaining,
+    ExecutionPlan& plan, AdmissionFeedback& feedback, Request* request, std::int32_t remaining,
     std::int32_t reserve_num_tokens_in_next_schedule_event) {
     const std::int32_t unscheduled = request->UnscheduledPrefillSize();
     const std::int32_t first_pos = request->PrefillSize() - unscheduled;
@@ -459,7 +460,7 @@ std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
         makeSnapshotStatePrefillSparse(demands, config_.cache_groups, coordinator_, first_pos + tokens_this_round);
     }
     setSnapshotStatePrefillReserve(demands, config_.cache_groups, checkpoint_tail_reserve);
-    if (!admitWithKvEventTracking(context, *request, cache_progress, completed.first_new_prefix_page, demands)) {
+    if (!admitWithKvEventTracking(plan, feedback, *request, cache_progress, completed.first_new_prefix_page, demands)) {
         return std::nullopt;
     }
 
@@ -471,7 +472,8 @@ std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
     };
 }
 
-std::optional<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(PlanBuildContext& context, Request* request) {
+std::optional<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(ExecutionPlan& plan, AdmissionFeedback& feedback,
+                                                                  Request* request) {
     std::vector<BlockTable>& tables = request->BlockTablesRef();
     const std::int32_t reserve_tokens = request->ReserveNumTokensInNextScheduleEvent();
     fsm::CacheProgress cache_progress = request->CacheProgress();
@@ -498,7 +500,8 @@ std::optional<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(PlanBuildConte
                                          .completed_boundary_kind = completed.boundary_kind,
                                          .num_computed_tokens = num_computed_tokens,
                                      });
-        if (!admitWithKvEventTracking(context, *request, cache_progress, completed.first_new_prefix_page, demands)) {
+        if (!admitWithKvEventTracking(plan, feedback, *request, cache_progress, completed.first_new_prefix_page,
+                                      demands)) {
             return std::nullopt;
         }
     }
@@ -543,17 +546,17 @@ DecodeOperation Scheduler::applyEventAndBuildOperation(Request* request, fsm::Sc
     return operation;
 }
 
-std::optional<PrefillOperation> Scheduler::schedulePrefillCandidate(PlanBuildContext& context, Request* request,
-                                                                    std::int32_t token_budget,
+std::optional<PrefillOperation> Scheduler::schedulePrefillCandidate(ExecutionPlan& plan, AdmissionFeedback& feedback,
+                                                                    Request* request, std::int32_t token_budget,
                                                                     std::int32_t decode_reserve,
                                                                     std::vector<LoadBackOperation>& load_backs) {
     if (request->Is<fsm::Prefilling>()) {
-        if (auto event = schedulePrefill(context, request, token_budget, decode_reserve)) {
+        if (auto event = schedulePrefill(plan, feedback, request, token_budget, decode_reserve)) {
             return applyEventAndBuildOperation(request, std::move(*event));
         }
         return std::nullopt;
     }
-    if (auto event = schedulePrefillFirstChunk(context, request, token_budget, decode_reserve)) {
+    if (auto event = schedulePrefillFirstChunk(plan, feedback, request, token_budget, decode_reserve)) {
         return applyEventAndBuildOperation(request, std::move(*event), load_backs);
     }
     return std::nullopt;
@@ -664,10 +667,10 @@ void Scheduler::retractVictim(Request& victim, std::vector<WriteBackOperation>& 
 // already-built decode batch, where the role's grammar keeps them apart)
 // still retracts one victim: the next round's phase order tries the blocker
 // before any other claim on the freed pages.
-void Scheduler::maybeRetractForCapacity(PlanBuildContext& context, PlanBuild& build,
+void Scheduler::maybeRetractForCapacity(AdmissionFeedback& feedback, PlanBuild& build,
                                         std::span<Request* const> candidates,
                                         std::vector<WriteBackOperation>& write_back_operations) {
-    Request* blocker = std::exchange(context.capacity_blocker, nullptr);
+    Request* blocker = std::exchange(feedback.capacity_blocker, nullptr);
     if (!build.NoPrefillProgress() || blocker == nullptr) {
         return;
     }
@@ -717,9 +720,9 @@ void Scheduler::maybeRetractForCapacity(PlanBuildContext& context, PlanBuild& bu
             return;
         }
 
-        context.admission_failed = false;
+        feedback.admission_failed = false;
         if (blocked_on_decode) {
-            if (auto event = scheduleDecode(context, blocker)) {
+            if (auto event = scheduleDecode(build.plan, feedback, blocker)) {
                 pushOperation(build, *blocker, applyEventAndBuildOperation(blocker, std::move(*event)));
                 blocker->TrackScheduledForward();
                 return;
@@ -730,8 +733,8 @@ void Scheduler::maybeRetractForCapacity(PlanBuildContext& context, PlanBuild& bu
             // plan.remote_prefill beside whatever batch this round built.
             // Everything else is local prefill work joining the model batch.
             const std::int32_t budget = remote_grant ? blocker->PrefillSize() : build.token_budget;
-            if (auto operation =
-                    schedulePrefillCandidate(context, blocker, budget, config_.decode_input_tokens, build.load_backs)) {
+            if (auto operation = schedulePrefillCandidate(build.plan, feedback, blocker, budget,
+                                                          config_.decode_input_tokens, build.load_backs)) {
                 if (remote_grant) {
                     build.scheduled.insert(blocker);
                     build.remote_prefill.emplace_back(std::move(*operation));
@@ -747,7 +750,7 @@ void Scheduler::maybeRetractForCapacity(PlanBuildContext& context, PlanBuild& bu
                 return;
             }
         }
-        if (!context.admission_failed) {
+        if (!feedback.admission_failed) {
             return;  // not a capacity failure (zero-token alignment); stop retracting
         }
     }
@@ -784,21 +787,21 @@ Request* Scheduler::nextReadmission(std::span<Request* const> candidates) {
 // capacity blocker (retracting a victim for it is pure thrash -- the two
 // simply do not fit together), but it does seal new-prompt admission:
 // a newcomer taking the pages it is waiting for would starve it.
-void Scheduler::scheduleLocalPrefillWork(PlanBuildContext& context, PlanBuild& build,
+void Scheduler::scheduleLocalPrefillWork(AdmissionFeedback& feedback, PlanBuild& build,
                                          std::span<Request* const> candidates, Request* readmission,
                                          std::int32_t decode_reserve) {
     bool new_prompts_sealed = false;
     if (readmission != nullptr) {
-        context.admission_failed = false;
-        if (auto operation =
-                schedulePrefillCandidate(context, readmission, build.token_budget, decode_reserve, build.load_backs)) {
+        feedback.admission_failed = false;
+        if (auto operation = schedulePrefillCandidate(build.plan, feedback, readmission, build.token_budget,
+                                                      decode_reserve, build.load_backs)) {
             pushOperation(build, *readmission, std::move(*operation));
             readmission->TrackScheduledForward();
             if (holdsHeadOfLine(*readmission)) {
                 return;
             }
         } else {
-            new_prompts_sealed = context.admission_failed;
+            new_prompts_sealed = feedback.admission_failed;
         }
     }
     for (const bool resident : {true, false}) {
@@ -813,9 +816,9 @@ void Scheduler::scheduleLocalPrefillWork(PlanBuildContext& context, PlanBuild& b
                 build.Scheduled(*request)) {
                 continue;
             }
-            context.admission_failed = false;
-            if (auto operation =
-                    schedulePrefillCandidate(context, request, build.token_budget, decode_reserve, build.load_backs)) {
+            feedback.admission_failed = false;
+            if (auto operation = schedulePrefillCandidate(build.plan, feedback, request, build.token_budget,
+                                                          decode_reserve, build.load_backs)) {
                 pushOperation(build, *request, std::move(*operation));
                 if (config_.enable_pd_cache) {
                     // Pages stay pinned until the PD transfer completes.
@@ -825,9 +828,9 @@ void Scheduler::scheduleLocalPrefillWork(PlanBuildContext& context, PlanBuild& b
                 if (holdsHeadOfLine(*request)) {
                     return;
                 }
-            } else if (context.admission_failed) {
-                if (context.capacity_blocker == nullptr) {
-                    context.capacity_blocker = request;
+            } else if (feedback.admission_failed) {
+                if (feedback.capacity_blocker == nullptr) {
+                    feedback.capacity_blocker = request;
                 }
                 if (resident) {
                     return;
@@ -841,7 +844,8 @@ void Scheduler::scheduleLocalPrefillWork(PlanBuildContext& context, PlanBuild& b
 // (its first decode) and Decoding candidate. The budget guard protects the
 // mamba state reserve of a prefill scheduled beside them in mixed mode; on
 // the D role decodes consume no budget, so it never binds there.
-void Scheduler::scheduleDecodeBatch(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates) {
+void Scheduler::scheduleDecodeBatch(AdmissionFeedback& feedback, PlanBuild& build,
+                                    std::span<Request* const> candidates) {
     for (Request* request : candidates) {
         if (build.Full(config_.max_batch_size) ||
             build.token_budget < build.state_prefill_reserve + config_.decode_input_tokens) {
@@ -850,12 +854,12 @@ void Scheduler::scheduleDecodeBatch(PlanBuildContext& context, PlanBuild& build,
         if ((!request->Is<fsm::PrefillDone>() && !request->Is<fsm::Decoding>()) || build.Scheduled(*request)) {
             continue;
         }
-        context.admission_failed = false;
-        if (auto event = scheduleDecode(context, request)) {
+        feedback.admission_failed = false;
+        if (auto event = scheduleDecode(build.plan, feedback, request)) {
             pushOperation(build, *request, applyEventAndBuildOperation(request, std::move(*event)));
             request->TrackScheduledForward();
-        } else if (context.admission_failed && context.capacity_blocker == nullptr) {
-            context.capacity_blocker = request;
+        } else if (feedback.admission_failed && feedback.capacity_blocker == nullptr) {
+            feedback.capacity_blocker = request;
         }
     }
 }
@@ -867,7 +871,7 @@ void Scheduler::scheduleDecodeBatch(PlanBuildContext& context, PlanBuild& build,
 // retraction either: a P node's pressure valve is the transfer itself, so
 // this grammar never calls maybeRetractForCapacity and nothing here is ever
 // readmitted.
-void Scheduler::buildPrefillWorkerPlan(PlanBuildContext& context, PlanBuild& build,
+void Scheduler::buildPrefillWorkerPlan(AdmissionFeedback& feedback, PlanBuild& build,
                                        std::span<Request* const> candidates) {
     // The prompt decodes on the peer node: its KV goes out on the plan's own
     // stream, occupying no token budget and no batch slot. A prompt still
@@ -878,21 +882,22 @@ void Scheduler::buildPrefillWorkerPlan(PlanBuildContext& context, PlanBuild& bui
     // its fence is the PD ACK.
     for (Request* request : candidates) {
         if (request->Is<fsm::PrefillDone>()) {
-            if (auto event = scheduleDecode(context, request)) {
+            if (auto event = scheduleDecode(build.plan, feedback, request)) {
                 build.scheduled.insert(request);
                 build.remote_decode.emplace_back(applyEventAndBuildOperation(request, std::move(*event)));
             }
         }
     }
 
-    scheduleLocalPrefillWork(context, build, candidates, /*readmission=*/nullptr, /*decode_reserve=*/0);
+    scheduleLocalPrefillWork(feedback, build, candidates, /*readmission=*/nullptr, /*decode_reserve=*/0);
 }
 
 // D role: decode worker. Local recovery work runs alone in its batch;
 // otherwise the round is a decode batch, beside which at most ONE remote
 // admission rides plan.remote_prefill. Retraction picks decode victims and
 // retries the blocked admission in the same round.
-void Scheduler::buildDecodeWorkerPlan(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates,
+void Scheduler::buildDecodeWorkerPlan(AdmissionFeedback& feedback, PlanBuild& build,
+                                      std::span<Request* const> candidates,
                                       std::vector<WriteBackOperation>& write_back_operations) {
     // Phase 1: local recovery, alone in its batch -- a resident chunk if one
     // is mid-prompt (always recovery here: a remote prompt is
@@ -905,21 +910,21 @@ void Scheduler::buildDecodeWorkerPlan(PlanBuildContext& context, PlanBuild& buil
     const auto resident = std::ranges::find_if(candidates, &Request::Is<fsm::Prefilling>);
     Request* recovery = resident != candidates.end() ? *resident : nextReadmission(candidates);
     if (recovery != nullptr) {
-        context.admission_failed = false;
-        if (auto operation = schedulePrefillCandidate(context, recovery, build.token_budget,
+        feedback.admission_failed = false;
+        if (auto operation = schedulePrefillCandidate(build.plan, feedback, recovery, build.token_budget,
                                                       config_.decode_input_tokens, build.load_backs)) {
             pushOperation(build, *recovery, std::move(*operation));
             recovery->TrackScheduledForward();
             return;  // recovery runs alone
         }
-        if (recovery->Is<fsm::Prefilling>() && context.admission_failed && context.capacity_blocker == nullptr) {
-            context.capacity_blocker = recovery;
+        if (recovery->Is<fsm::Prefilling>() && feedback.admission_failed && feedback.capacity_blocker == nullptr) {
+            feedback.capacity_blocker = recovery;
         }
     }
 
     // Phase 2: the decode batch. Completed prefills' first decodes go ahead
     // of the running ones; neither consumes token budget on this role.
-    scheduleDecodeBatch(context, build, candidates);
+    scheduleDecodeBatch(feedback, build, candidates);
 
     // Phase 3: at most one remote admission -- the whole prompt reserves at
     // once, so admitting a queue's worth in one round would drain the pool
@@ -931,8 +936,8 @@ void Scheduler::buildDecodeWorkerPlan(PlanBuildContext& context, PlanBuild& buil
         if (!admitsLikeNewPrompt(*request)) {
             continue;
         }
-        context.admission_failed = false;
-        if (auto operation = schedulePrefillCandidate(context, request, request->PrefillSize(),
+        feedback.admission_failed = false;
+        if (auto operation = schedulePrefillCandidate(build.plan, feedback, request, request->PrefillSize(),
                                                       config_.decode_input_tokens, build.load_backs)) {
             build.scheduled.insert(request);
             build.remote_prefill.emplace_back(std::move(*operation));
@@ -941,12 +946,12 @@ void Scheduler::buildDecodeWorkerPlan(PlanBuildContext& context, PlanBuild& buil
             }
             break;
         }
-        if (context.admission_failed && context.capacity_blocker == nullptr) {
-            context.capacity_blocker = request;
+        if (feedback.admission_failed && feedback.capacity_blocker == nullptr) {
+            feedback.capacity_blocker = request;
         }
     }
 
-    maybeRetractForCapacity(context, build, candidates, write_back_operations);
+    maybeRetractForCapacity(feedback, build, candidates, write_back_operations);
 }
 
 // Fused role: one engine does everything locally. In mixed mode resident
@@ -956,7 +961,7 @@ void Scheduler::buildDecodeWorkerPlan(PlanBuildContext& context, PlanBuild& buil
 // the rest. Outside mixed mode prefill work runs alone, and decodes get a
 // round only when no prefill scheduled. Recovery readmission is live when a
 // host cache gives victims a way back.
-void Scheduler::buildFusedPlan(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates,
+void Scheduler::buildFusedPlan(AdmissionFeedback& feedback, PlanBuild& build, std::span<Request* const> candidates,
                                std::vector<WriteBackOperation>& write_back_operations) {
     Request* readmission = nextReadmission(candidates);
     if (config_.enable_mixed_prefill_decode) {
@@ -966,34 +971,34 @@ void Scheduler::buildFusedPlan(PlanBuildContext& context, PlanBuild& build, std:
             });
         build.state_prefill_reserve =
             coordinator_.HasMambaStateGroup() && has_local_prefill ? coordinator_.PrefixGranularity() : 0;
-        scheduleDecodeBatch(context, build, candidates);
+        scheduleDecodeBatch(feedback, build, candidates);
     }
 
-    scheduleLocalPrefillWork(context, build, candidates, readmission, config_.decode_input_tokens);
+    scheduleLocalPrefillWork(feedback, build, candidates, readmission, config_.decode_input_tokens);
 
     if (!config_.enable_mixed_prefill_decode && !build.pushed_prefill) {
-        scheduleDecodeBatch(context, build, candidates);
+        scheduleDecodeBatch(feedback, build, candidates);
     }
 
-    maybeRetractForCapacity(context, build, candidates, write_back_operations);
+    maybeRetractForCapacity(feedback, build, candidates, write_back_operations);
 }
 
 std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> Scheduler::buildForwardOperations(
     ExecutionPlan& plan, std::vector<Request*> candidates, std::vector<WriteBackOperation>& write_back_operations) {
     // The candidates arrive in submission order (requests_ is the FIFO),
     // identical on every rank -- so within a phase, older requests win.
-    PlanBuildContext context{plan};
-    PlanBuild build;
+    AdmissionFeedback feedback;
+    PlanBuild build{plan};
     build.token_budget = config_.max_scheduled_tokens;
     switch (config_.role) {
         case Role::kP:
-            buildPrefillWorkerPlan(context, build, candidates);
+            buildPrefillWorkerPlan(feedback, build, candidates);
             break;
         case Role::kD:
-            buildDecodeWorkerPlan(context, build, candidates, write_back_operations);
+            buildDecodeWorkerPlan(feedback, build, candidates, write_back_operations);
             break;
         case Role::kFused:
-            buildFusedPlan(context, build, candidates, write_back_operations);
+            buildFusedPlan(feedback, build, candidates, write_back_operations);
             break;
     }
 

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -83,7 +83,7 @@ void Scheduler::handleEvent(const pd::RemotePrefillDoneEvent& event) {
 }
 
 void Scheduler::handleEvent(const forward::Finish& event) {
-    if (config_.enable_pd_cache && pd_transfer_pins_.contains(event.request_id)) {
+    if (pd_transfer_pins_.contains(event.request_id)) {
         throw std::logic_error("PD Finish received while transfer pages are pinned");
     }
     if (Request* request = findRequest(event.request_id)) {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -163,15 +163,13 @@ std::int64_t Scheduler::singleRequestLcmBlocksRequired(std::int32_t token_limit)
         if (coordinator_.GroupIsPrefixClosed(i)) {
             child_pages = ceilDiv(static_cast<std::int64_t>(token_limit) + protected_tokens, block_granularity);
         } else if (config_.role == Role::kD) {
-            const bool latest_snapshot =
-                config_.enable_pd_cache && group.transfer_policy == CacheTransferPolicy::LatestSnapshot;
-            if (latest_snapshot) {
+            if (group.transfer_policy == CacheTransferPolicy::LatestSnapshot) {
                 const std::int64_t snapshot_pages = token_limit == 0 ? 0 : 1;
                 // A retracted Decode request may recover by locally
                 // recomputing its suffix. Old State checkpoints are
                 // evictable, but one recovery chunk and its lookback must fit.
                 child_pages = std::max(snapshot_pages, local_prefill_peak());
-            } else if (config_.enable_pd_cache && group.retention == CacheGroupConfig::Retention::SlidingWindow) {
+            } else if (group.retention == CacheGroupConfig::Retention::SlidingWindow) {
                 const std::int64_t dense_pages =
                     ceilDiv(static_cast<std::int64_t>(token_limit) + protected_tokens, block_granularity);
                 const std::int64_t window_pages = ceilDiv(static_cast<std::int64_t>(*group.sliding_window_tokens - 1) +

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -96,10 +96,12 @@ private:
         std::vector<std::uint64_t> block_hashes;
     };
 
-    struct PlanBuildContext {
-        explicit PlanBuildContext(ExecutionPlan& output_plan) : plan{output_plan} {}
-
-        ExecutionPlan& plan;
+    // What the per-request admission layer reports back to the role
+    // grammars. Together with the output ExecutionPlan (where admit()
+    // records fresh pages to zero) this is ALL that layer sees of a
+    // plan-building pass: batch composition lives in PlanBuild, which the
+    // grammars alone hold, so nothing below them can bypass pushOperation.
+    struct AdmissionFeedback {
         // Set by admit() when the last admission failed for capacity (as
         // opposed to a chunk that aligned to zero tokens). The phases clear
         // it before each attempt.
@@ -113,14 +115,16 @@ private:
 
     std::pair<std::vector<ForwardOperation>, std::vector<LoadBackOperation>> buildForwardOperations(
         ExecutionPlan& plan, std::vector<Request*> candidates, std::vector<WriteBackOperation>& write_back_operations);
-    std::optional<fsm::SchedulePrefillFirstChunkEvent> schedulePrefillFirstChunk(PlanBuildContext& context,
+    std::optional<fsm::SchedulePrefillFirstChunkEvent> schedulePrefillFirstChunk(ExecutionPlan& plan,
+                                                                                 AdmissionFeedback& feedback,
                                                                                  Request* request,
                                                                                  std::int32_t remaining,
                                                                                  std::int32_t decode_input_tokens);
-    std::optional<fsm::SchedulePrefillEvent> schedulePrefill(PlanBuildContext& context, Request* request,
-                                                             std::int32_t remaining,
+    std::optional<fsm::SchedulePrefillEvent> schedulePrefill(ExecutionPlan& plan, AdmissionFeedback& feedback,
+                                                             Request* request, std::int32_t remaining,
                                                              std::int32_t reserve_num_tokens_in_next_schedule_event);
-    std::optional<fsm::ScheduleDecodeEvent> scheduleDecode(PlanBuildContext& context, Request* request);
+    std::optional<fsm::ScheduleDecodeEvent> scheduleDecode(ExecutionPlan& plan, AdmissionFeedback& feedback,
+                                                           Request* request);
 
     PrefillOperation applyEventAndBuildOperation(Request* request, fsm::SchedulePrefillFirstChunkEvent event,
                                                  std::vector<LoadBackOperation>& load_back_operations);
@@ -129,13 +133,14 @@ private:
 
     AdmissionMatch matchPrefixAtAdmission(Request* request);
     std::optional<CacheCoordinator::AdmissionResult> admit(
-        PlanBuildContext& context, CacheCoordinator::PrefixProbe&& prefix, std::span<const GroupDemand> demands,
-        std::optional<std::uint64_t> request_access_epoch = std::nullopt);
-    std::optional<CacheCoordinator::AdmissionResult> admit(PlanBuildContext& context,
+        ExecutionPlan& plan, AdmissionFeedback& feedback, CacheCoordinator::PrefixProbe&& prefix,
+        std::span<const GroupDemand> demands, std::optional<std::uint64_t> request_access_epoch = std::nullopt);
+    std::optional<CacheCoordinator::AdmissionResult> admit(ExecutionPlan& plan, AdmissionFeedback& feedback,
                                                            std::span<const GroupDemand> demands,
                                                            std::uint64_t request_access_epoch);
-    bool admitWithKvEventTracking(PlanBuildContext& context, Request& request, const fsm::CacheProgress& cache_progress,
-                                  std::int32_t new_prefix_hash_begin, std::span<const GroupDemand> demands);
+    bool admitWithKvEventTracking(ExecutionPlan& plan, AdmissionFeedback& feedback, Request& request,
+                                  const fsm::CacheProgress& cache_progress, std::int32_t new_prefix_hash_begin,
+                                  std::span<const GroupDemand> demands);
     std::vector<CacheKey> registerKvEventPrefixPages(const Request& request, std::span<const std::string> prefix_hashes,
                                                      std::int32_t first_page);
     void discardUncachedKvEventPages(std::span<const CacheKey> keys);
@@ -156,11 +161,16 @@ private:
     void handleEvent(const forward::Finish& event);
     void handleEvent(const forward::UpdateReserveNumTokens& event);
 
-    // Mutable state of one plan-building pass: the model batch under
-    // construction, the transfer peer's two streams, and the composition
-    // flags the role grammars consult. buildForwardOperations owns one and
-    // hands it to the role's builder.
+    // Mutable state of one plan-building pass: the output plan, the model
+    // batch under construction, the transfer peer's two streams, and the
+    // composition flags the role grammars consult. buildForwardOperations
+    // owns one and hands it to the role's builder. The admission layer never
+    // sees this struct -- it receives build.plan and an AdmissionFeedback --
+    // so batch and budget accounting stay behind pushOperation.
     struct PlanBuild {
+        explicit PlanBuild(ExecutionPlan& output_plan) : plan{output_plan} {}
+
+        ExecutionPlan& plan;
         std::vector<ForwardOperation> operations;
         std::vector<ForwardOperation> remote_decode;
         std::vector<ForwardOperation> remote_prefill;
@@ -211,10 +221,11 @@ private:
 
     // Admission for one prefill-work candidate: a resumed chunk for a
     // Prefilling request, the first chunk otherwise. Returns the built
-    // operation, or nullopt when admission fails (context.admission_failed
+    // operation, or nullopt when admission fails (feedback.admission_failed
     // says whether capacity was the reason).
-    std::optional<PrefillOperation> schedulePrefillCandidate(PlanBuildContext& context, Request* request,
-                                                             std::int32_t token_budget, std::int32_t decode_reserve,
+    std::optional<PrefillOperation> schedulePrefillCandidate(ExecutionPlan& plan, AdmissionFeedback& feedback,
+                                                             Request* request, std::int32_t token_budget,
+                                                             std::int32_t decode_reserve,
                                                              std::vector<LoadBackOperation>& load_backs);
 
     // The readmission this round may schedule, or nullptr: among the
@@ -231,7 +242,7 @@ private:
     // victims and RETRIES the blocked admission in the same plan build, so
     // the freed capacity reaches the request it was freed for -- never a
     // free page waiting for whoever asks first next round.
-    void maybeRetractForCapacity(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates,
+    void maybeRetractForCapacity(AdmissionFeedback& feedback, PlanBuild& build, std::span<Request* const> candidates,
                                  std::vector<WriteBackOperation>& write_back_operations);
     Request* chooseVictim(std::span<Request* const> candidates) const;
     void retractVictim(Request& victim, std::vector<WriteBackOperation>& write_back_operations);
@@ -243,14 +254,14 @@ private:
     // role conditionals. Every phase walks the candidates in submission
     // order (requests_ is the FIFO) -- what used to be a priority ladder is
     // now the phase sequence itself, and within a phase older requests win.
-    void buildPrefillWorkerPlan(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates);
-    void buildDecodeWorkerPlan(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates,
+    void buildPrefillWorkerPlan(AdmissionFeedback& feedback, PlanBuild& build, std::span<Request* const> candidates);
+    void buildDecodeWorkerPlan(AdmissionFeedback& feedback, PlanBuild& build, std::span<Request* const> candidates,
                                std::vector<WriteBackOperation>& write_back_operations);
-    void buildFusedPlan(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates,
+    void buildFusedPlan(AdmissionFeedback& feedback, PlanBuild& build, std::span<Request* const> candidates,
                         std::vector<WriteBackOperation>& write_back_operations);
-    void scheduleLocalPrefillWork(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates,
+    void scheduleLocalPrefillWork(AdmissionFeedback& feedback, PlanBuild& build, std::span<Request* const> candidates,
                                   Request* readmission, std::int32_t decode_reserve);
-    void scheduleDecodeBatch(PlanBuildContext& context, PlanBuild& build, std::span<Request* const> candidates);
+    void scheduleDecodeBatch(AdmissionFeedback& feedback, PlanBuild& build, std::span<Request* const> candidates);
 
     std::int32_t calculateMaxSingleRequestTokens(std::int64_t usable_lcm_blocks) const;
     std::int64_t singleRequestLcmBlocksRequired(std::int32_t token_limit) const;

--- a/tokenspeed-scheduler/csrc/scheduler/types.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/types.cpp
@@ -33,7 +33,7 @@ void validateGroup(const SchedulerConfig& config, const CacheGroupConfig& group)
     if (config.prefix_granularity % group.BlockGranularity() != 0) {
         throw std::invalid_argument(where + "block_granularity must divide the scheduler prefix_granularity");
     }
-    if (!config.enable_pd_cache) {
+    if (config.role == Role::kFused) {
         return;
     }
     // A group's transfer policy is dictated by the destination layout the

--- a/tokenspeed-scheduler/csrc/scheduler/types.h
+++ b/tokenspeed-scheduler/csrc/scheduler/types.h
@@ -58,8 +58,11 @@ struct SchedulerConfig {
     bool enable_kv_cache_events{false};
     bool enable_mixed_prefill_decode{false};
 
+    // The P and D roles ARE the cache-transfer PD protocol: there is no
+    // disaggregated deployment without it, so everything PD-specific
+    // (transfer pins, destination layouts, transfer_policy validation) keys
+    // on the role directly.
     Role role{Role::kFused};
-    bool enable_pd_cache{false};
 
     bool disable_prefix_cache{false};
     // Minimum prompt tail that must be recomputed after a prefix-cache hit.

--- a/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
+++ b/tokenspeed-scheduler/python/tests/test_fsm_and_scheduling.py
@@ -293,7 +293,6 @@ class TestPrefillFirst:
         cfg = make_config(max_scheduled_tokens=8)
         cfg.role = SchedulerConfig.Role.P
         cfg.decode_input_tokens = 0
-        cfg.enable_pd_cache = True
         cfg.cache_groups[0].transfer_policy = CacheTransferPolicy.FullSuffix
         s = Scheduler(cfg)
         s.submit_requests(

--- a/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
@@ -102,6 +102,7 @@ TEST(CacheOperationTest, DecodeCanStartWithoutHostL2) {
             .total_pages = 4,
             .retention = CacheGroupConfig::Retention::FullHistory,
             .family = CacheGroupFamily::History,
+            .transfer_policy = CacheTransferPolicy::FullSuffix,
         });
         return config;
     };
@@ -131,6 +132,7 @@ TEST(CacheOperationTest, DeviceRequestLimitDoesNotDependOnHostCapacity) {
             .total_pages = 9,
             .retention = CacheGroupConfig::Retention::FullHistory,
             .family = CacheGroupFamily::History,
+            .transfer_policy = CacheTransferPolicy::FullSuffix,
         });
         return config;
     };
@@ -237,6 +239,7 @@ TEST(CacheOperationTest, DecodeRejectsRequestWhoseMaximumExtentCannotFitDevice) 
         .total_pages = 4,
         .retention = CacheGroupConfig::Retention::FullHistory,
         .family = CacheGroupFamily::History,
+        .transfer_policy = CacheTransferPolicy::FullSuffix,
     });
     Scheduler scheduler{std::move(config)};
     ASSERT_EQ(scheduler.MaxSingleRequestTokens(), 6);
@@ -264,6 +267,7 @@ TEST(CacheOperationTest, PrefillAcceptsPromptThatFitsWithoutReservingDecodeToken
         .total_pages = 4,
         .retention = CacheGroupConfig::Retention::FullHistory,
         .family = CacheGroupFamily::History,
+        .transfer_policy = CacheTransferPolicy::FullSuffix,
     });
     Scheduler scheduler{std::move(config)};
     ASSERT_EQ(scheduler.MaxSingleRequestTokens(), 6);

--- a/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
@@ -303,7 +303,6 @@ protected:
     SchedulerConfig MakeConfig() override {
         SchedulerConfig cfg = MambaStateCheckpointSplitSuite::MakeConfig();
         cfg.role = Role::kP;
-        cfg.enable_pd_cache = true;
         for (CacheGroupConfig& group : cfg.cache_groups) {
             group.transfer_policy =
                 group.IsSnapshotStateGroup() ? CacheTransferPolicy::LatestSnapshot : CacheTransferPolicy::FullSuffix;
@@ -2087,7 +2086,6 @@ protected:
     SchedulerConfig MakeConfig() override {
         SchedulerConfig cfg = RetractSuite::MakeConfig();
         cfg.role = Role::kP;
-        cfg.enable_pd_cache = true;
         for (CacheGroupConfig& group : cfg.cache_groups) {
             group.transfer_policy = CacheTransferPolicy::FullSuffix;
         }
@@ -2247,7 +2245,6 @@ TEST(PdSlidingCapacityTest, CountsPrefixIslandPhasePageAndGroupPacking) {
     cfg.max_batch_size = 1;
     cfg.decode_input_tokens = 1;
     cfg.role = Role::kD;
-    cfg.enable_pd_cache = true;
     cfg.disable_l2_cache = true;
 
     CacheGroupConfig sliding;

--- a/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_forward_cache_ops.cpp
@@ -559,7 +559,10 @@ TEST(SchedulerConfigValidateTest, RejectsSnapshotStateGroupBelowOneCacheBlock) {
 
 TEST(SchedulerConfigValidateTest, RejectsPdTransferPolicyMismatch) {
     SchedulerConfig config = MakeValidConfig();
-    config.enable_pd_cache = true;
+    // A P or D role IS the cache-transfer PD protocol, so it demands an
+    // explicit transfer_policy; the fused role (MakeValidConfig's default)
+    // never does.
+    config.role = Role::kD;
     CacheGroupConfig& history = config.cache_groups[0];
 
     // A History group ships its full suffix; leaving the policy to the default

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -135,7 +135,6 @@ protected:
         cfg.decode_input_tokens = 1;
         cfg.role = Role::kD;
         cfg.enable_l3_storage = false;
-        cfg.enable_pd_cache = true;
         cfg.disable_l2_cache = false;
         cfg.disable_prefix_cache = true;
 
@@ -654,7 +653,6 @@ protected:
         cfg.host_allocator.total_pages = 32;   // Keep retraction capacity outside these placement tests.
         cfg.max_scheduled_tokens = 2;
         cfg.overlap_schedule_depth = 0;
-        cfg.enable_pd_cache = true;
         cfg.disable_prefix_cache = false;
 
         CacheGroupConfig full = cfg.cache_groups.front();
@@ -718,7 +716,6 @@ protected:
         cfg.device_allocator.total_pages = 8;
         cfg.host_allocator.total_pages = 0;
         cfg.max_scheduled_tokens = 16;
-        cfg.enable_pd_cache = true;
         cfg.disable_prefix_cache = false;
 
         CacheGroupConfig sliding;


### PR DESCRIPTION
Five follow-ups to #1239, each standing alone as one commit:

- **docs(scheduler): describe head-of-line round composition** — pins down that a round carries every prefill that completes within it plus at most one truncated one (necessarily last), and that decodes are never ordered behind a prefill.
- **refactor(scheduler): split plan-build state into AdmissionFeedback and PlanBuild** — `PlanBuildContext` mixed the output plan with the admission-outcome bits. The split states the layer boundary in the signatures: the per-request admission layer receives only the plan and an `AdmissionFeedback`, never `PlanBuild`, so batch and budget accounting stay behind `pushOperation`. `scheduler.md` §3 documents the boundary.
- **refactor(scheduler)!: drop `enable_pd_cache` and key PD behavior on the role** — the flag descends from `enable_flatkv_pd`, whose job was to keep a legacy non-flat PD path alive; that path is long gone and the flag is always exactly `role != Fused` (encode nodes never build an EventLoop). Each gate falls back to what it really meant; see the commit message for the per-gate reasoning. **BREAKING**: `SchedulerConfig` loses the field, and P/D configs must declare an explicit `transfer_policy` on every cache group.
- **refactor(scheduler): move the PD-only states into pd_states.h** — `RemotePrefilling` (D role) and `PrefillAwaitingResult` (P role) are deployment-exclusive, exactly like `Bootstrapping`; `forward_states.h` now holds just the universal lifecycle.
- **refactor(runtime): retire the "Paged cache" system name from prose and errors** — page vocabulary belongs to KV-based attention alone: a recurrent-state group transfers checkpoints, not pages, and the PD protocol carries both. The identifiers dropped the word long ago (see the cache-group vocabulary refactor); prose and error strings now follow (cache-transfer PD, cache-group tables, cache metadata). Genuine kernel paging — `PagedAttention`, kernel page sizes, flashinfer's paged prefill, inkling's paged conv bridges — is untouched.

## Testing

- C++ scheduler suite: 435/435 at every commit that touches C++ (bisect-clean).
- Python binding tests: 58/58.
- Runtime unit batches (scheduler config + event loop, PD manifest / transfer plan / executors / layerwise, K3 cudagraph / KDA, V4 config): all green; the three tests matching renamed error strings are updated in step.
- `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)