### PR TITLE
fix(moe): let the Kimi-K3 sigmoid top-k router use PDL

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/sigmoid_topk.py
@@ -8,7 +8,7 @@ import torch
 from tokenspeed_kernel.ops.moe.triton.kimi3_sigmoid_topk import (
     kimi3_sigmoid_bias_topk,
 )
-from tokenspeed_kernel.platform import CapabilityRequirement, Platform
+from tokenspeed_kernel.platform import CapabilityRequirement, Platform, pdl_enabled
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import (
@@ -120,6 +120,7 @@ def moe_sigmoid_bias_topk(
         topk_weights, topk_ids = kimi3_sigmoid_bias_topk(
             router_logits,
             correction_bias,
+            enable_pdl=pdl_enabled(),
             routed_scaling_factor=routed_scaling_factor,
             normalize_topk_weights=normalize_topk_weights,
             logical_to_physical_map=(


### PR DESCRIPTION
The packed router kernel takes enable_pdl and implements the launch attribute, but moe_sigmoid_bias_topk never passed it, so the flag was unreachable from serving. Its siblings softmax_topk and inkling_topk both resolve pdl_enabled() at the call site; this one was missed when #1238 wired the runtime pdl flag through the kernels.

Isolated at the K3 decode shape (896 experts, top-16, M = 64 rows, CUDA graph timing, 200 calls per replay, median of 15) the kernel goes 3.67 -> 3.27 us, and -0.29 us as the marginal cost in a router GEMV -> top-k chain. Selected ids and weights are bit-identical over 30 draws. No end-to-end change was measured: the router overlaps other work, and at bs = 8 a serving A/B cannot resolve an effect this small (that batch carries ~1.4 ms of bimodal measurement noise).


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
