### PR TITLE
feat(moe): add gfx1250 MXFP4 SiTU support 

### DIFF
--- a/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
@@ -75,6 +75,7 @@ env:
     --deselect=tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_amd.py::test_static_fp8_activation_moe_gfx1250[decode-m2-adaptive]
     --deselect=tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_amd.py::test_static_fp8_activation_moe_gfx1250[decode-m4-adaptive]
     --deselect=tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_amd.py::test_static_fp8_activation_moe_gfx1250[decode-m8-adaptive]
+    --deselect=tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx1250.py::test_kimi_k3_tp_situ_matches_a8w4_reference_gfx1250
     --deselect=tokenspeed-kernel/test/ops/test_attention_dsa.py::test_dsa_decode_dense_kvcache[q_fp8]
     --deselect=tokenspeed-kernel/test/ops/test_attention_dsa.py::test_dsa_with_kvcache[q_bf16-triton-decode]
     --deselect=tokenspeed-kernel/test/ops/test_attention_dsa.py::test_dsa_with_kvcache[q_bf16-triton-prefill]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
@@ -191,6 +191,22 @@ def _swiglu_gfx1250(acc, alpha: gl.constexpr, limit: gl.constexpr, beta: gl.cons
     return s * (linear + beta)
 
 
+@gluon.jit
+def _situ_gfx1250(
+    acc,
+    beta: gl.constexpr,
+    linear_beta: gl.constexpr,
+):
+    BLOCK_M: gl.constexpr = acc.shape[0]
+    OUT_BLOCK_N: gl.constexpr = acc.shape[1] // 2
+    # Match Kimi-K3's BF16 gate/up boundary before applying SiTU.
+    acc = acc.to(gl.bfloat16).to(gl.float32)
+    gate, linear = gl.split(acc.reshape((BLOCK_M, OUT_BLOCK_N, 2)))
+    gate = beta * gl.extra.libdevice.tanh(gate / beta) / (1.0 + gl.exp(-gate))
+    linear = linear_beta * gl.extra.libdevice.tanh(linear / linear_beta)
+    return gate * linear
+
+
 @gluon.constexpr_function
 def get_bitwidth(dtype):
     if isinstance(dtype, gl.pointer_type):

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
@@ -25,6 +25,7 @@ from tokenspeed_kernel_amd._triton import gl, gluon
 from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4._common import (
     MoEConfig,
     MoEPipelinedProgram,
+    _situ_gfx1250,
     _swiglu_gfx1250,
     compute_offsets,
     compute_pids,
@@ -90,6 +91,9 @@ def _matmul_decode(
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
     SWIGLU_BETA: gl.constexpr,
+    DO_SITU: gl.constexpr,
+    SITU_BETA: gl.constexpr,
+    SITU_LINEAR_BETA: gl.constexpr,
     ACTIVATION_REDUCTION_N: gl.constexpr,
     # MoE config
     N_EXPTS_TOT: gl.constexpr,
@@ -299,7 +303,17 @@ def _matmul_decode(
     bias = gl.convert_layout(bias, gl.SliceLayout(0, cfg.acc_layout))
     acc += bias[None, :]
 
-    if DO_SWIGLU:
+    gl.static_assert(
+        not (DO_SWIGLU and DO_SITU),
+        "SwiGLU and SiTU cannot both be enabled",
+    )
+    if DO_SITU:
+        out = _situ_gfx1250(acc, SITU_BETA, SITU_LINEAR_BETA)
+        gl.static_assert(
+            out.shape[1] == OUT_BLOCK_N,
+            f"Activation fn out.shape[1] ({out.shape[1]}) doesn't match computed OUT_BLOCK_N ({OUT_BLOCK_N})",
+        )
+    elif DO_SWIGLU:
         out = _swiglu_gfx1250(acc, SWIGLU_ALPHA, SWIGLU_LIMIT, SWIGLU_BETA)
         gl.static_assert(
             out.shape[1] == OUT_BLOCK_N,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
@@ -49,6 +49,7 @@ from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4._common import (
     MoEConfig,
     MoEPipelinedProgram,
     MoEProgramBase,
+    _situ_gfx1250,
     _swiglu_gfx1250,
     composition,
     compute_offsets,
@@ -818,6 +819,9 @@ def _matmul(
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
     SWIGLU_BETA: gl.constexpr,
+    DO_SITU: gl.constexpr,
+    SITU_BETA: gl.constexpr,
+    SITU_LINEAR_BETA: gl.constexpr,
     ACTIVATION_REDUCTION_N: gl.constexpr,
     # MoE config
     N_EXPTS_TOT: gl.constexpr,
@@ -1064,7 +1068,17 @@ def _matmul(
     bias = gl.convert_layout(bias, gl.SliceLayout(0, cfg.acc_layout))
     acc += bias[None, :]
 
-    if DO_SWIGLU:
+    gl.static_assert(
+        not (DO_SWIGLU and DO_SITU),
+        "SwiGLU and SiTU cannot both be enabled",
+    )
+    if DO_SITU:
+        out = _situ_gfx1250(acc, SITU_BETA, SITU_LINEAR_BETA)
+        gl.static_assert(
+            out.shape[1] == OUT_BLOCK_N,
+            f"Activation fn out.shape[1] ({out.shape[1]}) doesn't match computed OUT_BLOCK_N ({OUT_BLOCK_N})",
+        )
+    elif DO_SWIGLU:
         out = _swiglu_gfx1250(acc, SWIGLU_ALPHA, SWIGLU_LIMIT, SWIGLU_BETA)
         gl.static_assert(
             out.shape[1] == OUT_BLOCK_N,
@@ -1181,13 +1195,31 @@ def _mark_scale_preshuffled(scale: Tensor | None, enabled: bool) -> Tensor | Non
 
 def _activation_config(fused_activation: FusedActivation | None):
     if fused_activation is None:
-        return False, 0.0, 0.0, 0.0, 1
+        return False, 0.0, 0.0, 0.0, False, 0.0, 0.0, 1
     specs = fused_activation.specs
     if specs.name == FnSpecs.default().name:
-        return False, 0.0, 0.0, 0.0, 1
+        return False, 0.0, 0.0, 0.0, False, 0.0, 0.0, 1
+    if specs.name == "situ":
+        if len(fused_activation.fn_args) < 2:
+            raise ValueError("SiTU activation requires beta and linear_beta")
+        situ_beta = float(fused_activation.fn_args[0])
+        situ_linear_beta = float(fused_activation.fn_args[1])
+        if situ_beta <= 0.0 or situ_linear_beta <= 0.0:
+            raise ValueError("SiTU beta and linear_beta must be positive")
+        return (
+            False,
+            0.0,
+            0.0,
+            0.0,
+            True,
+            situ_beta,
+            situ_linear_beta,
+            int(specs.reduction_n),
+        )
     if specs.name != "swiglu":
         raise NotImplementedError(
-            f"gfx1250 MoE only supports no activation or SwiGLU, got {specs.name!r}"
+            "gfx1250 MoE only supports no activation, SwiGLU, or SiTU, "
+            f"got {specs.name!r}"
         )
     if len(fused_activation.fn_args) < 2:
         raise ValueError("SwiGLU activation requires at least alpha and limit")
@@ -1198,7 +1230,7 @@ def _activation_config(fused_activation: FusedActivation | None):
         if len(fused_activation.fn_args) >= 3
         else 1.0
     )
-    return True, alpha, limit, beta, int(specs.reduction_n)
+    return True, alpha, limit, beta, False, 0.0, 0.0, int(specs.reduction_n)
 
 
 def _validate_schedule(
@@ -1287,7 +1319,7 @@ def matmul(
         scatter_indx: Optional destination row indices for combine writeback.
         precision_config: MX scale/output dtype configuration.
         x_global_scale: Optional scalar activation dequantization scale.
-        fused_activation: Optional SwiGLU activation descriptor.
+        fused_activation: Optional SwiGLU or SiTU activation descriptor.
         block_m: Concrete row tile resolved by the caller.
         decode: Select the small-M, M-ragged decode kernel.
 
@@ -1313,9 +1345,16 @@ def matmul(
     if precision_config is None:
         precision_config = PrecisionConfig()
     fused_activation = fused_activation or FusedActivation(FnSpecs.default(), tuple())
-    do_swiglu, swiglu_alpha, swiglu_limit, swiglu_beta, activation_reduction_n = (
-        _activation_config(fused_activation)
-    )
+    (
+        do_swiglu,
+        swiglu_alpha,
+        swiglu_limit,
+        swiglu_beta,
+        do_situ,
+        situ_beta,
+        situ_linear_beta,
+        activation_reduction_n,
+    ) = _activation_config(fused_activation)
 
     a_torch = a.storage.data if isinstance(a, Tensor) else a
     b_torch = b.storage.data if isinstance(b, Tensor) else b
@@ -1461,6 +1500,9 @@ def matmul(
         swiglu_alpha,
         swiglu_limit,
         swiglu_beta,
+        do_situ,
+        situ_beta,
+        situ_linear_beta,
         activation_reduction_n,
         n_valid_slices,
         opt_flags.block_m,
@@ -1496,85 +1538,6 @@ def _index_tensor(obj: Any | None, attr: str) -> torch.Tensor | None:
     if obj is None:
         return None
     return getattr(obj, attr) if hasattr(obj, attr) else obj
-
-
-def gluon_mxfp_dispatch_swiglu(
-    x: torch.Tensor,
-    w: torch.Tensor,
-    w_scale: torch.Tensor,
-    *,
-    x_scale: torch.Tensor | None = None,
-    x_format: str = "e2m1",
-    x_global_scale: torch.Tensor | float = 1.0,
-    bias: torch.Tensor | None,
-    a_ragged_metadata,
-    gather_indx,
-    out_dtype: torch.dtype = torch.bfloat16,
-    swiglu_alpha: float = 1.0,
-    swiglu_limit: float = 0.0,
-    swiglu_beta: float = 1.0,
-    block_m: int | None = None,
-    block_n: int = 256,
-    block_k: int = 256,
-    num_warps: int = 4,
-    num_buffers: int = 3,
-    use_warp_pipeline: bool | None = None,
-    use_slice_mn: bool | None = None,
-    use_slice_n: bool | None = None,
-    scale_load_mode: str = "transpose",
-    w_transpose: bool = True,
-    persistent: bool | None = None,
-    num_ctas: int | None = None,
-    out_quant_scale: torch.Tensor | float | None = None,
-    out_quant_format: str | None = None,
-    w_preshuffle: bool = False,
-    x_scale_ragged_padded: bool = False,
-    decode: bool = False,
-) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-    """Dispatch GEMM + fused SwiGLU using the gfx1250 Gluon MoE kernel."""
-    del use_warp_pipeline, use_slice_mn, use_slice_n
-    del persistent, num_ctas, w_preshuffle, x_scale_ragged_padded
-    if out_quant_scale is not None or out_quant_format is not None:
-        raise NotImplementedError(
-            "gfx1250 dispatch wrapper does not support output quantization"
-        )
-    if x_format == "e2m1" and x_scale is None:
-        raise ValueError("x_scale is required for e2m1/MXFP4 activation input")
-    if x_format != "e2m1" and x_scale is not None:
-        raise ValueError("x_scale is only supported for e2m1/MXFP4 activation input")
-    gather_tensor = _index_tensor(gather_indx, "src_indx")
-    m = int(x.shape[-2] if gather_tensor is None else gather_tensor.shape[0])
-    num_experts = None if a_ragged_metadata is None else a_ragged_metadata.n_slices
-    if block_m is None:
-        block_m = _resolve_block_m(decode, m, num_experts, is_combine=False)
-    activation = FusedActivation(
-        FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
-        (float(swiglu_alpha), float(swiglu_limit), float(swiglu_beta)),
-    )
-    precision = PrecisionConfig(
-        out_dtype=out_dtype,
-        a_mx_scale=x_scale,
-        b_mx_scale=w_scale,
-    )
-    out, _ = matmul(
-        x,
-        w,
-        bias,
-        a_ragged_metadata=a_ragged_metadata,
-        gather_indx=gather_tensor,
-        precision_config=precision,
-        x_global_scale=x_global_scale,
-        fused_activation=activation,
-        scale_preshuffle=(scale_load_mode == "swizzle"),
-        block_m=block_m,
-        block_n=block_n,
-        block_k=block_k,
-        num_warps=num_warps,
-        num_buffers=num_buffers,
-        w_transpose=w_transpose,
-        decode=decode,
-    )
-    return out
 
 
 def gluon_mxfp_combine(
@@ -1759,11 +1722,15 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
     w13_bias: Optional[torch.Tensor] = None,
     w2_bias: Optional[torch.Tensor] = None,
     out_dtype: torch.dtype = torch.bfloat16,
+    activation: str = "swiglu",
     swiglu_alpha: float = 1.702,
     swiglu_limit: float = 7.0,
     swiglu_beta: float = 1.0,
+    situ_beta: float = 4.0,
+    situ_linear_beta: float = 25.0,
     decode: bool = False,
     block_m: int | None = None,
+    out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Dispatch + combine for gfx1250 MXFP4-weight MoE with precomputed top-k.
 
@@ -1779,11 +1746,16 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
         w13_bias: Optional expert bias for the gate/up projection.
         w2_bias: Optional expert bias for the down projection.
         out_dtype: Final output dtype.
+        activation: Fused gate activation, either ``"swiglu"``/``"silu"`` or
+            ``"situ"``.
         swiglu_alpha: SwiGLU gate scale.
         swiglu_limit: Optional SwiGLU clamp limit; ``0`` disables clamping.
         swiglu_beta: SwiGLU linear branch offset.
+        situ_beta: SiTU gate clamp.
+        situ_linear_beta: SiTU linear-branch clamp.
         decode: Select the small-M decode kernel for both MoE projections.
         block_m: Optional row-tile override; unset values resolve per projection.
+        out: Optional destination tensor for the finalized expert output.
 
     Returns:
         Tensor shaped ``(n_tokens, hidden_size)``.
@@ -1824,25 +1796,43 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
         hidden_states,
         w13_weight.act_scale,
     )
-    intermediate = gluon_mxfp_dispatch_swiglu(
+    if activation == "situ":
+        fused_activation = FusedActivation(
+            FnSpecs("situ", None, ("beta", "linear_beta"), reduction_n=2),
+            (float(situ_beta), float(situ_linear_beta)),
+        )
+    elif activation == "silu":
+        fused_activation = FusedActivation(
+            FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
+            (1.0, 0.0, 0.0),
+        )
+    elif activation == "swiglu":
+        fused_activation = FusedActivation(
+            FnSpecs("swiglu", swiglu_fn, ("alpha", "limit", "beta"), reduction_n=2),
+            (float(swiglu_alpha), float(swiglu_limit), float(swiglu_beta)),
+        )
+    else:
+        raise ValueError(
+            "gfx1250 Gluon MXFP4 MoE supports activation 'silu', "
+            f"'swiglu', or 'situ', got {activation!r}"
+        )
+    intermediate = gluon_mxfp_ragged_matmul(
         x_fp8,
         w13_weight,
-        w13_mx_scale,
+        w13_bias,
+        w_mx_scale=w13_mx_scale,
         x_format="e4m3",
         x_global_scale=w13_weight.act_scale,
-        bias=w13_bias,
         a_ragged_metadata=ragged_metadata,
         gather_indx=gather_indx,
         out_dtype=out_dtype,
-        swiglu_alpha=swiglu_alpha,
-        swiglu_limit=swiglu_limit,
-        swiglu_beta=swiglu_beta,
+        fused_activation=fused_activation,
+        scale_preshuffle=True,
         block_m=block_m,
         block_n=256,
         block_k=256,
         num_warps=4,
         num_buffers=3,
-        scale_load_mode="swizzle",
         decode=decode,
     )
     intermediate_fp8 = _quantize_fp8_activation(
@@ -1868,11 +1858,24 @@ def gluon_mxfp_precomputed_mxfp4_fused_moe(
         decode=decode,
     )
     weighted = flat.float() * topk_weights.reshape(-1, 1)
-    return (
+    result = (
         weighted.view(hidden_states.shape[0], topk_ids.shape[1], flat.shape[-1])
         .sum(dim=1)
         .to(out_dtype)
     )
+    if out is None:
+        return result
+    if (
+        out.shape != result.shape
+        or out.dtype != result.dtype
+        or out.device != result.device
+    ):
+        raise ValueError(
+            "gfx1250 Gluon MXFP4 MoE output buffer must match the result's "
+            "shape, dtype, and device"
+        )
+    out.copy_(result)
+    return out
 
 
 def gluon_mxfp_ragged_matmul(
@@ -1919,7 +1922,7 @@ def gluon_mxfp_ragged_matmul(
         "decode",
     }
     launch_kwargs = {k: extra_kwargs.pop(k) for k in list(extra_kwargs) if k in allowed}
-    wrapper_launch_kwargs = {
+    combine_launch_kwargs = {
         k: v
         for k, v in launch_kwargs.items()
         if k in {"block_m", "block_n", "block_k", "num_buffers", "num_warps", "decode"}
@@ -1945,30 +1948,19 @@ def gluon_mxfp_ragged_matmul(
             out_dtype=out_dtype,
             scale_load_mode=scale_load_mode,
             w_transpose=w_transpose,
-            **wrapper_launch_kwargs,
+            **combine_launch_kwargs,
         )
     if fused_activation is not None:
-        swiglu_args = _activation_config(fused_activation)
-        if not swiglu_args[0]:
-            raise NotImplementedError("only SwiGLU fused activation is supported")
-        return gluon_mxfp_dispatch_swiglu(
-            x,
-            w,
-            w_mx_scale,
-            x_scale=x_mx_scale,
-            x_format=x_format,
-            x_global_scale=x_global_scale,
-            bias=bias,
-            a_ragged_metadata=a_ragged_metadata,
-            gather_indx=gather_indx,
-            out_dtype=out_dtype,
-            swiglu_alpha=swiglu_args[1],
-            swiglu_limit=swiglu_args[2],
-            swiglu_beta=swiglu_args[3],
-            scale_load_mode=scale_load_mode,
-            w_transpose=w_transpose,
-            **wrapper_launch_kwargs,
-        )
+        if x_format == "e2m1" and x_mx_scale is None:
+            raise ValueError("x_mx_scale is required for e2m1/MXFP4 activation input")
+        if x_format != "e2m1" and x_mx_scale is not None:
+            raise ValueError(
+                "x_mx_scale is only supported for e2m1/MXFP4 activation input"
+            )
+        launch_kwargs.setdefault("block_n", 256)
+        launch_kwargs.setdefault("block_k", 256)
+        launch_kwargs.setdefault("num_warps", 4)
+        launch_kwargs.setdefault("num_buffers", 3)
     precision = PrecisionConfig(
         out_dtype=out_dtype, a_mx_scale=x_mx_scale, b_mx_scale=w_mx_scale
     )
@@ -1987,6 +1979,7 @@ def gluon_mxfp_ragged_matmul(
         gather_indx=gather_tensor,
         scatter_indx=_index_tensor(scatter_indx, "dst_indx"),
         precision_config=precision,
+        fused_activation=fused_activation,
         block_m=block_m,
         x_global_scale=x_global_scale,
         scale_preshuffle=scale_preshuffle,
@@ -2000,6 +1993,6 @@ def gluon_mxfp_ragged_matmul(
 __all__ = [
     "PrecisionConfig",
     "gluon_mxfp_combine",
-    "gluon_mxfp_dispatch_swiglu",
     "gluon_mxfp_precomputed_mxfp4_fused_moe",
+    "gluon_mxfp_ragged_matmul",
 ]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/deep_gemm/dsv4_mega_moe.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/deep_gemm/dsv4_mega_moe.py
@@ -281,7 +281,7 @@ if fp8_fp4_mega_moe is not None and stage_dsv4_mega_moe_inputs is not None:
             "scale_block_size": frozenset({_MXFP4_BLOCK_SIZE}),
             "supports_ep": frozenset({True}),
         },
-        priority=Priority.SPECIALIZED + 2,
+        priority=Priority.SPECIALIZED,
         tags={"throughput"},
         weight_preprocessor=_deep_gemm_dsv4_mega_moe_process_weights,
     )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -256,7 +256,7 @@ if platform.is_amd:
             "ispp_alignment": frozenset({128}),
             "internal_activation_dtype": frozenset({"input"}),
         },
-        priority=Priority.SPECIALIZED + 3,
+        priority=Priority.SPECIALIZED,
     )
     def gluon_mxfp4_a8w4_situ_precomputed_moe_apply(
         plan: dict,
@@ -334,10 +334,9 @@ if platform.is_amd:
             "ispp_alignment": frozenset({1}),
             "internal_activation_dtype": frozenset({"input"}),
         },
-        # Gfx950 A16W4 SiTU EP8 is the measured K3 fast path. Capability and
-        # ep_size traits keep this specialized priority from affecting other
-        # platforms or EP degrees.
-        priority=Priority.SPECIALIZED + 1,
+        # Capability and ep_size traits restrict this measured K3 fast path to
+        # gfx950 EP8, so it needs no intra-band priority offset.
+        priority=Priority.SPECIALIZED,
     )
     def gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply(
         plan: dict,
@@ -390,7 +389,7 @@ if platform.is_amd:
             "internal_activation_dtype": frozenset({"input"}),
             "supports_bias": frozenset({False}),
         },
-        priority=Priority.SPECIALIZED + 1,
+        priority=Priority.SPECIALIZED,
     )
     def gluon_mxfp4_a16w4_swiglu_ep_precomputed_moe_apply(
         plan: dict,
@@ -411,6 +410,98 @@ if platform.is_amd:
             topk_ids,
             activation="swiglu",
             do_finalize=do_finalize,
+        )
+
+    @register_kernel(
+        "moe",
+        "apply",
+        name="gluon_mxfp4_a8w4_situ_gfx1250_precomputed_moe_apply",
+        solution="gluon",
+        weight_preprocessor=gluon_mxfp4_gfx1250_moe_weights,
+        capability=CapabilityRequirement(
+            vendors=frozenset({"amd"}),
+            min_arch_version=ArchVersion(12, 5),
+            max_arch_version=ArchVersion(12, 5),
+        ),
+        signatures=format_signatures("x", "dense", {torch.bfloat16}),
+        traits={
+            "weight_dtype": frozenset({"mxfp4"}),
+            "activation": frozenset({"situ"}),
+            "routing_mode": frozenset({"precomputed_topk"}),
+            "supports_deferred_finalize": frozenset({False}),
+            "supports_ep": frozenset({False}),
+            "supports_all_to_all_ep": frozenset({False}),
+            # K3 TP8 shards the 3072-wide expert intermediate to 384 columns.
+            "ispp": frozenset({384}),
+            "ispp_alignment": frozenset({128}),
+            "internal_activation_dtype": frozenset({"input"}),
+        },
+        priority=Priority.SPECIALIZED,
+    )
+    def gluon_mxfp4_a8w4_situ_gfx1250_precomputed_moe_apply(
+        plan: dict,
+        x: torch.Tensor,
+        w: torch.nn.Module,
+        router_logits: torch.Tensor,
+        topk_weights: torch.Tensor | None = None,
+        topk_ids: torch.Tensor | None = None,
+        num_tokens_global: int | None = None,
+        max_num_tokens_per_gpu: int | None = None,
+        do_finalize: bool = True,
+        enable_pdl: bool = False,
+        shared_input: torch.Tensor | None = None,
+        shared_weight: torch.Tensor | None = None,
+        shared_out: torch.Tensor | None = None,
+    ):
+        del plan, router_logits, num_tokens_global, max_num_tokens_per_gpu
+        del enable_pdl
+        if not do_finalize:
+            raise ValueError("gfx1250 A8W4 SiTU MoE cannot defer finalization")
+        if topk_weights is None or topk_ids is None:
+            raise ValueError("gfx1250 A8W4 SiTU MoE requires precomputed top-k")
+        if (
+            shared_input is not None
+            or shared_weight is not None
+            or shared_out is not None
+        ):
+            raise ValueError(
+                "gfx1250 A8W4 SiTU MoE does not support shared projection fusion"
+            )
+
+        situ_beta = float(getattr(w, "activation_situ_beta", 1.0))
+        situ_linear_beta = getattr(w, "activation_situ_linear_beta", None)
+        if situ_linear_beta is None:
+            raise ValueError("gfx1250 A8W4 SiTU MoE requires linear_beta")
+        w13_pc = w.w13_precision_config
+        w2_pc = w.w2_precision_config
+        decode = _use_gfx1250_moe_decode(
+            topk_ids.numel(), w.w13_weight_triton_tensor.shape[0]
+        )
+
+        return fused_mxfp_gfx1250.gluon_mxfp_precomputed_mxfp4_fused_moe(
+            x,
+            topk_weights,
+            topk_ids,
+            w.w13_weight_triton_tensor,
+            w.w2_weight_triton_tensor,
+            w13_bias=(
+                None
+                if getattr(w, "_gluon_w13_bias_is_zero", False)
+                else getattr(w, "w13_weight_bias", None)
+            ),
+            w2_bias=(
+                None
+                if getattr(w, "_gluon_w2_bias_is_zero", False)
+                else getattr(w, "w2_weight_bias", None)
+            ),
+            w13_mx_scale=w13_pc.b_mx_scale,
+            w2_mx_scale=w2_pc.b_mx_scale,
+            out_dtype=w2_pc.out_dtype or torch.bfloat16,
+            activation="situ",
+            situ_beta=situ_beta,
+            situ_linear_beta=float(situ_linear_beta),
+            decode=decode,
+            out=getattr(w, "_situ_output_buffer", None),
         )
 
     @register_kernel(
@@ -440,7 +531,7 @@ if platform.is_amd:
             "internal_activation_dtype": frozenset({"fp8"}),
             "supports_bias": frozenset({True}),
         },
-        priority=Priority.SPECIALIZED + 4,
+        priority=Priority.SPECIALIZED,
     )
     def gluon_mxfp4_gfx1250_precomputed_moe_apply(
         plan: dict,
@@ -521,7 +612,10 @@ if platform.is_amd:
             "internal_activation_dtype": frozenset({"input"}),
             "supports_bias": frozenset({True}),
         },
-        priority=Priority.SPECIALIZED + 3,
+        # ``routing_mode=None`` deliberately leaves moe_plan unconstrained, so
+        # this and the precomputed sibling both match. Prefer kernel routing;
+        # an explicit precomputed_topk request still filters this entry out.
+        priority=Priority.SPECIALIZED + 1,
     )
     def gluon_mxfp4_dynamic_moe_apply(
         plan: dict,
@@ -611,7 +705,7 @@ if platform.is_amd:
             "internal_activation_dtype": frozenset({"input"}),
             "supports_bias": frozenset({True}),
         },
-        priority=Priority.SPECIALIZED + 2,
+        priority=Priority.SPECIALIZED,
     )
     def gluon_mxfp4_precomputed_moe_apply(
         plan: dict,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/decode_sigmoid_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/decode_sigmoid_topk.py
@@ -169,6 +169,8 @@ def _decode_sigmoid_bias_topk(
     solution="triton",
     capability=CapabilityRequirement(vendors=frozenset({"amd"})),
     signatures=format_signatures("router_logits", "dense", {torch.float32}),
+    # The broader gfx950 Gluon kernel declares no shape traits, so the caller's
+    # single-token traits cannot filter it out. Prefer this decode specialization.
     priority=Priority.SPECIALIZED + 1,
     traits={
         "tokens": frozenset({1}),
@@ -203,7 +205,7 @@ def triton_decode_sigmoid_bias_topk(
     solution="triton",
     capability=CapabilityRequirement(vendors=frozenset({"amd"})),
     signatures=format_signatures("router_logits", "dense", {torch.float32}),
-    priority=Priority.SPECIALIZED + 1,
+    priority=Priority.SPECIALIZED,
     traits={
         "tokens": frozenset({1}),
         "experts": frozenset(range(1, 1025)),

--- a/tokenspeed-kernel/test/kimi3_reference.py
+++ b/tokenspeed-kernel/test/kimi3_reference.py
@@ -141,11 +141,15 @@ def _mxfp4_linear(
     x: torch.Tensor,
     packed_weight: torch.Tensor,
     scales: torch.Tensor,
+    *,
+    activation_dtype: torch.dtype,
+    output_dtype: torch.dtype,
 ) -> torch.Tensor:
-    return F.linear(x.float(), dequantize_mxfp4(packed_weight, scales)).to(x.dtype)
+    x = x.to(activation_dtype).float()
+    return F.linear(x, dequantize_mxfp4(packed_weight, scales)).to(output_dtype)
 
 
-def a16w4_mxfp4_moe_reference(
+def mxfp4_moe_reference(
     hidden_states: torch.Tensor,
     w13_packed: torch.Tensor,
     w13_scales: torch.Tensor,
@@ -154,10 +158,11 @@ def a16w4_mxfp4_moe_reference(
     topk_ids: torch.Tensor,
     topk_weights: torch.Tensor,
     *,
+    activation_dtype: torch.dtype,
     situ_beta: float = 1.0,
     situ_linear_beta: float | None = None,
 ) -> torch.Tensor:
-    """A16W4 routed experts with BF16 boundaries around FP32 SiTU."""
+    """Routed MXFP4 experts with explicit activation-quantization boundaries."""
 
     combined = torch.zeros_like(hidden_states, dtype=torch.float32)
     for expert_id in range(w13_packed.shape[0]):
@@ -169,6 +174,8 @@ def a16w4_mxfp4_moe_reference(
             hidden_states.index_select(0, token_ids),
             w13_packed[expert_id],
             w13_scales[expert_id],
+            activation_dtype=activation_dtype,
+            output_dtype=hidden_states.dtype,
         )
         output = _mxfp4_linear(
             situ_and_mul(
@@ -178,6 +185,8 @@ def a16w4_mxfp4_moe_reference(
             ),
             w2_packed[expert_id],
             w2_scales[expert_id],
+            activation_dtype=activation_dtype,
+            output_dtype=hidden_states.dtype,
         )
         route_weights = topk_weights[token_ids, slot_ids].float().unsqueeze(-1)
         combined.index_add_(0, token_ids, output.float() * route_weights)

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_amd.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_amd.py
@@ -33,6 +33,9 @@ from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.situ_decode import (  # noqa: E4
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.weight_preprocess import (  # noqa: E402
     preprocess_gluon_mxfp4_gfx950_moe_weights,
 )
+from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4 import (  # noqa: E402
+    fused as gfx1250_fused,
+)
 from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4.fused import (  # noqa: E402
     _resolve_block_m,
 )
@@ -443,6 +446,44 @@ def test_gfx1250_resolve_block_m_defaults(
         )
         == expected_block_m
     )
+
+
+def test_gfx1250_ragged_matmul_forwards_fused_activation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    x = torch.empty((2, 4), dtype=torch.bfloat16)
+    output = torch.empty_like(x)
+    activation = gfx1250_fused.FusedActivation(
+        gfx1250_fused.FnSpecs(
+            "situ",
+            None,
+            ("beta", "linear_beta"),
+            reduction_n=2,
+        ),
+        (4.0, 25.0),
+    )
+    captured: dict[str, object] = {}
+
+    def fake_matmul(*args, **kwargs):
+        captured.update(kwargs)
+        return output, None
+
+    monkeypatch.setattr(gfx1250_fused, "matmul", fake_matmul)
+
+    actual = gfx1250_fused.gluon_mxfp_ragged_matmul(
+        x,
+        torch.empty((1, 4, 8), dtype=torch.uint8),
+        None,
+        w_mx_scale=torch.empty(1),
+        fused_activation=activation,
+    )
+
+    assert actual is output
+    assert captured["fused_activation"] is activation
+    assert captured["block_n"] == 256
+    assert captured["block_k"] == 256
+    assert captured["num_warps"] == 4
+    assert captured["num_buffers"] == 3
 
 
 @pytest.mark.parametrize(

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx1250.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx1250.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from kimi3_reference import mxfp4_moe_reference
+from utils import is_cdna5, make_mxfp4_moe_weights, make_round_robin_topk
+
+if not is_cdna5():
+    pytest.skip(
+        "AMD CDNA5 is required for gfx1250 Gluon MXFP4 SiTU tests",
+        allow_module_level=True,
+    )
+
+import tokenspeed_kernel  # noqa: E402
+
+_KERNEL_NAME = "gluon_mxfp4_a8w4_situ_gfx1250_precomputed_moe_apply"
+
+
+def _make_mxfp4_module(
+    *,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    generator: torch.Generator,
+) -> tuple[torch.nn.Module, dict[str, torch.Tensor]]:
+    raw = make_mxfp4_moe_weights(
+        num_experts,
+        hidden_size,
+        intermediate_size,
+        generator,
+    )
+    module = torch.nn.Module()
+    module.w13_weight = torch.nn.Parameter(
+        raw["w13_weight"].clone(), requires_grad=False
+    )
+    module.w13_weight_scale = torch.nn.Parameter(
+        raw["w13_scale"].clone(), requires_grad=False
+    )
+    module.w2_weight = torch.nn.Parameter(raw["w2_weight"].clone(), requires_grad=False)
+    module.w2_weight_scale = torch.nn.Parameter(
+        raw["w2_scale"].clone(), requires_grad=False
+    )
+    module.top_k = top_k
+    module.num_experts = num_experts
+    module.ep_size = 1
+    module.activation_situ_beta = 4.0
+    module.activation_situ_linear_beta = 25.0
+    return module, raw
+
+
+def _make_case(
+    num_tokens: int,
+) -> tuple[
+    torch.nn.Module,
+    dict[str, torch.Tensor],
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    generator = torch.Generator(device="cuda").manual_seed(20260829 + num_tokens)
+    num_experts, hidden_size, intermediate_size, top_k = 16, 3584, 384, 16
+    module, raw = _make_mxfp4_module(
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        generator=generator,
+    )
+    hidden_states = 0.1 * torch.randn(
+        num_tokens,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    topk_weights, topk_ids = make_round_robin_topk(
+        num_tokens,
+        num_experts,
+        top_k,
+    )
+    router_logits = torch.zeros(
+        (num_tokens, num_experts),
+        dtype=torch.float32,
+        device="cuda",
+    )
+    return module, raw, hidden_states, topk_weights, topk_ids, router_logits
+
+
+def _make_plan() -> dict:
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="situ",
+        routing_mode="precomputed_topk",
+        ep_size=1,
+        ispp=384,
+        internal_activation_dtype="input",
+        solution="gluon",
+    )
+    assert plan["apply_kernel_name"] == _KERNEL_NAME
+    return plan
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4, 32])
+def test_kimi_k3_tp_situ_matches_a8w4_reference_gfx1250(
+    num_tokens: int,
+) -> None:
+    module, raw, hidden_states, topk_weights, topk_ids, router_logits = _make_case(
+        num_tokens
+    )
+    plan = _make_plan()
+    tokenspeed_kernel.moe_process_weights(plan, module)
+
+    actual = tokenspeed_kernel.moe_apply(
+        plan,
+        hidden_states,
+        module,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+    expected = mxfp4_moe_reference(
+        hidden_states,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        topk_ids,
+        topk_weights,
+        activation_dtype=torch.float8_e4m3fn,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+
+    torch.cuda.synchronize()
+    assert torch.count_nonzero(expected).item() > 0
+    torch.testing.assert_close(actual, expected, atol=2e-2, rtol=5e-2)
+
+
+def test_kimi_k3_tp_situ_is_cuda_graph_capturable_gfx1250() -> None:
+    module, _, hidden_states, topk_weights, topk_ids, router_logits = _make_case(1)
+    plan = _make_plan()
+    tokenspeed_kernel.moe_process_weights(plan, module)
+
+    expected = tokenspeed_kernel.moe_apply(
+        plan,
+        hidden_states,
+        module,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    ).clone()
+    output = torch.empty_like(expected)
+    module._situ_output_buffer = output
+
+    def apply() -> torch.Tensor:
+        result = tokenspeed_kernel.moe_apply(
+            plan,
+            hidden_states,
+            module,
+            router_logits,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+        )
+        assert result.data_ptr() == output.data_ptr()
+        return result
+
+    for _ in range(3):
+        apply()
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = apply()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(captured, expected, atol=0.0, rtol=0.0)

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import pytest
 import torch
 from kimi3_reference import (
-    a16w4_mxfp4_moe_reference,
+    mxfp4_moe_reference,
 )
 from utils import is_cdna4, make_mxfp4_moe_weights, make_round_robin_topk
 
@@ -144,7 +144,7 @@ def test_ep_decode_matches_kimi_k3_shape_gfx950(
     local_weights = torch.where(
         local_mask, topk_weights, torch.zeros_like(topk_weights)
     )
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -152,6 +152,7 @@ def test_ep_decode_matches_kimi_k3_shape_gfx950(
         raw["w2_scale"],
         local_ids,
         local_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
@@ -255,7 +256,7 @@ def test_gluon_grouped_a16w4_situ_matches_kimi_k3_shape_gfx950() -> None:
         topk_weights=topk_weights,
         topk_ids=topk_ids,
     )
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -263,6 +264,7 @@ def test_gluon_grouped_a16w4_situ_matches_kimi_k3_shape_gfx950() -> None:
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
@@ -323,7 +325,7 @@ def test_grouped_atomic_combine_matches_partial_reduction_gfx950(
     )
     atomic = run()
 
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -331,6 +333,7 @@ def test_grouped_atomic_combine_matches_partial_reduction_gfx950(
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
@@ -442,7 +445,7 @@ def test_gluon_grouped_device_align_localizes_global_ep_routes_gfx950() -> None:
         topk_weights,
         torch.zeros_like(topk_weights),
     )
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         module.w13_weight,
         module.w13_weight_scale,
@@ -450,6 +453,7 @@ def test_gluon_grouped_device_align_localizes_global_ep_routes_gfx950() -> None:
         module.w2_weight_scale,
         local_ids,
         local_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
@@ -518,7 +522,7 @@ def test_mxfp4_situ_virtual_ep_sum_matches_global_reference_gfx950(
         )
     actual = torch.stack([partial.float() for partial in partials]).sum(0)
     actual = actual.to(torch.bfloat16)
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -526,6 +530,7 @@ def test_mxfp4_situ_virtual_ep_sum_matches_global_reference_gfx950(
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )
@@ -672,7 +677,7 @@ def test_tp_situ_selects_a8w4_and_matches_reference_gfx950(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
     )
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -680,6 +685,7 @@ def test_tp_situ_selects_a8w4_and_matches_reference_gfx950(
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )

--- a/tokenspeed-kernel/test/ops/moe/test_marlin_deepep_distributed.py
+++ b/tokenspeed-kernel/test/ops/moe/test_marlin_deepep_distributed.py
@@ -41,7 +41,7 @@ import os
 import pytest
 import torch
 import torch.distributed as dist
-from kimi3_reference import a16w4_mxfp4_moe_reference
+from kimi3_reference import mxfp4_moe_reference
 from utils import make_mxfp4_moe_weights
 
 deep_ep = pytest.importorskip("deep_ep", reason="deep_ep is an optional dependency")
@@ -103,7 +103,7 @@ def test_marlin_deepep_matches_replicated_reference() -> None:
     )
     topk_weights = topk_weights / topk_weights.sum(-1, keepdim=True)
 
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         x,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -111,6 +111,7 @@ def test_marlin_deepep_matches_replicated_reference() -> None:
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=beta,
         situ_linear_beta=linear_beta,
     )

--- a/tokenspeed-kernel/test/ops/moe/test_marlin_mxfp4_apply.py
+++ b/tokenspeed-kernel/test/ops/moe/test_marlin_mxfp4_apply.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import pytest
 import torch
-from kimi3_reference import a16w4_mxfp4_moe_reference
+from kimi3_reference import mxfp4_moe_reference
 from tokenspeed_kernel.ops.moe.marlin.mxfp4 import (
     marlin_mxfp4_moe_weights,
     marlin_mxfp4_precomputed_moe_apply,
@@ -90,7 +90,7 @@ def test_marlin_mxfp4_situ_matches_reference(num_tokens: int) -> None:
     )
     topk_weights = topk_weights / topk_weights.sum(-1, keepdim=True)
 
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         x,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -98,6 +98,7 @@ def test_marlin_mxfp4_situ_matches_reference(num_tokens: int) -> None:
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=beta,
         situ_linear_beta=linear_beta,
     )
@@ -146,7 +147,7 @@ def test_marlin_mxfp4_ep_masks_nonlocal_experts() -> None:
     )
     topk_weights = topk_weights / topk_weights.sum(-1, keepdim=True)
 
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         x,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -154,6 +155,7 @@ def test_marlin_mxfp4_ep_masks_nonlocal_experts() -> None:
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=beta,
         situ_linear_beta=linear_beta,
     )

--- a/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_ep_distributed_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_ep_distributed_gfx950.py
@@ -34,7 +34,7 @@ import tokenspeed_kernel
 import torch
 import torch.distributed as dist
 from kimi3_reference import (
-    a16w4_mxfp4_moe_reference,
+    mxfp4_moe_reference,
 )
 from utils import make_mxfp4_moe_weights
 
@@ -122,7 +122,7 @@ def test_distributed_ep_partial_sum_matches_global_reference() -> None:
     )
     dist.all_reduce(partial, op=dist.ReduceOp.SUM)
 
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         w13,
         s13,
@@ -130,6 +130,7 @@ def test_distributed_ep_partial_sum_matches_global_reference() -> None:
         s2,
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=4.0,
         situ_linear_beta=25.0,
     )

--- a/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_flashinfer_trtllm.py
+++ b/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_flashinfer_trtllm.py
@@ -22,7 +22,7 @@
 
 Exercises the full in-repo chain -- the weight preprocessor (concatenated
 [gate|up] loader layout -> shuffled TRTLLM [up|gate]) and the registered
-apply -- against ``a16w4_mxfp4_moe_reference`` on the same MXFP4 weights.
+apply -- against ``mxfp4_moe_reference`` on the same MXFP4 weights.
 """
 
 from __future__ import annotations
@@ -31,7 +31,7 @@ from importlib.util import find_spec
 
 import pytest
 import torch
-from kimi3_reference import a16w4_mxfp4_moe_reference
+from kimi3_reference import mxfp4_moe_reference
 from utils import make_mxfp4_moe_weights
 
 NUM_EXPERTS = 8
@@ -131,7 +131,7 @@ def test_flashinfer_situ_kernel_routing_matches_portable_reference() -> None:
     raw, hidden_states, router_logits, bias, topk_ids, topk_weights = (
         _kernel_routing_case(20260825, num_tokens)
     )
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -139,6 +139,7 @@ def test_flashinfer_situ_kernel_routing_matches_portable_reference() -> None:
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=SITU_BETA,
         situ_linear_beta=SITU_LINEAR_BETA,
     )
@@ -162,7 +163,7 @@ def test_flashinfer_situ_precomputed_routing_matches_portable_reference() -> Non
     raw, hidden_states, router_logits, bias, topk_ids, topk_weights = (
         _kernel_routing_case(20260827, 16)
     )
-    expected = a16w4_mxfp4_moe_reference(
+    expected = mxfp4_moe_reference(
         hidden_states,
         raw["w13_weight"],
         raw["w13_scale"],
@@ -170,6 +171,7 @@ def test_flashinfer_situ_precomputed_routing_matches_portable_reference() -> Non
         raw["w2_scale"],
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=SITU_BETA,
         situ_linear_beta=SITU_LINEAR_BETA,
     )

--- a/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_latent_moe_reference.py
+++ b/tokenspeed-kernel/test/ops/moe/test_mxfp4_situ_latent_moe_reference.py
@@ -22,10 +22,10 @@ from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
-from kimi3_reference import (
-    a16w4_mxfp4_moe_reference,
-)
 from kimi3_reference import dequantize_mxfp4 as dequantize_mxfp4_reference
+from kimi3_reference import (
+    mxfp4_moe_reference,
+)
 from utils import make_mxfp4_moe_weights
 
 
@@ -55,7 +55,7 @@ def test_a16w4_moe_matches_explicit_token_slot_reference() -> None:
     beta = 2.0
     linear_beta = 3.0
 
-    actual = a16w4_mxfp4_moe_reference(
+    actual = mxfp4_moe_reference(
         hidden_states,
         w13_packed,
         w13_scales,
@@ -63,6 +63,7 @@ def test_a16w4_moe_matches_explicit_token_slot_reference() -> None:
         w2_scales,
         topk_ids,
         topk_weights,
+        activation_dtype=torch.bfloat16,
         situ_beta=beta,
         situ_linear_beta=linear_beta,
     )

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -64,6 +64,7 @@ import tokenspeed_kernel.ops.moe.deep_gemm as _moe_deep_gemm
 import tokenspeed_kernel.ops.moe.flashinfer as _moe_flashinfer
 import tokenspeed_kernel.ops.moe.gluon as _moe_gluon
 import tokenspeed_kernel.ops.moe.gluon.dsv4 as _moe_gluon_dsv4
+import tokenspeed_kernel.ops.moe.gluon.sigmoid_topk as _moe_gluon_sigmoid_topk
 import tokenspeed_kernel.ops.moe.triton as _moe_triton
 import tokenspeed_kernel.ops.quantization as _quantization_pkg
 import tokenspeed_kernel.ops.quantization.flashinfer as _quantization_flashinfer
@@ -112,10 +113,18 @@ from tokenspeed_kernel.ops.moe.flashinfer import trtllm_nvfp4 as _moe_trtllm_nvf
 from tokenspeed_kernel.ops.moe.flashinfer import trtllm_unquant as _moe_trtllm_unquant
 from tokenspeed_kernel.ops.moe.gluon import mxfp4 as _moe_gluon_mxfp4
 from tokenspeed_kernel.ops.moe.triton import bf16 as _moe_triton_bf16
+from tokenspeed_kernel.ops.moe.triton import (
+    decode_sigmoid_topk as _moe_triton_decode_sigmoid_topk,
+)
 from tokenspeed_kernel.ops.moe.triton import mxfp4 as _moe_triton_mxfp4
 from tokenspeed_kernel.platform import ArchVersion, Platform, PlatformInfo
-from tokenspeed_kernel.registry import KernelRegistry, error_fn
-from tokenspeed_kernel.selection import SelectedKernel, spec_matches_traits
+from tokenspeed_kernel.registry import KernelRegistry, Priority, error_fn
+from tokenspeed_kernel.selection import (
+    SelectedKernel,
+    select_kernel,
+    spec_matches_traits,
+)
+from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
 _RELOAD_MODULES = [
     # Attention registration modules.
@@ -168,8 +177,10 @@ _RELOAD_MODULES = [
     _moe_flashinfer,
     _moe_gluon_dsv4,
     _moe_gluon_mxfp4,
+    _moe_gluon_sigmoid_topk,
     _moe_gluon,
     _moe_triton_bf16,
+    _moe_triton_decode_sigmoid_topk,
     _moe_triton_mxfp4,
     _moe_triton,
     _moe_pkg,
@@ -206,6 +217,28 @@ def test_builtin_moe_preprocessor_links_are_callables():
     assert process_weight_kernels == []
 
     assert errors == []
+
+
+def test_builtin_moe_specialized_offsets_are_intentional() -> None:
+    """Only proven same-band overlaps may use specialized priority offsets."""
+    registry = KernelRegistry.get()
+    expected_offsets = {
+        "gluon_mxfp4_dynamic_moe_apply": Priority.SPECIALIZED + 1,
+        "triton_decode_sigmoid_bias_topk": Priority.SPECIALIZED + 1,
+    }
+    actual_offsets = {
+        spec.name: spec.priority
+        for spec in registry.list_kernels("moe")
+        if Priority.SPECIALIZED < spec.priority < Priority.PLUGIN
+    }
+    available_expected = {
+        name: priority
+        for name, priority in expected_offsets.items()
+        if registry.get_by_name(name) is not None
+    }
+
+    assert actual_offsets == available_expected
+    assert all(spec.priority < Priority.PLUGIN for spec in registry.list_kernels("moe"))
 
 
 def test_dsv4_padded_heads_platform_policy(
@@ -2097,14 +2130,12 @@ def test_gluon_dsa_prefill_topk_exact_override_checks_page_size() -> None:
 def test_gluon_mxfp4_apply_priority_prefers_dynamic_over_precomputed() -> None:
     """The dynamic gluon mxfp4 apply outranks the precomputed one.
 
-    ``moe_plan`` never requests a ``routing_mode`` trait, so both the
-    ``kernel_routing`` (dynamic) and ``precomputed_topk`` apply kernels match a
-    gluon mxfp4 plan's traits. Selection therefore falls to declared priority.
-    The dynamic entry (``SPECIALIZED + 3``) is the one that forwards caller
-    top-k into BOTH the decode and package-prefill fast paths, so it must win
-    over the precomputed entry (``SPECIALIZED + 2``), which only runs the
-    generic ragged path. This test pins that ordering so a future priority
-    bump doesn't silently route the AMD mxfp4 MoE onto the slower entry.
+    When a caller leaves ``routing_mode=None``, ``moe_plan`` deliberately omits
+    that trait so both the ``kernel_routing`` (dynamic) and
+    ``precomputed_topk`` apply kernels match. The dynamic entry is the one that
+    forwards caller top-k into both the decode and package-prefill fast paths,
+    so its single intra-band offset must beat the base-priority precomputed
+    entry. An explicit routing-mode request differentiates them by trait.
     """
     registry = KernelRegistry.get()
     dynamic = registry.get_by_name("gluon_mxfp4_dynamic_moe_apply")
@@ -2124,7 +2155,40 @@ def test_gluon_mxfp4_apply_priority_prefers_dynamic_over_precomputed() -> None:
         "ispp_alignment",
     ):
         assert dynamic.traits.get(trait) == precomputed.traits.get(trait)
-    assert dynamic.priority > precomputed.priority
+    assert dynamic.priority == Priority.SPECIALIZED + 1
+    assert precomputed.priority == Priority.SPECIALIZED
+
+
+def test_triton_decode_sigmoid_topk_priority_beats_broad_gluon(
+    mi350_platform: PlatformInfo,
+) -> None:
+    """Single-token caller traits overlap the trait-less gfx950 Gluon entry."""
+    registry = KernelRegistry.get()
+    triton_spec = registry.get_by_name("triton_decode_sigmoid_bias_topk")
+    gluon_spec = registry.get_by_name("gluon_sigmoid_bias_topk_gfx950")
+    if triton_spec is None or gluon_spec is None:
+        pytest.skip("AMD sigmoid top-k kernels are unavailable")
+
+    real_platform = Platform.get()
+    try:
+        Platform.override(mi350_platform)
+        registry.clear_cache()
+        selected = select_kernel(
+            "moe",
+            "sigmoid_bias_topk",
+            format_signature(
+                router_logits=dense_tensor_format(torch.float32),
+            ),
+            traits={"tokens": 1, "experts": 256, "topk": 8},
+        )
+    finally:
+        Platform.override(real_platform)
+        registry.clear_cache()
+
+    assert gluon_spec.traits == {}
+    assert triton_spec.priority == Priority.SPECIALIZED + 1
+    assert gluon_spec.priority == Priority.SPECIALIZED
+    assert selected.name == "triton_decode_sigmoid_bias_topk"
 
 
 def test_gluon_mxfp4_plan_selects_dynamic_apply_on_cdna4(
@@ -2150,6 +2214,7 @@ def test_gluon_mxfp4_plan_selects_dynamic_apply_on_cdna4(
             "mxfp4",
             input_dtype=torch.bfloat16,
             activation="swiglu",
+            ep_size=1,
             ispp=128,
             internal_activation_dtype="input",
             with_bias=True,
@@ -2193,16 +2258,25 @@ def test_triton_mxfp4_supports_input_activation_dtype(
 
 
 @pytest.mark.parametrize(
-    "ep_size,solution,kernel_name,preprocessor",
+    "ep_size,ispp,solution,kernel_name,preprocessor",
     [
         (
+            1,
+            384,
+            None,
+            "gluon_mxfp4_a8w4_situ_precomputed_moe_apply",
+            "gluon_mxfp4_gfx950_moe_weights",
+        ),
+        (
             8,
+            3072,
             None,
             "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply",
             "validate_linear_mxfp4_moe_weights",
         ),
         (
             8,
+            3072,
             "gluon",
             "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply",
             "validate_linear_mxfp4_moe_weights",
@@ -2212,6 +2286,7 @@ def test_triton_mxfp4_supports_input_activation_dtype(
 def test_kimi3_mxfp4_situ_selection_on_cdna4(
     mi350_platform: PlatformInfo,
     ep_size: int,
+    ispp: int,
     solution: str | None,
     kernel_name: str,
     preprocessor: str,
@@ -2229,7 +2304,7 @@ def test_kimi3_mxfp4_situ_selection_on_cdna4(
             activation="situ",
             routing_mode="precomputed_topk",
             ep_size=ep_size,
-            ispp=3072,
+            ispp=ispp,
             internal_activation_dtype="input",
             solution=solution,
         )
@@ -2238,6 +2313,78 @@ def test_kimi3_mxfp4_situ_selection_on_cdna4(
         registry.clear_cache()
 
     _assert_moe_plan(plan, apply=kernel_name, preprocessor=preprocessor)
+    assert plan["activation"] == "situ"
+    assert plan["support_routing"] is False
+
+
+@pytest.mark.parametrize(
+    "ep_size,kernel_name",
+    [
+        (1, "gluon_mxfp4_precomputed_moe_apply"),
+        (8, "gluon_mxfp4_a16w4_swiglu_ep_precomputed_moe_apply"),
+    ],
+)
+def test_gluon_mxfp4_swiglu_ep_traits_select_matching_kernel(
+    mi350_platform: PlatformInfo,
+    ep_size: int,
+    kernel_name: str,
+) -> None:
+    """The caller's EP traits separate TP and EP precomputed registrations."""
+    registry = KernelRegistry.get()
+    if registry.get_by_name(kernel_name) is None:
+        pytest.skip(f"{kernel_name} is unavailable")
+
+    real_platform = Platform.get()
+    try:
+        Platform.override(mi350_platform)
+        registry.clear_cache()
+        plan = tokenspeed_kernel.moe_plan(
+            "mxfp4",
+            input_dtype=torch.bfloat16,
+            activation="swiglu",
+            routing_mode="precomputed_topk",
+            ep_size=ep_size,
+            ispp=128,
+            internal_activation_dtype="input",
+            solution="gluon",
+        )
+    finally:
+        Platform.override(real_platform)
+        registry.clear_cache()
+
+    assert plan["apply_kernel_name"] == kernel_name
+
+
+def test_kimi3_mxfp4_situ_tp_selection_on_cdna5(
+    mi450_platform: PlatformInfo,
+) -> None:
+    kernel_name = "gluon_mxfp4_a8w4_situ_gfx1250_precomputed_moe_apply"
+    registry = KernelRegistry.get()
+    if registry.get_by_name(kernel_name) is None:
+        pytest.skip(f"{kernel_name} is unavailable")
+    real_platform = Platform.get()
+    try:
+        Platform.override(mi450_platform)
+        registry.clear_cache()
+        plan = tokenspeed_kernel.moe_plan(
+            "mxfp4",
+            input_dtype=torch.bfloat16,
+            activation="situ",
+            routing_mode="precomputed_topk",
+            ep_size=1,
+            ispp=384,
+            internal_activation_dtype="input",
+            solution="gluon",
+        )
+    finally:
+        Platform.override(real_platform)
+        registry.clear_cache()
+
+    _assert_moe_plan(
+        plan,
+        apply=kernel_name,
+        preprocessor="gluon_mxfp4_gfx1250_moe_weights",
+    )
     assert plan["activation"] == "situ"
     assert plan["support_routing"] is False
 
@@ -2375,6 +2522,60 @@ def test_gluon_mxfp4_gfx1250_apply_selects_kernel_by_average_bpe(
 
     assert out == "sentinel"
     assert captured["decode"] is expected_decode
+
+
+def test_gluon_mxfp4_gfx1250_situ_apply_forwards_activation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    apply_name = "gluon_mxfp4_a8w4_situ_gfx1250_precomputed_moe_apply"
+    if not hasattr(_moe_gluon_mxfp4, apply_name):
+        pytest.skip("gfx1250 Gluon MXFP4 SiTU apply is AMD-only")
+
+    captured: dict[str, object] = {}
+
+    def fake_fused_moe(*args, **kwargs):
+        captured.update(kwargs)
+        return "sentinel"
+
+    monkeypatch.setattr(
+        _moe_gluon_mxfp4.fused_mxfp_gfx1250,
+        "gluon_mxfp_precomputed_mxfp4_fused_moe",
+        fake_fused_moe,
+    )
+
+    num_experts = 16
+    w = torch.nn.Module()
+    w.activation_situ_beta = 4.0
+    w.activation_situ_linear_beta = 25.0
+    w.w13_weight_triton_tensor = torch.empty((num_experts, 0, 0))
+    w.w2_weight_triton_tensor = object()
+    w.w13_precision_config = type("PC", (), {"b_mx_scale": object()})()
+    w.w2_precision_config = type(
+        "PC", (), {"b_mx_scale": object(), "out_dtype": torch.bfloat16}
+    )()
+    output = torch.empty((1, 16), dtype=torch.bfloat16)
+    w._situ_output_buffer = output
+    x = torch.empty_like(output)
+    router_logits = torch.empty((1, num_experts), dtype=torch.float32)
+    topk_weights = torch.ones((1, num_experts), dtype=torch.float32)
+    topk_ids = torch.arange(num_experts, dtype=torch.int32).view(1, -1)
+
+    apply = getattr(_moe_gluon_mxfp4, apply_name)
+    out = apply(
+        {},
+        x,
+        w,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+    assert out == "sentinel"
+    assert captured["activation"] == "situ"
+    assert captured["situ_beta"] == 4.0
+    assert captured["situ_linear_beta"] == 25.0
+    assert captured["decode"] is True
+    assert captured["out"] is output
 
 
 def _moe_apply_unquant_trtllm() -> object:


### PR DESCRIPTION
## Summary
- Add gfx1250 Gluon A8W4 MXFP4 SiTU MoE support for the Kimi-K3 TP8/EP1 precomputed-TopK path.
- Simplify activation dispatch by forwarding `FusedActivation` directly and consolidate MXFP4 reference implementations.
- Remove unnecessary MoE priority offsets and expand kernel-selection coverage