### PR TITLE
perf(k3): end the fused MoE tail at its profit edge, not its capacity

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -99,6 +99,9 @@ class K3MoETailTier(IntEnum):
 # in-graph (correct, but decode-suboptimal) — a follow-up should add an
 # is_decode axis rather than gate on the graph phase, which prefill graphs
 # legitimately share.
+# Measured profit edge of the fused tail; the kernel's own capacity is larger.
+TAIL_FUSION_MAX_TOKENS = 32
+
 MULTIMEM_AR_MIN_TOKENS = 256
 # Upper edge of the measured window; larger batches take the join's grouped path.
 MULTIMEM_AR_MAX_TOKENS = 8192
@@ -117,7 +120,8 @@ def select_k3_moe_tail_tier(
     Args:
         num_tokens: Tokens in this forward (identical on every rank).
         graph_phase: Whether the forward runs under the CUDA-graph phase.
-        tail_fusion_max_tokens: Fused decode kernel capacity, 0 when absent.
+        tail_fusion_max_tokens: Largest token count the fused tail is both
+            able and worth running at, 0 when absent.
         fused_moe_ar: Whether the fused-AR execution plan is armed.
         multimem_ok: Collectively-agreed multimem availability.
 
@@ -594,7 +598,9 @@ class K3MoeTailComm:
             num_tokens=num_tokens,
             graph_phase=get_is_cuda_graph_phase(),
             tail_fusion_max_tokens=(
-                self.latent_tail.max_num_tokens if self.latent_tail is not None else 0
+                min(self.latent_tail.max_num_tokens, TAIL_FUSION_MAX_TOKENS)
+                if self.latent_tail is not None
+                else 0
             ),
             fused_moe_ar=self.execution_plan.fused_moe_ar,
             multimem_ok=self.state.multimem_ar_ok,

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -264,7 +264,9 @@ def test_call_deferred_shape_hardening():
     seen = {}
 
     class FakeCollective:
-        def call_deferred(self, gemm2, weights, idx, shared, gamma, num_tokens):
+        def call_deferred(
+            self, gemm2, weights, idx, shared, gamma, num_tokens, **kwargs
+        ):
             seen.update(gemm2=gemm2, weights=weights, idx=idx, m=num_tokens)
             return "LATENT", "SHARD"
 
@@ -353,6 +355,38 @@ def test_selector_boundaries():
         assert pick(n, fused_ar=False) is K3MoETailTier.SEPARATE_REDUCE
 
 
+def test_profit_cap_stops_the_fused_tail_below_its_capacity(monkeypatch):
+    """The fused tail ends at the measured profit edge, not the kernel's capacity.
+
+    Serving A/B showed the multicast tail losing to a plain reduce past
+    ``TAIL_FUSION_MAX_TOKENS`` even though the kernel still accepts the shape,
+    so ``plan`` must decline it there.
+    """
+    from tokenspeed.runtime.models import kimi_k3_comm as mod
+
+    monkeypatch.setattr(mod, "get_is_cuda_graph_phase", lambda: True)
+    monkeypatch.setattr(mod, "get_is_capture_mode", lambda: True)
+
+    comm = object.__new__(mod.K3MoeTailComm)
+    comm.latent_tail = SimpleNamespace(
+        max_num_tokens=mod.TAIL_FUSION_MAX_TOKENS * 2,
+        supports_deferred_finalize=True,
+        supports_split_collective=True,
+        split_collective_min_tokens=9,
+    )
+    comm.execution_plan = SimpleNamespace(fused_moe_ar=True)
+    comm.state = SimpleNamespace(multimem_ar_ok=False)
+    comm._shard_up_projection = False
+    comm.routed_hidden, comm.hidden_size = L, H
+
+    cap = mod.TAIL_FUSION_MAX_TOKENS
+    assert comm.plan(cap, None).tier is mod.K3MoETailTier.TAIL_FUSION
+    # Past the cap the plan leaves the fused tail's early return, so it needs
+    # real hidden states to reach the lane decision.
+    above = comm.plan(cap + 1, torch.zeros(cap + 1, H))
+    assert above.tier is not mod.K3MoETailTier.TAIL_FUSION
+
+
 def test_tail_fusion_plan_defer_decision(monkeypatch):
     """TAIL_FUSION defers finalize iff the tail op and the fused-AR plan agree.
 
@@ -385,7 +419,7 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
     assert plan.lane is None and not plan.routed_in_fork
 
     # A tail op without the deferred variant must keep the materialized mode.
-    plan = build(supports_deferred=False, fused_ar=True).plan(64, None)
+    plan = build(supports_deferred=False, fused_ar=True).plan(32, None)
     assert plan.tier is mod.K3MoETailTier.TAIL_FUSION
     assert not plan.defer_finalize
     assert plan.split_shared_rs


### PR DESCRIPTION
``plan`` handed ``select_k3_moe_tail_tier`` the latent tail kernel's own ``max_num_tokens``, so the fused multicast tail ran wherever the kernel could run. That was the same number until #1174 raised the kernel's capacity from 16 to 64 tokens; the tier gate followed it and the fused tail silently extended past the point where it still pays.

The tail trades communication volume for a fabric round trip per MoE layer: it projects into the latent space before the reduce, but adds a multicast and a Lamport wait that the plain reduce does not have. The round trips are a fixed cost, so the trade only wins while the volume it saves is small.

Serving A/B on two GB300 nodes (TP8, DSpark with 8 draft tokens, so a decode step carries batch x 8 tokens), alternating boot pairs, paired step-period difference, positive meaning the fused tail is slower:

     8 tokens   -984, -1100 us      32 tokens   -768,  -567 us
    16 tokens   -701,  -716 us      48 tokens   +714, +1138 us
    24 tokens  -1657,  -576 us      64 tokens  +1198, +1553 us

Both pairs agree in sign at every point, so the edge sits between 32 and 64 tokens with room on either side. Capping the tier gate at 32 leaves the win at small counts intact and gives back the loss at the sizes speculative decoding actually runs at.

Re-measured against this commit's parent, three boot pairs, eight in-process repeats at batch 8 (the only multi-modal size):

    batch  1   15.09 -> 15.11 ms     -14 us   95% CI [ -70,  +43]
    batch  8   23.61 -> 22.15 ms   +1461 us   95% CI [+1196, +1725]
    batch 32   34.96 -> 34.98 ms     -19 us   95% CI [ -44,   +6]
    batch 64   47.62 -> 47.60 ms     +19 us   95% CI [ -87, +124]

Batch 8 is 6.2% faster and nothing else moves, which is what the cap predicts: it only changes 33..64 tokens, so batches 1-4 keep the fusion they profit from and batches 9+ were already above the kernel's capacity. Above the cap the tail lands on FUSED_LANE_AR, which already serves 65..255 tokens today, so this widens an existing path rather than introducing one; greedy decoding with the prompts batched eight-wide gives the same answers on both sides.

The kernel keeps its larger capacity; only the tier gate is capped, so the split-collective path #1174 added still covers the shapes it was built for.

``call_deferred`` gained an ``include_reduce_scatter`` keyword in that same #1174, but the stub in ``test_call_deferred_shape_hardening`` kept the old signature, so the test has raised ``TypeError`` ever since instead of exercising the shape hardening it is named for. Fixed here so the tail's test file passes as a whole.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
