### PR TITLE
perf(dspark): project the whole proposal block in one GEMM

### DIFF
--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -374,8 +374,14 @@ class DFlash(BaseDrafter):
         hidden_states: torch.Tensor,
         out: torch.Tensor | None = None,
         bias_fn: "Callable[[int, int], torch.Tensor] | None" = None,
+        base_logits: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Shared vocab-parallel greedy argmax primitive."""
+        """Shared vocab-parallel greedy argmax primitive.
+
+        ``base_logits`` lets a caller that walks several positions supply the
+        org-vocab projection it already computed for all of them at once; only
+        the bias and the argmax have to follow the previous token.
+        """
         if not hasattr(self.lm_head, "weight") or not hasattr(
             self.lm_head, "shard_indices"
         ):
@@ -406,7 +412,8 @@ class DFlash(BaseDrafter):
         # with an empty org shard skipping it would strand the rest.
         dist_state = self._ensure_dist_argmax_state(weight.dtype, weight.device)
         if num_org > 0:
-            base_logits = torch.matmul(hidden_states, weight[:num_org].T)
+            if base_logits is None:
+                base_logits = torch.matmul(hidden_states, weight[:num_org].T)
             if bias_fn is not None:
                 base_logits = base_logits + bias_fn(org_vocab_start, num_org).to(
                     base_logits.dtype

--- a/python/tokenspeed/runtime/execution/drafter/dspark.py
+++ b/python/tokenspeed/runtime/execution/drafter/dspark.py
@@ -55,6 +55,8 @@ class DSpark(DFlash):
     ) -> torch.Tensor:
         """Semi-autoregressive greedy proposal over the block positions."""
         next_tokens[:, 0] = block_ids[:, 0]
+        # Only the bias follows the previous token; the projection does not.
+        block_logits = self._block_base_logits(draft_hidden)
         for k in range(1, self.spec_num_tokens):
             # The Markov head embeds the previous token, so it must be in range
             # before this step, not after the loop: the anchor comes from the
@@ -62,13 +64,46 @@ class DSpark(DFlash):
             # from a vocab-parallel argmax that can lose every shard. An
             # out-of-range id here indexes past the embedding table.
             bias_fn = self._make_step_bias_fn(next_tokens[:, k - 1])
-            self._greedy_argmax_vocab_parallel(
-                draft_hidden[:, k - 1, :],
-                out=next_tokens[:, k],
-                bias_fn=bias_fn,
-            )
+            if block_logits is None:
+                self._greedy_argmax_vocab_parallel(
+                    draft_hidden[:, k - 1, :],
+                    out=next_tokens[:, k],
+                    bias_fn=bias_fn,
+                )
+            else:
+                self._greedy_argmax_vocab_parallel(
+                    draft_hidden[:, k - 1, :],
+                    out=next_tokens[:, k],
+                    bias_fn=bias_fn,
+                    base_logits=block_logits[k - 1],
+                )
         next_tokens.clamp_(min=0)
         return next_tokens
+
+    def _block_base_logits(self, draft_hidden: torch.Tensor):
+        """Project every block position's hidden state in one GEMM.
+
+        Returns ``[positions, rows, org_vocab_shard]``, or None when the head
+        has no shard metadata and the caller must take its own path.
+        """
+        head = getattr(self, "lm_head", None)
+        if head is None:
+            return None
+        if not hasattr(head, "weight") or not hasattr(head, "shard_indices"):
+            return None
+        num_org = int(head.shard_indices.num_org_elements)
+        if num_org <= 0:
+            return None
+        positions = int(draft_hidden.shape[1])
+        rows = int(draft_hidden.shape[0])
+        weight = head.weight
+        flat = draft_hidden.reshape(rows * positions, -1).to(weight.dtype)
+        logits = torch.matmul(flat, weight[:num_org].T)
+        # draft_hidden is [rows, positions, H]; the walk indexes by position.
+        # The walk slices one position at a time; transpose alone would hand
+        # each slice a positions-strided row layout, which the distributed
+        # argmax's compact-row kernel must not see.
+        return logits.view(rows, positions, num_org).transpose(0, 1).contiguous()
 
     def _make_step_bias_fn(self, prev_tokens: torch.Tensor):
         """Build the per-position additive-bias hook for the Markov head.

--- a/test/runtime/test_dspark_proposal.py
+++ b/test/runtime/test_dspark_proposal.py
@@ -396,3 +396,80 @@ def test_kda_commit_is_skipped_outside_decode() -> None:
         attn_backend=_BackendWithCommit(),
         forward_mode=ForwardMode.EXTEND,
     )
+
+
+class _ShardIndices:
+    def __init__(self, num_org: int) -> None:
+        self.num_org_elements = num_org
+
+
+class _ShardedHead:
+    """Enough of a vocab-parallel head for the block projection to run."""
+
+    def __init__(self, weight: torch.Tensor) -> None:
+        self.weight = weight
+        self.shard_indices = _ShardIndices(weight.shape[0])
+
+
+def test_the_walk_feeds_each_round_its_own_positions_hoisted_slice() -> None:
+    """The whole proposal walk must hand round k the hoisted projection of
+    position k-1, bit-for-bit what projecting that position alone gives."""
+    torch.manual_seed(11)
+    drafter = _drafter()
+    weight = torch.randn(VOCAB, HIDDEN)
+    drafter.lm_head = _ShardedHead(weight)
+    received: list[torch.Tensor] = []
+
+    def fake_argmax(hidden, out=None, bias_fn=None, base_logits=None):
+        assert base_logits is not None, "the walk must use the hoisted slice"
+        assert base_logits.is_contiguous()
+        received.append(base_logits.clone())
+        logits = base_logits.float()
+        if bias_fn is not None:
+            logits = logits + bias_fn(0, logits.shape[-1]).float()
+        argmax = torch.argmax(logits, dim=-1)
+        if out is not None:
+            out.copy_(argmax.view_as(out))
+            return out
+        return argmax
+
+    drafter._greedy_argmax_vocab_parallel = fake_argmax
+    hidden = torch.randn(3, drafter.spec_num_tokens, HIDDEN)
+    ids = torch.zeros(3, drafter.spec_num_tokens, dtype=torch.long)
+    block = torch.randint(0, VOCAB, (3, drafter.spec_num_tokens))
+    drafter._sample_block(hidden, block, ids)
+
+    assert len(received) == drafter.spec_num_tokens - 1
+    for k, got in enumerate(received, start=1):
+        want = hidden[:, k - 1, :].to(weight.dtype) @ weight.T
+        assert torch.equal(got, want)
+
+
+def test_the_block_projection_matches_projecting_each_position() -> None:
+    """The walk is semi-autoregressive, so the projection is hoisted out of it
+    while the bias and the argmax stay behind. A layout slip here would feed
+    each position another position's logits and go unnoticed: every proposal
+    would still be a valid token id."""
+    rows, positions = 3, 8
+    drafter = _drafter(spec_num_tokens=positions)
+    torch.manual_seed(1)
+    weight = torch.randn(VOCAB, HIDDEN)
+    drafter.lm_head = _ShardedHead(weight)
+    draft_hidden = torch.randn(rows, positions, HIDDEN)
+
+    block = drafter._block_base_logits(draft_hidden)
+
+    assert block is not None
+    assert block.shape == (positions, rows, VOCAB)
+    for k in range(positions):
+        expected = torch.matmul(draft_hidden[:, k, :], weight.T)
+        assert torch.allclose(block[k], expected, atol=1e-5), f"position {k}"
+
+
+def test_the_block_projection_stands_down_without_a_sharded_head() -> None:
+    """Drafters whose head carries no shard metadata keep the per-step path."""
+    drafter = _drafter(spec_num_tokens=4)
+    assert drafter._block_base_logits(torch.randn(2, 4, HIDDEN)) is None
+
+    drafter.lm_head = _ShardedHead(torch.randn(0, HIDDEN))
+    assert drafter._block_base_logits(torch.randn(2, 4, HIDDEN)) is None

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -1168,6 +1168,10 @@ def distributed_argmax(
     cross-rank exchange is collective and slot bands are reused across
     calls. Do not share one ``DistArgmaxState`` across concurrent streams.
     """
+    assert logits.is_contiguous(), (
+        "distributed_argmax wraps its input as compact rows; a strided view "
+        "would be read with the wrong row pitch"
+    )
     M, N = _dist_argmax_validate_inputs(state, logits, out_max, out_idx)
     device = logits.device
 


### PR DESCRIPTION
The proposal walk is semi-autoregressive: only the Markov bias follows the previous token, the projection through the vocab-parallel head does not. So project every block position's hidden state in a single GEMM before the walk and hand each round its position's slice, instead of launching one skinny GEMM per round. The rounds still add their bias and take the distributed argmax as before; a head without shard metadata keeps the legacy path.

The hoisted block is transposed to position-major and compacted once: a per-position slice of the bare transpose would carry a positions-strided row layout, and distributed_argmax wraps its input as compact rows -- it now asserts that instead of reading with the wrong pitch. The compaction holds a second copy of the block logits (a few MB at max batch) for the graph's lifetime, which is the deliberate trade for seven fewer GEMM launches.

Measured on GB200, four-node TP16, same main and prebuilt kernels on both arms: decode goes 477.1/472.1/459.9/450.1 to 484.1/478.6/466.6/452.8 tok/s (+1.2%, every sample moving together) with accepted tokens per round bitwise unchanged at 6.7237/6.0007. The gain is orthogonal to the distributed argmax already on main: that removed the per-round collectives, this removes the per-round projections.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
