### PR TITLE
refactor(config): composite AttnConfig — model-wide container + per-mechanism component specs

### DIFF
--- a/python/tokenspeed/runtime/configs/inkling_config.py
+++ b/python/tokenspeed/runtime/configs/inkling_config.py
@@ -22,9 +22,10 @@
 
 Adapted from the Inkling reference implementation. The runtime-facing surface is
 intentionally *scheduler-blind*: the C++ scheduler must see Inkling as a plain
-dense GQA model, so this config MUST NOT define ``mamba2_cache_params`` (or
-any other attribute the engine probes to enable mamba scheduling). The sconv
-rolling state is managed entirely engine-side, keyed on request pool indices
+dense GQA model, so this config MUST NOT expose a non-empty
+``linear_layer_ids`` (the probe that registers a linear-attention component
+and with it mamba scheduling). The sconv rolling state is managed entirely
+engine-side, keyed on request pool indices
 (see ``tokenspeed.runtime.layers.attention.backends.inkling``).
 
 KV-head note: the checkpoint uses 8 KV heads on full-attention layers and 16

--- a/python/tokenspeed/runtime/configs/kimi_k3_config.py
+++ b/python/tokenspeed/runtime/configs/kimi_k3_config.py
@@ -314,7 +314,9 @@ class KimiLinearConfig(PretrainedConfig):
         from tokenspeed.runtime.utils.env import global_server_args_dict
 
         mapping = global_server_args_dict["mapping"]
-        attn_tp_size = mapping.attn.tp_size
+        # KDA state shards by the linear-attention mapping (defaults to
+        # attention TP).
+        attn_tp_size = mapping.linear_attn.tp_size
 
         la = self.linear_attn_config
         num_heads = la["num_heads"]

--- a/python/tokenspeed/runtime/configs/kimi_k3_config.py
+++ b/python/tokenspeed/runtime/configs/kimi_k3_config.py
@@ -32,12 +32,8 @@ All default values below are taken verbatim from the reference checkpoint
 ``a527b42cb673d79569f3ffe0b3a0a655df98a739``).
 """
 
-import math
-
-import torch
 from transformers.configuration_utils import PretrainedConfig
 
-from tokenspeed.runtime.distributed.utils import divide
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     FULL_ATTENTION,
     LINEAR_ATTENTION,
@@ -133,7 +129,7 @@ class KimiLinearConfig(PretrainedConfig):
       KV-cache allocator.
 
     The ``layers_block_type`` / ``layer_types`` / ``linear_layer_ids`` /
-    ``full_attention_layer_ids`` / ``mamba2_cache_params`` / ``mamba_cache_per_req``
+    ``full_attention_layer_ids``
     properties are the **interface consumed by the KV-cache / hybrid-attention
     layer** (owned by the KV-cache team). Their shapes are derived from the KDA
     config here; the final state layout/dtype is validated on the cache side.
@@ -297,62 +293,6 @@ class KimiLinearConfig(PretrainedConfig):
         return [
             i for i, t in enumerate(self.layers_block_type) if t == _ATTENTION_LAYER
         ]
-
-    @property
-    def mamba2_cache_params(self):
-        """KDA per-request state spec consumed by the hybrid KV-cache allocator.
-
-        Returns ``(conv_state_shape, temporal_state_shape, conv_dtype,
-        ssm_dtype, mamba_layer_ids)``. KDA runs three short causal convolutions
-        (q/k/v), each ``num_heads * head_dim`` wide, and keeps a per-head
-        ``head_dim x head_dim`` recurrent (delta-rule) state in fp32.
-
-        NOTE: this is the interface for the KV-cache team; the concrete state
-        layout is validated on the cache side.
-        """
-        # Imported lazily to avoid config/env import cycles at module load.
-        from tokenspeed.runtime.utils.env import global_server_args_dict
-
-        mapping = global_server_args_dict["mapping"]
-        # KDA state shards by the linear-attention mapping (defaults to
-        # attention TP).
-        attn_tp_size = mapping.linear_attn.tp_size
-
-        la = self.linear_attn_config
-        num_heads = la["num_heads"]
-        head_dim = la["head_dim"]
-        conv_kernel_size = la["short_conv_kernel_size"]
-
-        conv_dim = 3 * num_heads * head_dim
-        conv_state_shape = (
-            divide(conv_dim, attn_tp_size),
-            conv_kernel_size - 1,
-        )
-        temporal_state_shape = (
-            divide(num_heads, attn_tp_size),
-            head_dim,
-            head_dim,
-        )
-        conv_dtype = torch.bfloat16
-        # KDA recurrent (delta-rule) state is fp32.
-        ssm_dtype = torch.float32
-        return (
-            conv_state_shape,
-            temporal_state_shape,
-            conv_dtype,
-            ssm_dtype,
-            self.linear_layer_ids,
-        )
-
-    @property
-    def mamba_cache_per_req(self) -> int:
-        conv_state_shape, temporal_state_shape, conv_dtype, ssm_dtype, mamba_layers = (
-            self.mamba2_cache_params
-        )
-        return (
-            math.prod(conv_state_shape) * conv_dtype.itemsize
-            + math.prod(temporal_state_shape) * ssm_dtype.itemsize
-        ) * len(mamba_layers)
 
 
 def _default_linear_attn_config() -> dict:

--- a/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
+++ b/python/tokenspeed/runtime/configs/qwen3_5_text_base_config.py
@@ -27,17 +27,13 @@
 
 import enum
 
-import numpy as np
-import torch
 from transformers.configuration_utils import PretrainedConfig
 from transformers.modeling_rope_utils import rope_config_validation
 from transformers.utils import logging
 
-from tokenspeed.runtime.distributed.utils import divide
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     FULL_ATTENTION,
 )
-from tokenspeed.runtime.utils.env import envs
 
 logger = logging.get_logger(__name__)
 
@@ -310,57 +306,3 @@ class Qwen3_5BaseTextConfig(PretrainedConfig):
             for i, type_value in enumerate(self.layers_block_type)
             if type_value == HybridLayerType.full_attention.value
         ]
-
-    @property
-    def mamba2_cache_params(self):
-        """Return per-layer cache shapes using the kernels' native layouts.
-
-        The temporal/SSM state shape is K-last ``[Hv, V, K]``, matching the
-        GDN decode, MTP, and chunk-prefill kernel boundary directly.
-        """
-        # Imported lazily to avoid config/env import cycles during module initialization.
-        from tokenspeed.runtime.utils.env import global_server_args_dict
-
-        self.mapping = global_server_args_dict["mapping"]
-        attn_tp_size = self.mapping.attn.tp_size
-
-        conv_dim = (
-            self.linear_key_head_dim * self.linear_num_key_heads * 2
-            + self.linear_value_head_dim * self.linear_num_value_heads
-        )
-        conv_state_shape = (
-            divide(conv_dim, attn_tp_size),
-            self.linear_conv_kernel_dim - 1,
-        )
-
-        temporal_state_shape = (
-            divide(self.linear_num_value_heads, attn_tp_size),
-            self.linear_value_head_dim,
-            self.linear_key_head_dim,
-        )
-        conv_dtype = torch.bfloat16
-        dtype_map = {
-            "float32": torch.float32,
-            "bfloat16": torch.bfloat16,
-        }
-        ssm_dtype = dtype_map[envs.TOKENSPEED_MAMBA_SSM_DTYPE.get()]
-        mamba_layers = self.linear_layer_ids
-        return (
-            conv_state_shape,
-            temporal_state_shape,
-            conv_dtype,
-            ssm_dtype,
-            mamba_layers,
-        )
-
-    @property
-    def mamba_cache_per_req(self):
-        conv_state_shape, temporal_state_shape, conv_dtype, ssm_dtype, mamba_layers = (
-            self.mamba2_cache_params
-        )
-        mamba_layers_len = len(mamba_layers)
-
-        return (
-            int(np.prod(conv_state_shape)) * conv_dtype.itemsize
-            + int(np.prod(temporal_state_shape)) * ssm_dtype.itemsize
-        ) * mamba_layers_len

--- a/python/tokenspeed/runtime/distributed/mapping.py
+++ b/python/tokenspeed/runtime/distributed/mapping.py
@@ -312,6 +312,52 @@ class VisionTowerMapping(MappingBase):
         return _make_parallelism_group(self.rank, self.dp_size, stride=self.tp_size)
 
 
+class LinearAttnLayerMapping(MappingBase):
+    """Parallel mapping for linear-attention layers (KDA, GDN).
+
+    Linear-attention layers default to the attention TP width, which
+    preserves the historical behavior on every existing deployment. Unlike
+    MLA — whose per-token latent KV cannot shard by heads and therefore
+    needs attention-DP — linear attention is TP-friendly: weights and the
+    per-head recurrent state both shard by head. A wider ``tp_size`` (up to
+    the stage world) head-shards them across ranks that are data-parallel
+    for the full-attention layers (the MLA-DP + linear-attn-TP hybrid).
+    The TP group is contiguous (stride 1) inside a pipeline stage.
+    """
+
+    def __init__(
+        self,
+        rank: int | None = None,
+        world_size: int = 1,
+        tp_size: int | None = None,
+    ):
+        super().__init__(rank, world_size)
+        # dp is the implicit complement: the number of KDA-TP replicas.
+        self.tp_size, self.dp_size = _resolve_parallelism_sizes(
+            self.world_size, tp_size, None
+        )
+
+    @cached_property
+    def has_tp(self) -> bool:
+        return self.tp_size > 1
+
+    @cached_property
+    def tp_rank(self) -> int:
+        return _make_parallelism_rank(self.rank, self.tp_size, stride=1)
+
+    @cached_property
+    def tp_group(self) -> Group:
+        return _make_parallelism_group(self.rank, self.tp_size, stride=1)
+
+    @cached_property
+    def dp_rank(self) -> int:
+        return _make_parallelism_rank(self.rank, self.dp_size, stride=self.tp_size)
+
+    @cached_property
+    def dp_group(self) -> Group:
+        return _make_parallelism_group(self.rank, self.dp_size, stride=self.tp_size)
+
+
 class Mapping(MappingBase):
 
     def __init__(
@@ -329,6 +375,7 @@ class Mapping(MappingBase):
         moe_dp_size: int | None = None,
         vision_tp_size: int | None = None,
         vision_dp_size: int | None = None,
+        linear_attn_tp_size: int | None = None,
         pp_size: int = 1,
         pp_layer_partition: tuple[int, ...] | None = None,
         nprocs_per_node: int | None = None,
@@ -384,6 +431,18 @@ class Mapping(MappingBase):
             tp_size=vision_tp_size,
             dp_size=vision_dp_size,
         )
+        # Linear-attention layers follow the attention TP width unless
+        # overridden — the default is behavior-identical to reading
+        # mapping.attn.tp_size.
+        self.linear_attn = LinearAttnLayerMapping(
+            rank=rank,
+            world_size=stage_world_size,
+            tp_size=(
+                linear_attn_tp_size
+                if linear_attn_tp_size is not None
+                else self.attn.tp_size
+            ),
+        )
         self.nprocs_per_node, self.nnodes = _resolve_parallelism_sizes(
             self.world_size, nprocs_per_node, nnodes
         )
@@ -397,6 +456,7 @@ class Mapping(MappingBase):
         self.dense.rank = rank
         self.moe.rank = rank
         self.vision.rank = rank
+        self.linear_attn.rank = rank
 
     @cached_property
     def has_pp(self) -> bool:

--- a/python/tokenspeed/runtime/execution/distributed_initializer.py
+++ b/python/tokenspeed/runtime/execution/distributed_initializer.py
@@ -167,6 +167,9 @@ class DistributedInitializer:
         pg_manager.init_process_group(config.mapping.world_group)
         pg_manager.init_process_group(config.mapping.attn.tp_group)
         pg_manager.init_process_group(config.mapping.attn.dp_group)
+        # No-op at the default linear_attn.tp == attn.tp (same group,
+        # idempotent).
+        pg_manager.init_process_group(config.mapping.linear_attn.tp_group)
         pg_manager.init_process_group(config.mapping.dense.tp_group)
         pg_manager.init_process_group(config.mapping.moe.tp_ep_group)
         if config.mapping.has_pp:

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -31,7 +31,10 @@ from tokenspeed.runtime.execution.breakable_cuda_graph import break_point
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-    from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+    from tokenspeed.runtime.layers.attention.configs.base import (
+        AttnConfig,
+        SoftmaxAttnConfig,
+    )
     from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
     from tokenspeed.runtime.pd.utils import StepCounter
@@ -99,12 +102,14 @@ class AttentionBackend(ABC):
     # Backend-owned cuda-graph cache-seqlens buffer the decode metadata views.
     draft_seq_lens_attr: str = "cuda_graph_seq_lens"
 
-    def __init__(self, config: BaseAttnConfig) -> None:
+    def __init__(self, config: AttnConfig, spec: SoftmaxAttnConfig) -> None:
+        # ``spec`` is the component this backend serves; hybrid sub-backends
+        # built over the softmax component's plumbing receive that spec.
         self.device = config.device
-        self.num_qo_heads = config.num_attention_heads // config.attn_tp_size
-        self.num_kv_heads = max(config.num_kv_heads // config.attn_tp_size, 1)
+        self.num_qo_heads = spec.num_attention_heads // spec.attn_tp_size
+        self.num_kv_heads = max(spec.num_kv_heads // spec.attn_tp_size, 1)
         self.dtype = config.dtype
-        self.head_dim = config.head_dim
+        self.head_dim = spec.head_dim
         self.is_draft = config.is_draft
         self.spec_num_tokens = config.speculative_num_draft_tokens
         self.cache_pool: CachePool | None = None

--- a/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/deepseek_v4.py
@@ -33,6 +33,8 @@ from tokenspeed_kernel import (
 from tokenspeed.runtime.configs.model_config import AttentionArch
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
+from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.deepseek_v4.metadata import (
     DeepseekV4ForwardMetadata,
 )
@@ -230,8 +232,8 @@ class DeepseekV4AttentionBackend(AttentionBackend):
     cache_consumer_families = frozenset({"history", "state"})
     uses_padded_decode_token_mask = True
 
-    def __init__(self, config) -> None:
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MLAConfig) -> None:
+        super().__init__(config, spec)
         self.kernel_page_size = (
             config.kernel_page_size
             if config.kernel_page_size is not None
@@ -250,7 +252,9 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 f"({self.kernel_page_size}), got {config.prefix_granularity}"
             )
         self.swa_storage_rows = int(
-            getattr(config, "sliding_window_tokens", V4_KERNEL_BLOCK_ROWS * 2)
+            spec.sliding_window_tokens
+            if spec.sliding_window_tokens is not None
+            else V4_KERNEL_BLOCK_ROWS * 2
         )
         self.context_len = config.context_len
         prefill_chunk_size = getattr(config, "deepseek_v4_prefill_chunk_size", None)

--- a/python/tokenspeed/runtime/layers/attention/backends/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/dsa.py
@@ -36,6 +36,7 @@ from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.backends.mla import MLAAttnBackend
 from tokenspeed.runtime.layers.attention.backends.trtllm_mla import TRTLLMMLABackend
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     DSA_SPARSE_PAGE_SIZE,
@@ -43,11 +44,13 @@ from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
 from tokenspeed.runtime.layers.attention.registry import register_backend
 
 
-def _make_dense_backend(config: DSAConfig, platform) -> AttentionBackend:
+def _make_dense_backend(
+    config: AttnConfig, spec: DSAConfig, platform
+) -> AttentionBackend:
     if platform.is_nvidia:
-        return TRTLLMMLABackend(config)
+        return TRTLLMMLABackend(config, spec)
     if platform.is_amd:
-        return MLAAttnBackend(config)
+        return MLAAttnBackend(config, spec)
     raise RuntimeError(f"DSA backend does not support platform {platform.vendor!r}.")
 
 
@@ -63,26 +66,26 @@ class DSABackend(AttentionBackend):
     # outermost backend, not the delegate.
     cache_consumer_families = frozenset({"history"})
 
-    def __init__(self, config: DSAConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: DSAConfig):
+        super().__init__(config, spec)
         platform = current_platform()
-        self._dense_backend = _make_dense_backend(config, platform)
-        self.index_topk = config.index_topk
+        self._dense_backend = _make_dense_backend(config, spec, platform)
+        self.index_topk = spec.index_topk
         self.max_context_len = config.context_len
         self.kernel_page_size = (
             config.kernel_page_size
             if config.kernel_page_size is not None
             else DSA_SPARSE_PAGE_SIZE
         )
-        self.kv_lora_rank = config.kv_lora_rank
-        self.qk_nope_head_dim = config.qk_nope_head_dim
-        self.qk_rope_head_dim = config.qk_rope_head_dim
-        self.v_head_dim = config.v_head_dim
-        self.kv_cache_dim = config.kv_cache_dim
-        self.scaling = config.scaling
+        self.kv_lora_rank = spec.kv_lora_rank
+        self.qk_nope_head_dim = spec.qk_nope_head_dim
+        self.qk_rope_head_dim = spec.qk_rope_head_dim
+        self.v_head_dim = spec.v_head_dim
+        self.kv_cache_dim = spec.kv_cache_dim
+        self.scaling = spec.scaling
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
-        self.num_local_heads = config.num_attention_heads // config.attn_tp_size
+        self.num_local_heads = spec.num_attention_heads // spec.attn_tp_size
         self._prefill_page_table: torch.Tensor | None = None
 
     @property

--- a/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/flashmla.py
@@ -44,6 +44,7 @@ from tokenspeed.runtime.layers.attention.backends.mla_cache_groups import (
 from tokenspeed.runtime.layers.attention.chunk import (
     build_chunked_prefill_metadata_arrays,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     FLASH_MLA_PAGE_SIZE as PAGE_SIZE,
@@ -118,8 +119,8 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
 
     draft_seq_lens_attr: str = "cuda_graph_seq_lens_k"
 
-    def __init__(self, config: MLAConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MLAConfig):
+        super().__init__(config, spec)
 
         # Parse constants
         self.max_context_len = config.context_len
@@ -140,17 +141,17 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
         self.max_num_pages = (self.max_context_len + PAGE_SIZE - 1) // PAGE_SIZE
 
         # MLA-specific dimensions
-        self.kv_lora_rank = config.kv_lora_rank
-        self.qk_nope_head_dim = config.qk_nope_head_dim
-        self.qk_rope_head_dim = config.qk_rope_head_dim
-        self.v_head_dim = config.v_head_dim
-        self.kv_cache_dim = config.kv_lora_rank + config.qk_rope_head_dim
-        self.scaling = config.scaling
-        self.softmax_scale = config.scaling
+        self.kv_lora_rank = spec.kv_lora_rank
+        self.qk_nope_head_dim = spec.qk_nope_head_dim
+        self.qk_rope_head_dim = spec.qk_rope_head_dim
+        self.v_head_dim = spec.v_head_dim
+        self.kv_cache_dim = spec.kv_lora_rank + spec.qk_rope_head_dim
+        self.scaling = spec.scaling
+        self.softmax_scale = spec.scaling
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
-        self.num_local_heads = config.num_attention_heads // config.attn_tp_size
-        self.num_q_heads = config.num_attention_heads // config.attn_tp_size
+        self.num_local_heads = spec.num_attention_heads // spec.attn_tp_size
+        self.num_q_heads = spec.num_attention_heads // spec.attn_tp_size
 
         # FlashMLA-specific
         self.draft_token_num = 0
@@ -195,7 +196,7 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
             self.workspace_buffer,
             backend="auto",
         )
-        self.indices_updater_prefill = _PrefillIndicesUpdater(config, self)
+        self.indices_updater_prefill = _PrefillIndicesUpdater(config, spec, self)
 
         # Metadata state. Decode and prefill metadata are split so MIXED batches
         # can carry both simultaneously (decode-half + prefill-half sub-contexts
@@ -925,14 +926,16 @@ class FlashMLABackend(MlaCacheGroupMixin, AttentionBackend):
 class _PrefillIndicesUpdater:
     """Plans FlashInfer MLA prefill wrappers for the EXTEND path."""
 
-    def __init__(self, config: MLAConfig, attn_backend: FlashMLABackend):
-        self.num_local_heads = config.num_attention_heads // config.attn_tp_size
+    def __init__(
+        self, config: AttnConfig, spec: MLAConfig, attn_backend: FlashMLABackend
+    ):
+        self.num_local_heads = spec.num_attention_heads // spec.attn_tp_size
         self.kv_cache_quant_method = config.kv_cache_quant_method
-        self.kv_lora_rank = config.kv_lora_rank
-        self.qk_nope_head_dim = config.qk_nope_head_dim
-        self.qk_rope_head_dim = config.qk_rope_head_dim
-        self.v_head_dim = config.v_head_dim
-        self.scaling = config.scaling
+        self.kv_lora_rank = spec.kv_lora_rank
+        self.qk_nope_head_dim = spec.qk_nope_head_dim
+        self.qk_rope_head_dim = spec.qk_rope_head_dim
+        self.v_head_dim = spec.v_head_dim
+        self.scaling = spec.scaling
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
         self.attn_backend = attn_backend

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_kda.py
@@ -57,7 +57,10 @@ from tokenspeed.runtime.layers.attention.backends.hybrid_linear_attn import (
 )
 
 if TYPE_CHECKING:
-    from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+    from tokenspeed.runtime.layers.attention.configs.base import (
+        AttnConfig,
+        SoftmaxAttnConfig,
+    )
 
 
 KDA_PREFILL_BACKENDS = ("auto", "fla", "flashkda", "cutedsl_kda")
@@ -96,10 +99,12 @@ class KdaAttnBackend(MambaAttnBackend):
 
     def __init__(
         self,
-        config: BaseAttnConfig,
+        config: AttnConfig,
+        spec: SoftmaxAttnConfig,
+        *,
         kda_backend: str = "auto",
     ) -> None:
-        super().__init__(config)
+        super().__init__(config, spec)
         self.max_bs = config.max_bs
         # The platform layout; the workspace planner probes the same one.
         self.kda_recurrent_layout = kda_recurrent_layout_default()

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid_linear_attn.py
@@ -54,6 +54,7 @@ from tokenspeed.runtime.layers.attention.backends.base import (
     AttentionBackend,
     init_backend_cuda_graph_state,
 )
+from tokenspeed.runtime.layers.attention.configs.linear_attn import LinearAttnConfig
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.cache_runtime import (
     cache_debug_enabled,
 )
@@ -69,7 +70,10 @@ from tokenspeed.runtime.layers.attention.linear.gdn import fused_gdn_gating
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+    from tokenspeed.runtime.layers.attention.configs.base import (
+        AttnConfig,
+        SoftmaxAttnConfig,
+    )
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 # Default cache group id carrying GDN/Mamba state pages.
@@ -351,8 +355,8 @@ class MambaAttnBackend(AttentionBackend):
     cache_consumer_families = frozenset({"state"})
     _replay_active: bool = False
 
-    def __init__(self, config: BaseAttnConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: SoftmaxAttnConfig):
+        super().__init__(config, spec)
         self.pad_slot_id = -1
         self.forward_metadata: MambaForwardMetadata = None
         self.query_start_loc_list = []
@@ -370,7 +374,8 @@ class MambaAttnBackend(AttentionBackend):
         # size. Values are keyed by group ID and indexed by ``bs - 1``.
         self.state_in_by_group: dict[str, list[torch.Tensor]] = {}
         self.state_out_by_group: dict[str, list[torch.Tensor]] = {}
-        self.replay_ssm = bool(getattr(config, "replay_ssm", False))
+        linear_attn = config.component(LinearAttnConfig)
+        self.replay_ssm = linear_attn is not None and bool(linear_attn.replay_ssm)
         self._gdn_replay: _GDNReplayWorkspace | None = None
         self._verify_scratch = None
         self._verify_commit_ctx = None

--- a/python/tokenspeed/runtime/layers/attention/backends/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mha.py
@@ -44,6 +44,7 @@ from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.backends.cache_groups import (
     CacheGroupsMixin,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     MHA_PAGE_SIZE,
@@ -127,10 +128,10 @@ class MHAAttnBackend(CacheGroupsMixin, AttentionBackend):
     ) -> bool:
         return forward_mode is not None and forward_mode.is_decode()
 
-    def __init__(self, config: MHAConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MHAConfig):
+        super().__init__(config, spec)
         # Map the selected backend to the corresponding kernel solution string.
-        backend_name = config.backend_name or "mha"
+        backend_name = spec.backend_name or "mha"
         self.kernel_solution = _KERNEL_SOLUTION_BY_BACKEND[backend_name]
 
         # Static information needed for metadata construction and kernel dispatch
@@ -141,11 +142,11 @@ class MHAAttnBackend(CacheGroupsMixin, AttentionBackend):
             else MHA_PAGE_SIZE
         )
         self.max_num_pages = ceil_div(self.max_context_len, self.kernel_page_size)
-        num_q_heads = config.num_attention_heads
-        num_kv_heads = config.num_kv_heads
-        self.tp_q_head_num = max(num_q_heads // config.attn_tp_size, 1)
-        self.tp_kv_head_num = max(num_kv_heads // config.attn_tp_size, 1)
-        self.head_dim = config.head_dim
+        num_q_heads = spec.num_attention_heads
+        num_kv_heads = spec.num_kv_heads
+        self.tp_q_head_num = max(num_q_heads // spec.attn_tp_size, 1)
+        self.tp_kv_head_num = max(num_kv_heads // spec.attn_tp_size, 1)
+        self.head_dim = spec.head_dim
         self.qkv_dtype = config.dtype
         self.kv_cache_dtype = config.kv_cache_dtype
         self.is_mxfp8 = bool(getattr(config, "kv_cache_mxfp8", False))

--- a/python/tokenspeed/runtime/layers/attention/backends/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/mla.py
@@ -41,6 +41,7 @@ from tokenspeed.runtime.layers.attention.backends.mla_cache_groups import (
 from tokenspeed.runtime.layers.attention.chunk import (
     build_chunked_prefill_metadata_arrays,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     MLA_PAGE_SIZE,
@@ -106,8 +107,8 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
 
     supports_mla_projected_value_decode = True
 
-    def __init__(self, config: MLAConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MLAConfig):
+        super().__init__(config, spec)
 
         self._cache_groups_bound = False
         self._cache_contract_bound = False
@@ -119,15 +120,15 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         )
         self.max_num_pages = ceil_div(self.max_context_len, self.kernel_page_size)
 
-        self.kv_lora_rank = config.kv_lora_rank
-        self.qk_nope_head_dim = config.qk_nope_head_dim
-        self.qk_rope_head_dim = config.qk_rope_head_dim
-        self.v_head_dim = config.v_head_dim
-        self.kv_cache_dim = config.kv_cache_dim
-        self.scaling = config.scaling
+        self.kv_lora_rank = spec.kv_lora_rank
+        self.qk_nope_head_dim = spec.qk_nope_head_dim
+        self.qk_rope_head_dim = spec.qk_rope_head_dim
+        self.v_head_dim = spec.v_head_dim
+        self.kv_cache_dim = spec.kv_cache_dim
+        self.scaling = spec.scaling
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
-        self.num_local_heads = config.num_attention_heads // config.attn_tp_size
+        self.num_local_heads = spec.num_attention_heads // spec.attn_tp_size
 
         # DFLASH/DSpark draft: the drafter proposes a whole block in one decode
         # forward and needs the block to be non-causal. Rather than a mask, each
@@ -137,7 +138,7 @@ class MLAAttnBackend(MlaCacheGroupMixin, AttentionBackend):
         # target verify and ordinary decode are untouched.
         self.draft_block_decode = bool(config.draft_block_decode)
 
-        backend_name = config.backend_name or "mla"
+        backend_name = spec.backend_name or "mla"
         self.kernel_solution = {"mla": None, "gluon": "gluon"}[backend_name]
 
         self.forward_decode_metadata: MLADecodeMetadata | None = None

--- a/python/tokenspeed/runtime/layers/attention/backends/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/msa.py
@@ -49,6 +49,7 @@ from tokenspeed.runtime.layers.attention.backends.base import (
 from tokenspeed.runtime.layers.attention.backends.cache_groups import (
     CacheGroupsMixin,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.msa import (
     MSAConfig,
 )
@@ -126,8 +127,8 @@ class MSAAttnBackend(CacheGroupsMixin, AttentionBackend):
     ) -> bool:
         return False
 
-    def __init__(self, config: MSAConfig) -> None:
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MSAConfig) -> None:
+        super().__init__(config, spec)
 
         # Static information needed for metadata construction and kernel dispatch
         self.max_context_len = config.context_len
@@ -137,9 +138,9 @@ class MSAAttnBackend(CacheGroupsMixin, AttentionBackend):
             else MSA_PAGE_SIZE
         )
         self.max_num_pages = ceil_div(self.max_context_len, self.kernel_page_size)
-        self.tp_q_head_num = max(config.num_attention_heads // config.attn_tp_size, 1)
-        self.tp_kv_head_num = max(config.num_kv_heads // config.attn_tp_size, 1)
-        self.head_dim = config.head_dim
+        self.tp_q_head_num = max(spec.num_attention_heads // spec.attn_tp_size, 1)
+        self.tp_kv_head_num = max(spec.num_kv_heads // spec.attn_tp_size, 1)
+        self.head_dim = spec.head_dim
         self.qkv_dtype = config.dtype
         self.kv_cache_dtype = config.kv_cache_dtype
         self.is_fp8 = self.kv_cache_dtype in (
@@ -148,11 +149,11 @@ class MSAAttnBackend(CacheGroupsMixin, AttentionBackend):
         )
 
         # Sparse attention parameters
-        self.sparse_layer_ids = config.sparse_layer_ids
-        self.index_head_dim = config.index_head_dim
-        self.index_topk_blocks = config.index_topk_blocks
-        self.index_init_blocks = config.index_init_blocks
-        self.index_local_blocks = config.index_local_blocks
+        self.sparse_layer_ids = spec.sparse_layer_ids
+        self.index_head_dim = spec.index_head_dim
+        self.index_topk_blocks = spec.index_topk_blocks
+        self.index_init_blocks = spec.index_init_blocks
+        self.index_local_blocks = spec.index_local_blocks
 
         # DFLASH draft: expand decode metadata to spec_num_tokens rows/request
         # (whole block in one decode forward), with uniform non-causal seq_lens.
@@ -790,26 +791,26 @@ class MSAHybridAttnBackend(AttentionBackend):
 
     uses_cache_groups: bool = True
 
-    def __init__(self, config: MSAConfig) -> None:
+    def __init__(self, config: AttnConfig, spec: MSAConfig) -> None:
         from tokenspeed.runtime.layers.attention.registry import (
             _create_attn_backend_with_name,
         )
 
-        super().__init__(config)
+        super().__init__(config, spec)
         full_attn_backend = _create_attn_backend_with_name(
-            config.full_attn_backend_name,
+            spec.full_attn_backend_name,
             AttentionArch.MHA,
             config,
         )
-        sparse_attn_backend = MSAAttnBackend(config)
+        sparse_attn_backend = MSAAttnBackend(config, spec)
         self.full_attn_backend = full_attn_backend
         self.sparse_attn_backend = sparse_attn_backend
         self.sparse_layer_ids = sparse_attn_backend.sparse_layer_ids
         logger.info(
             "Created MiniMax hybrid attention backend: %d dense layers, "
             "%d sparse layers (dense=%s, sparse=%s)",
-            len(config.compute_layer_types) - len(config.sparse_layer_ids),
-            len(config.sparse_layer_ids),
+            len(spec.compute_layer_types) - len(spec.sparse_layer_ids),
+            len(spec.sparse_layer_ids),
             type(full_attn_backend).__name__,
             type(sparse_attn_backend).__name__,
         )

--- a/python/tokenspeed/runtime/layers/attention/backends/qwen4_exp.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/qwen4_exp.py
@@ -38,7 +38,10 @@ from tokenspeed.runtime.layers.attention.kv_cache.qwen4_exp import (
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
-    from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+    from tokenspeed.runtime.layers.attention.configs.base import (
+        AttnConfig,
+        SoftmaxAttnConfig,
+    )
     from tokenspeed.runtime.layers.attention.qsa.indexer import QSAIndexer
     from tokenspeed.runtime.models.qwen4_exp_ple import Qwen4ExpPLELayer
 
@@ -57,8 +60,8 @@ def qwen4_exp_linear_backend(
 class Qwen4ExpMambaAttnBackend(MambaAttnBackend):
     """GDN backend with Qwen4-Exp PLE verification state."""
 
-    def __init__(self, config: BaseAttnConfig) -> None:
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: SoftmaxAttnConfig) -> None:
+        super().__init__(config, spec)
         self._ple_layers: tuple[Qwen4ExpPLELayer, ...] = ()
         self._ple_verify_scratch: dict[str, torch.Tensor] = {}
 

--- a/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py
@@ -56,6 +56,7 @@ from tokenspeed.runtime.layers.attention.backends.trtllm_mla import (
 from tokenspeed.runtime.layers.attention.chunk import (
     build_chunked_prefill_metadata_arrays,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     TOKENSPEED_MLA_DEFAULT_PAGE_SIZE,
@@ -115,8 +116,8 @@ class CuteDSLMLABackend(AttentionBackend):
     cache_consumer_families = frozenset({"history"})
     draft_seq_lens_attr: str = "cuda_graph_seq_lens_buf"
 
-    def __init__(self, config: MLAConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MLAConfig):
+        super().__init__(config, spec)
 
         # Latched the first time cache metadata arrives. Once bound, a
         # forward without cache metadata is a hard error: the cache contract
@@ -136,12 +137,12 @@ class CuteDSLMLABackend(AttentionBackend):
         )
 
         # MLA dimensions
-        self.kv_lora_rank = config.kv_lora_rank
-        self.qk_nope_head_dim = config.qk_nope_head_dim
-        self.qk_rope_head_dim = config.qk_rope_head_dim
-        self.v_head_dim = config.v_head_dim
-        self.kv_cache_dim = config.kv_cache_dim
-        self.scaling = config.scaling
+        self.kv_lora_rank = spec.kv_lora_rank
+        self.qk_nope_head_dim = spec.qk_nope_head_dim
+        self.qk_rope_head_dim = spec.qk_rope_head_dim
+        self.v_head_dim = spec.v_head_dim
+        self.kv_cache_dim = spec.kv_cache_dim
+        self.scaling = spec.scaling
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
 
@@ -152,7 +153,7 @@ class CuteDSLMLABackend(AttentionBackend):
         # consumed within each op and never zero-initialized, so sharing the
         # block is safe. Warm to the verify-path peak now: graph capture runs
         # the decode forward with the pool frozen.
-        self._num_heads_per_tp = config.num_attention_heads // config.attn_tp_size
+        self._num_heads_per_tp = spec.num_attention_heads // spec.attn_tp_size
         self._workspace_pool = workspace_pool(config.device)
         self.cutedsl_workspace = self._cutedsl_workspace(
             max(_CUTEDSL_WARMUP_Q_LEN_FLOOR, self.spec_num_tokens or 1)

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm.py
@@ -50,6 +50,7 @@ from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
 from tokenspeed.runtime.layers.attention.backends.cache_groups import (
     CacheGroupsMixin,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     TRTLLM_MHA_PAGE_SIZE,
@@ -141,8 +142,8 @@ class TRTLLMMHAAttnBackend(CacheGroupsMixin, AttentionBackend):
     def sinks_dtype(self) -> torch.dtype:
         return torch.float32
 
-    def __init__(self, config: MHAConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MHAConfig):
+        super().__init__(config, spec)
 
         self.kernel_page_size = (
             config.kernel_page_size

--- a/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/trtllm_mla.py
@@ -47,6 +47,7 @@ from tokenspeed.runtime.layers.attention.backends.mla_cache_groups import (
 from tokenspeed.runtime.layers.attention.chunk import (
     build_chunked_prefill_metadata_arrays,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
     TRTLLM_MLA_DEFAULT_PAGE_SIZE,
@@ -131,8 +132,8 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
 
     draft_seq_lens_attr: str = "cuda_graph_seq_lens_buf"
 
-    def __init__(self, config: MLAConfig):
-        super().__init__(config)
+    def __init__(self, config: AttnConfig, spec: MLAConfig):
+        super().__init__(config, spec)
 
         self.max_context_len = config.context_len
         self.kernel_page_size = (
@@ -151,12 +152,12 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
         self.max_num_pages = self._calc_padded_blocks(config.context_len)
 
         # MLA dimensions
-        self.kv_lora_rank = config.kv_lora_rank
-        self.qk_nope_head_dim = config.qk_nope_head_dim
-        self.qk_rope_head_dim = config.qk_rope_head_dim
-        self.v_head_dim = config.v_head_dim
-        self.kv_cache_dim = config.kv_cache_dim
-        self.scaling = config.scaling
+        self.kv_lora_rank = spec.kv_lora_rank
+        self.qk_nope_head_dim = spec.qk_nope_head_dim
+        self.qk_rope_head_dim = spec.qk_rope_head_dim
+        self.v_head_dim = spec.v_head_dim
+        self.kv_cache_dim = spec.kv_cache_dim
+        self.scaling = spec.scaling
         self.data_type = config.kv_cache_dtype
         self.q_data_type = config.dtype
         self.draft_block_decode = config.draft_block_decode
@@ -170,7 +171,7 @@ class TRTLLMMLABackend(MlaCacheGroupMixin, AttentionBackend):
                 f"trtllm_mla backend requires page_size 32 or 64, got {self.kernel_page_size}"
             )
 
-        self.num_local_heads = config.num_attention_heads // config.attn_tp_size
+        self.num_local_heads = spec.num_attention_heads // spec.attn_tp_size
 
         # Metadata
         self.forward_decode_metadata: TRTLLMMLADecodeMetadata | None = None

--- a/python/tokenspeed/runtime/layers/attention/configs/base.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/base.py
@@ -18,14 +18,31 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""Composite attention configuration.
+
+``AttnConfig`` carries the model-wide serving facts (device, cache precision,
+paging, capacity, speculative shape) and a tuple of attention components.
+Each component is an ``AttnComponentSpec`` subclass owning one mechanism's
+kernel choice, head geometry, per-layer vectors, and parallel width;
+``SoftmaxAttnConfig`` is the softmax-family base (MHA/MLA/DSA/MSA), the
+counterpart of ``LinearAttnConfig``'s recurrent state.
+
+The softmax component is unique per model (validated at construction) and
+addressed by type: ``config.component(SoftmaxAttnConfig)``. Backends receive
+their component explicitly: ``Backend(config, spec)``.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypeVar
 
 import torch
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.utils.server_args import ServerArgs
+
+ComponentT = TypeVar("ComponentT", bound="AttnComponentSpec")
 
 
 def resolve_speculative_num_tokens(
@@ -58,15 +75,65 @@ def resolve_dtype(kv_cache_dtype_str: str) -> torch.dtype:
 
 
 @dataclass(kw_only=True)
-class BaseAttnConfig:
-    device: str
-    backend_name: str
+class AttnComponentSpec:
+    """One attention mechanism's boot-constant facts.
+
+    Subclasses are the identity; a mixed full+sliding softmax model stays ONE
+    component carrying its per-layer vectors.
+    """
+
+    # The compute backend requested for this component; None lets the backend
+    # registry pick the component's default.
+    backend_name: str | None = None
+
+
+@dataclass(kw_only=True)
+class SoftmaxAttnConfig(AttnComponentSpec):
+    """Base of the softmax-attention families (MHA / MLA / DSA / MSA)."""
+
     num_attention_heads: int
     num_kv_heads: int
     head_dim: int
     attn_tp_size: int
+    # Per-layer attention-type labels, forwarded to the KV pool for
+    # cache_group_specs publication (empty -> single full-history group).
+    layer_types: tuple[str, ...] = ()
+    # Retention window; families narrow the type (per-layer tuple on MHA,
+    # DeepSeek V4's int on MLA, None on MSA).
+    sliding_window_tokens: int | tuple[int | None, ...] | None = None
+
+    @classmethod
+    def generate(
+        cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool = False
+    ) -> AttnConfig:
+        raise NotImplementedError("Not Implemented!")
+
+    def cache_cell_size(self, config: AttnConfig) -> int:
+        """Per-token cache bytes of this component's dominant field.
+
+        A per-TOKEN concept, hence softmax-family only: linear-attention
+        state is fixed-size per request, sized via its shape properties.
+        Takes the ``AttnConfig`` for the model-wide facts (cache dtype,
+        quant method) that deliberately do not live on the spec.
+        """
+        raise NotImplementedError("Not Implemented!")
+
+
+@dataclass(kw_only=True)
+class AttnConfig:
+    """The model's attention configuration: model-wide facts + components.
+
+    Exactly one component is the softmax family (validated below); extra
+    components (linear attention) ride alongside as peers. Built exclusively
+    by ``registry._create_attn_config`` — one construction seam.
+    """
+
+    device: str
     dtype: torch.dtype
     kv_cache_dtype: torch.dtype
+    kv_cache_quant_method: str
+    # MXFP8 KV: UE8M0 vec-32 scale sidecar in pool buffers; kv_cache_dtype alone can't express it
+    kv_cache_mxfp8: bool = False
     # Scheduler prefix granularity (CLI --block-size): the identity axis.
     prefix_granularity: int
     # Tokens covered by one attention-kernel page. None picks the backend's
@@ -80,9 +147,10 @@ class BaseAttnConfig:
     context_len: int
     max_bs: int
     max_graph_bs: int
-    kv_cache_quant_method: str
-    # MXFP8 KV: UE8M0 vec-32 scale sidecar in pool buffers; kv_cache_dtype alone can't express it
-    kv_cache_mxfp8: bool = False
+    max_scheduled_tokens: int = 0
+    # True iff server_args.disaggregation_mode != "null"; cache recipes use
+    # it to stamp transfer policies onto the cache group specs.
+    pd_disaggregation_enabled: bool = False
     speculative_num_steps: int = 0
     speculative_num_draft_tokens: int = 1
     is_draft: bool = False
@@ -90,12 +158,73 @@ class BaseAttnConfig:
     # per request) instead of Eagle/MTP's per-step single-token decode. Backends
     # use this to expand decode metadata to spec_num_tokens rows per request.
     draft_block_decode: bool = False
+    components: tuple[AttnComponentSpec, ...]
 
-    @classmethod
-    def generate(
-        cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool = False
-    ):
-        raise NotImplementedError("Not Implemented!")
+    def __post_init__(self):
+        softmax_components = [
+            c for c in self.components if isinstance(c, SoftmaxAttnConfig)
+        ]
+        if len(softmax_components) != 1:
+            raise ValueError(
+                "AttnConfig requires exactly one softmax-family component, got "
+                f"{[type(c).__name__ for c in self.components] or 'none'}"
+            )
+
+    def component(self, cls: type[ComponentT]) -> ComponentT | None:
+        """The first component that is a ``cls``, or None.
+
+        The one generic accessor — ``config.component(LinearAttnConfig)``;
+        new component classes need no change here.
+        """
+        for component in self.components:
+            if isinstance(component, cls):
+                return component
+        return None
 
     def cache_cell_size(self) -> int:
-        raise NotImplementedError("Not Implemented!")
+        return self.component(SoftmaxAttnConfig).cache_cell_size(self)
+
+
+def model_wide_kwargs(
+    server_args: ServerArgs,
+    model_config: ModelConfig,
+    is_draft: bool,
+    *,
+    kv_cache_dtype: torch.dtype,
+    kv_cache_mxfp8: bool = False,
+    draft_block_decode: bool = False,
+    speculative_num_draft_tokens: int | None = None,
+) -> dict:
+    """The AttnConfig fields shared by every family's generate().
+
+    The softmax family passes in the facts its policies decide (cache dtype,
+    block-decode mode, and — for families that bypass the DSpark width
+    convention — the raw speculative width).
+    """
+    kwargs = dict(
+        device=server_args.device,
+        dtype=model_config.dtype,
+        kv_cache_dtype=kv_cache_dtype,
+        kv_cache_mxfp8=kv_cache_mxfp8,
+        kv_cache_quant_method=server_args.kv_cache_quant_method,
+        prefix_granularity=server_args.prefix_granularity,
+        context_len=model_config.context_len + server_args.spec_context_pad,
+        max_bs=server_args.max_num_seqs
+        // (server_args.data_parallel_size or server_args.mapping.attn.dp_size),
+        max_graph_bs=server_args.max_cudagraph_capture_size,
+        max_scheduled_tokens=getattr(server_args, "chunked_prefill_size", 8192),
+        pd_disaggregation_enabled=getattr(server_args, "disaggregation_mode", "null")
+        != "null",
+        is_draft=is_draft,
+        draft_block_decode=draft_block_decode,
+    )
+    if server_args.speculative_algorithm is not None:
+        kwargs.update(
+            speculative_num_steps=server_args.speculative_num_steps,
+            speculative_num_draft_tokens=(
+                speculative_num_draft_tokens
+                if speculative_num_draft_tokens is not None
+                else resolve_speculative_num_tokens(server_args, is_draft)
+            ),
+        )
+    return kwargs

--- a/python/tokenspeed/runtime/layers/attention/configs/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/dsa.py
@@ -26,6 +26,7 @@ import torch
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
@@ -44,11 +45,22 @@ def dsa_index_k_row_bytes(index_head_dim: int) -> int:
     )
 
 
-@dataclass
+@dataclass(kw_only=True)
 class DSAConfig(MLAConfig):
     index_topk: int
     index_head_dim: int
     index_n_heads: int
+
+    @classmethod
+    def _spec_kwargs(
+        cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool
+    ) -> dict:
+        return dict(
+            **super()._spec_kwargs(server_args, model_config, is_draft),
+            index_topk=model_config.index_topk,
+            index_head_dim=model_config.index_head_dim,
+            index_n_heads=model_config.index_n_heads,
+        )
 
     @classmethod
     def generate(
@@ -56,9 +68,9 @@ class DSAConfig(MLAConfig):
         server_args: ServerArgs,
         model_config: ModelConfig,
         is_draft: bool = False,
-    ):
-        base = MLAConfig.generate(server_args, model_config, is_draft)
-        if base.kv_cache_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+    ) -> AttnConfig:
+        config = super().generate(server_args, model_config, is_draft)
+        if config.kv_cache_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
             platform = current_platform()
             if not (platform.is_blackwell_plus or platform.is_cdna4_plus):
                 raise ValueError(
@@ -67,15 +79,10 @@ class DSAConfig(MLAConfig):
                     "auto or bfloat16 on this platform, got "
                     f"{server_args.kv_cache_dtype}."
                 )
-        return cls(
-            **base.__dict__,
-            index_topk=model_config.index_topk,
-            index_head_dim=model_config.index_head_dim,
-            index_n_heads=model_config.index_n_heads,
-        )
+        return config
 
-    def cache_cell_size(self) -> int:
+    def cache_cell_size(self, config: AttnConfig) -> int:
         index_k_cell_size = dsa_index_k_row_bytes(
             self.index_head_dim,
         )
-        return super().cache_cell_size() + index_k_cell_size
+        return super().cache_cell_size(config) + index_k_cell_size

--- a/python/tokenspeed/runtime/layers/attention/configs/linear_attn.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/linear_attn.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Linear-attention (KDA / GDN) boot-time configuration.
+
+``LinearAttnConfig`` is the linear-attention component: registered per
+architecture (``registry._LINEAR_ATTN_CLS``), built through the same
+``generate()`` protocol as the softmax families, and carried in
+``AttnConfig.components``. Models without linear-attention layers simply
+have no such component.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tokenspeed.runtime.configs.model_config import ModelConfig
+from tokenspeed.runtime.layers.attention.configs.base import AttnComponentSpec
+from tokenspeed.runtime.utils.server_args import ServerArgs
+
+
+@dataclass(kw_only=True)
+class LinearAttnConfig(AttnComponentSpec):
+    """Boot-constant facts about a model's linear-attention layers.
+
+    Field names are unified across the two in-tree families:
+
+    * Kimi-K3 KDA — ``linear_attn_config`` dict: symmetric heads/dims
+      (``num_heads``/``head_dim`` for both k and v).
+    * Qwen3.5 GDN — flat ``linear_*`` fields: asymmetric key/value heads.
+
+    ``tp_size`` is the linear-attention TP width distilled from
+    ``mapping.linear_attn`` (the same copy-a-scalar convention as
+    ``SoftmaxAttnConfig.attn_tp_size``).
+    """
+
+    num_k_heads: int
+    num_v_heads: int
+    head_k_dim: int
+    head_v_dim: int
+    conv_kernel_size: int
+    # 0-based global indices of the linear-attention layers. Non-empty by
+    # construction: a model without linear layers gets no LinearAttnConfig.
+    layer_ids: tuple[int, ...]
+    tp_size: int
+    # Whether verify replays the SSM state instead of checkpoint-restoring.
+    # Resolved by the GDN cache recipe after checking the engine option,
+    # verify width, device, and registered kernel support.
+    replay_ssm: bool = False
+
+    def __post_init__(self):
+        if not self.layer_ids:
+            raise ValueError("layer_ids must be non-empty")
+        if self.tp_size <= 0:
+            raise ValueError(f"tp_size must be positive, got {self.tp_size}")
+        if self.num_k_heads % self.tp_size or self.num_v_heads % self.tp_size:
+            raise ValueError(
+                f"linear-attention heads (k={self.num_k_heads}, "
+                f"v={self.num_v_heads}) must be divisible by "
+                f"tp_size={self.tp_size}"
+            )
+
+    @property
+    def conv_dim(self) -> int:
+        """Width of the short causal conv over q/k/v (q and k share key geometry)."""
+        return (
+            2 * self.num_k_heads * self.head_k_dim + self.num_v_heads * self.head_v_dim
+        )
+
+    @property
+    def conv_state_shape(self) -> tuple[int, int]:
+        """Per-rank rolling conv state: (conv_dim / tp, kernel - 1)."""
+        return (self.conv_dim // self.tp_size, self.conv_kernel_size - 1)
+
+    @property
+    def temporal_state_shape(self) -> tuple[int, int, int]:
+        """Per-rank recurrent (delta-rule/SSM) state, K-last: (Hv / tp, V, K)."""
+        return (
+            self.num_v_heads // self.tp_size,
+            self.head_v_dim,
+            self.head_k_dim,
+        )
+
+    @classmethod
+    def generate(
+        cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool = False
+    ) -> LinearAttnConfig | None:
+        """Build the linear-attention config, or None for checkpoints without one.
+
+        Which architectures may carry this component is declared in
+        ``registry._LINEAR_ATTN_CLS``; here the checkpoint decides presence
+        via a non-empty ``linear_layer_ids`` (not field presence — base
+        configs expose the geometry fields with defaults even for
+        full-attention-only variants, and NextN drafts may have no linear
+        layers). ``is_draft`` is accepted for construction-protocol parity;
+        the linear half has no draft-specific facts yet.
+        """
+        del is_draft
+        hf_config = model_config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
+        linear_layer_ids = getattr(text_config, "linear_layer_ids", None)
+        if not linear_layer_ids:
+            return None
+
+        tp_size = server_args.mapping.linear_attn.tp_size
+        kda = getattr(text_config, "linear_attn_config", None)
+        if isinstance(kda, dict):
+            # Kimi-K3 KDA: symmetric k/v geometry in one dict.
+            num_heads = int(kda["num_heads"])
+            head_dim = int(kda["head_dim"])
+            return cls(
+                num_k_heads=num_heads,
+                num_v_heads=num_heads,
+                head_k_dim=head_dim,
+                head_v_dim=head_dim,
+                conv_kernel_size=int(kda["short_conv_kernel_size"]),
+                layer_ids=tuple(linear_layer_ids),
+                tp_size=tp_size,
+            )
+        # Qwen3.5 GDN: flat fields, asymmetric k/v heads.
+        return cls(
+            num_k_heads=int(text_config.linear_num_key_heads),
+            num_v_heads=int(text_config.linear_num_value_heads),
+            head_k_dim=int(text_config.linear_key_head_dim),
+            head_v_dim=int(text_config.linear_value_head_dim),
+            conv_kernel_size=int(text_config.linear_conv_kernel_dim),
+            layer_ids=tuple(linear_layer_ids),
+            tp_size=tp_size,
+        )

--- a/python/tokenspeed/runtime/layers/attention/configs/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mha.py
@@ -26,40 +26,24 @@ import torch
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.layers.attention.configs.base import (
-    BaseAttnConfig,
+    AttnConfig,
+    SoftmaxAttnConfig,
+    model_wide_kwargs,
     resolve_dtype,
-    resolve_speculative_num_tokens,
 )
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
 
-@dataclass
-class MHAConfig(BaseAttnConfig):
-    # Resolved by the Qwen GDN cache recipe after checking the engine option,
-    # verify width, device, and registered kernel support.
-    replay_ssm: bool = False
-    # Per-layer attention-type labels + window, forwarded to the KV pool for
-    # cache_group_specs publication (empty -> single full-history group).
-    layer_types: tuple[str, ...] = ()
-    sliding_window_tokens: int | tuple[int | None, ...] | None = None
-    max_scheduled_tokens: int = 0
-    # True iff server_args.disaggregation_mode != "null"; cache recipes use
-    # it to stamp transfer policies onto the cache group specs.
-    pd_disaggregation_enabled: bool = False
+@dataclass(kw_only=True)
+class MHAConfig(SoftmaxAttnConfig):
+    # Mixed full+sliding models are ONE component: the per-layer kv-head
+    # vector lives here alongside the inherited layer_types/window.
     layer_kv_head_counts: tuple[int, ...] | None = None
 
     @classmethod
     def generate(
         cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool = False
-    ):
-        kwargs = {}
-        if server_args.speculative_algorithm is not None:
-            kwargs.update(
-                speculative_num_steps=server_args.speculative_num_steps,
-                speculative_num_draft_tokens=resolve_speculative_num_tokens(
-                    server_args, is_draft
-                ),
-            )
+    ) -> AttnConfig:
         kv_cache_dtype = server_args.kv_cache_dtype
         draft_block_decode = bool(
             is_draft and server_args.speculative_algorithm in ("DFLASH", "DSPARK")
@@ -88,9 +72,7 @@ class MHAConfig(BaseAttnConfig):
             # attention mask the draft applies in its own layers.
             layer_types = ()
             sliding_window_tokens = None
-        return cls(
-            device=server_args.device,
-            context_len=model_config.context_len + server_args.spec_context_pad,
+        spec = cls(
             backend_name=(
                 server_args.attention_backend
                 if not is_draft
@@ -100,34 +82,29 @@ class MHAConfig(BaseAttnConfig):
             num_kv_heads=model_config.num_key_value_heads,
             head_dim=model_config.head_dim,
             attn_tp_size=server_args.attn_tp_size or server_args.mapping.attn.tp_size,
-            dtype=model_config.dtype,
-            kv_cache_dtype=resolve_dtype(kv_cache_dtype),
-            kv_cache_mxfp8=kv_cache_dtype == "mxfp8",
-            prefix_granularity=server_args.prefix_granularity,
-            max_bs=server_args.max_num_seqs
-            // (server_args.data_parallel_size or server_args.mapping.attn.dp_size),
-            max_graph_bs=server_args.max_cudagraph_capture_size,
-            kv_cache_quant_method=server_args.kv_cache_quant_method,
-            is_draft=is_draft,
-            draft_block_decode=draft_block_decode,
             layer_types=layer_types,
             sliding_window_tokens=sliding_window_tokens,
-            max_scheduled_tokens=getattr(server_args, "chunked_prefill_size", 8192),
-            pd_disaggregation_enabled=getattr(
-                server_args, "disaggregation_mode", "null"
-            )
-            != "null",
-            **kwargs,
+        )
+        return AttnConfig(
+            components=(spec,),
+            **model_wide_kwargs(
+                server_args,
+                model_config,
+                is_draft,
+                kv_cache_dtype=resolve_dtype(kv_cache_dtype),
+                kv_cache_mxfp8=kv_cache_dtype == "mxfp8",
+                draft_block_decode=draft_block_decode,
+            ),
         )
 
-    def cache_cell_size(self) -> int:
+    def cache_cell_size(self, config: AttnConfig) -> int:
         cell = (
             max(self.num_kv_heads // self.attn_tp_size, 1)
             * self.head_dim
             * 2
-            * torch._utils._element_size(self.kv_cache_dtype)
+            * torch._utils._element_size(config.kv_cache_dtype)
         )
-        if self.kv_cache_mxfp8:
+        if config.kv_cache_mxfp8:
             # One UE8M0 byte per 32 fp8 data bytes.
             cell += cell // 32
         return cell

--- a/python/tokenspeed/runtime/layers/attention/configs/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/mla.py
@@ -20,15 +20,16 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import torch
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.layers.attention.configs.base import (
-    BaseAttnConfig,
+    AttnConfig,
+    SoftmaxAttnConfig,
+    model_wide_kwargs,
     resolve_dtype,
-    resolve_speculative_num_tokens,
 )
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
@@ -54,42 +55,30 @@ def resolve_mla_kv_cache_dtype(
     return resolve_dtype(server_args.kv_cache_dtype)
 
 
-@dataclass
-class MLAConfig(BaseAttnConfig):
+@dataclass(kw_only=True)
+class MLAConfig(SoftmaxAttnConfig):
     kv_lora_rank: int
     qk_nope_head_dim: int
     qk_rope_head_dim: int
     v_head_dim: int
     scaling: float
     kv_cache_dim: int
-    layer_types: tuple[str, ...] = field(default=(), kw_only=True)
-    max_scheduled_tokens: int = field(default=0, kw_only=True)
-    pd_disaggregation_enabled: bool = field(default=False, kw_only=True)
+    # DeepSeek V4 stamps its window here post-construction (declared so the
+    # write is a real field, not a __dict__ stowaway).
+    sliding_window_tokens: int | None = None
 
     @classmethod
-    def generate(
-        cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool = False
-    ):
-        kwargs = {}
-        if server_args.speculative_algorithm is not None:
-            kwargs.update(
-                speculative_num_steps=server_args.speculative_num_steps,
-                speculative_num_draft_tokens=resolve_speculative_num_tokens(
-                    server_args, is_draft
-                ),
-            )
+    def _spec_kwargs(
+        cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool
+    ) -> dict:
+        """MLA component fields, shared with the DSA subclass."""
         hf_config = getattr(model_config, "hf_config", None)
         layer_types = tuple(
             getattr(hf_config, "cache_layer_types", None)
             or getattr(hf_config, "layer_types", None)
             or ()
         )
-        draft_block_decode = bool(
-            is_draft and server_args.speculative_algorithm in ("DFLASH", "DSPARK")
-        )
-        return cls(
-            device=server_args.device,
-            context_len=model_config.context_len + server_args.spec_context_pad,
+        return dict(
             backend_name=(
                 server_args.attention_backend
                 if not is_draft
@@ -99,17 +88,6 @@ class MLAConfig(BaseAttnConfig):
             num_kv_heads=model_config.num_key_value_heads,
             head_dim=model_config.head_dim,
             attn_tp_size=server_args.attn_tp_size or server_args.mapping.attn.tp_size,
-            dtype=model_config.dtype,
-            kv_cache_dtype=resolve_mla_kv_cache_dtype(
-                server_args, model_config, is_draft
-            ),
-            prefix_granularity=server_args.prefix_granularity,
-            max_graph_bs=server_args.max_cudagraph_capture_size,
-            max_bs=server_args.max_num_seqs
-            // (server_args.data_parallel_size or server_args.mapping.attn.dp_size),
-            kv_cache_quant_method=server_args.kv_cache_quant_method,
-            is_draft=is_draft,
-            draft_block_decode=draft_block_decode,
             kv_lora_rank=model_config.kv_lora_rank,
             qk_nope_head_dim=model_config.qk_nope_head_dim,
             qk_rope_head_dim=model_config.qk_rope_head_dim,
@@ -117,23 +95,38 @@ class MLAConfig(BaseAttnConfig):
             scaling=model_config.scaling,
             kv_cache_dim=model_config.kv_lora_rank + model_config.qk_rope_head_dim,
             layer_types=layer_types,
-            max_scheduled_tokens=getattr(server_args, "chunked_prefill_size", 8192),
-            pd_disaggregation_enabled=getattr(
-                server_args, "disaggregation_mode", "null"
-            )
-            != "null",
-            **kwargs,
         )
 
-    def cache_cell_size(self) -> int:
-        if self.kv_cache_quant_method == "per_token_head":
+    @classmethod
+    def generate(
+        cls, server_args: ServerArgs, model_config: ModelConfig, is_draft: bool = False
+    ) -> AttnConfig:
+        draft_block_decode = bool(
+            is_draft and server_args.speculative_algorithm in ("DFLASH", "DSPARK")
+        )
+        spec = cls(**cls._spec_kwargs(server_args, model_config, is_draft))
+        return AttnConfig(
+            components=(spec,),
+            **model_wide_kwargs(
+                server_args,
+                model_config,
+                is_draft,
+                kv_cache_dtype=resolve_mla_kv_cache_dtype(
+                    server_args, model_config, is_draft
+                ),
+                draft_block_decode=draft_block_decode,
+            ),
+        )
+
+    def cache_cell_size(self, config: AttnConfig) -> int:
+        if config.kv_cache_quant_method == "per_token_head":
             cell_size = (
-                self.kv_lora_rank * torch._utils._element_size(self.kv_cache_dtype)
-                + self.qk_rope_head_dim * torch._utils._element_size(self.dtype)
+                self.kv_lora_rank * torch._utils._element_size(config.kv_cache_dtype)
+                + self.qk_rope_head_dim * torch._utils._element_size(config.dtype)
                 + 1 * torch._utils._element_size(torch.float32)
             )
         else:
             cell_size = (
                 self.kv_lora_rank + self.qk_rope_head_dim
-            ) * torch._utils._element_size(self.kv_cache_dtype)
+            ) * torch._utils._element_size(config.kv_cache_dtype)
         return cell_size

--- a/python/tokenspeed/runtime/layers/attention/configs/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/configs/msa.py
@@ -28,28 +28,32 @@ import torch
 
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.layers.attention.configs.base import (
-    BaseAttnConfig,
+    AttnConfig,
+    SoftmaxAttnConfig,
+    model_wide_kwargs,
     resolve_dtype,
 )
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
 
 @dataclass(kw_only=True)
-class MSAConfig(BaseAttnConfig):
-    """Runtime and cache contract for MiniMax sparse attention."""
+class MSAConfig(SoftmaxAttnConfig):
+    """Runtime and cache contract for MiniMax sparse attention.
+
+    One component: the sparse label selects dense-vs-sparse COMPUTE per layer,
+    while every layer retains full history in the one shared cache — so the
+    dense sub-backend is this component's business (``full_attn_backend_name``),
+    not a second component.
+    """
 
     full_attn_backend_name: str | None = None
 
     # Compute-layer labels select dense versus sparse execution. Cache-layer
-    # labels remain empty because every MiniMax layer retains full history.
+    # labels (inherited layer_types) remain empty because every MiniMax layer
+    # retains full history.
     compute_layer_types: tuple[str, ...] = ()
     sparse_layer_ids: frozenset[int] = frozenset()
-    layer_types: tuple[str, ...] = ()
     sliding_window_tokens: None = None
-    max_scheduled_tokens: int = 0
-    # True iff server_args.disaggregation_mode != "null"; cache recipes use
-    # it to stamp transfer policies onto the cache group specs.
-    pd_disaggregation_enabled: bool = False
 
     index_head_dim: int = 0
     index_n_heads: int = 0
@@ -64,7 +68,7 @@ class MSAConfig(BaseAttnConfig):
         server_args: ServerArgs,
         model_config: ModelConfig,
         is_draft: bool = False,
-    ) -> "MSAConfig":
+    ) -> AttnConfig:
         text_config = model_config.hf_text_config
         sparse_layer_type = model_config.hf_config.runtime_attention_layer_type
 
@@ -74,8 +78,6 @@ class MSAConfig(BaseAttnConfig):
             for layer_id, layer_type in enumerate(compute_layer_types)
             if layer_type == sparse_layer_type
         )
-
-        index_block_size = text_config.index_block_size
 
         kv_cache_dtype = server_args.kv_cache_dtype
         draft_block_decode = bool(
@@ -91,65 +93,52 @@ class MSAConfig(BaseAttnConfig):
             raise ValueError(
                 f"MiniMax sparse attention does not support kv_cache_quant_method={server_args.kv_cache_quant_method!r}."
             )
-        resolved_kv_cache_dtype = resolve_dtype(kv_cache_dtype)
 
-        # The sparse label selects compute, not cache retention. Dense and MSA
-        # layers share the standard full-history MHA cache group.
-        kwargs = {}
-        if server_args.speculative_algorithm is not None:
-            kwargs.update(
-                speculative_num_steps=server_args.speculative_num_steps,
-                speculative_num_draft_tokens=server_args.speculative_num_draft_tokens,
-            )
-        full_attn_backend_name = (
-            server_args.attention_backend
-            if not is_draft
-            else server_args.drafter_attention_backend
-        )
-        return cls(
-            device=server_args.device,
-            context_len=model_config.context_len + server_args.spec_context_pad,
+        spec = cls(
             backend_name="msa",
-            full_attn_backend_name=full_attn_backend_name,
+            full_attn_backend_name=(
+                server_args.attention_backend
+                if not is_draft
+                else server_args.drafter_attention_backend
+            ),
             num_attention_heads=model_config.num_attention_heads,
             num_kv_heads=model_config.num_key_value_heads,
             head_dim=model_config.head_dim,
             attn_tp_size=server_args.attn_tp_size or server_args.mapping.attn.tp_size,
-            dtype=model_config.dtype,
-            kv_cache_dtype=resolved_kv_cache_dtype,
-            prefix_granularity=server_args.prefix_granularity,
-            max_bs=server_args.max_num_seqs
-            // (server_args.data_parallel_size or server_args.mapping.attn.dp_size),
-            max_graph_bs=server_args.max_cudagraph_capture_size,
-            kv_cache_quant_method=server_args.kv_cache_quant_method,
-            is_draft=is_draft,
-            draft_block_decode=draft_block_decode,
             compute_layer_types=compute_layer_types,
             sparse_layer_ids=sparse_layer_ids,
             layer_types=(),
             sliding_window_tokens=None,
-            max_scheduled_tokens=getattr(server_args, "chunked_prefill_size", 8192),
-            pd_disaggregation_enabled=getattr(
-                server_args, "disaggregation_mode", "null"
-            )
-            != "null",
             index_head_dim=int(text_config.index_head_dim),
             index_n_heads=int(text_config.index_n_heads),
-            index_block_size=index_block_size,
+            index_block_size=text_config.index_block_size,
             index_topk_blocks=int(text_config.index_topk_blocks),
             index_init_blocks=int(getattr(text_config, "index_init_blocks", 0)),
             index_local_blocks=int(text_config.index_local_blocks),
-            **kwargs,
+        )
+        # MSA verify uses the raw configured width (no DSpark width convention).
+        return AttnConfig(
+            components=(spec,),
+            **model_wide_kwargs(
+                server_args,
+                model_config,
+                is_draft,
+                kv_cache_dtype=resolve_dtype(kv_cache_dtype),
+                draft_block_decode=draft_block_decode,
+                speculative_num_draft_tokens=server_args.speculative_num_draft_tokens,
+            ),
         )
 
-    def cache_cell_size(self) -> int:
+    def cache_cell_size(self, config: AttnConfig) -> int:
         kv_cache_bytes = (
             max(self.num_kv_heads // self.attn_tp_size, 1)
             * self.head_dim
             * 2
-            * torch._utils._element_size(self.kv_cache_dtype)
+            * torch._utils._element_size(config.kv_cache_dtype)
         )
-        index_cache_bytes = self.index_head_dim * torch._utils._element_size(self.dtype)
+        index_cache_bytes = self.index_head_dim * torch._utils._element_size(
+            config.dtype
+        )
         num_layers = len(self.compute_layer_types)
         if num_layers:
             # The common profiler multiplies this per-layer value by num_layers.

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/factory.py
@@ -1,6 +1,9 @@
 """Concrete cache-pool construction from a prepared cache spec."""
 
-from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+from tokenspeed.runtime.layers.attention.configs.base import (
+    AttnConfig,
+    SoftmaxAttnConfig,
+)
 from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
@@ -63,7 +66,7 @@ def _mha_pool_class(family: str, *, mxfp8: bool) -> type[CachePool]:
 
 def create_cache_pool(
     spec: CachePoolSpec,
-    config: BaseAttnConfig,
+    config: AttnConfig,
     arena: CacheArena,
     *,
     num_layers: int,
@@ -76,6 +79,7 @@ def create_cache_pool(
     merged plan's global layer window, so a draft view names the
     continuation fields the target's plan already reserved.
     """
+    softmax_attn = config.component(SoftmaxAttnConfig)
     if spec.family == "deepseek_v4":
         from tokenspeed.runtime.layers.attention.kv_cache.hybrid_deepseek_v4 import (
             HybridDeepseekV4TokenToKVPool,
@@ -95,7 +99,7 @@ def create_cache_pool(
             rank=rank,
             field_layer_offset=field_layer_offset,
         )
-    if isinstance(config, DSAConfig):
+    if isinstance(softmax_attn, DSAConfig):
         from tokenspeed.runtime.layers.attention.kv_cache.dsa import (
             DSATokenToKVPool,
         )
@@ -105,14 +109,14 @@ def create_cache_pool(
             dtype=config.kv_cache_dtype,
             model_dtype=config.dtype,
             quant_method=config.kv_cache_quant_method,
-            kv_lora_rank=config.kv_lora_rank,
-            qk_rope_head_dim=config.qk_rope_head_dim,
+            kv_lora_rank=softmax_attn.kv_lora_rank,
+            qk_rope_head_dim=softmax_attn.qk_rope_head_dim,
             layer_num=num_layers,
             rank=rank,
-            index_head_dim=config.index_head_dim,
+            index_head_dim=softmax_attn.index_head_dim,
             field_layer_offset=field_layer_offset,
         )
-    if isinstance(config, MSAConfig):
+    if isinstance(softmax_attn, MSAConfig):
         from tokenspeed.runtime.layers.attention.kv_cache.msa import (
             MSATokenToKVPool,
         )
@@ -120,31 +124,31 @@ def create_cache_pool(
         return MSATokenToKVPool(
             arena=arena,
             dtype=config.kv_cache_dtype,
-            head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
-            head_dim=config.head_dim,
+            head_num=max(softmax_attn.num_kv_heads // softmax_attn.attn_tp_size, 1),
+            head_dim=softmax_attn.head_dim,
             layer_num=num_layers,
             rank=rank,
-            index_head_dim=config.index_head_dim,
+            index_head_dim=softmax_attn.index_head_dim,
             index_dtype=config.dtype,
-            indexed_layer_ids=config.sparse_layer_ids,
+            indexed_layer_ids=softmax_attn.sparse_layer_ids,
             layer_types=spec.layer_types,
             field_layer_offset=field_layer_offset,
         )
-    if isinstance(config, MHAConfig):
+    if isinstance(softmax_attn, MHAConfig):
         pool_cls = _mha_pool_class(spec.family, mxfp8=bool(config.kv_cache_mxfp8))
         return pool_cls(
             arena=arena,
             dtype=config.kv_cache_dtype,
-            head_num=max(config.num_kv_heads // config.attn_tp_size, 1),
-            head_dim=config.head_dim,
+            head_num=max(softmax_attn.num_kv_heads // softmax_attn.attn_tp_size, 1),
+            head_dim=softmax_attn.head_dim,
             layer_num=num_layers,
             rank=rank,
             layer_types=spec.layer_types,
             layer_kv_head_counts=spec.layer_kv_head_counts,
-            kv_alloc_head_count=config.num_kv_heads,
+            kv_alloc_head_count=softmax_attn.num_kv_heads,
             field_layer_offset=field_layer_offset,
         )
-    if isinstance(config, MLAConfig):
+    if isinstance(softmax_attn, MLAConfig):
         if spec.family == "mla":
             from tokenspeed.runtime.layers.attention.kv_cache.mla import (
                 MLATokenToKVPool,
@@ -155,8 +159,8 @@ def create_cache_pool(
                 dtype=config.kv_cache_dtype,
                 model_dtype=config.dtype,
                 quant_method=config.kv_cache_quant_method,
-                kv_lora_rank=config.kv_lora_rank,
-                qk_rope_head_dim=config.qk_rope_head_dim,
+                kv_lora_rank=softmax_attn.kv_lora_rank,
+                qk_rope_head_dim=softmax_attn.qk_rope_head_dim,
                 layer_num=num_layers,
                 rank=rank,
                 field_layer_offset=field_layer_offset,
@@ -176,11 +180,13 @@ def create_cache_pool(
             dtype=config.kv_cache_dtype,
             model_dtype=config.dtype,
             quant_method=config.kv_cache_quant_method,
-            kv_lora_rank=config.kv_lora_rank,
-            qk_rope_head_dim=config.qk_rope_head_dim,
+            kv_lora_rank=softmax_attn.kv_lora_rank,
+            qk_rope_head_dim=softmax_attn.qk_rope_head_dim,
             layer_num=num_layers,
             rank=rank,
             layer_types=spec.layer_types,
             field_layer_offset=field_layer_offset,
         )
-    raise TypeError(f"cache setup does not support config type {type(config).__name__}")
+    raise TypeError(
+        f"cache setup does not support config type {type(softmax_attn).__name__}"
+    )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
@@ -27,6 +27,9 @@ from collections.abc import Mapping, Sequence
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from tokenspeed.runtime.layers.attention.configs.base import (
+    SoftmaxAttnConfig,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes import (
     configured_token_limit,
 )
@@ -232,9 +235,9 @@ class CacheRecipe(ABC):
         return group(
             layer_types=self.layer_types,
             group_ids=self.group_ids,
-            sliding_window_tokens=getattr(
-                self.attn_config, "sliding_window_tokens", None
-            ),
+            sliding_window_tokens=self.attn_config.component(
+                SoftmaxAttnConfig
+            ).sliding_window_tokens,
             prefix_granularity=self.prefix_granularity,
             fields_for_layer=self.fields_for_layer,
             pd_disaggregation_enabled=self.pd_disaggregation_enabled,

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/inkling.py
@@ -33,6 +33,9 @@ from functools import cached_property
 import torch
 from typing_extensions import override
 
+from tokenspeed.runtime.layers.attention.configs.base import (
+    SoftmaxAttnConfig,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
     CacheGroupDeclaration,
     CacheRecipe,
@@ -67,7 +70,7 @@ class InklingRecipe(CacheRecipe):
     @property
     @override
     def num_target_layers(self) -> int:
-        return len(self.attn_config.layer_types)
+        return len(self.attn_config.component(SoftmaxAttnConfig).layer_types)
 
     @property
     @override
@@ -85,10 +88,12 @@ class InklingRecipe(CacheRecipe):
 
     @cached_property
     def layer_types(self) -> tuple[str, ...]:
-        target = tuple(self.attn_config.layer_types)
+        target = tuple(self.attn_config.component(SoftmaxAttnConfig).layer_types)
         if self.draft_attn_config is None:
             return target
-        return target + tuple(self.draft_attn_config.layer_types)
+        return target + tuple(
+            self.draft_attn_config.component(SoftmaxAttnConfig).layer_types
+        )
 
     @property
     def group_ids(self) -> tuple[str, ...]:
@@ -149,11 +154,12 @@ class InklingRecipe(CacheRecipe):
     ) -> tuple[CacheFieldSpec, ...]:
         """This layer's attention pages. Its conv checkpoints are columns."""
         config = self._layer_config(layer_id)
+        spec = self._layer_spec(layer_id)
         # mxfp8_kv_scale_fields owns the page-span and head-dim constraints the
         # interleaved scale layout imposes.
         mxfp8 = bool(config.kv_cache_mxfp8)
         kv_heads = self._layer_kv_heads(layer_id)
-        kv_shape = (self.prefix_granularity, kv_heads, config.head_dim)
+        kv_shape = (self.prefix_granularity, kv_heads, spec.head_dim)
         kv_dtype = (
             cache_dtype_name(torch.float8_e4m3fn)
             if mxfp8
@@ -179,7 +185,7 @@ class InklingRecipe(CacheRecipe):
             layer_id=layer_id,
             occurrence=occurrence,
             kv_heads=kv_heads,
-            head_dim=config.head_dim,
+            head_dim=spec.head_dim,
             prefix_granularity=self.prefix_granularity,
         )
 
@@ -203,7 +209,7 @@ class InklingRecipe(CacheRecipe):
             text_config = self._layer_model_config(layer_id).hf_config.get_text_config()
             checkpoint_rows = text_config.sconv_kernel_size - 1
             kv_row = (
-                self._layer_kv_heads(layer_id) * self._layer_config(layer_id).head_dim
+                self._layer_kv_heads(layer_id) * self._layer_spec(layer_id).head_dim
             )
             k_plane = f"unit.{occurrence}.k"
             v_plane = f"unit.{occurrence}.v"
@@ -248,6 +254,10 @@ class InklingRecipe(CacheRecipe):
             else self.draft_attn_config
         )
 
+    def _layer_spec(self, layer_id: int):
+        """The owning attn config's softmax (MHA) component spec."""
+        return self._layer_config(layer_id).component(SoftmaxAttnConfig)
+
     def _layer_model_config(self, layer_id: int):
         return (
             self.model_config
@@ -256,8 +266,8 @@ class InklingRecipe(CacheRecipe):
         )
 
     def _layer_kv_heads(self, layer_id: int) -> int:
-        config = self._layer_config(layer_id)
-        return max(1, self.layer_kv_head_counts[layer_id] // config.attn_tp_size)
+        spec = self._layer_spec(layer_id)
+        return max(1, self.layer_kv_head_counts[layer_id] // spec.attn_tp_size)
 
     # ---- extras ----
 
@@ -316,7 +326,9 @@ def _conv_ring_bytes(*, text_config, attn_config, num_layers: int, spec_tokens: 
     # Must match _wrap_inkling_backend's ring sizing: (W-1) taps + K chunk rows.
     spec_tokens = max(1, int(spec_tokens))
     ring_rows = int(text_config.sconv_kernel_size) - 1 + spec_tokens
-    conv_dim = inkling_conv_total_dim(text_config, attn_config.attn_tp_size)
+    conv_dim = inkling_conv_total_dim(
+        text_config, attn_config.component(SoftmaxAttnConfig).attn_tp_size
+    )
     pending_bytes = rows * torch.bool.itemsize
     return (
         num_layers * rows * ring_rows * conv_dim * torch.bfloat16.itemsize

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/kimi_k3.py
@@ -35,6 +35,10 @@ from functools import cached_property
 import torch
 from typing_extensions import override
 
+from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+    LinearAttnConfig,
+)
+from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
     CacheGroupDeclaration,
     CacheRecipe,
@@ -183,10 +187,12 @@ class KimiK3Recipe(CacheRecipe):
 
     @cached_property
     def _kda_shapes(self):
-        """(conv shape, recurrent shape) per rank, validated against tp size."""
-        tp_size = self.attn_config.attn_tp_size
-        if tp_size <= 0:
-            raise ValueError(f"tp_size must be positive, got {tp_size}")
+        """(conv shape, recurrent shape) per rank, from the linear component.
+
+        Geometry, TP width, and divisibility validation live on
+        ``LinearAttnConfig`` (sourced from ``mapping.linear_attn``); the
+        recipe only validates the cache-dtype contract around them.
+        """
         cache_dtype = self.attn_config.kv_cache_dtype
         if cache_dtype not in (torch.float8_e4m3fn, torch.bfloat16):
             raise ValueError(
@@ -197,18 +203,10 @@ class KimiK3Recipe(CacheRecipe):
             raise ValueError("Kimi-K3 cache does not support per_token_head MLA cache")
         if getattr(self._text_config, "mla_use_nope", None) is not True:
             raise ValueError("Kimi-K3 cache requires mla_use_nope=True")
-        linear = self._text_config.linear_attn_config
-        num_heads = int(linear["num_heads"])
-        head_dim = int(linear["head_dim"])
-        kernel_size = int(linear["short_conv_kernel_size"])
-        if num_heads % tp_size:
-            raise ValueError(
-                f"KDA num_heads={num_heads} must be divisible by tp_size={tp_size}"
-            )
-        return (
-            (3 * num_heads * head_dim // tp_size, kernel_size - 1),
-            (num_heads // tp_size, head_dim, head_dim),
-        )
+        linear_attn = self.attn_config.component(LinearAttnConfig)
+        if linear_attn is None:
+            raise ValueError("Kimi-K3 cache requires a linear-attention component")
+        return (linear_attn.conv_state_shape, linear_attn.temporal_state_shape)
 
     @override
     def fields_for_layer(
@@ -221,7 +219,8 @@ class KimiK3Recipe(CacheRecipe):
                 if layer_id < self.num_target_layers
                 else self.draft_attn_config
             )
-            latent_width = config.kv_lora_rank + config.qk_rope_head_dim
+            spec = config.component(MLAConfig)
+            latent_width = spec.kv_lora_rank + spec.qk_rope_head_dim
             return (
                 CacheFieldSpec(
                     f"layer.{layer_id}.latent_kv",

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/ordinary.py
@@ -33,6 +33,9 @@ from functools import cached_property
 import torch
 from typing_extensions import override
 
+from tokenspeed.runtime.layers.attention.configs.base import (
+    SoftmaxAttnConfig,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
     CacheGroupDeclaration,
     CacheRecipe,
@@ -83,12 +86,16 @@ class OrdinaryRecipe(CacheRecipe):
         draft layer against 61 target labels), so misaligned labels degrade to
         full-history rather than mislabeling a group.
         """
-        target = tuple(getattr(self.attn_config, "layer_types", ()))
+        target = tuple(self.attn_config.component(SoftmaxAttnConfig).layer_types)
         if len(target) != self.num_target_layers:
             target = ()
         if self.draft_attn_config is None:
             return target if target else ()
-        draft = tuple(getattr(self.draft_attn_config, "layer_types", ()))
+        draft = tuple(
+            getattr(
+                self.draft_attn_config.component(SoftmaxAttnConfig), "layer_types", ()
+            )
+        )
         if len(draft) != self.num_draft_layers:
             draft = (FULL_ATTENTION,) * self.num_draft_layers
         merged = target + draft
@@ -155,9 +162,10 @@ class OrdinaryRecipe(CacheRecipe):
 
 
 def _storage_layers(config, num_layers: int) -> int:
+    spec = config.component(SoftmaxAttnConfig)
     group_size = hybrid_slab_group_size(
-        getattr(config, "layer_types", None),
-        sliding_window_tokens=getattr(config, "sliding_window_tokens", None),
+        getattr(spec, "layer_types", None),
+        sliding_window_tokens=spec.sliding_window_tokens,
     )
     return group_size if group_size is not None else num_layers
 
@@ -167,13 +175,14 @@ def _config_group_ids(config, num_layers: int) -> tuple[str, ...]:
     from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
     from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
 
-    if isinstance(config, MHAConfig | MSAConfig):
-        layer_types = tuple(config.layer_types)
+    spec = config.component(SoftmaxAttnConfig)
+    if isinstance(spec, MHAConfig | MSAConfig):
+        layer_types = tuple(spec.layer_types)
         if layer_types:
             ids = tuple(
                 layer_group_ids(
                     layer_types=layer_types,
-                    sliding_window_tokens=config.sliding_window_tokens,
+                    sliding_window_tokens=spec.sliding_window_tokens,
                 )
             )
             if len(ids) != num_layers:
@@ -191,24 +200,26 @@ def _config_layer_fields(
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
     from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
 
-    if isinstance(config, DSAConfig):
+    spec = config.component(SoftmaxAttnConfig)
+    if isinstance(spec, DSAConfig):
         return _mla_layer_fields(config, layer_id, occurrence) + (
             _index_k_field(config, layer_id),
         )
-    if isinstance(config, MSAConfig):
+    if isinstance(spec, MSAConfig):
         fields = _mha_layer_fields(config, layer_id, occurrence)
-        if local_layer_id in config.sparse_layer_ids:
+        if local_layer_id in spec.sparse_layer_ids:
             fields += (_index_k_field(config, layer_id),)
         return fields
-    if isinstance(config, MLAConfig):
+    if isinstance(spec, MLAConfig):
         return _mla_layer_fields(config, layer_id, occurrence)
-    if isinstance(config, MHAConfig):
+    if isinstance(spec, MHAConfig):
         return _mha_layer_fields(config, layer_id, occurrence)
-    raise TypeError(f"no ordinary cache recipe for {type(config).__name__}")
+    raise TypeError(f"no ordinary cache recipe for {type(spec).__name__}")
 
 
 def _mha_layer_fields(config, layer_id: int, occurrence: int):
     """One MHA layer's K/V pages, with mxfp8 scale planes when enabled."""
+    spec = config.component(SoftmaxAttnConfig)
     mxfp8 = bool(config.kv_cache_mxfp8)
     if mxfp8 and config.prefix_granularity != MXFP8_KV_SCALE_TILE_TOKENS:
         raise AssertionError(
@@ -216,8 +227,8 @@ def _mha_layer_fields(config, layer_id: int, occurrence: int):
             f"{MXFP8_KV_SCALE_TILE_TOKENS} (the attention kernel consumes "
             "the interleaved paged scale layout)"
         )
-    kv_heads = max(config.num_kv_heads // config.attn_tp_size, 1)
-    head_dim = config.head_dim
+    kv_heads = max(spec.num_kv_heads // spec.attn_tp_size, 1)
+    head_dim = spec.head_dim
     if config.prefix_granularity <= 0 or kv_heads <= 0 or head_dim <= 0:
         raise ValueError("MHA full-attention geometry must be positive")
     shape = (config.prefix_granularity, kv_heads, head_dim)
@@ -245,10 +256,11 @@ def _mha_layer_fields(config, layer_id: int, occurrence: int):
 
 def _mla_layer_fields(config, layer_id: int, occurrence: int):
     """One MLA layer's latent page, split into planes when quantized."""
+    spec = config.component(SoftmaxAttnConfig)
     if config.prefix_granularity <= 0:
         raise ValueError("MLA full-attention geometry must be positive")
     if config.kv_cache_quant_method != "per_token_head":
-        latent_width = config.kv_lora_rank + config.qk_rope_head_dim
+        latent_width = spec.kv_lora_rank + spec.qk_rope_head_dim
         return (
             CacheFieldSpec(
                 f"layer.{layer_id}.latent_kv",
@@ -267,7 +279,7 @@ def _mla_layer_fields(config, layer_id: int, occurrence: int):
         for name, shape, dtype in (
             (
                 "latent_kv",
-                (config.prefix_granularity, 1, config.kv_lora_rank),
+                (config.prefix_granularity, 1, spec.kv_lora_rank),
                 scatter_stored_dtype_name(config.kv_cache_dtype),
             ),
             (
@@ -277,7 +289,7 @@ def _mla_layer_fields(config, layer_id: int, occurrence: int):
             ),
             (
                 "rope_k",
-                (config.prefix_granularity, 1, config.qk_rope_head_dim),
+                (config.prefix_granularity, 1, spec.qk_rope_head_dim),
                 cache_dtype_name(config.dtype),
             ),
         )
@@ -291,16 +303,17 @@ def _index_k_field(config, layer_id: int) -> CacheFieldSpec:
         dsa_index_k_row_bytes,
     )
 
-    if isinstance(config, DSAConfig):
+    spec = config.component(SoftmaxAttnConfig)
+    if isinstance(spec, DSAConfig):
         return CacheFieldSpec(
             f"layer.{layer_id}.index_k",
             f"layer.{layer_id}.index_k",
-            (config.prefix_granularity, dsa_index_k_row_bytes(config.index_head_dim)),
+            (config.prefix_granularity, dsa_index_k_row_bytes(spec.index_head_dim)),
             "uint8",
         )
     return CacheFieldSpec(
         f"layer.{layer_id}.index_k",
         f"layer.{layer_id}.index_k",
-        (config.prefix_granularity, config.index_head_dim),
+        (config.prefix_granularity, spec.index_head_dim),
         cache_dtype_name(config.dtype),
     )

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen35.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/qwen35.py
@@ -7,6 +7,12 @@ from functools import cached_property
 import torch
 from typing_extensions import override
 
+from tokenspeed.runtime.layers.attention.configs.base import (
+    SoftmaxAttnConfig,
+)
+from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+    LinearAttnConfig,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecipe
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.plan import (
     CacheFieldSpec,
@@ -19,6 +25,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
     LINEAR_ATTENTION,
     split_recurrent_state_groups,
 )
+from tokenspeed.runtime.utils.env import envs
 
 _QWEN_GDN_PREFIX_GRANULARITY = 128
 
@@ -39,15 +46,18 @@ class QwenGDNRecipe(CacheRecipe):
                 "Qwen cache buffer does not yet support the MXFP8 interleaved "
                 "scale layout"
             )
+        linear_attn = self.attn_config.component(LinearAttnConfig)
+        if linear_attn is None:
+            raise ValueError("Qwen GDN cache requires a linear-attention component")
         # The GDN backend reads the same decision, so publish it once here
         # rather than as a side effect of sizing the workspace.
-        self.attn_config.replay_ssm = self.replay_ssm
+        linear_attn.replay_ssm = self.replay_ssm
 
     # ---- layer vocabulary ----
 
     @cached_property
     def target_layer_types(self) -> tuple[str, ...]:
-        return tuple(self.attn_config.layer_types)
+        return tuple(self.attn_config.component(SoftmaxAttnConfig).layer_types)
 
     @cached_property
     def layer_types(self) -> tuple[str, ...]:
@@ -102,31 +112,38 @@ class QwenGDNRecipe(CacheRecipe):
 
     @cached_property
     def _state_shapes(self):
-        conv_shape, ssm_shape, conv_dtype, ssm_dtype, _ = (
-            self._text_config.mamba2_cache_params
-        )
+        """Per-rank GDN state shapes from the linear component.
+
+        Dtypes are the recipe's contract: conv bf16, SSM per the engine env.
+        """
+        linear_attn = self.attn_config.component(LinearAttnConfig)
+        ssm_dtype = {
+            "float32": torch.float32,
+            "bfloat16": torch.bfloat16,
+        }[envs.TOKENSPEED_MAMBA_SSM_DTYPE.get()]
         return (
-            tuple(conv_shape),
-            cache_dtype_name(conv_dtype),
-            tuple(ssm_shape),
+            linear_attn.conv_state_shape,
+            cache_dtype_name(torch.bfloat16),
+            linear_attn.temporal_state_shape,
             cache_dtype_name(ssm_dtype),
         )
 
     @cached_property
     def _kv_shape(self) -> tuple[int, ...]:
+        spec = self.attn_config.component(SoftmaxAttnConfig)
         return (
             self.prefix_granularity,
-            max(self.attn_config.num_kv_heads // self.attn_config.attn_tp_size, 1),
-            self.attn_config.head_dim,
+            max(spec.num_kv_heads // spec.attn_tp_size, 1),
+            spec.head_dim,
         )
 
     @cached_property
     def _draft_kv_shape(self) -> tuple[int, ...]:
-        config = self.draft_attn_config
+        spec = self.draft_attn_config.component(SoftmaxAttnConfig)
         return (
             self.prefix_granularity,
-            max(config.num_kv_heads // config.attn_tp_size, 1),
-            config.head_dim,
+            max(spec.num_kv_heads // spec.attn_tp_size, 1),
+            spec.head_dim,
         )
 
     @override
@@ -193,7 +210,7 @@ class QwenGDNRecipe(CacheRecipe):
             layer_id=layer_id,
             occurrence=occurrence,
             kv_heads=self._draft_kv_shape[1],
-            head_dim=config.head_dim,
+            head_dim=config.component(SoftmaxAttnConfig).head_dim,
             prefix_granularity=self.prefix_granularity,
         )
 
@@ -223,7 +240,7 @@ class QwenGDNRecipe(CacheRecipe):
             int(self.server_args.speculative_num_draft_tokens) + 1
         )
         # Replay reconstructs the ssm state, so only the conv checkpoint is
-        # staged; the backend reads the same decision off attn_config.
+        # staged; the backend reads the same decision off the linear component.
         staged = verify_rows * sum(
             field.payload_bytes
             for _, fields in self.groups()

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, replace
 from functools import partial
 from typing import Literal
 
-from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecipe
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4 import (
     DeepseekV4Recipe,
@@ -171,9 +171,9 @@ def prepare_cache_setup(
     family: CacheModelFamily,
     server_args,
     model_config,
-    attn_config: BaseAttnConfig,
+    attn_config: AttnConfig,
     draft_model_config,
-    draft_attn_config: BaseAttnConfig | None,
+    draft_attn_config: AttnConfig | None,
     cache_budget_bytes: int,
     decode_input_tokens: int,
     overlap_schedule_depth: int,

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 from typing import TYPE_CHECKING
 
@@ -31,8 +32,12 @@ from tokenspeed.runtime.configs.model_config import (
     is_deepseek_v4,
     is_qwen4_exp,
 )
-from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+from tokenspeed.runtime.layers.attention.configs.base import (
+    AttnConfig,
+    SoftmaxAttnConfig,
+)
 from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
+from tokenspeed.runtime.layers.attention.configs.linear_attn import LinearAttnConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import (
@@ -68,14 +73,17 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.utils.server_args import ServerArgs
 
 
-def _ordinary_cache_family(config: BaseAttnConfig | None) -> CacheModelFamily | None:
-    if type(config) is MHAConfig:
+def _ordinary_cache_family(config: AttnConfig | None) -> CacheModelFamily | None:
+    if config is None:
+        return None
+    softmax_attn = config.component(SoftmaxAttnConfig)
+    if type(softmax_attn) is MHAConfig:
         return "mha"
-    if type(config) is MLAConfig:
+    if type(softmax_attn) is MLAConfig:
         return "mla"
-    if isinstance(config, DSAConfig):
+    if isinstance(softmax_attn, DSAConfig):
         return "dsa"
-    if isinstance(config, MSAConfig):
+    if isinstance(softmax_attn, MSAConfig):
         return "msa"
     return None
 
@@ -246,7 +254,7 @@ def _get_backend_cls(name: str, arch: AttentionArch) -> type[AttentionBackend]:
 
 
 def _validate_lcm_page_size(
-    config: BaseAttnConfig,
+    config: AttnConfig,
     *,
     prefix_granularity: int,
 ) -> None:
@@ -271,41 +279,65 @@ def _validate_lcm_page_size(
 
 # ---------- arch -> config class ----------
 
-_CONFIG_CLS: dict[AttentionArch, type[BaseAttnConfig]] = {
+_CONFIG_CLS: dict[AttentionArch, type[SoftmaxAttnConfig]] = {
     AttentionArch.MHA: MHAConfig,
     AttentionArch.MLA: MLAConfig,
     AttentionArch.DSA: DSAConfig,
     AttentionArch.MSA: MSAConfig,
 }
 
+# Architectures declaring a linear-attention component, registered like
+# _CONFIG_CLS. Whether a given checkpoint actually has linear layers is
+# decided by generate() (NextN drafts may carry none).
+_LINEAR_ATTN_CLS: dict[str, type[LinearAttnConfig]] = {
+    arch: LinearAttnConfig
+    for arch in (*_HYBRID_GDN_ARCHITECTURES, *_HYBRID_MLA_KDA_ARCHITECTURES)
+}
+
 
 def _create_attn_config(
     server_args: ServerArgs, model_config: ModelConfig, is_draft: bool = False
-) -> BaseAttnConfig:
+) -> AttnConfig:
     arch = model_config.attention_arch
     if arch not in _CONFIG_CLS:
         raise NotImplementedError(f"Not supported Attention Arch: {arch!r}")
-    return _CONFIG_CLS[arch].generate(server_args, model_config, is_draft)
+    config = _CONFIG_CLS[arch].generate(server_args, model_config, is_draft)
+    # Extra components are built through the same generate() protocol and
+    # composed into config.components (consumers look them up by class via
+    # ``component()``).
+    architectures = getattr(model_config.hf_config, "architectures", None) or ()
+    linear_cls = next(
+        (_LINEAR_ATTN_CLS[a] for a in architectures if a in _LINEAR_ATTN_CLS), None
+    )
+    if linear_cls is not None:
+        linear_attn = linear_cls.generate(server_args, model_config, is_draft)
+        if linear_attn is not None:
+            config = dataclasses.replace(
+                config, components=config.components + (linear_attn,)
+            )
+    return config
 
 
 def _create_attn_backend(
     arch: AttentionArch,
-    config: BaseAttnConfig,
+    config: AttnConfig,
 ) -> AttentionBackend:
-    return _get_backend_cls(config.backend_name, arch)(config)
+    spec = config.component(SoftmaxAttnConfig)
+    return _get_backend_cls(spec.backend_name, arch)(config, spec)
 
 
 def _create_attn_backend_with_name(
     name: str | None,
     arch: AttentionArch,
-    config: BaseAttnConfig,
+    config: AttnConfig,
 ) -> AttentionBackend:
-    original_name = config.backend_name
-    config.backend_name = name
+    spec = config.component(SoftmaxAttnConfig)
+    original_name = spec.backend_name
+    spec.backend_name = name
     try:
-        return _get_backend_cls(name, arch)(config)
+        return _get_backend_cls(name, arch)(config, spec)
     finally:
-        config.backend_name = original_name
+        spec.backend_name = original_name
 
 
 def _resolve_kda_backend(kda_backend: str) -> str:
@@ -367,7 +399,7 @@ def _resolve_hybrid_full_backend_name(
 def _create_hybrid_linear_attn_backend(
     server_args: ServerArgs,
     model_config: ModelConfig,
-    config: BaseAttnConfig,
+    config: AttnConfig,
     *,
     pool,
     full_attn_backend_name: str | None = None,
@@ -407,23 +439,23 @@ def _create_hybrid_linear_attn_backend(
 
     # Create mamba/linear attention backend. Only propagate the configured
     # verify width when spec-dec is actually enabled — matches MLAConfig /
-    # MHAConfig.generate. Otherwise the BaseAttnConfig sentinel (1) wins so
+    # MHAConfig.generate. Otherwise the AttnConfig sentinel (1) wins so
     # non-spec hybrid decode doesn't get misclassified as target verify /
     # draft extend by `self.spec_num_tokens > 1`.
     if server_args.speculative_algorithm is not None:
         config.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
 
-    # Read mamba2_cache_params to decide whether this model actually has
-    # any linear / mamba layers. A draft model on a hybrid-GDN target
+    # The linear component's presence decides whether this model actually
+    # has any linear / mamba layers. A draft model on a hybrid-GDN target
     # (e.g. MTP on Qwen3.5) shares the same architecture class as the
     # target but commonly ships with *zero* mamba layers — in that case
     # we skip the mamba backend entirely so that its
     # ``init_forward_metadata_*`` hooks do not run (they would otherwise
     # touch a zero-sized pool on the same persistent state_indices_list
     # as the target, which breaks the captured CUDA graph).
-    mamba_layer_ids = text_config.mamba2_cache_params[-1]
+    linear_attn = config.component(LinearAttnConfig)
 
-    if len(mamba_layer_ids) == 0:
+    if linear_attn is None:
         logger.info(
             "Created hybrid_linear_attn backend: %d full attn layers, 0 linear "
             "attn layers (skipping mamba backend)",
@@ -434,15 +466,21 @@ def _create_hybrid_linear_attn_backend(
     kda_backend = (getattr(server_args, "kda_backend", None) or "auto").strip().lower()
     if is_kda:
         kda_backend = _resolve_kda_backend(kda_backend)
-        linear_attn_backend = KdaAttnBackend(config, kda_backend=kda_backend)
+        linear_attn_backend = KdaAttnBackend(
+            config, config.component(SoftmaxAttnConfig), kda_backend=kda_backend
+        )
     elif is_qwen4_exp(hf_config):
         from tokenspeed.runtime.layers.attention.backends.qwen4_exp import (
             Qwen4ExpMambaAttnBackend,
         )
 
-        linear_attn_backend = Qwen4ExpMambaAttnBackend(config)
+        linear_attn_backend = Qwen4ExpMambaAttnBackend(
+            config, config.component(SoftmaxAttnConfig)
+        )
     else:
-        linear_attn_backend = MambaAttnBackend(config)
+        linear_attn_backend = MambaAttnBackend(
+            config, config.component(SoftmaxAttnConfig)
+        )
 
     # Recurrent state lives in the LCM arena and is addressed by the
     # per-group block tables, so no separate request-indexed Mamba pool exists.
@@ -453,7 +491,7 @@ def _create_hybrid_linear_attn_backend(
     logger.info(
         "Created hybrid_linear_attn backend: %d full attn layers, %d linear attn layers, %s",
         len(full_attn_layers),
-        len(mamba_layer_ids),
+        len(linear_attn.layer_ids),
         "LCM state fields",
     )
     return backend
@@ -490,7 +528,9 @@ def _wrap_inkling_backend(
         num_layers=num_layers,
         # Row 0 is reserved (1-based indices); +2 covers it plus a padding slot
         num_slots=attn_config.max_bs + 2,
-        conv_dim=inkling_conv_total_dim(text_config, attn_config.attn_tp_size),
+        conv_dim=inkling_conv_total_dim(
+            text_config, attn_config.component(SoftmaxAttnConfig).attn_tp_size
+        ),
         kernel_size=kernel_size,
         ring_size=ring_size,
         dtype=torch.bfloat16,
@@ -772,8 +812,9 @@ def create_attn_components(
             server_args.drafter_attention_backend = None
 
     config = _create_attn_config(server_args, model_config)
+    softmax_attn = config.component(SoftmaxAttnConfig)
     if is_deepseek_v4_model:
-        config.sliding_window_tokens = int(model_config.hf_config.sliding_window)
+        softmax_attn.sliding_window_tokens = int(model_config.hf_config.sliding_window)
     if (
         (is_inkling or is_inkling_draft_model)
         and server_args.disaggregation_mode in ("prefill", "decode")
@@ -786,16 +827,13 @@ def create_attn_components(
             "Inkling PD supports target-only decoding; speculative/draft "
             "ShortConv checkpoint transfer is not implemented"
         )
-    target_text_config = getattr(
-        model_config.hf_config, "text_config", model_config.hf_config
-    )
-    target_mamba_params = getattr(target_text_config, "mamba2_cache_params", None)
     has_state = bool(
-        target_mamba_params
-        and target_mamba_params[-1]
+        config.component(LinearAttnConfig) is not None
         and any(
             layer_type in STATE_LAYER_TYPES
-            for layer_type in getattr(config, "layer_types", ())
+            for layer_type in getattr(
+                config.component(SoftmaxAttnConfig), "layer_types", ()
+            )
         )
     )
     use_cache_gdn = is_hybrid_gdn and has_state
@@ -815,20 +853,20 @@ def create_attn_components(
         cache_family = "kimi_k3"
     elif use_cache_inkling:
         cache_family = "inkling"
-    elif type(config) is MHAConfig:
+    elif type(softmax_attn) is MHAConfig:
         cache_family = "mha"
-    elif type(config) is MLAConfig:
+    elif type(softmax_attn) is MLAConfig:
         cache_family = "mla"
-    elif isinstance(config, DSAConfig):
+    elif isinstance(softmax_attn, DSAConfig):
         cache_family = "dsa"
-    elif isinstance(config, MSAConfig):
+    elif isinstance(softmax_attn, MSAConfig):
         cache_family = "msa"
     else:
         cache_family = None
     if cache_family is None:
         raise RuntimeError(
             "No cache recipe is registered for "
-            f"attention config {type(config).__name__}"
+            f"attention config {type(softmax_attn).__name__}"
         )
     target_full_attn_backend_name = (
         _resolve_hybrid_full_backend_name(
@@ -837,15 +875,20 @@ def create_attn_components(
             has_cache_plan=True,
         )
         if is_hybrid_linear
-        else config.backend_name
+        else config.component(SoftmaxAttnConfig).backend_name
     )
     draft_attn_config = (
         _create_attn_config(server_args, draft_model_config, is_draft=True)
         if draft_model_config and not is_dspark_draft_model
         else None
     )
+    draft_softmax_attn = (
+        draft_attn_config.component(SoftmaxAttnConfig)
+        if draft_attn_config is not None
+        else None
+    )
     if is_deepseek_v4_draft_model:
-        draft_attn_config.sliding_window_tokens = int(
+        draft_softmax_attn.sliding_window_tokens = int(
             draft_model_config.hf_config.sliding_window
         )
     draft_is_hybrid_gdn = any(
@@ -860,12 +903,12 @@ def create_attn_components(
     if draft_attn_config is not None:
         if draft_is_hybrid_gdn or draft_is_hybrid_mla_kda:
             draft_full_attn_backend_name = _resolve_hybrid_full_backend_name(
-                draft_attn_config.backend_name,
+                draft_softmax_attn.backend_name,
                 is_kda=draft_is_hybrid_mla_kda,
                 has_cache_plan=True,
             )
         else:
-            draft_full_attn_backend_name = draft_attn_config.backend_name
+            draft_full_attn_backend_name = draft_softmax_attn.backend_name
     draft_cache_family = _ordinary_cache_family(draft_attn_config)
     heterogeneous_draft_family = _resolve_heterogeneous_draft_family(
         cache_family,

--- a/python/tokenspeed/runtime/layers/attention/utils.py
+++ b/python/tokenspeed/runtime/layers/attention/utils.py
@@ -25,7 +25,7 @@ import triton.language as tl
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
 )
-from tokenspeed.runtime.layers.attention.configs.base import BaseAttnConfig
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.utils import get_available_gpu_memory
 
 
@@ -90,7 +90,7 @@ def build_page_table(
 
 
 def profile_available_cache_memory_bytes(
-    attn_config: BaseAttnConfig,
+    attn_config: AttnConfig,
     gpu_id: int,
     tp_size: int,
     gpu_memory_utilization: float,

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1038,9 +1038,12 @@ class KimiLinearKDA(nn.Module):
         proj = self.num_heads * self.head_dim
         hidden = config.hidden_size
 
-        tp_rank = mapping.attn.tp_rank
-        tp_size = mapping.attn.tp_size
-        tp_group = mapping.attn.tp_group
+        # KDA parallelism reads the linear-attention mapping: it defaults to
+        # the attention TP width and diverges only under the
+        # MLA-DP + linear-attn-TP hybrid.
+        tp_rank = mapping.linear_attn.tp_rank
+        tp_size = mapping.linear_attn.tp_size
+        tp_group = mapping.linear_attn.tp_group
         self.local_num_heads = self.num_heads // tp_size
         proj_local = proj // tp_size
 
@@ -1235,7 +1238,7 @@ class KimiLinearKDA(nn.Module):
             activation="silu",
             key_dim=proj,
             value_dim=proj,
-            attention_tp_size=self.mapping.attn.tp_size,
+            attention_tp_size=self.mapping.linear_attn.tp_size,
             head_k_dim=hd,
             head_v_dim=hd,
             f_a_out=f_a_out,

--- a/test/runtime/conftest.py
+++ b/test/runtime/conftest.py
@@ -47,31 +47,63 @@ def kimi_recipe(
     kv_cache_dtype: torch.dtype = torch.float8_e4m3fn,
 ):
     """A Kimi-K3 recipe over the reference config, with tiny scheduler limits."""
+    import dataclasses
     from types import SimpleNamespace
 
     from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
+    from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+        LinearAttnConfig,
+    )
+    from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
     from tokenspeed.runtime.layers.attention.kv_cache.recipes.kimi_k3 import (
         KimiK3Recipe,
     )
 
     text_config = text_config if text_config is not None else KimiLinearConfig()
-    attn_config = SimpleNamespace(
+    # The real components, not namespace fakes: the recipe reads the linear
+    # component's state-shape properties and the MLA spec's latent dims.
+    kda = text_config.linear_attn_config
+    linear_attn = LinearAttnConfig(
+        num_k_heads=int(kda["num_heads"]),
+        num_v_heads=int(kda["num_heads"]),
+        head_k_dim=int(kda["head_dim"]),
+        head_v_dim=int(kda["head_dim"]),
+        conv_kernel_size=int(kda["short_conv_kernel_size"]),
+        layer_ids=tuple(text_config.linear_layer_ids),
+        tp_size=tp_size,
+    )
+    mla = MLAConfig(
+        backend_name="mla",
+        num_attention_heads=text_config.num_attention_heads,
+        num_kv_heads=text_config.num_key_value_heads,
+        head_dim=text_config.qk_nope_head_dim + text_config.qk_rope_head_dim,
         attn_tp_size=tp_size,
+        kv_lora_rank=text_config.kv_lora_rank,
+        qk_nope_head_dim=text_config.qk_nope_head_dim,
+        qk_rope_head_dim=text_config.qk_rope_head_dim,
+        v_head_dim=text_config.v_head_dim,
+        scaling=(text_config.qk_nope_head_dim + text_config.qk_rope_head_dim) ** -0.5,
+        kv_cache_dim=text_config.kv_lora_rank + text_config.qk_rope_head_dim,
+    )
+    attn_config = AttnConfig(
+        device="cpu",
         dtype=torch.bfloat16,
         kv_cache_dtype=kv_cache_dtype,
         kv_cache_quant_method=None,
-        kv_lora_rank=text_config.kv_lora_rank,
-        qk_rope_head_dim=text_config.qk_rope_head_dim,
         prefix_granularity=128,
         max_bs=max_bs,
+        max_graph_bs=max_bs,
         # K3's per-group demand reads the scheduler's concurrency through
         # CacheRecipe.scheduler_limits, context length included.
         context_len=context_len,
         pd_disaggregation_enabled=pd_enabled,
+        speculative_num_draft_tokens=speculative_num_draft_tokens,
+        components=(mla, linear_attn),
     )
     # The real K3 draft is BF16 MLA over the FP8 target arena.
     draft_attn_config = (
-        SimpleNamespace(**{**vars(attn_config), "kv_cache_dtype": torch.bfloat16})
+        dataclasses.replace(attn_config, kv_cache_dtype=torch.bfloat16)
         if draft_layers
         else None
     )

--- a/test/runtime/distributed/test_cache_pd_manifest.py
+++ b/test/runtime/distributed/test_cache_pd_manifest.py
@@ -595,6 +595,7 @@ def test_pd_derives_ordinary_transfer_metadata_from_physical_plan(
 ) -> None:
     import torch
 
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
     from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
     from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
@@ -603,19 +604,11 @@ def test_pd_derives_ordinary_transfer_metadata_from_physical_plan(
     )
 
     common = {
-        "device": "cpu",
         "backend_name": "test",
         "num_attention_heads": 8,
         "num_kv_heads": 4,
         "head_dim": 8,
         "attn_tp_size": 2,
-        "dtype": torch.bfloat16,
-        "kv_cache_dtype": torch.bfloat16,
-        "prefix_granularity": 16,
-        "context_len": 256,
-        "max_bs": 4,
-        "max_graph_bs": 4,
-        "kv_cache_quant_method": "none",
     }
     classes = {"mha": MHAConfig, "mla": MLAConfig, "dsa": DSAConfig}
     extras = {}
@@ -630,11 +623,22 @@ def test_pd_derives_ordinary_transfer_metadata_from_physical_plan(
         )
     if family == "dsa":
         extras.update(index_topk=4, index_head_dim=128, index_n_heads=1)
-    config = classes[family](
+    spec = classes[family](
         **common,
         **extras,
         layer_types=(),
+    )
+    config = AttnConfig(
+        device="cpu",
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        prefix_granularity=16,
+        context_len=256,
+        max_bs=4,
+        max_graph_bs=4,
+        kv_cache_quant_method="none",
         pd_disaggregation_enabled=True,
+        components=(spec,),
     )
 
     recipe = OrdinaryRecipe(

--- a/test/runtime/distributed/test_mla_dsa_pd_contract.py
+++ b/test/runtime/distributed/test_mla_dsa_pd_contract.py
@@ -55,17 +55,30 @@ _NUM_LCM_BLOCKS = 6
 
 
 def _attn_config(family: str, pd_enabled: bool):
-    """A real MLA/DSA config: the recipe dispatches fields on the type."""
+    """A real MLA/DSA config: the recipe dispatches fields on the spec type."""
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
     from tokenspeed.runtime.layers.attention.configs.dsa import DSAConfig
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 
     common = dict(
-        device="cpu",
         backend_name="mla",
         num_attention_heads=64,
         num_kv_heads=64,
         attn_tp_size=1,
         head_dim=192,
+        kv_lora_rank=512,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=64,
+        v_head_dim=128,
+        scaling=1.0,
+        kv_cache_dim=576,
+    )
+    if family == "dsa":
+        spec = DSAConfig(index_topk=1, index_head_dim=128, index_n_heads=1, **common)
+    else:
+        spec = MLAConfig(**common)
+    return AttnConfig(
+        device="cpu",
         dtype=torch.bfloat16,
         kv_cache_dtype=torch.bfloat16,
         context_len=1024,
@@ -74,18 +87,10 @@ def _attn_config(family: str, pd_enabled: bool):
         prefix_granularity=_P,
         kernel_page_size=_P,
         kv_cache_quant_method="",
-        kv_lora_rank=512,
-        qk_nope_head_dim=128,
-        qk_rope_head_dim=64,
-        v_head_dim=128,
-        scaling=1.0,
-        kv_cache_dim=576,
         max_scheduled_tokens=_P,
         pd_disaggregation_enabled=pd_enabled,
+        components=(spec,),
     )
-    if family == "dsa":
-        return DSAConfig(index_topk=1, index_head_dim=128, index_n_heads=1, **common)
-    return MLAConfig(**common)
 
 
 def _recipe(family: str, pd_enabled: bool = False):

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -9,6 +9,8 @@ from tokenspeed.runtime.cache.transfer.layout import (
     combine_cache_transfer_layouts,
     select_layer_fields,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
+from tokenspeed.runtime.layers.attention.configs.linear_attn import LinearAttnConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
@@ -48,73 +50,63 @@ def _pool_over_new_arena(spec, config, *, num_layers: int, rank: int = 0):
     )
 
 
-def _mha_config() -> MHAConfig:
-    return MHAConfig(
+def _model_wide_kwargs(**overrides) -> dict:
+    """The AttnConfig (model-wide) tier the test configs share."""
+    kwargs = dict(
         device="cpu",
-        backend_name="fa2",
-        num_attention_heads=1,
-        layer_types=(),
-        kv_cache_mxfp8=False,
-        num_kv_heads=1,
-        attn_tp_size=1,
-        head_dim=2,
         dtype=torch.bfloat16,
         kv_cache_dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=2,
-        max_bs=2,
+        kv_cache_quant_method="none",
+        kv_cache_mxfp8=False,
         prefix_granularity=64,
         kernel_page_size=64,
-        kv_cache_quant_method="none",
+        context_len=1024,
+        max_bs=2,
+        max_graph_bs=2,
         max_scheduled_tokens=128,
     )
+    kwargs.update(overrides)
+    return kwargs
 
 
-def _mla_config() -> MLAConfig:
-    return MLAConfig(
-        device="cpu",
+def _mha_config() -> AttnConfig:
+    spec = MHAConfig(
+        backend_name="fa2",
+        num_attention_heads=1,
+        num_kv_heads=1,
+        head_dim=2,
+        attn_tp_size=1,
+        layer_types=(),
+    )
+    return AttnConfig(components=(spec,), **_model_wide_kwargs())
+
+
+def _mla_config() -> AttnConfig:
+    spec = MLAConfig(
         backend_name="trtllm_mla",
         num_attention_heads=1,
         num_kv_heads=1,
-        attn_tp_size=1,
         head_dim=8,
-        dtype=torch.bfloat16,
-        kv_cache_dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=2,
-        max_bs=2,
-        prefix_granularity=64,
-        kernel_page_size=64,
-        kv_cache_quant_method="none",
+        attn_tp_size=1,
         kv_lora_rank=4,
         qk_nope_head_dim=2,
         qk_rope_head_dim=2,
         v_head_dim=4,
         scaling=1.0,
         kv_cache_dim=6,
-        max_scheduled_tokens=128,
     )
+    return AttnConfig(components=(spec,), **_model_wide_kwargs())
 
 
-def _msa_config() -> MSAConfig:
-    return MSAConfig(
-        device="cpu",
+def _msa_config() -> AttnConfig:
+    spec = MSAConfig(
         backend_name="msa",
         num_attention_heads=1,
         num_kv_heads=1,
-        attn_tp_size=1,
         head_dim=2,
-        dtype=torch.bfloat16,
-        kv_cache_dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=2,
-        max_bs=2,
-        prefix_granularity=64,
-        kernel_page_size=64,
-        kv_cache_quant_method="none",
+        attn_tp_size=1,
         compute_layer_types=("full_attention", "sparse_attention"),
         sparse_layer_ids=frozenset({1}),
-        max_scheduled_tokens=128,
         index_head_dim=4,
         index_n_heads=1,
         index_block_size=64,
@@ -122,6 +114,7 @@ def _msa_config() -> MSAConfig:
         index_init_blocks=1,
         index_local_blocks=1,
     )
+    return AttnConfig(components=(spec,), **_model_wide_kwargs())
 
 
 class _SyntheticHybridRecipe(CacheRecipe):
@@ -148,8 +141,9 @@ class _SyntheticHybridRecipe(CacheRecipe):
         super().__init__(
             server_args=SimpleNamespace(max_total_tokens=None),
             model_config=None,
-            attn_config=SimpleNamespace(
-                prefix_granularity=4, sliding_window_tokens=windows
+            attn_config=_ns_config(
+                prefix_granularity=4,
+                spec=SimpleNamespace(sliding_window_tokens=windows),
             ),
             draft_model_config=None,
             draft_attn_config=None,
@@ -228,47 +222,56 @@ def test_attention_configs_do_not_own_cache_setup() -> None:
         "token_capacity",
     }
 
+    assert cache_setup_fields.isdisjoint(field.name for field in fields(AttnConfig))
     assert cache_setup_fields.isdisjoint(field.name for field in fields(MHAConfig))
     assert cache_setup_fields.isdisjoint(field.name for field in fields(MLAConfig))
+    assert not hasattr(AttnConfig, "create_pool")
     assert not hasattr(MHAConfig, "create_pool")
     assert not hasattr(MLAConfig, "create_pool")
 
 
+def _ns_config(*, spec, **fields):
+    """Namespace micro-stub honoring the component(cls) query with one spec."""
+    return SimpleNamespace(
+        components=(spec,), component=lambda cls, _s=spec: _s, **fields
+    )
+
+
+def _tiny_linear_attn():
+    """Tiny GDN component whose state payloads (conv 8B, ssm 8B) keep the
+    shared planes aligned with the 512-byte KV page stride."""
+    from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+        LinearAttnConfig,
+    )
+
+    return LinearAttnConfig(
+        num_k_heads=1,
+        num_v_heads=2,
+        head_k_dim=1,
+        head_v_dim=1,
+        conv_kernel_size=2,
+        layer_ids=(0,),
+        tp_size=1,
+    )
+
+
 def test_qwen_recipe_preserves_backend_kernel_page_size() -> None:
-    text_config = SimpleNamespace(
-        mamba2_cache_params=(
-            (3, 2),
-            (1, 2, 2),
-            torch.bfloat16,
-            torch.float32,
-            (0,),
-        ),
-        linear_key_head_dim=1,
-        linear_num_key_heads=1,
-        linear_value_head_dim=1,
-        linear_num_value_heads=1,
-    )
     model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(text_config=text_config),
+        hf_config=SimpleNamespace(text_config=SimpleNamespace()),
     )
-    attn_config = MHAConfig(
-        device="cpu",
-        backend_name="fa2",
-        num_attention_heads=1,
-        layer_types=(LINEAR_ATTENTION, FULL_ATTENTION),
-        kv_cache_mxfp8=False,
-        num_kv_heads=1,
-        attn_tp_size=1,
-        head_dim=2,
-        dtype=torch.bfloat16,
-        kv_cache_dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=2,
-        max_bs=2,
-        prefix_granularity=64,
-        kernel_page_size=64,
-        kv_cache_quant_method="none",
-        max_scheduled_tokens=128,
+    attn_config = AttnConfig(
+        components=(
+            MHAConfig(
+                backend_name="fa2",
+                num_attention_heads=1,
+                num_kv_heads=1,
+                head_dim=2,
+                attn_tp_size=1,
+                layer_types=(LINEAR_ATTENTION, FULL_ATTENTION),
+            ),
+            _tiny_linear_attn(),
+        ),
+        **_model_wide_kwargs(),
     )
     server_args = SimpleNamespace(
         prefix_granularity=64,
@@ -313,9 +316,10 @@ def test_qwen_recipe_preserves_backend_kernel_page_size() -> None:
 
 @pytest.mark.parametrize(
     ("replay_enabled", "replay_supported", "expected_workspace_bytes"),
-    # Replay: 64 conv staging bytes plus the captured payload (6 rows of 4
-    # bf16 channels) and the fp32 A_log/dt_bias pair -- 64 + 48 + 8.
-    ((False, True, 192), (True, False, 192), (True, True, 120)),
+    # Non-replay stages conv+ssm for 8 verify rows: 8 * (8 + 8). Replay: 64
+    # conv staging bytes plus the captured payload (6 rows of 7 bf16
+    # channels) and the fp32 A_log/dt_bias pairs -- 64 + 84 + 16.
+    ((False, True, 128), (True, False, 128), (True, True, 164)),
 )
 def test_qwen_recipe_sizes_verify_workspace_for_replay_ssm(
     monkeypatch,
@@ -327,40 +331,24 @@ def test_qwen_recipe_sizes_verify_workspace_for_replay_ssm(
         "tokenspeed_kernel.ops.attention.gdn_replay_commit_supported",
         lambda dtype: replay_supported,
     )
-    text_config = SimpleNamespace(
-        mamba2_cache_params=(
-            (2, 2),
-            (1, 2, 2),
-            torch.bfloat16,
-            torch.float32,
-            (0,),
-        )
-    )
     model_config = SimpleNamespace(
-        hf_config=SimpleNamespace(text_config=text_config),
+        hf_config=SimpleNamespace(text_config=SimpleNamespace()),
     )
-    attn_config = MHAConfig(
-        device="cuda",
+    target_spec = MHAConfig(
         backend_name="fa2",
         num_attention_heads=1,
-        layer_types=(LINEAR_ATTENTION, FULL_ATTENTION),
-        kv_cache_mxfp8=False,
         num_kv_heads=1,
-        attn_tp_size=1,
         head_dim=2,
-        dtype=torch.bfloat16,
-        kv_cache_dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=2,
-        max_bs=2,
-        prefix_granularity=64,
-        kernel_page_size=64,
-        kv_cache_quant_method="none",
-        max_scheduled_tokens=128,
+        attn_tp_size=1,
+        layer_types=(LINEAR_ATTENTION, FULL_ATTENTION),
+    )
+    attn_config = AttnConfig(
+        components=(target_spec, _tiny_linear_attn()),
+        **_model_wide_kwargs(device="cuda"),
     )
     draft_config = replace(
         attn_config,
-        layer_types=(FULL_ATTENTION,),
+        components=(replace(target_spec, layer_types=(FULL_ATTENTION,)),),
     )
     server_args = SimpleNamespace(
         block_size=64,
@@ -382,7 +370,9 @@ def test_qwen_recipe_sizes_verify_workspace_for_replay_ssm(
     )
 
     assert setup.fixed_workspace_bytes == expected_workspace_bytes
-    assert attn_config.replay_ssm is (replay_enabled and replay_supported)
+    linear_attn = attn_config.component(LinearAttnConfig)
+    assert linear_attn is not None
+    assert linear_attn.replay_ssm is (replay_enabled and replay_supported)
 
 
 def test_ordinary_mha_reserves_null_parent_within_cache_budget() -> None:
@@ -828,11 +818,10 @@ def test_ordinary_profile_reserves_null_page_inside_budget() -> None:
     recipe = OrdinaryRecipe.__new__(OrdinaryRecipe)
     recipe.cache_budget_bytes = 16_384
     recipe.server_args = SimpleNamespace(max_total_tokens=None)
-    recipe.attn_config = SimpleNamespace(
+    recipe.attn_config = _ns_config(
         prefix_granularity=64,
+        spec=SimpleNamespace(layer_types=(), sliding_window_tokens=None),
         cache_cell_size=lambda: 16,
-        layer_types=(),
-        sliding_window_tokens=None,
     )
     recipe.draft_attn_config = None
     recipe.model_config = SimpleNamespace(num_attention_layers=1)

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -159,6 +159,28 @@ from tokenspeed.runtime.utils.hf_transformers_utils import (
 )
 from tokenspeed.runtime.utils.server_args import ServerArgs
 
+# MLAConfig component fields; everything else in the flat test namespaces is
+# model-wide and stays on the config argument.
+_V4_SPEC_FIELDS = (
+    "num_attention_heads",
+    "num_kv_heads",
+    "head_dim",
+    "attn_tp_size",
+    "sliding_window_tokens",
+    "qk_rope_head_dim",
+)
+
+
+def _v4_backend(flat: SimpleNamespace) -> DeepseekV4AttentionBackend:
+    """Split a flat test namespace into the (config, spec) backend arguments."""
+    fields = vars(flat)
+    spec_fields = {k: v for k, v in fields.items() if k in _V4_SPEC_FIELDS}
+    spec_fields.setdefault("sliding_window_tokens", None)
+    config_fields = {k: v for k, v in fields.items() if k not in _V4_SPEC_FIELDS}
+    return DeepseekV4AttentionBackend(
+        SimpleNamespace(**config_fields), SimpleNamespace(**spec_fields)
+    )
+
 
 def _v4_spec_set(hf_config, *, layer_ratio, decode_input_tokens: int = 1):
     """The spec set a ratio vector declares, in the recipe's own order."""
@@ -2496,7 +2518,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_backend_preserves_compact_cache_contract(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -2531,7 +2553,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.equal(metadata.cache.swa_base_logical_page, base))
 
     def test_deepseek_v4_lcm_graph_tables_keep_absolute_logical_positions(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -2572,7 +2594,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(widths[v4_compressed_kv_group_id(128)], 17)
 
     def test_deepseek_v4_lcm_tables_are_already_kernel_ready(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -2612,7 +2634,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         return backend
 
     def test_deepseek_v4_runtime_configures_eager_cache_group_contract(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -2841,7 +2863,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         draft_counts = {str(spec.group_id): 4096 for spec in draft_specs}
 
         def make_backend(*, is_draft: bool) -> DeepseekV4AttentionBackend:
-            return DeepseekV4AttentionBackend(
+            return _v4_backend(
                 SimpleNamespace(
                     prefix_granularity=64,
                     kernel_page_size=64,
@@ -2981,7 +3003,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertLessEqual(torch.cuda.memory_reserved(), reserved_before)
 
     def test_deepseek_v4_mixed_metadata_keeps_decode_rows_single_token(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3024,7 +3046,7 @@ class TestDeepseekV4Config(unittest.TestCase):
     def test_deepseek_v4_mixed_metadata_uses_runtime_verify_width(self):
         for verify_width in (1, 2, 4, 8):
             with self.subTest(verify_width=verify_width):
-                backend = DeepseekV4AttentionBackend(
+                backend = _v4_backend(
                     SimpleNamespace(
                         prefix_granularity=64,
                         kernel_page_size=64,
@@ -3083,7 +3105,7 @@ class TestDeepseekV4Config(unittest.TestCase):
                 )
 
     def test_deepseek_v4_mixed_metadata_rejects_packed_token_mismatch(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3115,7 +3137,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
 
     def test_deepseek_v4_prefill_metadata_uses_complete_cpu_mirrors(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3153,7 +3175,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(metadata.token_to_req_indices.tolist(), [0] * 5 + [1] * 9)
 
     def test_deepseek_v4_prefill_metadata_requires_complete_cpu_mirrors(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3294,7 +3316,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
 
     def test_deepseek_v4_chunked_prefill_uses_cpu_query_offsets(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3382,7 +3404,7 @@ class TestDeepseekV4Config(unittest.TestCase):
 
     def test_deepseek_v4_draft_keeps_mixed_step0_and_decode_step_metadata(self):
         verify_width = 4
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3440,7 +3462,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertIs(_deepseek_v4_forward_metadata(decode_ctx), decode_metadata)
 
     def test_deepseek_v4_cuda_graph_refresh_keeps_compact_table_columns(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3481,7 +3503,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.equal(table[:, 2:], torch.full_like(table[:, 2:], -1)))
 
     def test_deepseek_v4_metadata_splits_named_cache_groups(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3557,7 +3579,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_metadata_slice_preserves_compact_base_offsets(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3831,7 +3853,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.equal(slots, torch.tensor([10, -1, -1, -1])))
 
     def test_deepseek_v4_mixed_metadata_splits_prefill_and_decode(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3934,7 +3956,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_mixed_metadata_accepts_prefill_prefix_lens_only(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -3980,7 +4002,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_mixed_backend_slices_prefill_and_decode(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4075,7 +4097,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.equal(out[3:], torch.full((2, 2, 4), 2.0)))
 
     def test_deepseek_v4_mixed_prefill_replaces_stale_slice(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4175,7 +4197,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         kernel page: kernel geometry is registry-sourced, never P-derived."""
 
         def build(prefix_granularity):
-            return DeepseekV4AttentionBackend(
+            return _v4_backend(
                 SimpleNamespace(
                     prefix_granularity=prefix_granularity,
                     kernel_page_size=None,
@@ -4223,7 +4245,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(c128.block_granularity, 256)
 
     def test_deepseek_v4_spec_metadata_requires_uniform_pack(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4258,7 +4280,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(backend.forward_metadata.decode_req_count(), 2)
         self.assertEqual(backend.forward_metadata.decode_token_count(), 8)
 
-        draft_backend = DeepseekV4AttentionBackend(
+        draft_backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4303,7 +4325,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
 
     def test_deepseek_v4_decode_metadata_defaults_to_one_token(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4337,7 +4359,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(backend.forward_metadata.decode_token_count(), 2)
 
     def test_deepseek_v4_select_decode_metadata_ignores_prefill_fallback(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4383,7 +4405,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertIs(backend._select_decode_metadata(8), decode_metadata)
 
     def test_deepseek_v4_cuda_graph_replay_without_num_tokens_uses_plain_decode(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4423,7 +4445,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(backend.forward_metadata.decode_token_count(), 2)
 
     def test_deepseek_v4_decode_backend_maps_compressed_slots_batched(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4513,7 +4535,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         if not torch.cuda.is_available():
             self.skipTest("CUDA is required for capture cache semantics")
         device = torch.device("cuda")
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4581,7 +4603,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_c128a_prefill_local_compressed_indices_contract(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4663,7 +4685,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
 
     def test_deepseek_v4_decode_backend_masks_padding_tokens(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4733,7 +4755,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.equal(lens, torch.tensor([1, 0], dtype=torch.int32)))
 
     def test_deepseek_v4_cuda_graph_replay_marks_padding_tokens_invalid(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4783,7 +4805,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(metadata.decode_token_count(), 4)
 
     def test_deepseek_v4_cuda_graph_replay_preserves_padded_cache_tables(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -4988,7 +5010,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_cuda_graph_decode_uses_packed_metadata(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -5070,7 +5092,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(metadata.decode_token_count(), 16)
 
     def test_deepseek_v4_cuda_graph_packed_draft_decode_advances_metadata(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -5163,7 +5185,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertIs(_deepseek_v4_forward_metadata(ctx), decode_metadata)
 
     def test_deepseek_v4_eager_draft_decode_refreshes_stale_graph_metadata(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,
@@ -5223,7 +5245,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         )
 
     def test_deepseek_v4_prefill_uses_prefill_metadata_slot(self):
-        backend = DeepseekV4AttentionBackend(
+        backend = _v4_backend(
             SimpleNamespace(
                 prefix_granularity=64,
                 kernel_page_size=64,

--- a/test/runtime/test_draft_advance_seqlens.py
+++ b/test/runtime/test_draft_advance_seqlens.py
@@ -25,18 +25,24 @@ from tokenspeed.runtime.layers.attention.backends.msa import (
 from tokenspeed.runtime.layers.attention.backends.trtllm import (
     TRTLLMMHAAttnBackend,
 )
+from tokenspeed.runtime.layers.attention.configs.base import (
+    AttnConfig,
+    SoftmaxAttnConfig,
+)
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.configs.msa import MSAConfig
 
 
-def _cfg() -> MHAConfig:
-    return MHAConfig(
-        device="cpu",
+def _cfg() -> AttnConfig:
+    spec = MHAConfig(
         backend_name="mha",
         num_attention_heads=8,
         num_kv_heads=8,
         head_dim=128,
         attn_tp_size=1,
+    )
+    return AttnConfig(
+        device="cpu",
         dtype=torch.bfloat16,
         kv_cache_dtype=torch.bfloat16,
         prefix_granularity=64,
@@ -48,7 +54,13 @@ def _cfg() -> MHAConfig:
         speculative_num_steps=3,
         speculative_num_draft_tokens=4,
         is_draft=True,
+        components=(spec,),
     )
+
+
+def _mha_backend(backend_cls=MHAAttnBackend):
+    cfg = _cfg()
+    return backend_cls(cfg, cfg.component(SoftmaxAttnConfig))
 
 
 def _seqlens_field(be, metadata):
@@ -60,7 +72,7 @@ def _seqlens_field(be, metadata):
 
 @pytest.mark.parametrize("backend_cls", [MHAAttnBackend, TRTLLMMHAAttnBackend])
 def test_advance_updates_draft_decode_metadata(backend_cls):
-    be = backend_cls(_cfg())
+    be = _mha_backend(backend_cls)
     max_bs, bs = 8, 4
     be.init_cuda_graph_state(max_bs)
 
@@ -92,7 +104,7 @@ def test_advance_updates_draft_decode_metadata(backend_cls):
 
 
 def test_advance_does_not_mutate_caller_tensor():
-    be = MHAAttnBackend(_cfg())
+    be = _mha_backend()
     be.init_cuda_graph_state(8)
     draft_seq_lens = torch.tensor([7, 8, 9, 10], dtype=torch.int32)
     original = draft_seq_lens.clone()
@@ -103,27 +115,29 @@ def test_advance_does_not_mutate_caller_tensor():
 
 
 def _msa_backend() -> MSAAttnBackend:
-    return MSAAttnBackend(
-        MSAConfig(
-            device="cpu",
-            backend_name="msa",
-            num_attention_heads=8,
-            num_kv_heads=8,
-            head_dim=128,
-            attn_tp_size=1,
-            dtype=torch.bfloat16,
-            kv_cache_dtype=torch.bfloat16,
-            prefix_granularity=64,
-            kernel_page_size=64,
-            context_len=4096,
-            max_bs=8,
-            max_graph_bs=8,
-            kv_cache_quant_method="none",
-            speculative_num_steps=3,
-            speculative_num_draft_tokens=4,
-            is_draft=True,
-        )
+    spec = MSAConfig(
+        backend_name="msa",
+        num_attention_heads=8,
+        num_kv_heads=8,
+        head_dim=128,
+        attn_tp_size=1,
     )
+    config = AttnConfig(
+        device="cpu",
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        prefix_granularity=64,
+        kernel_page_size=64,
+        context_len=4096,
+        max_bs=8,
+        max_graph_bs=8,
+        kv_cache_quant_method="none",
+        speculative_num_steps=3,
+        speculative_num_draft_tokens=4,
+        is_draft=True,
+        components=(spec,),
+    )
+    return MSAAttnBackend(config, spec)
 
 
 def test_msa_init_cuda_graph_state_matches_helper_signature():
@@ -176,7 +190,7 @@ def test_msa_hybrid_composes_cache_contract_from_children():
 def test_default_advance_is_a_noop_before_graph_state_exists():
     """The hook may fire before init_cuda_graph_state (eager runs); it must not
     raise, just do nothing."""
-    be = MHAAttnBackend(_cfg())
+    be = _mha_backend()
     be.advance_draft_forward_metadata(torch.tensor([5, 6], dtype=torch.int32))
 
 
@@ -188,7 +202,7 @@ def test_capture_seeds_owned_seqlens(backend_cls):
     without seeding the warmup/capture forward attends over seq_len 0 (empty
     causal span -> NaN, or a schedule recorded against zero lengths).
     """
-    be = backend_cls(_cfg())
+    be = _mha_backend(backend_cls)
     max_bs, bs = 8, 4
     be.init_cuda_graph_state(max_bs)
     capture_seq_lens = torch.full((max_bs,), 37, dtype=torch.int32)
@@ -210,7 +224,7 @@ def test_hybrid_composite_forwards_advance_to_full_attn_child():
         HybridLinearAttnBackend,
     )
 
-    full = MHAAttnBackend(_cfg())
+    full = _mha_backend()
     full.init_cuda_graph_state(8)
     hybrid = object.__new__(HybridLinearAttnBackend)
     hybrid.full_attn_backend = full
@@ -244,7 +258,7 @@ def _correction_models():
 def test_first_step_correction_reaches_backend(name, correction):
     from types import SimpleNamespace
 
-    be = MHAAttnBackend(_cfg())
+    be = _mha_backend()
     max_bs, bs = 8, 4
     be.init_cuda_graph_state(max_bs)
 

--- a/test/runtime/test_dspark_config.py
+++ b/test/runtime/test_dspark_config.py
@@ -23,6 +23,7 @@ from tokenspeed.runtime.execution.drafter.dflash import (
 )
 from tokenspeed.runtime.execution.drafter.dspark import DSpark
 from tokenspeed.runtime.layers.attention.configs.base import (
+    SoftmaxAttnConfig,
     resolve_speculative_num_tokens,
 )
 from tokenspeed.runtime.layers.attention.configs.mla import (
@@ -329,17 +330,21 @@ def test_block_draft_shares_the_targets_retention() -> None:
     die with the target's pages; a sliding cache group of its own would both
     evict rows the target still owns and collide with the target's planes.
     """
-    config = _draft_attn_config("DSPARK", ("sliding_attention",) * 6)
+    spec = _draft_attn_config("DSPARK", ("sliding_attention",) * 6).component(
+        SoftmaxAttnConfig
+    )
 
-    assert config.layer_types == ()
-    assert config.sliding_window_tokens is None
+    assert spec.layer_types == ()
+    assert spec.sliding_window_tokens is None
 
 
 def test_a_non_block_draft_keeps_its_own_labels() -> None:
-    config = _draft_attn_config("EAGLE3", ("sliding_attention",) * 6)
+    spec = _draft_attn_config("EAGLE3", ("sliding_attention",) * 6).component(
+        SoftmaxAttnConfig
+    )
 
-    assert config.layer_types == ("sliding_attention",) * 6
-    assert config.sliding_window_tokens == 1024
+    assert spec.layer_types == ("sliding_attention",) * 6
+    assert spec.sliding_window_tokens == 1024
 
 
 # --------------------------------------------------------------------------

--- a/test/runtime/test_flashmla_cache_groups.py
+++ b/test/runtime/test_flashmla_cache_groups.py
@@ -54,17 +54,31 @@ register_cuda_ci(est_time=60, suite="runtime-1gpu")
 _KERNEL_PAGE = 64
 
 
-def _make_flashmla_backend(pool, speculative_num_draft_tokens: int = 1):
-    from tokenspeed.runtime.layers.attention.backends.flashmla import FlashMLABackend
+def _flashmla_spec():
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 
-    config = MLAConfig(
-        device="cuda",
+    return MLAConfig(
         backend_name="flashmla",
         num_attention_heads=16,
         num_kv_heads=1,
         head_dim=_LATENT_DIM,
         attn_tp_size=1,
+        kv_lora_rank=_KV_LORA_RANK,
+        qk_nope_head_dim=128,
+        qk_rope_head_dim=_QK_ROPE_DIM,
+        v_head_dim=128,
+        scaling=192**-0.5,
+        kv_cache_dim=_LATENT_DIM,
+    )
+
+
+def _make_flashmla_backend(pool, speculative_num_draft_tokens: int = 1):
+    from tokenspeed.runtime.layers.attention.backends.flashmla import FlashMLABackend
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
+
+    spec = _flashmla_spec()
+    config = AttnConfig(
+        device="cuda",
         dtype=torch.bfloat16,
         kv_cache_dtype=torch.bfloat16,
         prefix_granularity=_KERNEL_PAGE,
@@ -73,15 +87,10 @@ def _make_flashmla_backend(pool, speculative_num_draft_tokens: int = 1):
         max_bs=8,
         max_graph_bs=8,
         kv_cache_quant_method="",
-        kv_lora_rank=_KV_LORA_RANK,
-        qk_nope_head_dim=128,
-        qk_rope_head_dim=_QK_ROPE_DIM,
-        v_head_dim=128,
-        scaling=192**-0.5,
-        kv_cache_dim=_LATENT_DIM,
         speculative_num_draft_tokens=speculative_num_draft_tokens,
+        components=(spec,),
     )
-    return FlashMLABackend(config)
+    return FlashMLABackend(config, spec)
 
 
 def _init_cache_decode(backend, pool, logical_rows, seq_lens_cpu, spec=1):
@@ -252,15 +261,11 @@ def test_flashmla_classic_path_uses_page_table() -> None:
 
 def _make_draft_flashmla_backend(pool):
     from tokenspeed.runtime.layers.attention.backends.flashmla import FlashMLABackend
-    from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 
-    config = MLAConfig(
+    spec = _flashmla_spec()
+    config = AttnConfig(
         device="cuda",
-        backend_name="flashmla",
-        num_attention_heads=16,
-        num_kv_heads=1,
-        head_dim=_LATENT_DIM,
-        attn_tp_size=1,
         dtype=torch.bfloat16,
         kv_cache_dtype=torch.bfloat16,
         prefix_granularity=_KERNEL_PAGE,
@@ -269,15 +274,10 @@ def _make_draft_flashmla_backend(pool):
         max_bs=8,
         max_graph_bs=8,
         kv_cache_quant_method="",
-        kv_lora_rank=_KV_LORA_RANK,
-        qk_nope_head_dim=128,
-        qk_rope_head_dim=_QK_ROPE_DIM,
-        v_head_dim=128,
-        scaling=192**-0.5,
-        kv_cache_dim=_LATENT_DIM,
         is_draft=True,
+        components=(spec,),
     )
-    backend = FlashMLABackend(config)
+    backend = FlashMLABackend(config, spec)
     backend.mark_cache_contract()
     return backend
 

--- a/test/runtime/test_gdn_state_paging.py
+++ b/test/runtime/test_gdn_state_paging.py
@@ -56,6 +56,56 @@ class _ContractPool:
         return conv_state if name == "conv_state" else recurrent_state
 
 
+def _mamba_config_pair(
+    torch,
+    *,
+    heads,
+    head_dim,
+    spec_tokens=1,
+    max_bs=8,
+    device="cpu",
+    replay_ssm=False,
+):
+    """(AttnConfig, softmax spec) for MambaAttnBackend: model-wide facts live on
+    the config, softmax geometry on the softmax spec, and the GDN geometry plus
+    replay_ssm on the LinearAttnConfig component."""
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
+    from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+        LinearAttnConfig,
+    )
+    from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
+
+    spec = MHAConfig(
+        num_attention_heads=heads,
+        num_kv_heads=heads,
+        head_dim=head_dim,
+        attn_tp_size=1,
+    )
+    linear = LinearAttnConfig(
+        num_k_heads=heads,
+        num_v_heads=heads,
+        head_k_dim=head_dim,
+        head_v_dim=head_dim,
+        conv_kernel_size=4,
+        layer_ids=(0,),
+        tp_size=1,
+        replay_ssm=replay_ssm,
+    )
+    config = AttnConfig(
+        device=device,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        kv_cache_quant_method="none",
+        prefix_granularity=64,
+        context_len=4096,
+        max_bs=max_bs,
+        max_graph_bs=max_bs,
+        speculative_num_draft_tokens=spec_tokens,
+        components=(spec, linear),
+    )
+    return config, spec
+
+
 class ComputeStatePageIndicesTest(unittest.TestCase):
     """CPU-only contract tests for the pure dual-index helper."""
 
@@ -188,18 +238,9 @@ class CacheContractMetadataTest(unittest.TestCase):
             self.skipTest(f"needs torch + tokenspeed_kernel: {exc}")
         self.torch = torch
         self.ForwardMode = ForwardMode
-        config = SimpleNamespace(
-            device="cpu",
-            num_attention_heads=16,
-            num_kv_heads=16,
-            attn_tp_size=1,
-            dtype=torch.bfloat16,
-            head_dim=128,
-            is_draft=False,
-            speculative_num_draft_tokens=1,
-            max_bs=8,
+        backend = MambaAttnBackend(
+            *_mamba_config_pair(torch, heads=16, head_dim=128, spec_tokens=1)
         )
-        backend = MambaAttnBackend(config)
         stub_pool = _ContractPool(
             self.P,
             {0: ("linear_attention", object(), object())},
@@ -337,18 +378,9 @@ class VerifyMetadataTest(unittest.TestCase):
             self.skipTest(f"needs torch + tokenspeed_kernel: {exc}")
         self.torch = torch
         self.ForwardMode = ForwardMode
-        config = SimpleNamespace(
-            device="cpu",
-            num_attention_heads=2,
-            num_kv_heads=2,
-            attn_tp_size=1,
-            dtype=torch.bfloat16,
-            head_dim=2,
-            is_draft=False,
-            speculative_num_draft_tokens=4,
-            max_bs=8,
+        self.backend = MambaAttnBackend(
+            *_mamba_config_pair(torch, heads=2, head_dim=2, spec_tokens=4)
         )
-        self.backend = MambaAttnBackend(config)
         self.state_buffers = {
             layer_id: (
                 torch.zeros((8, 2, 3), dtype=torch.bfloat16),
@@ -447,19 +479,16 @@ class GDNStatePagingGPUTest(unittest.TestCase):
         self, conv_slab, ssm_slab, spec_num_tokens=1, *, replay_ssm=False
     ):
         torch = self.torch
-        config = SimpleNamespace(
-            device="cuda",
-            num_attention_heads=self.H,
-            num_kv_heads=self.H,
-            attn_tp_size=1,
-            dtype=torch.bfloat16,
-            head_dim=self.D,
-            is_draft=False,
-            speculative_num_draft_tokens=spec_num_tokens,
-            replay_ssm=replay_ssm,
-            max_bs=8,
+        backend = self.MambaAttnBackend(
+            *_mamba_config_pair(
+                torch,
+                heads=self.H,
+                head_dim=self.D,
+                spec_tokens=spec_num_tokens,
+                device="cuda",
+                replay_ssm=replay_ssm,
+            )
         )
-        backend = self.MambaAttnBackend(config)
         stub_pool = _ContractPool(
             self.P,
             {0: ("linear_attention", conv_slab, ssm_slab)},

--- a/test/runtime/test_inkling_activation_parity.py
+++ b/test/runtime/test_inkling_activation_parity.py
@@ -175,6 +175,7 @@ class _Harness:
             InklingConvStatePool,
         )
         from tokenspeed.runtime.layers.attention.backends.mha import MHAAttnBackend
+        from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
         from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
         from tokenspeed.runtime.layers.attention.kv_cache.mha import (
             MHATokenToKVPool,
@@ -183,13 +184,15 @@ class _Harness:
         self.model = model
         self.text = text
         self.device = device
-        config = MHAConfig(
-            device=device,
+        spec = MHAConfig(
             backend_name="fa4",
             num_attention_heads=text.num_attention_heads,
             num_kv_heads=text.num_key_value_heads,
             head_dim=text.head_dim,
             attn_tp_size=1,
+        )
+        config = AttnConfig(
+            device=device,
             dtype=torch.bfloat16,
             kv_cache_dtype=torch.bfloat16,
             prefix_granularity=PAGE_SIZE,
@@ -198,8 +201,9 @@ class _Harness:
             max_bs=4,
             max_graph_bs=4,
             kv_cache_quant_method="none",
+            components=(spec,),
         )
-        inner = MHAAttnBackend(config)
+        inner = MHAAttnBackend(config, spec)
         from cache_pool_test_utils import make_mha_memory_plan, make_pool
 
         # One arena, one view over it: the pool owns no memory or geometry.

--- a/test/runtime/test_kimi_k3_cache_pool.py
+++ b/test/runtime/test_kimi_k3_cache_pool.py
@@ -90,6 +90,7 @@ def test_kimi_k3_pool_binds_mla_and_kda_to_one_lcm_backing() -> None:
 
 
 def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
     from tokenspeed.runtime.layers.attention.kv_cache.factory import (
         create_cache_arena,
@@ -119,32 +120,35 @@ def test_kimi_k3_bf16_draft_uses_typed_view_over_fp8_target_arena() -> None:
         family="mla",
     )
 
-    common_config = dict(
-        device="cpu",
+    mla_spec = MLAConfig(
         backend_name="mla",
         num_attention_heads=64,
         num_kv_heads=64,
         attn_tp_size=8,
         head_dim=192,
-        dtype=torch.bfloat16,
-        context_len=1024,
-        max_graph_bs=1,
-        max_bs=1,
-        prefix_granularity=plan.prefix_granularity,
-        kv_cache_quant_method="none",
         kv_lora_rank=512,
         qk_nope_head_dim=128,
         qk_rope_head_dim=64,
         v_head_dim=128,
         scaling=1.0,
         kv_cache_dim=576,
-        max_scheduled_tokens=128,
     )
-    target_config = MLAConfig(
+    common_config = dict(
+        device="cpu",
+        dtype=torch.bfloat16,
+        context_len=1024,
+        max_graph_bs=1,
+        max_bs=1,
+        prefix_granularity=plan.prefix_granularity,
+        kv_cache_quant_method="none",
+        max_scheduled_tokens=128,
+        components=(mla_spec,),
+    )
+    target_config = AttnConfig(
         kv_cache_dtype=torch.float8_e4m3fn,
         **common_config,
     )
-    draft_config = MLAConfig(
+    draft_config = AttnConfig(
         kv_cache_dtype=torch.bfloat16,
         is_draft=True,
         **common_config,

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -107,7 +107,9 @@ class KimiK3ConfigTests(unittest.TestCase):
 
     def test_mamba2_cache_params_shapes(self):
         c = KimiLinearConfig()
-        fake_mapping = SimpleNamespace(attn=SimpleNamespace(tp_size=1))
+        fake_mapping = SimpleNamespace(
+            attn=SimpleNamespace(tp_size=1), linear_attn=SimpleNamespace(tp_size=1)
+        )
         import tokenspeed.runtime.utils.env as env_mod
 
         with mock.patch.dict(
@@ -131,7 +133,9 @@ class KimiK3ConfigTests(unittest.TestCase):
 
     def test_mamba2_cache_params_respects_tp(self):
         c = KimiLinearConfig()
-        fake_mapping = SimpleNamespace(attn=SimpleNamespace(tp_size=4))
+        fake_mapping = SimpleNamespace(
+            attn=SimpleNamespace(tp_size=4), linear_attn=SimpleNamespace(tp_size=4)
+        )
         import tokenspeed.runtime.utils.env as env_mod
 
         with mock.patch.dict(
@@ -300,7 +304,8 @@ class KimiK3RegistrationTests(unittest.TestCase):
             },
         )
         mapping = SimpleNamespace(
-            attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=(0,))
+            attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=(0,)),
+            linear_attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=(0,)),
         )
         layer = KimiLinearKDA(config, mapping, layer_id=0)
 
@@ -369,7 +374,8 @@ class KimiK3RegistrationTests(unittest.TestCase):
             },
         )
         mapping = SimpleNamespace(
-            attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=(0,))
+            attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=(0,)),
+            linear_attn=SimpleNamespace(tp_rank=0, tp_size=1, tp_group=(0,)),
         )
         layer = KimiLinearKDA(config, mapping, layer_id=0)
         rows, projection_width = 4, 64

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -105,49 +105,42 @@ class KimiK3ConfigTests(unittest.TestCase):
             else:
                 self.assertEqual(cache_label, block_type)
 
-    def test_mamba2_cache_params_shapes(self):
-        c = KimiLinearConfig()
-        fake_mapping = SimpleNamespace(
-            attn=SimpleNamespace(tp_size=1), linear_attn=SimpleNamespace(tp_size=1)
+    @staticmethod
+    def _kda_spec(tp_size):
+        """The KDA component as boot construction builds it, at one TP width."""
+        from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+            LinearAttnConfig,
         )
-        import tokenspeed.runtime.utils.env as env_mod
 
-        with mock.patch.dict(
-            env_mod.global_server_args_dict, {"mapping": fake_mapping}
-        ):
-            (
-                conv_shape,
-                temporal_shape,
-                conv_dtype,
-                ssm_dtype,
-                mamba_layers,
-            ) = c.mamba2_cache_params
+        server_args = SimpleNamespace(
+            mapping=SimpleNamespace(linear_attn=SimpleNamespace(tp_size=tp_size))
+        )
+        model = SimpleNamespace(
+            hf_config=SimpleNamespace(text_config=KimiLinearConfig())
+        )
+        return LinearAttnConfig.generate(server_args, model)
 
+    def test_kda_state_shapes(self):
+        spec = self._kda_spec(tp_size=1)
         # conv over q/k/v (3 * num_heads * head_dim) wide, kernel_size - 1 deep.
-        self.assertEqual(conv_shape, (3 * _KDA_HEADS * _KDA_HEAD_DIM, _KDA_CONV - 1))
+        self.assertEqual(
+            spec.conv_state_shape, (3 * _KDA_HEADS * _KDA_HEAD_DIM, _KDA_CONV - 1)
+        )
         # per-head (head_dim x head_dim) recurrent state.
-        self.assertEqual(temporal_shape, (_KDA_HEADS, _KDA_HEAD_DIM, _KDA_HEAD_DIM))
-        self.assertEqual(conv_dtype, torch.bfloat16)
-        self.assertEqual(ssm_dtype, torch.float32)
-        self.assertEqual(mamba_layers, c.linear_layer_ids)
-
-    def test_mamba2_cache_params_respects_tp(self):
-        c = KimiLinearConfig()
-        fake_mapping = SimpleNamespace(
-            attn=SimpleNamespace(tp_size=4), linear_attn=SimpleNamespace(tp_size=4)
-        )
-        import tokenspeed.runtime.utils.env as env_mod
-
-        with mock.patch.dict(
-            env_mod.global_server_args_dict, {"mapping": fake_mapping}
-        ):
-            conv_shape, temporal_shape, *_ = c.mamba2_cache_params
-
         self.assertEqual(
-            conv_shape, (3 * _KDA_HEADS * _KDA_HEAD_DIM // 4, _KDA_CONV - 1)
+            spec.temporal_state_shape, (_KDA_HEADS, _KDA_HEAD_DIM, _KDA_HEAD_DIM)
+        )
+        self.assertEqual(spec.layer_ids, tuple(KimiLinearConfig().linear_layer_ids))
+
+    def test_kda_state_shapes_respect_tp(self):
+        spec = self._kda_spec(tp_size=4)
+        self.assertEqual(
+            spec.conv_state_shape,
+            (3 * _KDA_HEADS * _KDA_HEAD_DIM // 4, _KDA_CONV - 1),
         )
         self.assertEqual(
-            temporal_shape, (_KDA_HEADS // 4, _KDA_HEAD_DIM, _KDA_HEAD_DIM)
+            spec.temporal_state_shape,
+            (_KDA_HEADS // 4, _KDA_HEAD_DIM, _KDA_HEAD_DIM),
         )
 
 

--- a/test/runtime/test_kimi_k3_kda.py
+++ b/test/runtime/test_kimi_k3_kda.py
@@ -111,24 +111,37 @@ def test_prefill_hands_the_stored_state_to_the_op_untouched(monkeypatch) -> None
     assert final_state is final
 
 
-def _backend_config(device: str, *, spec_tokens: int = 1) -> SimpleNamespace:
-    return SimpleNamespace(
-        device=device,
+def _backend_config(device: str, *, spec_tokens: int = 1):
+    """(AttnConfig, softmax spec): model-wide facts + softmax geometry."""
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
+    from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
+
+    spec = MHAConfig(
         num_attention_heads=4,
         num_kv_heads=4,
-        attn_tp_size=1,
-        dtype=torch.bfloat16,
         head_dim=128,
+        attn_tp_size=1,
+    )
+    config = AttnConfig(
+        device=device,
+        dtype=torch.bfloat16,
+        kv_cache_dtype=torch.bfloat16,
+        kv_cache_quant_method="none",
+        prefix_granularity=64,
+        context_len=4096,
+        max_bs=8,
+        max_graph_bs=8,
         is_draft=False,
         speculative_num_draft_tokens=spec_tokens,
-        max_bs=8,
+        components=(spec,),
     )
+    return config, spec
 
 
 def _backend(device: str, *, contract_pool, spec_tokens: int = 1) -> KdaAttnBackend:
     kda_backend = "auto" if current_platform().is_amd else "fla"
     backend = KdaAttnBackend(
-        _backend_config(device, spec_tokens=spec_tokens),
+        *_backend_config(device, spec_tokens=spec_tokens),
         kda_backend=kda_backend,
     )
     backend.set_kv_pool(contract_pool)

--- a/test/runtime/test_kimi_k3_kda_eager_commit.py
+++ b/test/runtime/test_kimi_k3_kda_eager_commit.py
@@ -33,18 +33,23 @@ class _Harness:
         torch.manual_seed(seed)
         self.pool = _make_kimi_pool(DEV, usable_pages=24)
         self.contract = self.pool.arena.runtime_contract
-        config = SimpleNamespace(
-            device=DEV,
+        spec = SimpleNamespace(
             num_attention_heads=H,
             num_kv_heads=H,
             attn_tp_size=1,
-            dtype=torch.bfloat16,
             head_dim=D,
+        )
+        config = SimpleNamespace(
+            device=DEV,
+            dtype=torch.bfloat16,
             is_draft=False,
             speculative_num_draft_tokens=T,
             max_bs=8,
+            components=(spec,),
+            # Stub component(): this backend construction never queries components.
+            component=lambda cls: None,
         )
-        self.backend = KdaAttnBackend(config)
+        self.backend = KdaAttnBackend(config, spec)
         self.backend.set_kv_pool(self.pool)
         if eager_replay and not self.backend._replay_active:
             pytest.skip("KDA replay commit kernel unavailable")

--- a/test/runtime/test_kimi_k3_mla.py
+++ b/test/runtime/test_kimi_k3_mla.py
@@ -209,6 +209,7 @@ def gpu_pool(cuda_env):
 
 @pytest.fixture(scope="module")
 def backend_factory(cuda_env, gpu_pool):
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
     from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 
     def make():
@@ -224,13 +225,21 @@ def backend_factory(cuda_env, gpu_pool):
 
             backend_cls = CuteDSLMLABackend
             backend_name = "tokenspeed_mla"
-        config = MLAConfig(
-            device="cuda",
+        spec = MLAConfig(
             backend_name=backend_name,
             num_attention_heads=_HEADS,
             num_kv_heads=1,
             head_dim=_LATENT_DIM,
             attn_tp_size=1,
+            kv_lora_rank=_KV_LORA_RANK,
+            qk_nope_head_dim=128,
+            qk_rope_head_dim=_QK_ROPE_DIM,
+            v_head_dim=128,
+            scaling=192**-0.5,
+            kv_cache_dim=_LATENT_DIM,
+        )
+        config = AttnConfig(
+            device="cuda",
             dtype=torch.bfloat16,
             kv_cache_dtype=torch.float8_e4m3fn,
             prefix_granularity=_KERNEL_PAGE,
@@ -239,14 +248,9 @@ def backend_factory(cuda_env, gpu_pool):
             max_bs=8,
             max_graph_bs=8,
             kv_cache_quant_method="",
-            kv_lora_rank=_KV_LORA_RANK,
-            qk_nope_head_dim=128,
-            qk_rope_head_dim=_QK_ROPE_DIM,
-            v_head_dim=128,
-            scaling=192**-0.5,
-            kv_cache_dim=_LATENT_DIM,
+            components=(spec,),
         )
-        backend = backend_cls(config)
+        backend = backend_cls(config, spec)
         backend.set_cache_pool(gpu_pool)
         return backend
 

--- a/test/runtime/test_linear_attn_mapping.py
+++ b/test/runtime/test_linear_attn_mapping.py
@@ -94,5 +94,104 @@ class TestNoUserFacingParameterYet(unittest.TestCase):
         self.assertNotIn("kda_tp_size", names)
 
 
+class TestLinearAttnConfig(unittest.TestCase):
+    """LinearAttnConfig.generate: presence detection + unified geometry."""
+
+    @staticmethod
+    def _server_args(tp_size=1):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            mapping=SimpleNamespace(linear_attn=SimpleNamespace(tp_size=tp_size))
+        )
+
+    @staticmethod
+    def _model(text_config):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(hf_config=SimpleNamespace(text_config=text_config))
+
+    def test_kimi_k3_geometry(self):
+        from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
+        from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+            LinearAttnConfig,
+        )
+
+        text_config = KimiLinearConfig()
+        spec = LinearAttnConfig.generate(
+            self._server_args(tp_size=8), self._model(text_config)
+        )
+        self.assertIsNotNone(spec)
+        self.assertEqual((spec.num_k_heads, spec.num_v_heads), (96, 96))
+        self.assertEqual((spec.head_k_dim, spec.head_v_dim), (128, 128))
+        self.assertEqual(spec.conv_kernel_size, 4)
+        self.assertEqual(spec.layer_ids, tuple(text_config.linear_layer_ids))
+        self.assertEqual(len(spec.layer_ids), 69)
+        self.assertEqual(spec.tp_size, 8)
+
+    def test_qwen35_gdn_geometry(self):
+        from tokenspeed.runtime.configs.qwen3_5_text_base_config import (
+            Qwen3_5BaseTextConfig,
+        )
+        from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+            LinearAttnConfig,
+        )
+
+        # Real GDN checkpoints carry full_attention_interval; the bare base
+        # config has no linear layers (and generate correctly returns None
+        # for it — covered by test_non_hybrid_model_gets_none).
+        text_config = Qwen3_5BaseTextConfig(full_attention_interval=4)
+        spec = LinearAttnConfig.generate(self._server_args(), self._model(text_config))
+        self.assertIsNotNone(spec)
+        self.assertEqual((spec.num_k_heads, spec.num_v_heads), (16, 32))
+        self.assertEqual((spec.head_k_dim, spec.head_v_dim), (128, 128))
+        self.assertEqual(spec.layer_ids, tuple(text_config.linear_layer_ids))
+        # Every 4th layer is full attention, so index 3 is not a linear layer.
+        self.assertIn(0, spec.layer_ids)
+        self.assertNotIn(3, spec.layer_ids)
+        # Asymmetric-head state shapes: conv covers q/k (key geometry) + v.
+        self.assertEqual(
+            spec.conv_state_shape,
+            (2 * 16 * 128 + 32 * 128, spec.conv_kernel_size - 1),
+        )
+        self.assertEqual(spec.temporal_state_shape, (32, 128, 128))
+
+    def test_non_hybrid_model_gets_none(self):
+        from types import SimpleNamespace
+
+        from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+            LinearAttnConfig,
+        )
+
+        plain = SimpleNamespace()  # no linear_layer_ids at all
+        self.assertIsNone(
+            LinearAttnConfig.generate(self._server_args(), self._model(plain))
+        )
+
+    def test_indivisible_heads_raise(self):
+        from tokenspeed.runtime.configs.kimi_k3_config import KimiLinearConfig
+        from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+            LinearAttnConfig,
+        )
+
+        with self.assertRaises(ValueError):
+            LinearAttnConfig.generate(
+                self._server_args(tp_size=5), self._model(KimiLinearConfig())
+            )
+
+    def test_registered_alongside_family_configs(self):
+        # Hybrid architectures declare their linear component in the registry
+        # table, the same registration pattern as _CONFIG_CLS.
+        from tokenspeed.runtime.layers.attention.configs.linear_attn import (
+            LinearAttnConfig,
+        )
+        from tokenspeed.runtime.layers.attention.registry import _LINEAR_ATTN_CLS
+
+        self.assertIs(
+            _LINEAR_ATTN_CLS["KimiK3ForConditionalGeneration"], LinearAttnConfig
+        )
+        self.assertIs(_LINEAR_ATTN_CLS["Qwen3_5MoeForCausalLM"], LinearAttnConfig)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/runtime/test_linear_attn_mapping.py
+++ b/test/runtime/test_linear_attn_mapping.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Linear-attention parallel-mapping plumbing tests (cheap, no GPU).
+
+Phase 0 of the MLA-DP + linear-attn-TP hybrid: ``mapping.linear_attn`` must
+default to the attention TP width on every existing deployment shape
+(behavior-identical), and the KDA cache/state shape derivations must read
+the linear-attention mapping. No user-facing parameter exists yet: the
+``--linear-attn-tp-size`` CLI flag is registered together with the hybrid
+forward/state implementation.
+"""
+
+import unittest
+
+from tokenspeed.runtime.distributed.mapping import (
+    LinearAttnLayerMapping,
+    Mapping,
+)
+
+
+class TestLinearAttnMappingDefaults(unittest.TestCase):
+    def test_defaults_follow_attn_tp_tp8(self):
+        m = Mapping(rank=0, world_size=8, attn_tp_size=8)
+        self.assertEqual(m.linear_attn.tp_size, m.attn.tp_size)
+        self.assertEqual(m.linear_attn.tp_group, m.attn.tp_group)
+        self.assertEqual(m.linear_attn.dp_size, 1)
+
+    def test_defaults_follow_attn_tp_dp8(self):
+        # attention-DP8: attn tp=1, so linear-attn defaults to tp=1 per rank.
+        m = Mapping(rank=3, world_size=8, attn_tp_size=1, attn_dp_size=8)
+        self.assertEqual(m.linear_attn.tp_size, 1)
+        self.assertEqual(m.linear_attn.dp_size, 8)
+        self.assertEqual(m.linear_attn.tp_rank, 0)
+
+    def test_hybrid_shape_linear_attn_tp_spans_dp_ranks(self):
+        # The target hybrid: MLA-DP8 with KDA-TP8 over the same ranks.
+        m = Mapping(
+            rank=3, world_size=8, attn_tp_size=1, attn_dp_size=8, linear_attn_tp_size=8
+        )
+        self.assertEqual(m.linear_attn.tp_size, 8)
+        self.assertEqual(m.linear_attn.tp_rank, 3)
+        self.assertEqual(m.linear_attn.tp_group, tuple(range(8)))
+        self.assertEqual(m.linear_attn.dp_size, 1)
+        # MLA stays data-parallel.
+        self.assertEqual(m.attn.dp_size, 8)
+
+    def test_rank_propagates_to_linear_attn(self):
+        m = Mapping(world_size=8, attn_tp_size=1, attn_dp_size=8, linear_attn_tp_size=8)
+        m.rank = 5
+        self.assertEqual(m.linear_attn.tp_rank, 5)
+
+    def test_pp_stage_world(self):
+        # KDA mapping resolves inside one pipeline stage.
+        m = Mapping(rank=0, world_size=16, attn_tp_size=8, pp_size=2)
+        self.assertEqual(m.linear_attn.tp_size, 8)
+        self.assertEqual(m.linear_attn.dp_size, 1)
+
+    def test_standalone_linear_attn_mapping_complement(self):
+        km = LinearAttnLayerMapping(rank=6, world_size=8, tp_size=4)
+        self.assertEqual((km.tp_size, km.dp_size), (4, 2))
+        self.assertEqual(km.tp_rank, 2)
+        self.assertEqual(km.tp_group, (4, 5, 6, 7))
+        self.assertEqual(km.dp_rank, 1)
+
+
+class TestNoUserFacingParameterYet(unittest.TestCase):
+    def test_server_args_has_no_linear_attn_field(self):
+        # Phase 0 is internal plumbing only; the CLI flag ships with the
+        # hybrid implementation.
+        import dataclasses
+
+        from tokenspeed.runtime.utils.server_args import ServerArgs
+
+        names = {f.name for f in dataclasses.fields(ServerArgs)}
+        self.assertNotIn("linear_attn_tp_size", names)
+        self.assertNotIn("kda_tp_size", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_mla_block_decode.py
+++ b/test/runtime/test_mla_block_decode.py
@@ -351,9 +351,9 @@ def test_graph_buffers_are_unexpanded_without_block_decode() -> None:
     assert backend.cuda_graph_seq_lens.shape == (4,)
 
 
-def test_mla_config_carries_the_block_decode_flag_defaulting_off() -> None:
-    """MLAConfig must inherit the flag so generate() can set it for the draft."""
-    from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
+def test_attn_config_carries_the_block_decode_flag_defaulting_off() -> None:
+    """AttnConfig must carry the flag so generate() can set it for the draft."""
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 
-    field = MLAConfig.__dataclass_fields__["draft_block_decode"]
+    field = AttnConfig.__dataclass_fields__["draft_block_decode"]
     assert field.default is False

--- a/test/runtime/test_mxfp8_kv_pool.py
+++ b/test/runtime/test_mxfp8_kv_pool.py
@@ -260,15 +260,18 @@ def test_shared_field_store_matches_standalone_scatter(layer_id: int, heads_l: i
 
 
 def _make_config(prefix_granularity: int):
+    from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
     from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 
-    return MHAConfig(
-        device="cuda",
+    spec = MHAConfig(
         backend_name="mha",
         num_attention_heads=16,
         num_kv_heads=HEADS,
         head_dim=HEAD_DIM,
         attn_tp_size=1,
+    )
+    return AttnConfig(
+        device="cuda",
         dtype=torch.bfloat16,
         kv_cache_dtype=torch.float8_e4m3fn,
         kv_cache_mxfp8=True,
@@ -278,6 +281,7 @@ def _make_config(prefix_granularity: int):
         max_bs=8,
         max_graph_bs=8,
         kv_cache_quant_method="none",
+        components=(spec,),
     )
 
 

--- a/test/runtime/test_qwen35_gdn_replay.py
+++ b/test/runtime/test_qwen35_gdn_replay.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import os
 import sys
-from types import SimpleNamespace
 
 import pytest
 import torch
@@ -43,7 +42,11 @@ register_cuda_ci(est_time=30, suite="runtime-1gpu")
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)
 
-from test.runtime.test_gdn_state_paging import _CacheMetadata, _ContractPool
+from test.runtime.test_gdn_state_paging import (
+    _CacheMetadata,
+    _ContractPool,
+    _mamba_config_pair,
+)
 
 from tokenspeed_kernel.ops.attention import gdn_replay_commit_supported
 
@@ -66,15 +69,13 @@ DEVICE = "cuda"
 
 
 def _config(*, replay: bool):
-    return SimpleNamespace(
-        device=DEVICE,
-        num_attention_heads=NUM_K_HEADS,
-        num_kv_heads=NUM_K_HEADS,
-        attn_tp_size=1,
-        dtype=torch.bfloat16,
+    """(AttnConfig, primary spec) with replay_ssm on the linear component."""
+    return _mamba_config_pair(
+        torch,
+        heads=NUM_K_HEADS,
         head_dim=HEAD_K_DIM,
-        is_draft=False,
-        speculative_num_draft_tokens=DRAFT_TOKENS,
+        spec_tokens=DRAFT_TOKENS,
+        device=DEVICE,
         replay_ssm=replay,
     )
 
@@ -86,7 +87,7 @@ def _make_backend(conv_state, recurrent_state, *, replay: bool):
         4,
         {0: ("linear_attention", conv_state, recurrent_state)},
     )
-    backend = MambaAttnBackend(_config(replay=replay))
+    backend = MambaAttnBackend(*_config(replay=replay))
     backend.set_kv_pool(pool)
     return backend, pool
 
@@ -348,7 +349,7 @@ def test_qwen_replay_commits_all_layers_with_one_kernel_call(monkeypatch):
         )
         if replay and not gdn_replay_commit_supported(torch.bfloat16):
             pytest.skip("GDN ReplaySSM kernel unavailable on this platform")
-        backend = MambaAttnBackend(_config(replay=replay))
+        backend = MambaAttnBackend(*_config(replay=replay))
         backend.set_kv_pool(pool)
         return backend, pool
 

--- a/test/runtime/test_server_args_attention_backends.py
+++ b/test/runtime/test_server_args_attention_backends.py
@@ -149,30 +149,38 @@ class TestAttentionBackendChoices(unittest.TestCase):
         import torch
 
         from tokenspeed.runtime.layers.attention.backends.mla import MLAAttnBackend
+        from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
+        from tokenspeed.runtime.layers.attention.configs.mla import MLAConfig
 
-        config = SimpleNamespace(
-            device="cpu",
+        spec = MLAConfig(
             backend_name="gluon",
             num_attention_heads=128,
             num_kv_heads=1,
             head_dim=576,
             attn_tp_size=8,
-            dtype=torch.bfloat16,
-            kv_cache_dtype=torch.float8_e4m3fn,
-            is_draft=True,
-            speculative_num_draft_tokens=4,
-            context_len=65536,
-            kernel_page_size=64,
             kv_lora_rank=512,
             qk_nope_head_dim=128,
             qk_rope_head_dim=64,
             v_head_dim=128,
             kv_cache_dim=576,
             scaling=192**-0.5,
-            draft_block_decode=False,
+        )
+        config = AttnConfig(
+            device="cpu",
+            dtype=torch.bfloat16,
+            kv_cache_dtype=torch.float8_e4m3fn,
+            kv_cache_quant_method="none",
+            prefix_granularity=128,
+            is_draft=True,
+            speculative_num_draft_tokens=4,
+            context_len=65536,
+            kernel_page_size=64,
+            max_bs=8,
+            max_graph_bs=8,
+            components=(spec,),
         )
 
-        self.assertEqual(MLAAttnBackend(config).kernel_solution, "gluon")
+        self.assertEqual(MLAAttnBackend(config, spec).kernel_solution, "gluon")
 
     def test_defaults_to_mla_for_mla(self):
         self.assertEqual(registry._get_default_backend_name(AttentionArch.MLA), "mla")

--- a/test/runtime/test_trtllm_cache_groups.py
+++ b/test/runtime/test_trtllm_cache_groups.py
@@ -124,16 +124,19 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
         # metadata sees the same geometry a captured graph would, and state
         # groups land in state_group_ids rather than the span map.
         from tokenspeed.runtime.execution import workspace
+        from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
         from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
         from tokenspeed.runtime.utils.env import envs
 
-        config = MHAConfig(
-            device="cpu",
+        spec = MHAConfig(
             backend_name="trtllm",
             num_attention_heads=4,
             num_kv_heads=1,
             head_dim=64,
             attn_tp_size=1,
+        )
+        config = AttnConfig(
+            device="cpu",
             dtype=self.torch.bfloat16,
             kv_cache_dtype=self.torch.bfloat16,
             prefix_granularity=64,
@@ -142,12 +145,13 @@ class TRTLLMCacheGroupsTest(unittest.TestCase):
             max_bs=1,
             max_graph_bs=1,
             kv_cache_quant_method="none",
+            components=(spec,),
         )
         with (
             envs.TOKENSPEED_WORKSPACE_TRTLLM_MHA_MB.override(1),
             mock.patch.object(workspace, "_pools", {}),
         ):
-            backend = self.Backend(config)
+            backend = self.Backend(config, spec)
 
         # Nothing is known before the pool arrives.
         self.assertEqual(backend.group_block_granularities, {})

--- a/test/runtime/test_trtllm_spec_seqlen_clamp.py
+++ b/test/runtime/test_trtllm_spec_seqlen_clamp.py
@@ -32,19 +32,22 @@ from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.trtllm import (
     TRTLLMMHAAttnBackend,
 )
+from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
 from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 
 SPEC_NUM_TOKENS = 4
 
 
 def _make_backend(is_draft: bool = False) -> TRTLLMMHAAttnBackend:
-    cfg = MHAConfig(
-        device="cpu",
+    spec = MHAConfig(
         backend_name="trtllm",
         num_attention_heads=8,
         num_kv_heads=8,
         head_dim=128,
         attn_tp_size=1,
+    )
+    cfg = AttnConfig(
+        device="cpu",
         dtype=torch.bfloat16,
         kv_cache_dtype=torch.bfloat16,
         prefix_granularity=64,
@@ -56,8 +59,9 @@ def _make_backend(is_draft: bool = False) -> TRTLLMMHAAttnBackend:
         speculative_num_steps=3,
         speculative_num_draft_tokens=SPEC_NUM_TOKENS,
         is_draft=is_draft,
+        components=(spec,),
     )
-    return TRTLLMMHAAttnBackend(cfg)
+    return TRTLLMMHAAttnBackend(cfg, spec)
 
 
 def _page_table(req_pool_size: int, max_pages: int) -> torch.Tensor:


### PR DESCRIPTION
## What

- `AttnConfig` = the model-wide serving facts (device, cache precision, paging, capacity, speculative shape) + a `components` tuple. Each attention mechanism is an `AttnComponentSpec` subclass: `SoftmaxAttnConfig` is the family base (MHA/MLA/DSA/MSA), `LinearAttnConfig` is the linear component (KDA/GDN).
- Linear attention is registered per architecture (`_LINEAR_ATTN_CLS`, parallel to `_CONFIG_CLS`) and built through the same `generate()` protocol; presence is decided by the checkpoint (non-empty `linear_layer_ids`), so zero-linear NextN drafts resolve to no component.
- The linear component carries its own TP width (from the new `mapping.linear_attn`, defaulting to the attention TP), its layer ids, and its state-shape properties (`conv_state_shape` / `temporal_state_shape`, one formula covering K3's symmetric and GDN's asymmetric geometry).
- Backends receive `(config, spec)` explicitly; other consumers look components up by class via `config.component(...)`. The softmax component is validated unique at construction.
- Side channels retired: cache recipes read linear state shapes from the component, and the `mamba2_cache_params` / `mamba_cache_per_req` checkpoint-config properties (process-global mapping reads inside HF configs) are deleted.

## Why

MLA cannot shard its latent KV by heads and wants attention-DP; KDA/GDN shard cleanly by heads and want TP. A single `attn_tp_size` cannot describe both, so the linear half needed its own config identity and parallel width. This lands the config/mapping groundwork behavior-identically; the divergence flag ships with the hybrid decode implementation.

## Validation

- Runtime unit suite over the touched areas: 435 passed (2 failures reproduce identically on `main`).
- Kimi-K3-NVFP4 end-to-end: boots and serves in both TP8 and attention-DP8 shapes; full GSM8K (1319 questions) run to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)