### PR TITLE
feat(amd): support Gluon MLA for Kimi K3 EAGLE3

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -301,7 +301,9 @@ Blackwell GPU (B200/B300); on other NVIDIA platforms use
 
 ### AMD
 
-The standard AMD path on 8x gfx950 uses the `mla` backend. For TP8/EP8,
+The standard AMD path on 8x gfx950 uses the `mla` backend, which selects MLA
+kernels automatically. Use `gluon` to require Gluon MLA kernels for both the
+target and, when speculative decoding is enabled, its MLA drafter. For TP8/EP8,
 automatic MoE selection uses the specialized Gluon SiTU kernels:
 
 ```bash
@@ -321,6 +323,17 @@ tokenspeed serve moonshotai/Kimi-K3 \
   --host 0.0.0.0 \
   --port 8000
 ```
+
+To force Gluon attention for an Eagle3 launch, replace the attention option
+above and add the drafter option:
+
+```bash
+  --attention-backend gluon \
+  --drafter-attention-backend gluon
+```
+
+The explicit policy fails fast when the current GPU, dtype, or attention shape
+has no registered Gluon kernel instead of silently selecting another solution.
 
 On gfx950, the replicated 7168↔3584 latent projections automatically select
 among a one-token Triton GEMV, tuned Gluon GEMMs, and the vendor GEMM according

--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -137,7 +137,8 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         # target verify and ordinary decode are untouched.
         self.draft_block_decode = bool(config.draft_block_decode)
 
-        self.kernel_solution = None
+        backend_name = config.backend_name or "mla"
+        self.kernel_solution = {"mla": None, "gluon": "gluon"}[backend_name]
 
         self.forward_decode_metadata: MLADecodeMetadata | None = None
         self.forward_prefill_metadata: MLAPrefillMetadata | None = None
@@ -480,6 +481,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
             not self._cache_groups_bound
             or forward_mode is None
             or forward_mode.is_idle()
+            or (self.is_draft and getattr(self, "reads_staged_draft_page_table", False))
         ):
             return out_cache_loc
         if self._block_decode_active:
@@ -544,7 +546,13 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
                 f"mla CUDA graph capture not supported for {forward_mode}"
             )
 
-        uses_cache_groups = bool(cache_group_ids) or self._cache_contract_bound
+        # Contract-bound MLA drafts consume the staged, batch-ordered draft
+        # page table rather than the target's per-group tables.  Only an
+        # explicit group dispatch puts a draft on the grouped path; targets
+        # still use the contract marker established before graph allocation.
+        uses_cache_groups = bool(cache_group_ids) or (
+            self._cache_contract_bound and not self.is_draft
+        )
         if self._block_decode_active:
             if uses_cache_groups:
                 self._cache_groups_bound = True
@@ -981,4 +989,5 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         return result
 
 
-register_backend("mla", {AttentionArch.MLA}, MLAAttnBackend)
+for _backend_name in ("mla", "gluon"):
+    register_backend(_backend_name, {AttentionArch.MLA}, MLAAttnBackend)

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1574,6 +1574,7 @@ class ServerArgs:
             "fa3",
             "fa4",
             "triton",
+            "gluon",
             "flashinfer",
             "trtllm",
             "trtllm_mla",
@@ -1586,7 +1587,8 @@ class ServerArgs:
             type=str,
             choices=attention_backend_choices,
             default=ServerArgs.attention_backend,
-            help="Choose the kernels for attention layers.",
+            help="Choose the kernels for attention layers. 'gluon' forces "
+            "registered Gluon kernels for supported attention architectures.",
         )
         parser.add_argument(
             "--kda-backend",

--- a/test/runtime/test_mla_spec_write_locs.py
+++ b/test/runtime/test_mla_spec_write_locs.py
@@ -269,6 +269,19 @@ def test_count_mismatch_is_still_caught() -> None:
         )
 
 
+def test_staged_mla_draft_keeps_drafter_write_locations() -> None:
+    backend = _backend(spec_num_tokens=4, is_draft=True)
+    caller = torch.tensor([11, 12], dtype=torch.int64)
+    assert (
+        backend.select_out_cache_loc(
+            layer=None,
+            out_cache_loc=caller,
+            forward_mode=ForwardMode.DECODE,
+        )
+        is caller
+    )
+
+
 # --------------------------------------------------------------------------
 # Graph buffer sizing
 # --------------------------------------------------------------------------
@@ -326,6 +339,20 @@ def test_an_unmarked_draft_is_refused_on_the_group_graph_path() -> None:
             forward_mode=ForwardMode.DECODE,
             cache_group_ids=("full_attention",),
         )
+
+
+def test_contract_bound_draft_captures_staged_page_table_path() -> None:
+    """An Eagle MLA draft reads its staged table, not target group tables."""
+    backend = _backend(spec_num_tokens=4, is_draft=True)
+    backend.init_cuda_graph_state(max_bs=2)
+    backend.init_forward_metadata_capture_cuda_graph(
+        bs=2,
+        req_pool_indices=torch.tensor([0, 1]),
+        seq_lens=torch.tensor([100, 200], dtype=torch.int32),
+        forward_mode=ForwardMode.DECODE,
+    )
+    metadata = backend.decode_cuda_graph_metadata[2]
+    assert metadata.group_out_cache_loc is None
 
 
 def test_a_contract_bound_block_draft_is_admitted_on_the_group_graph_path() -> None:

--- a/test/runtime/test_server_args_attention_backends.py
+++ b/test/runtime/test_server_args_attention_backends.py
@@ -50,6 +50,12 @@ class TestAttentionBackendChoices(unittest.TestCase):
         )
         self.assertEqual(args.attention_backend, "mla")
 
+    def test_attention_backend_accepts_gluon(self):
+        args = self._build_parser().parse_args(
+            ["--model", "x", "--attention-backend", "gluon"]
+        )
+        self.assertEqual(args.attention_backend, "gluon")
+
     def test_attention_backend_accepts_mha_kernel_solutions(self):
         for backend in ("fa3", "fa4", "triton", "flashinfer"):
             args = self._build_parser().parse_args(
@@ -63,6 +69,12 @@ class TestAttentionBackendChoices(unittest.TestCase):
             ["--model", "x", "--drafter-attention-backend", "trtllm_mla"]
         )
         self.assertEqual(args.drafter_attention_backend, "trtllm_mla")
+
+    def test_drafter_attention_backend_accepts_gluon(self):
+        args = self._build_parser().parse_args(
+            ["--model", "x", "--drafter-attention-backend", "gluon"]
+        )
+        self.assertEqual(args.drafter_attention_backend, "gluon")
 
     def test_drafter_choices_match_main_choices(self):
         parser = self._build_parser()
@@ -118,6 +130,43 @@ class TestAttentionBackendChoices(unittest.TestCase):
             registry._get_backend_cls("mla", AttentionArch.MLA),
             MLAAttnBackend,
         )
+
+    def test_gluon_backend_registered_for_mla(self):
+        from tokenspeed.runtime.layers.attention.backends.mla import MLAAttnBackend
+
+        self.assertIs(
+            registry._get_backend_cls("gluon", AttentionArch.MLA),
+            MLAAttnBackend,
+        )
+
+    def test_gluon_mla_backend_forces_gluon_kernel_solution(self):
+        import torch
+
+        from tokenspeed.runtime.layers.attention.backends.mla import MLAAttnBackend
+
+        config = SimpleNamespace(
+            device="cpu",
+            backend_name="gluon",
+            num_attention_heads=128,
+            num_kv_heads=1,
+            head_dim=576,
+            attn_tp_size=8,
+            dtype=torch.bfloat16,
+            kv_cache_dtype=torch.float8_e4m3fn,
+            is_draft=True,
+            speculative_num_draft_tokens=4,
+            context_len=65536,
+            kernel_page_size=64,
+            kv_lora_rank=512,
+            qk_nope_head_dim=128,
+            qk_rope_head_dim=64,
+            v_head_dim=128,
+            kv_cache_dim=576,
+            scaling=192**-0.5,
+            draft_block_decode=False,
+        )
+
+        self.assertEqual(MLAAttnBackend(config).kernel_solution, "gluon")
 
     def test_defaults_to_mla_for_mla(self):
         self.assertEqual(registry._get_default_backend_name(AttentionArch.MLA), "mla")


### PR DESCRIPTION
## Summary

- expose `gluon` as an explicit MLA attention backend and forward that kernel policy through all MLA prefill, decode, and verify dispatches
- keep EAGLE3's MLA drafter on its staged draft page table and caller-owned write locations during eager execution and graph capture
- document the Kimi K3 AMD launch flags and add parser, registry, policy, write-location, and graph-capture regression tests

This lets Kimi K3 use Gluon MLA kernels consistently for both the target and EAGLE3 drafter with:

```bash
--attention-backend gluon \
--drafter-attention-backend gluon
```

The explicit backend remains fail-fast: unsupported Gluon shapes do not silently fall back to another kernel solution.

## Test Plan

- `pre-commit run --all-files`
- `python -m pytest -q test/runtime/test_server_args_attention_backends.py test/runtime/test_mla_spec_write_locs.py` (44 passed)
- `python -m pytest -q test/runtime/test_cudagraph_per_group.py test/runtime/test_group_write_locations.py test/runtime/test_kimi_k3_cudagraph.py test/runtime/layers/test_mla_verify_metadata.py` (72 passed)
- live AMD gfx950 TP8/EP8 smoke with `moonshotai/Kimi-K3`, `lightseekorg/kimi-k3-eagle3-mla`, EAGLE3 `topk=1`, `num_steps=3`, `num_draft_tokens=4`, and Gluon for target + drafter: model load, kernel tuning, graph capture, health check, and a 16-token OpenAI completion all succeeded
