### PR TITLE
fix(runtime): skip the CUPTI graph-capture warm-up on AMD

### DIFF
--- a/python/tokenspeed/runtime/engine/event_loop.py
+++ b/python/tokenspeed/runtime/engine/event_loop.py
@@ -93,6 +93,32 @@ from tokenspeed.runtime.utils.torch_memory_saver_adapter import TorchMemorySaver
 logger = get_colorful_logger(__name__)
 
 
+def maybe_warm_cupti_for_graph_capture() -> None:
+    """Preload CUPTI before any CUDA graph is captured. NVIDIA only.
+
+    A profiler that first attaches AFTER capture invalidates the captured
+    graphs -- every later replay dies with cudaErrorLaunchFailure -- which
+    would forbid runtime ``/start_profile`` on graph-mode servers. One empty
+    profiler session loads CUPTI ahead of every capture, making runtime
+    attach/detach safe.
+
+    Both the hazard and the remedy are CUDA-specific. CUPTI is CUDA's
+    profiling interface; ROCm routes torch profiling through roctracer, where
+    this empty warm-up session instead leaves activity collection permanently
+    dead for the life of the process: every subsequent ``/start_profile``
+    returns a trace with ``cpu_op`` entries but zero ``"cat": "kernel"``
+    events, on every rank, in eager and graph mode alike. So skip it on AMD.
+    """
+    from tokenspeed_kernel.platform import current_platform
+
+    if not torch.cuda.is_available() or current_platform().is_amd:
+        return
+
+    from torch.profiler._utils import _init_for_cuda_graphs
+
+    _init_for_cuda_graphs()
+
+
 class EventLoop:
     def __init__(
         self,
@@ -1156,17 +1182,7 @@ def run_event_loop(
                 lambda _signum, _frame: shutdown_event.set(),
             )
 
-        if torch.cuda.is_available():
-            # Warm up CUPTI before EventLoop init captures any CUDA graph
-            # (decode/prefill/encoder). A profiler that first attaches AFTER
-            # capture invalidates the captured graphs — every later replay
-            # dies with cudaErrorLaunchFailure — which would forbid runtime
-            # /start_profile on graph-mode servers. One empty profiler
-            # session loads CUPTI ahead of every capture, making runtime
-            # attach/detach safe.
-            from torch.profiler._utils import _init_for_cuda_graphs
-
-            _init_for_cuda_graphs()
+        maybe_warm_cupti_for_graph_capture()
 
         event_loop = EventLoop(
             server_args,

--- a/test/runtime/test_cupti_warmup_vendor_guard.py
+++ b/test/runtime/test_cupti_warmup_vendor_guard.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""The CUPTI graph-capture warm-up must not run on AMD.
+
+``_init_for_cuda_graphs()`` opens an empty profiler session so that CUPTI is
+loaded before any CUDA graph is captured. On ROCm there is no CUPTI: torch
+profiles through roctracer, and that empty session leaves activity collection
+permanently dead for the life of the process. Every later ``/start_profile``
+then returns a trace containing ``cpu_op`` entries and zero ``"cat": "kernel"``
+entries, on every rank, in eager and graph mode alike -- silently, since the
+request still reports success.
+
+Measured on 8x gfx950 serving Kimi-K3: 0 GPU events on all 8 ranks with the
+warm-up, 62k kernel events in the same decode trace without it.
+
+CPU-only: no CUDA context, no profiler session, just the vendor decision.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+# CI Registration (parsed via AST, runtime no-op)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+from tokenspeed.runtime.engine import event_loop  # noqa: E402
+
+register_cuda_ci(est_time=5, suite="runtime-1gpu")
+
+
+def _run(*, is_amd: bool, cuda_available: bool = True) -> bool:
+    """Return whether the CUPTI warm-up was invoked."""
+    called = False
+
+    def _fake_init():
+        nonlocal called
+        called = True
+
+    fake_utils = SimpleNamespace(_init_for_cuda_graphs=_fake_init)
+    with (
+        mock.patch.object(
+            event_loop.torch.cuda, "is_available", return_value=cuda_available
+        ),
+        mock.patch(
+            "tokenspeed_kernel.platform.current_platform",
+            return_value=SimpleNamespace(is_amd=is_amd),
+        ),
+        mock.patch.dict(sys.modules, {"torch.profiler._utils": fake_utils}),
+    ):
+        event_loop.maybe_warm_cupti_for_graph_capture()
+    return called
+
+
+def test_amd_skips_the_cupti_warmup():
+    """The regression: running this on ROCm kills roctracer capture."""
+    assert _run(is_amd=True) is False
+
+
+def test_nvidia_still_warms_cupti():
+    """The warm-up must be preserved where it is needed."""
+    assert _run(is_amd=False) is True
+
+
+def test_no_cuda_is_a_noop():
+    assert _run(is_amd=False, cuda_available=False) is False


### PR DESCRIPTION
## Problem

Worker startup opens an empty profiler session so CUPTI is loaded before any CUDA graph is captured:

```python
if torch.cuda.is_available():
    from torch.profiler._utils import _init_for_cuda_graphs
    _init_for_cuda_graphs()
```

The intent is sound — a profiler that first attaches *after* capture invalidates the captured graphs, which would forbid runtime `/start_profile` on graph-mode servers. But it runs on every vendor, and **there is no CUPTI on ROCm**. Torch profiles through roctracer there, and this empty session leaves activity collection permanently dead for the life of the process.

Every subsequent `/start_profile` then returns a trace containing `cpu_op` entries and **zero `"cat": "kernel"` entries** — on every rank, in eager and graph mode alike. The request still reports `"status": "success"`, so nothing surfaces the failure. GPU profiling is simply unavailable to AMD users, silently.

## Fix

Extract the warm-up into `maybe_warm_cupti_for_graph_capture()` and skip it on AMD. Both the hazard and the remedy are CUDA-specific.

## Evidence

8x gfx950 (MI355X, ROCm 7.2.2, torch 2.13.0+rocm7.2), Kimi-K3 MXFP4 at TP8/EP1.

A probe running a tiny `torch.profiler` session at four points across worker startup, on all 8 ranks:

| startup phase | before | after |
|---|---|---|
| distributed-init entry | 0 GPU events | **7** |
| before process groups | 0 | **6** |
| after process groups | 0 | **6** |
| after comm buffers | 0 | **6** |

End to end, the same decode trace:

| | before | after |
|---|---|---|
| `"cat": "kernel"` | **0** | **62,235** |
| `"cat": "cuda_runtime"` | 0 | 368,855 |
| `"cat": "cpu_op"` | 672 | 672 |

Bisected to the commit that introduced the call: profiling worked on its parent and not on it. The probe also isolates it cleanly — capture is alive at the top of `run_event_loop` and dead by distributed init, which is exactly where this call sits.

Ruled out along the way, in case it saves anyone else the search: torch/Proton import order, `HSA_TOOLS_ROCPROFILER_V1_TOOLS`, the smg version, `profile_by_stage`, explicit `activities`, `with_stack`, multi-process contention, and the ROCm userspace version (reproduced identically inside `tokenspeed-runner-amd:rocm7.2.4-pytorch-2.13.0-gfx950`).

## Test

`test/runtime/test_cupti_warmup_vendor_guard.py` covers all three branches (AMD skips, NVIDIA warms, no-CUDA is a no-op). CPU-only — no CUDA context and no real profiler session. Verified it fails on the unguarded version and passes on this one.

## Note

CI has no coverage here: nothing under `test/ci/` calls `/start_profile`, which is why this reached main unnoticed. Worth considering whether a profiling smoke check belongs in the AMD suite — happy to follow up separately if so.
