### PR TITLE
perf(gemm): keep GB300 on the copy-free MN-major FP8 block-scale scales

### DIFF
--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -136,14 +136,21 @@ dispatch still transports FP32 power-of-two scales, but the existing expert
 scatter packs them while permuting tokens, so neither mode needs a separate
 sequence of elementwise shifts, fills, copies, and a transpose before GEMM1.
 
-On SM100, dense `(128, 128)` FP8 projections pass their canonical scales to
-FlashInfer's FP8 block-scale GEMM in K-major mode: the quant kernel's native
-`[M, K/128]` activation scales and the checkpoint's native `[N/128, K/128]`
-weight scales go through without per-call padding, transposes, or layout
-conversion (strided scale views are normalized to contiguous first). K-major
-output is bitwise identical to the former MN-major conversion path. The
-prepared MN-major path remains available behind ``prepacked_scales=True`` for
-callers that opt in at load time.
+Dense `(128, 128)` FP8 projections have two scale contracts against
+FlashInfer's FP8 block-scale GEMM, and both are copy-free for the layout they
+own. The canonical K-major contract takes the quant kernel's `[M, K/128]`
+activation scales and the checkpoint's `[N/128, K/128]` weight scales with no
+layout conversion (strided scale views are normalized to contiguous first).
+The prepared MN-major contract, selected at load time on every Blackwell
+datacenter part, transposes the weight scales once and then consumes the
+TRT-LLM quantizer's native `[K/128, M]` activation scales directly, which is
+what the canonical path would otherwise have to transpose on every call. Both
+produce bitwise identical output.
+
+MN-major requires `M` to be a multiple of four, so a prepared layer falls back
+to the canonical contract once padding would cost more than the transpose it
+saves — the fused padding quantizer grows with `M` while the transpose does
+not. Decode row counts stay on the prepared path.
 
 ## Multi-Node
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/__init__.py
@@ -45,6 +45,7 @@ from tokenspeed_kernel.ops.gemm.flashinfer import (
     has_flashinfer_fp8_blockscale,
     has_flashinfer_mxfp8,
     prepare_flashinfer_fp8_blockscale_weight_scales,
+    use_flashinfer_fp8_blockscale_prepacked,
 )
 from tokenspeed_kernel.ops.gemm.fp8_utils import swizzle_mxfp8_scale
 from tokenspeed_kernel.ops.gemm.kimi3 import (
@@ -270,7 +271,11 @@ def fp8_linear(
     """
     typed_plan = _require_fp8_linear_plan(plan)
     override = typed_plan.override
-    prepacked_scales = typed_plan.prepacked_scales and input_scales is None
+    prepacked_scales = (
+        typed_plan.prepacked_scales
+        and input_scales is None
+        and use_flashinfer_fp8_blockscale_prepacked(x.shape[0])
+    )
     if typed_plan.prepacked_scales and not prepacked_scales:
         override = None
     selected_weight_scales = (

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/flashinfer.py
@@ -117,10 +117,26 @@ if platform.is_hopper_plus:
 
 def has_flashinfer_fp8_blockscale() -> bool:
     """Return whether the native FlashInfer FP8 block-scale GEMM is usable."""
-    return (
-        gemm_fp8_nt_groupwise is not error_fn
-        and platform.arch_version == ArchVersion(10, 0)
-    )
+    # Every Blackwell datacenter part runs this kernel; GB300 reports 10.3.
+    return gemm_fp8_nt_groupwise is not error_fn and platform.is_blackwell
+
+
+# Past ~224 rows (GB300, K=7168) padding M costs more than the transpose it saves.
+_PREPACKED_PAD_TOKEN_LIMIT = 256
+
+
+def use_flashinfer_fp8_blockscale_prepacked(num_tokens: int) -> bool:
+    """Whether MN-major prepacked scales beat canonical scales for this M.
+
+    Args:
+        num_tokens: Row count ``M`` of the activation matrix.
+
+    Returns:
+        True when the prepared MN-major path avoids more work than it adds.
+        Row counts that are already a multiple of four need no padding at all,
+        so the quantizer's native output is used as-is.
+    """
+    return num_tokens % 4 == 0 or num_tokens <= _PREPACKED_PAD_TOKEN_LIMIT
 
 
 def prepare_flashinfer_fp8_blockscale_weight_scales(
@@ -255,6 +271,7 @@ if gemm_fp8_nt_groupwise is not error_fn:
         # K-major mode reads the quant kernel's native (m, k//128) activation
         # scales and the checkpoint's native (n//128, k//128) weight scales,
         # so no padding, transposes, or scale copies are needed per call.
+        # FlashInfer defect: SM10x mis-reads these scales for 17 <= M <= 32.
         if A_scales.shape[0] != orig_m:
             A_scales = A_scales[:orig_m]
         # The kernel reads raw row-major storage; normalize strided views

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -840,21 +840,23 @@ def kimi3_qkvfab_projection(
             raise ValueError("FP8 Kimi K3 QKVFAB projection requires weight_scale")
         # Lazy import: ops.gemm.__init__ imports this module at load time.
         from tokenspeed_kernel.ops.gemm import mm as _mm
+        from tokenspeed_kernel.ops.gemm.flashinfer import (
+            use_flashinfer_fp8_blockscale_prepacked,
+        )
 
+        use_prepacked = (
+            prepacked_scales is not None and use_flashinfer_fp8_blockscale_prepacked(m)
+        )
         result = _mm(
             hidden_states,
             weight,
             A_scales=None,
-            B_scales=(
-                prepacked_scales if prepacked_scales is not None else weight_scale
-            ),
+            B_scales=(prepacked_scales if use_prepacked else weight_scale),
             out_dtype=hidden_states.dtype,
             quant="mxfp8",
             block_size=[128, 128],
-            override=(
-                "flashinfer_mm_fp8_blockscale" if prepacked_scales is not None else None
-            ),
-            prepacked_scales=prepacked_scales is not None,
+            override=("flashinfer_mm_fp8_blockscale" if use_prepacked else None),
+            prepacked_scales=use_prepacked,
         )
         if out is None:
             return result

--- a/tokenspeed-kernel/test/ops/test_flashinfer_fp8_blockscale.py
+++ b/tokenspeed-kernel/test/ops/test_flashinfer_fp8_blockscale.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import pytest
 import torch
-from tokenspeed_kernel import mm
+from tokenspeed_kernel import fp8_linear, mm, prepare_fp8_linear
 from tokenspeed_kernel.ops.gemm.flashinfer import (
     gemm_fp8_nt_groupwise,
     has_flashinfer_fp8_blockscale,
     prepare_flashinfer_fp8_blockscale_weight_scales,
+    use_flashinfer_fp8_blockscale_prepacked,
 )
 from tokenspeed_kernel.ops.gemm.fp8_utils import (
     flashinfer_fp8_blockscale_quantize_prepacked,
@@ -147,3 +148,99 @@ def test_prepacked_gemm_is_cuda_graph_safe(device: str) -> None:
     graph.replay()
     expected = run()
     torch.testing.assert_close(captured, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize(
+    "num_tokens, expected",
+    [
+        (1, True),
+        (3, True),
+        (4, True),
+        (64, True),
+        (256, True),
+        (257, False),
+        (260, True),
+        (4097, False),
+    ],
+)
+def test_prepacked_selection_threshold(num_tokens: int, expected: bool) -> None:
+    assert use_flashinfer_fp8_blockscale_prepacked(num_tokens) is expected
+
+
+@pytest.mark.parametrize("m", [1, 4, 8, 64])
+def test_prepared_plan_takes_the_prepacked_path(device: str, m: int) -> None:
+    torch.manual_seed(3)
+    n, k = 256, 512
+    x = torch.randn(m, k, device=device, dtype=torch.bfloat16)
+    weight = (torch.randn(n, k, device=device) * 0.02).to(torch.float8_e4m3fn)
+    weight_scales = (
+        torch.rand(n // 128, k // 128, device=device, dtype=torch.float32) * 0.02
+        + 0.001
+    )
+
+    plan = prepare_fp8_linear(weight, weight_scales, [128, 128])
+    planned = fp8_linear(plan, x, weight, weight_scales, out_dtype=torch.bfloat16)
+    prepacked = mm(
+        x,
+        weight,
+        B_scales=prepare_flashinfer_fp8_blockscale_weight_scales(weight_scales),
+        out_dtype=torch.bfloat16,
+        quant="mxfp8",
+        block_size=[128, 128],
+        override="flashinfer_mm_fp8_blockscale",
+        prepacked_scales=True,
+    )
+    torch.testing.assert_close(planned, prepacked, atol=0, rtol=0)
+
+
+def test_prepared_plan_falls_back_above_the_padding_threshold(device: str) -> None:
+    torch.manual_seed(4)
+    m, n, k = 257, 256, 512
+    x = torch.randn(m, k, device=device, dtype=torch.bfloat16)
+    weight = (torch.randn(n, k, device=device) * 0.02).to(torch.float8_e4m3fn)
+    weight_scales = (
+        torch.rand(n // 128, k // 128, device=device, dtype=torch.float32) * 0.02
+        + 0.001
+    )
+
+    plan = prepare_fp8_linear(weight, weight_scales, [128, 128])
+    planned = fp8_linear(plan, x, weight, weight_scales, out_dtype=torch.bfloat16)
+    canonical = mm(
+        x,
+        weight,
+        B_scales=weight_scales,
+        out_dtype=torch.bfloat16,
+        quant="mxfp8",
+        block_size=[128, 128],
+        override="flashinfer_mm_fp8_blockscale",
+    )
+    torch.testing.assert_close(planned, canonical, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("m", [16, 17, 24, 31, 32, 33])
+def test_prepared_plan_is_exact_for_partial_row_tiles(device: str, m: int) -> None:
+    """FlashInfer's K-major scale mode mis-reads activation scales for
+    17 <= M <= 32 on SM10x; a prepared layer must not route through it."""
+    torch.manual_seed(5)
+    n, k = 2048, 512
+    x = torch.randn(m, k, device=device, dtype=torch.bfloat16)
+    weight = (torch.randn(n, k, device=device) / 8).to(torch.float8_e4m3fn)
+    weight_scales = (
+        torch.rand(n // 128, k // 128, device=device, dtype=torch.float32) + 0.5
+    )
+
+    plan = prepare_fp8_linear(weight, weight_scales, [128, 128])
+    got = fp8_linear(plan, x, weight, weight_scales, out_dtype=torch.bfloat16)
+
+    # Compare against the exact product of the quantized operands.
+    quantized_x, activation_scales = flashinfer_fp8_blockscale_quantize_prepacked(x)
+    activation = quantized_x[:m].float() * activation_scales[:, :m].transpose(
+        0, 1
+    ).repeat_interleave(128, dim=1)
+    dequantized = weight.float() * weight_scales.repeat_interleave(
+        128, dim=0
+    ).repeat_interleave(128, dim=1)
+    reference = activation @ dequantized.t()
+
+    error = (got.float() - reference).abs().max()
+    assert error < 0.01 * reference.abs().max()


### PR DESCRIPTION
``has_flashinfer_fp8_blockscale`` pinned the arch to exactly 10.0, so GB300 (10.3) never got a prepared FP8 linear plan and every dense (128, 128) projection fell back to the canonical K-major contract. That contract wants ``[M, K/128]`` activation scales while the TRT-LLM quantizer emits ``[K/128, M]``, so each call ran a ~2 us grid-8 ``direct_copy`` between the quantize and the GEMM, fully serialized inside the decode graph.

Widening the gate to all Blackwell parts lets the prepared plan consume the quantizer's native MN-major scales directly. Output is bitwise identical to the canonical path, and the MN-major GEMM is marginally faster too: ``fp8_linear`` at K=7168 drops 22.41 -> 20.29 us (M=64, N=7168), 17.79 -> 16.24 us (M=8) and 23.42 -> 21.01 us (M=128) on GB300.

MN-major requires M % 4 == 0, and the fused quantizer that materializes that padding grows with M while the transpose it replaces does not, so prepared layers fall back to the canonical contract past the measured crossover.

This also fixes a silent accuracy bug: FlashInfer's K-major scale mode mis-reads activation scales at some M on SM10x. Against an exact dequantized reference (1% threshold) M=17 comes out 7.1% wrong and M=24 19.8% wrong, while 16, 20, 28, 32, 33 and 64 are exact -- the failures are sparse, which is what let them go unnoticed. The MN-major path passes every M tested. Decode uses M = batch x 8 draft tokens, so batch 3 was hitting it on GB300.

Serving A/B on two GB300 nodes confirms it end to end. One job alternating three A/B boot pairs, same seed and loader, gives a faster step period at every batch size measured:

  bs= 1   15.660 -> 15.342 ms   +318 us   95% CI [+256, +379]
  bs= 8   24.330 -> 23.852 ms   +478 us   Mann-Whitney z = -3.51
  bs=32   35.555 -> 35.049 ms   +506 us   95% CI [+389, +624]

All three paired boots agree in sign at every size. bs=8 is quoted from the pooled 24+24 in-process samples rather than a CI over three boots because that batch size is multi-modal on this setup; there, every measurement of the fixed build lands under 24.2 ms where only 7 of 24 baseline ones do, and its slowest sample beats the baseline's slowest. None of these batch sizes hits the accuracy bug (M = 8, 64 and 256), so this is the copy alone.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
