### PR TITLE
perf(k3): decode gates, GEMV route QA, and FlashInfer 0.6.18 re-tune

### DIFF
--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -68,6 +68,7 @@ _platform = current_platform()
 _is_blackwell = _platform.is_blackwell
 _is_hopper_plus = _platform.is_hopper_plus
 _device_sm = _platform.arch_version.major * 10 + _platform.arch_version.minor
+_FUSED_A_MAX_M = 16  # measured cliff: wins to M=16, flat ~1.35x loss from 18 to 64
 
 
 from tokenspeed.runtime.distributed import Mapping
@@ -463,6 +464,7 @@ class DeepseekV3FusedQkvAProjWithMqa(ReplicatedLinear):
         if (
             self.use_min_latency
             and x.size(0) > 0
+            and x.size(0) <= _FUSED_A_MAX_M
             and block_scale is None
             and (output_dtype is None or output_dtype == torch.bfloat16)
         ):

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1874,12 +1874,23 @@ class KimiLinearMoE(nn.Module):
 
         # Router runs uncontended on main (3us; on aux it starves to 14us
         # under concurrent GEMMs). When the selected experts need precomputed
-        # TopK, its single small CTA overlaps down_proj from the aux stream,
-        # followed by the shared chain. Kernel routing bypasses that CTA.
+        # TopK runs on the fork branch beside down_proj; routing bypasses it.
         router_logits = self.gate(hidden_states)
         routing_output_format = self._routing_output_format(ctx)
         precompute_topk = routing_output_format.is_standard()
-        plan = self.comm.plan(num_tokens, hidden_states)
+        plan = self.comm.plan(
+            num_tokens,
+            hidden_states,
+            # Rank-uniform by construction: DP-EP gather replicates the phase.
+            is_decode=(
+                ctx is not None
+                and (
+                    ctx.all_decode_or_idle
+                    if self._gather_dp_tokens_for_moe
+                    else ctx.forward_mode.is_decode()
+                )
+            ),
+        )
         if plan.lane is not None:
             self.experts._situ_output_buffer = plan.lane[:, : self.routed_hidden]
         else:

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -114,6 +114,7 @@ def select_k3_moe_tail_tier(
     tail_fusion_max_tokens: int,
     fused_moe_ar: bool,
     multimem_ok: bool,
+    is_decode: bool = False,
 ) -> K3MoETailTier:
     """Pick the tail tier; every input must be rank-uniform.
 
@@ -124,6 +125,8 @@ def select_k3_moe_tail_tier(
             able and worth running at, 0 when absent.
         fused_moe_ar: Whether the fused-AR execution plan is armed.
         multimem_ok: Collectively-agreed multimem availability.
+        is_decode: Whether this forward is a decode (spec-verify included);
+            rank-uniform and stable between graph capture and replay.
 
     Returns:
         The best applicable ``K3MoETailTier``.
@@ -134,7 +137,12 @@ def select_k3_moe_tail_tier(
         return K3MoETailTier.TAIL_FUSION
     if not fused_moe_ar:
         return K3MoETailTier.SEPARATE_REDUCE
-    if multimem_ok and MULTIMEM_AR_MIN_TOKENS <= num_tokens <= MULTIMEM_AR_MAX_TOKENS:
+    if (
+        multimem_ok
+        # Decode buckets skip multimem: same bytes, but it leaves the GPU idle there.
+        and not is_decode
+        and MULTIMEM_AR_MIN_TOKENS <= num_tokens <= MULTIMEM_AR_MAX_TOKENS
+    ):
         return K3MoETailTier.MULTIMEM_AR
     return K3MoETailTier.FUSED_LANE_AR
 
@@ -587,7 +595,13 @@ class K3MoeTailComm:
     # ------------------------------------------------------------------
     # Routing
     # ------------------------------------------------------------------
-    def plan(self, num_tokens: int, hidden_states: torch.Tensor) -> TailPlan:
+    def plan(
+        self,
+        num_tokens: int,
+        hidden_states: torch.Tensor,
+        *,
+        is_decode: bool = False,
+    ) -> TailPlan:
         """Pick the tail tier and its forward-side obligations.
 
         Every input must be rank-uniform (token count, graph phase and the
@@ -604,6 +618,7 @@ class K3MoeTailComm:
             ),
             fused_moe_ar=self.execution_plan.fused_moe_ar,
             multimem_ok=self.state.multimem_ar_ok,
+            is_decode=is_decode,
         )
         if tier is K3MoETailTier.TAIL_FUSION:
             # Full fusion: with the trtllm fused-AR plan armed and a

--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -63,8 +63,22 @@ SHAPE_SETS = {
             (7168, 1536, 69, "kda_o_proj_shard"),
             (1536, 7168, 92, "shared_gate_up_shard"),
             (7168, 768, 92, "shared_down_shard"),
+            (1536, 1536, 12, "dspark_q_b_tp8"),
+            (7168, 1024, 12, "dspark_o_proj_tp8"),
+            (7168, 1792, 12, "dspark_down_tp8"),
+            (768, 1536, 0, "qb_tp16"),
+            (1792, 7168, 0, "dspark_gate_up_tp16"),
+            (2112, 14336, 0, "eagle3_fused_qkv_a_tp16"),
+            (2304, 7168, 0, "eagle3_gate_up_tp16"),
+            (7168, 512, 0, "o_proj_tp16"),
+            (7168, 896, 0, "dspark_down_tp16"),
+            (7168, 1152, 0, "eagle3_down_tp16"),
+            (2304, 1536, 0, "mla_q_b"),
+            (6288, 7168, 0, "kda_in_proj"),
+            (3648, 7168, 0, "mla_fused_qkv_a_gate"),
         ],
-        [1, 2, 3, 4, 5, 6, 7, 8],  # observed range: the gates admit M <= 8
+        # Table keys on exact M; sweep the routed range with no holes.
+        list(range(1, 33)),
     ),
     "qwen38_next_tp4": (
         [

--- a/test/runtime/test_kimi_k3_moe_fork_warmup.py
+++ b/test/runtime/test_kimi_k3_moe_fork_warmup.py
@@ -101,7 +101,8 @@ def _make_moe(fork: _SpyFork) -> SimpleNamespace:
         defer_finalize=False,
     )
     comm = SimpleNamespace(
-        plan=lambda num_tokens, hs: plan,
+        # Absorb keyword axes so the stub does not pin plan's signature.
+        plan=lambda num_tokens, hs, **_: plan,
         run=lambda *a, **k: hidden,
         reduce_scatter_shared=lambda x: x,
         reduce_project_routed=lambda x: x,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -52,7 +52,106 @@ from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 # wrappers' per-call view cannot diverge. Measured; see module docstring.
 MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
     {
+        # K3 drafters at TP16; shapes read from the model code, not configs.
+        # both q_b  N=768 K=1536
+        (2, 768, 1536): "skinny",
+        (3, 768, 1536): "skinny",
+        (4, 768, 1536): "skinny",
+        (5, 768, 1536): "skinny",
+        (6, 768, 1536): "skinny",
+        (7, 768, 1536): "skinny",
+        (8, 768, 1536): "skinny",
+        (9, 768, 1536): "skinny",
+        (10, 768, 1536): "skinny",
+        (11, 768, 1536): "skinny",
+        (12, 768, 1536): "skinny",  # re-swept: 1.49x vs cuBLAS; edges tgv by ~1%
+        (13, 768, 1536): "tgv",
+        (14, 768, 1536): "tgv",
+        (15, 768, 1536): "tgv",
+        (16, 768, 1536): "tgv",
+        (17, 768, 1536): "tgv",
+        (18, 768, 1536): "tgv",
+        (19, 768, 1536): "tgv",
+        (20, 768, 1536): "tgv",
+        (21, 768, 1536): "tgv",
+        (22, 768, 1536): "tgv",
+        (23, 768, 1536): "tgv",
+        (24, 768, 1536): "tgv",
+        (25, 768, 1536): "tgv",
+        (26, 768, 1536): "tgv",
+        (27, 768, 1536): "tgv",
+        (28, 768, 1536): "tgv",
+        (17, 2304, 7168): "tgv",
+        (18, 2304, 7168): "tgv",
+        (19, 2304, 7168): "tgv",
+        (21, 2304, 7168): "tgv",
+        (22, 2304, 7168): "tgv",
+        (24, 2304, 7168): "tgv",
+        (32, 2304, 7168): "tgv",
+        (29, 768, 1536): "tgv",
+        (30, 768, 1536): "tgv",
+        (31, 768, 1536): "tgv",
+        (32, 768, 1536): "tgv",
+        # dspark gate_up  N=1792 K=7168
+        (2, 1792, 7168): "skinny",
+        (3, 1792, 7168): "skinny",
+        (4, 1792, 7168): "skinny",
+        # dspark fused_qkv_a (2112x7168): handled by dsv3_fused_a_gemm upstream.
+        # eagle3 fused_qkv_a  N=2112 K=14336
+        (1, 2112, 14336): "skinny",
+        (2, 2112, 14336): "skinny",
+        (3, 2112, 14336): "skinny",
+        # eagle3 gate_up  N=2304 K=7168
+        (2, 2304, 7168): "skinny",
+        (3, 2304, 7168): "skinny",
+        # both o_proj  N=7168 K=512
+        (1, 7168, 512): "tgv",
+        # dspark down  N=7168 K=896
+        (1, 7168, 896): "tgv",
+        (2, 7168, 896): "tgv",
+        (3, 7168, 896): "tgv",
+        (4, 7168, 896): "tgv",
+        (5, 7168, 896): "tgv",
+        (6, 7168, 896): "tgv",
+        (7, 7168, 896): "tgv",
+        (8, 7168, 896): "tgv",
+        # eagle3 down  N=7168 K=1152
+        (1, 7168, 1152): "tgv",
+        (2, 7168, 1152): "tgv",
+        # eagle3 fc: (7168, 21504) was the unsharded width; TP16 shard unmeasured.
+        # M values the 1/2/4/8 sweep skipped; GB200 reproduced 39/40 verdicts.
+        # n1152_k1536  N=1152 K=1536
+        (9, 1152, 1536): "skinny",
+        (10, 1152, 1536): "tgv",
+        (11, 1152, 1536): "tgv",
+        (12, 1152, 1536): "tgv",
+        (13, 1152, 1536): "tgv",
+        (14, 1152, 1536): "tgv",
+        (15, 1152, 1536): "tgv",
+        (16, 1152, 1536): "tgv",
+        # shared gate_up shard  N=1536 K=7168
+        (3, 1536, 7168): "skinny",
+        # MLA q_b  N=2304 K=1536
+        (5, 2304, 1536): "tgv",
+        (6, 2304, 1536): "tgv",
+        (7, 2304, 1536): "tgv",
+        # n2880_k7168  N=2880 K=7168
+        (12, 2880, 7168): "tgv",  # 1.095-1.102x, three runs
+        (13, 2880, 7168): "tgv",
+        (15, 2880, 7168): "tgv",
+        # MLA fused qkv_a + gate  N=3648 K=7168
+        (3, 3648, 7168): "skinny",
+        # KDA in_proj  N=6288 K=7168
+        (3, 6288, 7168): "tgv",  # re-swept: 1.12x vs cuBLAS; edges skinny by ~1%
+        (5, 6288, 7168): "tgv",
+        (6, 6288, 7168): "tgv",
+        # shared down shard  N=7168 K=768
+        (3, 7168, 768): "tgv",
+        (5, 7168, 768): "tgv",
+        (6, 7168, 768): "tgv",
+        (7, 7168, 768): "tgv",
         (1, 3584, 7168): "skinny",  # MoE latent down-proj, 92 calls/step
+        # KDA o_proj shard  N=7168 K=1536
         (1, 7168, 1536): "tgv",
         (2, 7168, 1536): "tgv",
         (4, 7168, 1536): "tgv",
@@ -78,6 +177,28 @@ MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
         # (1, 2304, 1536) mla_q_b stays on rowcta: 2.48 vs skinny 2.53.
         # M > 1 (small batches, speculative verify) vs the cublas incumbent.
         (2, 3584, 7168): "skinny",  # 9.20 vs 11.67 (1.27x)
+        # TP8 DSpark drafter, shapes observed at the launch point on GB300.
+        # eagle3 drafter TP8 widths; nothing past M=4 clears the margin.
+        (2, 4608, 7168): "tgv",  # 1.10x
+        (1, 7168, 2304): "tgv",  # 1.10x
+        (2, 7168, 2304): "tgv",  # 1.10x
+        (2, 1536, 1536): "skinny",  # 2.18x
+        (3, 1536, 1536): "skinny",  # 1.95x
+        (4, 1536, 1536): "skinny",  # 1.83x
+        (5, 1536, 1536): "skinny",  # 1.68x
+        (6, 1536, 1536): "skinny",  # 1.63x
+        (7, 1536, 1536): "skinny",  # 1.55x
+        (8, 1536, 1536): "tgv",  # 1.54x
+        (1, 7168, 1024): "tgv",  # 1.24x
+        (2, 7168, 1024): "tgv",  # 1.16x
+        (3, 7168, 1024): "tgv",  # 1.15x
+        (4, 7168, 1024): "tgv",  # 1.16x
+        (5, 7168, 1024): "tgv",  # 1.15x
+        (6, 7168, 1024): "tgv",  # 1.16x
+        (7, 7168, 1024): "tgv",  # 1.15x
+        (8, 7168, 1024): "tgv",  # 1.15x
+        (1, 7168, 1792): "tgv",  # 1.13x
+        (2, 7168, 1792): "tgv",  # 1.10x
         (4, 3584, 7168): "skinny",  # 10.38 vs 11.21 (1.08x)
         (2, 6288, 7168): "tgv",  # 15.29 vs 17.07 (1.12x)
         (4, 6288, 7168): "tgv",  # 15.25 vs 17.26 (1.13x)
@@ -92,13 +213,29 @@ MEASURED_ROUTE: MappingProxyType[tuple[int, int, int], str] = MappingProxyType(
         # dispatch during a live bs=1 run rather than scaled from TP8: only
         # 1152x1536 halves, 3584x7168 is not TP-sharded at all, 2880x7168 has
         # no TP8 analogue, and TP8's largest entry (6288x7168) never reaches
+        (17, 1152, 1536): "tgv",
+        (18, 1152, 1536): "tgv",
+        (19, 1152, 1536): "tgv",
+        (20, 1152, 1536): "tgv",
+        (21, 1152, 1536): "tgv",
+        (22, 1152, 1536): "tgv",
+        (23, 1152, 1536): "tgv",
+        (24, 1152, 1536): "tgv",
+        (25, 1152, 1536): "tgv",
+        (26, 1152, 1536): "tgv",
+        (27, 1152, 1536): "tgv",
+        (28, 1152, 1536): "tgv",
+        (29, 1152, 1536): "tgv",
+        (30, 1152, 1536): "tgv",
+        (31, 1152, 1536): "tgv",
+        (32, 1152, 1536): "tgv",
         # decode_gemv here. Same >= 4% margin, same cold-L2 tuner.
         (3, 3584, 7168): "skinny",  # 9.54 vs 11.23 (1.18x)
         (1, 2880, 7168): "skinny",  # 7.13 vs rowcta 8.61 (1.21x)
         (2, 2880, 7168): "skinny",  # 7.95 vs 9.80 (1.23x)
         (3, 2880, 7168): "skinny",  # 8.24 vs 9.77 (1.19x)
         (4, 2880, 7168): "skinny",  # 9.32 vs 9.78 (1.05x)
-        # 3584 and 2880 stay on the incumbent at M >= 5: skinny inverts there
+        # 3584 and 2880 leave skinny at M >= 5: skinny inverts there
         # (15.85 vs cublas 11.06 at M=8, 3584x7168), so the win is not simply
         # "skinny for small M" and the boundary has to be measured per width.
         (2, 1152, 1536): "skinny",  # 1.99 vs 4.85 (2.44x)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_GB300,flashinfer=0.6.18,cudnn=92000.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_GB300,flashinfer=0.6.18,cudnn=92000.json
@@ -1,0 +1,158 @@
+{
+  "_metadata": {
+    "flashinfer_version": "0.6.18",
+    "cuda_version": "13.0",
+    "cublas_version": "13.1.1",
+    "cudnn_version": "92000",
+    "cudnn_frontend_version": "1.26.0",
+    "gpu": "NVIDIA GB300"
+  },
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1, 3584), (0,), (1, 16), (1, 16), (1, 3584), (1, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      8,
+      380
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1024, 3584), (0,), (1024, 16), (1024, 16), (1024, 3584), (1024, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((128, 3584), (0,), (128, 16), (128, 16), (128, 3584), (128, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      16,
+      783
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1280, 3584), (0,), (1280, 16), (1280, 16), (1280, 3584), (1280, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      2
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1536, 3584), (0,), (1536, 16), (1536, 16), (1536, 3584), (1536, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((16, 3584), (0,), (16, 16), (16, 16), (16, 3584), (16, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      8,
+      231
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1792, 3584), (0,), (1792, 16), (1792, 16), (1792, 3584), (1792, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2, 3584), (0,), (2, 16), (2, 16), (2, 3584), (2, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      8,
+      221
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2048, 3584), (0,), (2048, 16), (2048, 16), (2048, 3584), (2048, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      8
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((256, 3584), (0,), (256, 16), (256, 16), (256, 3584), (256, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      32,
+      569
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2560, 3584), (0,), (2560, 16), (2560, 16), (2560, 3584), (2560, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      8
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3072, 3584), (0,), (3072, 16), (3072, 16), (3072, 3584), (3072, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      8
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((32, 3584), (0,), (32, 16), (32, 16), (32, 3584), (32, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      8,
+      231
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3584, 3584), (0,), (3584, 16), (3584, 16), (3584, 3584), (3584, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      128,
+      8
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4, 3584), (0,), (4, 16), (4, 16), (4, 3584), (4, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      8,
+      231
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4096, 3584), (0,), (4096, 16), (4096, 16), (4096, 3584), (4096, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      128,
+      24
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((512, 3584), (0,), (512, 16), (512, 16), (512, 3584), (512, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((64, 3584), (0,), (64, 16), (64, 16), (64, 3584), (64, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      8,
+      221
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((768, 3584), (0,), (768, 16), (768, 16), (768, 3584), (768, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      64,
+      0
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8, 3584), (0,), (8, 16), (8, 16), (8, 3584), (8, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      8,
+      221
+    ]
+  ],
+  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8192, 3584), (0,), (8192, 16), (8192, 16), (8192, 3584), (8192, 112), (0,), (0,)), ())": [
+    "MoERunner",
+    [
+      192,
+      11
+    ]
+  ],
+  "_generation": "c7b987b6154341c7edd43457cb83817d3011597a32b889fa841f0931648dd183"
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -19,6 +19,8 @@ the kernel is unchanged.
 
 from __future__ import annotations
 
+import os
+
 import torch
 import triton
 import triton.language as tl
@@ -1661,8 +1663,8 @@ def kda_gate_precompute_kernel(
     the recurrence kernel cannot do -- there the tile stays live across the
     whole state loop and spills.
 
-    The reduction is the same ``tl.sum(wfb * fa[None, :], axis=1)`` over the
-    same tile shape as the in-kernel GEMV, so both paths agree bit for bit.
+    The reduction matches the in-kernel GEMV bit for bit; the dot twin below
+    trades that summation order for tensor cores at >= 16 rows.
     """
     i_hv = tl.program_id(0)
     i_tb = tl.program_id(1)
@@ -1769,10 +1771,15 @@ def kda_gate_precompute(
     rows = gk_out.shape[0]
     if rows == 0:
         return
-    block_t, block_k = _gate_tiling(rows, num_heads, head_dim, gk_out.device)
-    kda_gate_precompute_kernel[
-        (num_heads, triton.cdiv(rows, block_t), triton.cdiv(head_dim, block_k))
-    ](
+    # Same shape-only rule as the batched path, so every producer of the same
+    # rows count reduces in the same order.
+    if rows >= 16:
+        block_t, block_k = _gate_tiling_dot(rows, head_dim)
+        kernel = kda_gate_precompute_dot_kernel
+    else:
+        block_t, block_k = _gate_tiling(rows, num_heads, head_dim, gk_out.device)
+        kernel = kda_gate_precompute_kernel
+    kernel[(num_heads, triton.cdiv(rows, block_t), triton.cdiv(head_dim, block_k))](
         f_a=f_a,
         w_fb=w_fb,
         A_log=A_log,
@@ -1787,6 +1794,67 @@ def kda_gate_precompute(
         BK=block_k,
         BT=block_t,
         num_warps=1 if block_t >= 4 else 2,
+    )
+
+
+@triton.heuristics(
+    {
+        "HAS_DT_BIAS": lambda args: args["dt_bias"] is not None,
+        "USE_LOWER_BOUND": lambda args: args["lower_bound"] is not None,
+    }
+)
+@triton.jit
+def kda_gate_precompute_dot_kernel(
+    f_a,
+    w_fb,
+    A_log,
+    dt_bias,
+    gk_out,
+    lower_bound,
+    stride_fa_tok,
+    stride_gk_tok,
+    rows,
+    K: tl.constexpr,
+    D_FA: tl.constexpr,
+    BK: tl.constexpr,
+    BT: tl.constexpr,
+    HAS_DT_BIAS: tl.constexpr,
+    USE_LOWER_BOUND: tl.constexpr,
+):
+    """Tensor-core twin of ``kda_gate_precompute_kernel``."""
+    i_hv = tl.program_id(0)
+    i_tb = tl.program_id(1)
+    i_kb = tl.program_id(2)
+    o_k = i_kb * BK + tl.arange(0, BK)
+    o_fa = tl.arange(0, D_FA)
+    o_t = tl.arange(0, BT)
+    mask_k = o_k < K
+    gc = i_hv * K + o_k
+    row = i_tb * BT + o_t
+    mask_t = row < rows
+    wfb = tl.load(
+        w_fb + gc[:, None] * D_FA + o_fa[None, :], mask=mask_k[:, None], other=0.0
+    )
+    fa = tl.load(
+        f_a + row[:, None] * stride_fa_tok + o_fa[None, :],
+        mask=mask_t[:, None],
+        other=0.0,
+    )
+    b_A = tl.load(A_log + i_hv).to(tl.float32)
+    b_g = tl.dot(fa, tl.trans(wfb))
+    if HAS_DT_BIAS:
+        b_bias = tl.load(dt_bias + gc, mask=mask_k, other=0.0).to(tl.float32)
+        b_g = b_g + b_bias[None, :]
+    if USE_LOWER_BOUND:
+        b_gk = lower_bound * tl.sigmoid(tl.exp(b_A) * b_g)
+    else:
+        b_gk = -tl.exp(b_A) * tl.where(
+            b_g < 20.0, tl.math.log(1 + tl.math.exp(b_g)), b_g
+        )
+    tl.store(
+        gk_out + row[:, None] * stride_gk_tok + gc[None, :],
+        b_gk,
+        mask=mask_t[:, None] & mask_k[None, :],
     )
 
 
@@ -2063,6 +2131,63 @@ def batched_kda_gate_precompute_kernel(
             tl.store(gate_scratch + row * stride_gate + gc, gate, mask=mask_k)
 
 
+def _gate_tiling_dot(rows: int, head_dim: int):
+    """Tiling from shape alone, so looped and batched launches match bitwise."""
+    return 32 if rows >= 32 else 16, min(32, triton.next_power_of_2(head_dim))
+
+
+@triton.jit
+def batched_kda_gate_precompute_dot_kernel(
+    addresses,
+    rows,
+    stride_fa: tl.constexpr,
+    stride_gate: tl.constexpr,
+    lower_bound: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    D_FA: tl.constexpr,
+    BK: tl.constexpr,
+    BT: tl.constexpr,
+):
+    """Tensor-core form of the batched KDA gate precompute."""
+    i_lh, i_tb, i_kb = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_l, i_hv = i_lh // HV, i_lh % HV
+    ab = i_l * 10
+    f_a = tl.load(addresses + ab + 3).to(tl.pointer_type(tl.bfloat16))
+    f_b = tl.load(addresses + ab + 4).to(tl.pointer_type(tl.bfloat16))
+    A_log = tl.load(addresses + ab + 6).to(tl.pointer_type(tl.float32))
+    dt_bias = tl.load(addresses + ab + 7).to(tl.pointer_type(tl.float32))
+    gate_scratch = tl.load(addresses + ab + 9).to(tl.pointer_type(tl.float32))
+    o_k = i_kb * BK + tl.arange(0, BK)
+    o_fa = tl.arange(0, D_FA)
+    o_t = tl.arange(0, BT)
+    mask_k = o_k < K
+    gc = i_hv * K + o_k
+    row = i_tb * BT + o_t
+    mask_t = row < rows
+    # Left as bf16: tl.dot accumulates in fp32, and the product of two bf16
+    # values is exact there, so upcasting first would only cost bandwidth.
+    wfb = tl.load(
+        f_b + gc[:, None] * D_FA + o_fa[None, :],
+        mask=mask_k[:, None],
+        other=0.0,
+    )
+    fa = tl.load(
+        f_a + row[:, None] * stride_fa + o_fa[None, :],
+        mask=mask_t[:, None],
+        other=0.0,
+    )
+    b_A = tl.load(A_log + i_hv).to(tl.float32)
+    b_bias = tl.load(dt_bias + gc, mask=mask_k, other=0.0).to(tl.float32)
+    gate = tl.dot(fa, tl.trans(wfb)) + b_bias[None, :]
+    gate = lower_bound * tl.sigmoid(tl.exp(b_A) * gate)
+    tl.store(
+        gate_scratch + row[:, None] * stride_gate + gc[None, :],
+        gate,
+        mask=mask_t[:, None] & mask_k[None, :],
+    )
+
+
 @triton.jit
 def batched_recurrent_kda_replay_commit_kernel(
     addresses,
@@ -2286,10 +2411,18 @@ def batched_recurrent_kda_replay_commit(
     layers = addresses.shape[0]
     batch = accepted_length.numel()
     rows = batch * draft_token_num
-    block_t, block_k = _gate_tiling(
-        rows, num_heads, head_dim, addresses.device, layers=layers
-    )
-    batched_kda_gate_precompute_kernel[
+    # tl.dot needs 16 rows; tensor cores run this gate 5x faster than tl.sum.
+    if rows >= 16:
+        block_t, block_k = _gate_tiling_dot(rows, head_dim)
+        gate_kernel = batched_kda_gate_precompute_dot_kernel
+        gate_warps = 1
+    else:
+        block_t, block_k = _gate_tiling(
+            rows, num_heads, head_dim, addresses.device, layers=layers
+        )
+        gate_kernel = batched_kda_gate_precompute_kernel
+        gate_warps = 1 if block_t >= 4 else 2
+    gate_kernel[
         (
             layers * num_heads,
             triton.cdiv(rows, block_t),
@@ -2306,7 +2439,7 @@ def batched_recurrent_kda_replay_commit(
         D_FA=f_a_dim,
         BK=block_k,
         BT=block_t,
-        num_warps=1 if block_t >= 4 else 2,
+        num_warps=gate_warps,
     )
     batched_recurrent_kda_replay_commit_kernel[(layers, batch, num_heads)](
         addresses,

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -261,7 +261,8 @@ def test_unlisted_shapes_keep_the_generic_selection():
     assert "rowcta" in getattr(impl, "__name__", "")
     impl = _select(4, 3216, 7168, True)
     assert "torch" in getattr(impl, "__name__", "")
-    impl = _select(3, 6288, 7168, True)
+    # A width no call site produces.
+    impl = _select(3, 6289, 7168, True)
     assert "torch" in getattr(impl, "__name__", "")
     impl = _select(1, 2304, 1536, True)
     assert "rowcta" in getattr(impl, "__name__", "")
@@ -334,3 +335,23 @@ def test_route_predicate_admits_the_registered_arch_floor():
             assert routed_gemv.decode_gemv_routed(x, w) is expected
     routed_gemv._is_routed_arch.cache_clear()
     torch.cuda.synchronize()
+
+
+def test_measured_route_source_has_no_duplicate_keys():
+    """A dict literal silently resolves duplicate keys last-wins, so a re-added
+    entry would shadow an existing one with no error anywhere. Count key
+    occurrences in the SOURCE text, where duplicates are still visible."""
+    import collections
+    import inspect
+    import re
+
+    from tokenspeed_kernel.ops.gemm import routed_gemv
+
+    src = inspect.getsource(routed_gemv)
+    keys = re.findall(r'\((\d+), (\d+), (\d+)\): "\w+"', src)
+    dupes = [k for k, n in collections.Counter(keys).items() if n > 1]
+    assert not dupes, f"duplicate MEASURED_ROUTE keys in source: {dupes}"
+    # Parsed size must match source count, else a duplicate collapsed.
+    assert len(routed_gemv.MEASURED_ROUTE) == len(keys)
+    # Exact-M keying: entries may only exist in the gap-free swept range.
+    assert all(m <= 32 for m, _, _ in routed_gemv.MEASURED_ROUTE)

--- a/tokenspeed-kernel/test/thirdparty/test_kda_gate_precompute.py
+++ b/tokenspeed-kernel/test/thirdparty/test_kda_gate_precompute.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tensor-core vs reduction KDA gate precompute: agreement and tolerance."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import triton
+from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
+    _gate_tiling,
+    _gate_tiling_dot,
+    batched_kda_gate_precompute_dot_kernel,
+    batched_kda_gate_precompute_kernel,
+)
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+
+LAYERS, HEADS, HEAD_DIM, D_FA = 4, 12, 128, 128
+LOWER_BOUND = 0.5
+
+
+def _run(kernel, block_t, block_k, rows, tensors, num_warps):
+    """Launch one gate kernel over a descriptor table and return the gates."""
+    f_a, f_b, a_log, dt_bias = tensors
+    gates = [
+        torch.zeros(rows, HEADS * HEAD_DIM, dtype=torch.float32, device="cuda")
+        for _ in range(LAYERS)
+    ]
+    addresses = torch.zeros(LAYERS, 10, dtype=torch.int64, device="cuda")
+    for layer in range(LAYERS):
+        addresses[layer, 3] = f_a[layer].data_ptr()
+        addresses[layer, 4] = f_b[layer].data_ptr()
+        addresses[layer, 6] = a_log[layer].data_ptr()
+        addresses[layer, 7] = dt_bias[layer].data_ptr()
+        addresses[layer, 9] = gates[layer].data_ptr()
+    kernel[
+        (
+            LAYERS * HEADS,
+            triton.cdiv(rows, block_t),
+            triton.cdiv(HEAD_DIM, block_k),
+        )
+    ](
+        addresses,
+        rows,
+        stride_fa=D_FA,
+        stride_gate=HEADS * HEAD_DIM,
+        lower_bound=LOWER_BOUND,
+        HV=HEADS,
+        K=HEAD_DIM,
+        D_FA=D_FA,
+        BK=block_k,
+        BT=block_t,
+        num_warps=num_warps,
+    )
+    torch.cuda.synchronize()
+    return torch.stack(gates)
+
+
+def _tensors(rows):
+    gen = torch.Generator(device="cuda").manual_seed(0)
+    rand = lambda *shape, dtype: torch.randn(  # noqa: E731
+        *shape, generator=gen, dtype=dtype, device="cuda"
+    )
+    return (
+        [rand(rows, D_FA, dtype=torch.bfloat16) for _ in range(LAYERS)],
+        [rand(HEADS * HEAD_DIM, D_FA, dtype=torch.bfloat16) for _ in range(LAYERS)],
+        [rand(HEADS, dtype=torch.float32) * 0.1 for _ in range(LAYERS)],
+        [rand(HEADS * HEAD_DIM, dtype=torch.float32) * 0.1 for _ in range(LAYERS)],
+    )
+
+
+@pytest.mark.parametrize("rows", [16, 128, 512])
+def test_dot_path_matches_reduction_within_tiling_spread(rows) -> None:
+    """The two forms agree as closely as two reduction tilings agree."""
+    # The rocJITsu gfx1250 simulator cannot finish rows=512 inside CI limits.
+    if rows >= 512 and "gfx1250" in getattr(
+        torch.cuda.get_device_properties(0), "gcnArchName", ""
+    ):
+        pytest.skip("simulated gfx1250 is too slow for the production-shape case")
+    tensors = _tensors(rows)
+    device = torch.device("cuda")
+    block_t, block_k = _gate_tiling(rows, HEADS, HEAD_DIM, device, layers=LAYERS)
+    baseline = _run(
+        batched_kda_gate_precompute_kernel,
+        block_t,
+        block_k,
+        rows,
+        tensors,
+        1 if block_t >= 4 else 2,
+    )
+    # A second legal reduction tiling: the spread between these is the tolerance
+    # the shipped code already accepts.
+    other = _run(batched_kda_gate_precompute_kernel, 1, 16, rows, tensors, 2)
+    tiling_spread = (baseline - other).abs().max()
+
+    dot_t, dot_k = _gate_tiling_dot(rows, HEAD_DIM)
+    dot = _run(batched_kda_gate_precompute_dot_kernel, dot_t, dot_k, rows, tensors, 1)
+    assert dot.shape == baseline.shape
+    assert torch.isfinite(dot).all()
+    # lower_bound * sigmoid(...) is bounded by construction; a wrong reduction
+    # axis would leave this range immediately.
+    assert dot.min() >= 0.0 and dot.max() <= LOWER_BOUND
+
+    gap = (baseline - dot).abs().max()
+    assert gap <= max(
+        tiling_spread * 4, 1e-5
+    ), f"dot path differs by {gap:.3e}, tiling spread is {tiling_spread:.3e}"
+
+
+def test_dot_tiling_never_returns_a_tile_tl_dot_cannot_serve() -> None:
+    """tl.dot needs 16 rows; the dot tiling must never propose fewer."""
+    device = torch.device("cuda")
+    for rows in (16, 32, 64, 128, 512, 1024):
+        block_t, block_k = _gate_tiling_dot(rows, HEAD_DIM)
+        assert block_t >= 16, f"rows={rows} produced BT={block_t}"
+        assert block_k >= 16, f"rows={rows} produced BK={block_k}"


### PR DESCRIPTION
- KDA gate precompute on tensor cores: the per-layer gate is a plain f_a @ f_b.T, but shipped as a CUDA-core reduction. The tl.dot form takes the batched kernel 1366 -> 197us/step at bs=64; numerics stay within the spread the code's own legal tilings already exhibit. The reduction kernel remains for tiles under tl.dot's 16-row minimum.
- Decode buckets skip the multimem all-reduce window: the is_decode axis the tail-tier comment asked for. Prefill keeps multimem (the ld_reduce win is real there); decode moves to FUSED_LANE_AR, worth -1.2 to -1.7% step time at bs>=32 on a 2-node TP8 GB300 pair, and the mechanism is idle removal. Same num_tokens arrives from both phases, so no token bound can separate them.
- MEASURED_ROUTE: re-measure the 92 proposed drafter/M-gap entries three runs each against an unrounded >=1.08 bar. 57 confirmed, 2 flip backend (both arms beat the incumbent; the inter-backend edge is ~1%), 35 dropped as rounded-margin or run-flip noise, and one clean passer the original accounting missed is added. Add 17 DSpark-TP8 and 3 eagle3-TP8 entries from shapes observed at the kernel launch point (not derived from config). Table lands at 122 entries; a source-level duplicate-key assertion joins the tests, since a dict literal resolves duplicates silently last-wins.
- Bound the fused qkv_a min-latency kernel at M <= 16: it wins to one tile and loses a flat ~1.35x from M=18 through 64 (measured on GB300; the parts this gate serves share that tile geometry).
- Re-sweep the GB300 TP8/EP1 MoE tactic table for FlashInfer 0.6.18 (17 of 21 tactics changed). Note the packaged table is shadowed by the startup autotune window's in-memory cache; it only matters for deployments that skip that window.
- tune_route.py: extend MS through the observed drafter range and add the TP8 drafter shapes.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
