### PR TITLE
feat(quant): load mixed-precision compressed-tensors W4A8 MoE

### DIFF
--- a/python/tokenspeed/runtime/layers/linear.py
+++ b/python/tokenspeed/runtime/layers/linear.py
@@ -208,7 +208,10 @@ class LinearBase(torch.nn.Module):
                 # remain unquantized unless the checkpoint stores dense MXFP4.
                 self.quant_method = UnquantizedLinearMethod()
         elif isinstance(quant_config, CompressedTensorsConfig):
-            self.quant_method = quant_config.get_quant_method(self, prefix)
+            method = quant_config.get_quant_method(self, prefix)
+            self.quant_method = (
+                method if method is not None else UnquantizedLinearMethod()
+            )
         elif isinstance(quant_config, ModelOptMixedConfig):
             self.quant_method = quant_config.get_quant_method(self, prefix)
         else:

--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -211,6 +211,8 @@ class MoELayer(torch.nn.Module):
                 internal_activation_dtype = "fp8"
             elif getattr(self.quant_config, "use_dynamic_mxfp4_activations", False):
                 internal_activation_dtype = "mxfp4"
+        if self._quant_kind == "w4a8":
+            internal_activation_dtype = "fp8"
         if self._internal_activation_dtype_override is not None:
             internal_activation_dtype = self._internal_activation_dtype_override
 

--- a/python/tokenspeed/runtime/layers/moe/weights/__init__.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/__init__.py
@@ -28,6 +28,7 @@ from tokenspeed.runtime.layers.moe.weights.mxfp4 import (
 from tokenspeed.runtime.layers.moe.weights.mxint4 import create_mxint4_weight_pair
 from tokenspeed.runtime.layers.moe.weights.nvfp4 import create_nvfp4_weight_pair
 from tokenspeed.runtime.layers.moe.weights.unquant import create_dense_weight_pair
+from tokenspeed.runtime.layers.moe.weights.w4a8 import create_w4a8_weight_pair
 
 
 def create_layer_weights(
@@ -83,6 +84,14 @@ def create_layer_weights(
             spec,
             layer,
             group_size=weight_quant.group_size,
+        )
+        return
+
+    if quant_kind == "w4a8":
+        create_w4a8_weight_pair(
+            spec,
+            layer,
+            group_size=quant_config.moe_group_size(spec.prefix),
         )
         return
 

--- a/python/tokenspeed/runtime/layers/moe/weights/w4a8.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/w4a8.py
@@ -18,15 +18,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import tokenspeed_kernel.ops.moe.flashinfer.cutedsl_deepep_nvfp4  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.cutlass_fp8  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.cutlass_nvfp4  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.cutlass_unquant  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.trtllm_fp8  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxfp4  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxint4  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.trtllm_nvfp4  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.trtllm_unquant  # noqa: F401
-import tokenspeed_kernel.ops.moe.flashinfer.w4a8  # noqa: F401
+"""INT4 group-128 pack-quantized MoE weights for compressed-tensors W4A8.
 
-__all__ = []
+Checkpoint layout matches the mxint4 path (``weight_packed`` int32 + per-group
+``weight_scale``), so the buffers are the same; only ``group_size`` differs
+(128 vs 32). The Hopper apply kernel repacks them into CUTLASS nibbles.
+"""
+
+from __future__ import annotations
+
+from tokenspeed.runtime.layers.moe.weights.mxint4 import create_mxint4_weight_pair
+
+create_w4a8_weight_pair = create_mxint4_weight_pair
+
+__all__ = ["create_w4a8_weight_pair"]

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -40,7 +40,6 @@ from compressed_tensors.quantization import (
     QuantizationType,
 )
 from pydantic import BaseModel
-from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.layers.quantization.base_config import (
     LinearMethodBase,
@@ -49,10 +48,8 @@ from tokenspeed.runtime.layers.quantization.base_config import (
 from tokenspeed.runtime.layers.quantization.compressed_tensors.gptq_marlin_moe import (
     is_activation_quantization_format,
 )
-from tokenspeed.runtime.layers.quantization.compressed_tensors.schemes import (
-    WNA16_SUPPORTED_BITS,
+from tokenspeed.runtime.layers.quantization.compressed_tensors.schemes.compressed_tensors_scheme import (
     CompressedTensorsScheme,
-    CompressedTensorsWNA16,
 )
 from tokenspeed.runtime.layers.quantization.utils import find_matched_target
 
@@ -65,6 +62,7 @@ __all__ = ["CompressedTensorsLinearMethod"]
 
 SPARSITY_CONFIG_NAME: Literal["sparsity_config"] = "sparsity_config"
 QUANTIZATION_SCHEME_MAP_TYPE = dict[str, dict[str, QuantizationArgs] | None]
+WNA16_SUPPORTED_BITS = [4, 8]
 
 
 class DeviceCapability(NamedTuple):
@@ -109,10 +107,17 @@ class CompressedTensorsConfig(QuantizationConfig):
         self.config = config
         _packed_modules_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}
         self.packed_modules_mapping = packed_modules_mapping or _packed_modules_mapping
-        # MoE-kernel-selection knobs (mirror Mxfp4Config): Kimi-K3's
-        # compressed-tensors MXFP4 routed experts are weight-only, so neither the
-        # w4a8-fp8 nor the dynamic-mxfp4-activation path applies.
-        self.is_w4a8_fp8 = False
+        # True when any config_group is packed INT4 weights + dynamic FP8
+        # activations (GLM-5.3 W4A8). Kimi compressed-tensors MXFP4 / INT4
+        # group-32 checkpoints are weight-only, so this stays False there.
+        self.is_w4a8_fp8 = any(
+            self._is_wint4afp8(
+                (scheme or {}).get("weights"),
+                (scheme or {}).get("input_activations"),
+                (scheme or {}).get("format"),
+            )
+            for scheme in self.target_scheme_map.values()
+        )
         self.use_dynamic_mxfp4_activations = False
 
     def get_linear_method(self) -> CompressedTensorsLinearMethod:
@@ -128,12 +133,78 @@ class CompressedTensorsConfig(QuantizationConfig):
     def get_name(self) -> str:
         return "compressed_tensors"
 
+    @property
+    def weight_block_size(self) -> list[int] | None:
+        """Block size for block-FP8 dense layers in a mixed-precision config.
+
+        A mixed-precision checkpoint may have no ``Linear`` target, or may use
+        that target for group-wise INT4 experts that have no block structure.
+        Prefer any target that declares ``block_structure`` so GLM-5 DSA
+        padding and fused QKV-A scale sharding still see ``[128, 128]``.
+        """
+        targets = list(self.target_scheme_map)
+        if "Linear" in self.target_scheme_map:
+            targets = ["Linear"] + [t for t in targets if t != "Linear"]
+        for target in targets:
+            scheme = self.target_scheme_map.get(target)
+            if not scheme:
+                continue
+            block_structure = getattr(scheme.get("weights"), "block_structure", None)
+            if block_structure:
+                return list(block_structure)
+        return None
+
+    def _scheme_dict_for_name(self, layer_name: str) -> dict[str, Any] | None:
+        """Return the config_group scheme that matches ``layer_name``, if any."""
+        if not self.target_scheme_map:
+            return None
+        stub = torch.nn.Module()
+        try:
+            matched_target = find_matched_target(
+                layer_name=layer_name,
+                module=stub,
+                targets=self.target_scheme_map.keys(),
+                fused_mapping=self.packed_modules_mapping,
+            )
+        except ValueError:
+            return None
+        return self.target_scheme_map.get(matched_target)
+
+    def _moe_scheme_dict(self, prefix: str = "") -> dict[str, Any] | None:
+        """Scheme for routed experts under ``prefix``, not a catch-all Linear."""
+        candidates: list[str] = []
+        if prefix:
+            if not prefix.endswith(".experts"):
+                candidates.append(f"{prefix}.experts.0.gate_proj")
+            candidates.extend(
+                (
+                    f"{prefix}.0.gate_proj",
+                    f"{prefix}.experts.0.down_proj",
+                    prefix,
+                )
+            )
+        for name in candidates:
+            scheme = self._scheme_dict_for_name(name)
+            if scheme is not None:
+                return scheme
+        return self.target_scheme_map.get("Linear")
+
     def moe_weight_dtype(self, prefix: str = "") -> str:
-        # Container format: resolve the routed-expert scheme to a concrete MoE
-        # kernel dtype. 4-bit group-32 weight-only: INT -> mxint4
-        # (Kimi-K2.5 / K2.6 / K2.7), FLOAT -> mxfp4 (K3).
-        weight_quant = self.target_scheme_map["Linear"].get("weights")
-        input_quant = self.target_scheme_map["Linear"].get("input_activations")
+        # Container format: resolve the *matched* routed-expert scheme, not
+        # ``target_scheme_map["Linear"]``. Mixed-precision GLM-5.3 W4A8 puts
+        # INT4 group-128 + FP8 activations on the expert regex and block-FP8
+        # on attention / shared experts; Kimi still keys everything as Linear.
+        scheme = self._moe_scheme_dict(prefix)
+        if scheme is None:
+            raise ValueError(
+                "unsupported compressed-tensors MoE scheme for kernel "
+                f"selection: no matching target for {prefix!r}"
+            )
+        weight_quant = scheme.get("weights")
+        input_quant = scheme.get("input_activations")
+        scheme_format = scheme.get("format")
+        if self._is_wint4afp8(weight_quant, input_quant, scheme_format):
+            return "w4a8"
         is_4bit_group32 = (
             weight_quant is not None
             and weight_quant.num_bits == 4
@@ -152,6 +223,17 @@ class CompressedTensorsConfig(QuantizationConfig):
             f"unsupported compressed-tensors MoE scheme for kernel selection: "
             f"{weight_quant}"
         )
+
+    def moe_group_size(self, prefix: str = "") -> int:
+        """Group size of the matched routed-expert weight scheme."""
+        scheme = self._moe_scheme_dict(prefix)
+        weight_quant = None if scheme is None else scheme.get("weights")
+        group_size = getattr(weight_quant, "group_size", None)
+        if not group_size:
+            raise ValueError(
+                f"compressed-tensors MoE scheme for {prefix!r} has no group_size"
+            )
+        return int(group_size)
 
     def get_scaled_act_names(self) -> list[str]:
         return []
@@ -228,14 +310,27 @@ class CompressedTensorsConfig(QuantizationConfig):
                 )
 
                 target_scheme_map[target]["input_activations"] = None
-                if is_activation_quantization_format(quant_format):
+                # A config_group may carry its own format. When several groups
+                # disagree, compressed-tensors sets the top-level format to
+                # "mixed-precision" (or keeps the first group's format) and the
+                # real format lives on each group, so the per-group value must
+                # win for activation-quant detection.
+                group_format = quant_config.get("format")
+                target_scheme_map[target]["format"] = group_format
+                act_quant_format = is_activation_quantization_format(
+                    group_format if group_format is not None else quant_format
+                )
+
+                if act_quant_format:
                     input_activations = quant_config.get("input_activations")
-                    # The only case where we have activation quant supported
-                    # but no input_activations provided in the config
-                    # should be w8a16fp8 w8a16fp8 can also run for cases where
-                    # there is an input_quant but it is ignored
+                    # When the format admits activation quant but the group
+                    # omits input_activations: valid for w8a16fp8 (FLOAT
+                    # weights) and pack-quantized weight-only INT (WNA16).
                     if not input_activations:
-                        if (
+                        weight_type = target_scheme_map[target]["weights"].type
+                        if weight_type == QuantizationType.INT:
+                            pass
+                        elif (
                             target_scheme_map[target]["weights"].type
                             != QuantizationType.FLOAT
                         ):
@@ -255,6 +350,8 @@ class CompressedTensorsConfig(QuantizationConfig):
         return []
 
     def _check_scheme_supported(self, min_capability: int, error: bool = True) -> bool:
+        from tokenspeed_kernel.platform import current_platform
+
         platform = current_platform()
         capability_tuple = DeviceCapability(
             platform.arch_version.major, platform.arch_version.minor
@@ -285,10 +382,15 @@ class CompressedTensorsConfig(QuantizationConfig):
         )
         is_symmetric_weight = weight_quant.symmetric
         is_static_weight = not weight_quant.dynamic
-        is_per_tensor_or_channel_weight = weight_quant.strategy in [
+        strategy = getattr(weight_quant.strategy, "value", weight_quant.strategy)
+        is_per_tensor_or_channel_weight = strategy in {
             QuantizationStrategy.TENSOR,
             QuantizationStrategy.CHANNEL,
-        ]
+            getattr(QuantizationStrategy, "BLOCK", "block"),
+            getattr(QuantizationStrategy.TENSOR, "value", "tensor"),
+            getattr(QuantizationStrategy.CHANNEL, "value", "channel"),
+            "block",
+        }
         if not (
             is_floating_point
             and is_symmetric_weight
@@ -345,16 +447,45 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         return is_channel_group and input_quant_none and is_symmetric and is_static
 
+    def _is_wint4afp8(
+        self,
+        weight_quant: BaseModel | None,
+        input_quant: BaseModel | None,
+        format: str | None = None,
+    ) -> bool:
+        """Detect W4A8: packed INT4 weights + 8-bit dynamic per-token activations."""
+        if weight_quant is None or input_quant is None:
+            return False
+        quant_format = format if format is not None else self.quant_format
+        return (
+            quant_format == CompressionFormat.pack_quantized.value
+            and weight_quant.num_bits == 4
+            and weight_quant.type == QuantizationType.INT
+            and weight_quant.symmetric
+            and not weight_quant.dynamic
+            and input_quant.num_bits == 8
+            and input_quant.type in [QuantizationType.FLOAT, QuantizationType.INT]
+            and bool(input_quant.dynamic)
+        )
+
     def _get_scheme_from_parts(
-        self, weight_quant: BaseModel, input_quant: BaseModel
+        self,
+        weight_quant: BaseModel,
+        input_quant: BaseModel,
+        format: str | None = None,
     ) -> CompressedTensorsScheme:
+        quant_format = format if format is not None else self.quant_format
 
         # Detect If Mixed Precision
         if self._is_wNa16_group_channel(weight_quant, input_quant):
             if (
-                self.quant_format == CompressionFormat.pack_quantized.value
+                quant_format == CompressionFormat.pack_quantized.value
                 and weight_quant.num_bits in WNA16_SUPPORTED_BITS
             ):
+                from tokenspeed.runtime.layers.quantization.compressed_tensors.schemes import (
+                    CompressedTensorsWNA16,
+                )
+
                 return CompressedTensorsWNA16(
                     num_bits=weight_quant.num_bits,
                     strategy=weight_quant.strategy,
@@ -366,7 +497,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                     "Other method (CompressedTensorsW4A16Sparse24) is not supported now"
                 )
 
-        if is_activation_quantization_format(self.quant_format):
+        if is_activation_quantization_format(quant_format):
             if self._is_fp8_w8a8(weight_quant, input_quant):
                 is_fp8_w8a8_supported = self._check_scheme_supported(
                     CompressedTensorsW8A8Fp8.get_min_capability(), error=False
@@ -419,6 +550,7 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         # Will be empty for models with only sparsity
         weight_quant = input_quant = None
+        scheme_format = None
         if self.target_scheme_map:
             matched_target = find_matched_target(
                 layer_name=layer_name,
@@ -430,6 +562,7 @@ class CompressedTensorsConfig(QuantizationConfig):
             scheme_dict = self.target_scheme_map[matched_target]
             weight_quant = scheme_dict.get("weights")
             input_quant = scheme_dict.get("input_activations")
+            scheme_format = scheme_dict.get("format")
 
         # Find the sparsity scheme of the layer
         # assume that fused layers inerhit first component's sparsity scheme
@@ -465,6 +598,7 @@ class CompressedTensorsConfig(QuantizationConfig):
             scheme = self._get_scheme_from_parts(  # type: ignore
                 weight_quant=weight_quant,
                 input_quant=input_quant,
+                format=scheme_format,
             )
 
         # Raise error if device does not support the scheme
@@ -472,6 +606,83 @@ class CompressedTensorsConfig(QuantizationConfig):
         self._check_scheme_supported(scheme.get_min_capability())
         logger.debug("Using scheme: %s for %s", scheme.__class__.__name__, layer_name)
         return scheme
+
+    def get_quant_method(self, layer: torch.nn.Module, prefix: str) -> LinearMethodBase:
+        """Select a linear method for ``prefix``.
+
+        Mixed-precision compressed-tensors checkpoints (GLM-5.3 W4A8) keep
+        attention / shared-expert projections as block-FP8 and routed experts
+        as packed INT4. TokenSpeed has no CompressedTensorsW8A8Fp8 scheme, so
+        block-FP8 linears reuse :class:`Fp8LinearMethod`. Packed INT4 dense
+        linears keep :class:`CompressedTensorsLinearMethod` (WNA16).
+        """
+        from tokenspeed.runtime.layers.quantization.fp8 import Fp8Config
+        from tokenspeed.runtime.layers.quantization.utils import (
+            should_ignore_quant_layer,
+        )
+
+        def _unquantized():
+            from tokenspeed.runtime.layers.dense import UnquantizedLinearMethod
+
+            return UnquantizedLinearMethod()
+
+        if should_ignore_quant_layer(
+            prefix, self.ignored_layers, self.packed_modules_mapping
+        ):
+            return _unquantized()
+
+        try:
+            matched_target = find_matched_target(
+                layer_name=prefix,
+                module=layer,
+                targets=self.target_scheme_map.keys(),
+                fused_mapping=self.packed_modules_mapping,
+            )
+        except ValueError:
+            return _unquantized()
+
+        scheme_dict = self.target_scheme_map[matched_target]
+        weight_quant = scheme_dict.get("weights")
+        input_quant = scheme_dict.get("input_activations")
+        scheme_format = scheme_dict.get("format")
+        if weight_quant is None:
+            return _unquantized()
+
+        if self._is_wint4afp8(weight_quant, input_quant, scheme_format):
+            raise NotImplementedError(
+                "Dense W4A8 compressed-tensors linears are not supported; "
+                f"{prefix!r} matched packed INT4 + FP8 activations. Routed "
+                "experts use moe_weight_dtype() instead."
+            )
+
+        if self._is_fp8_w8a8(weight_quant, input_quant) or self._is_fp8_w8a16(
+            weight_quant, input_quant
+        ):
+            from tokenspeed.runtime.layers.dense import Fp8LinearMethod
+
+            block_structure = getattr(weight_quant, "block_structure", None)
+            activation_scheme = (
+                "dynamic" if (input_quant is None or input_quant.dynamic) else "static"
+            )
+            if block_structure is not None:
+                activation_scheme = "dynamic"
+            fp8_config = Fp8Config(
+                is_checkpoint_fp8_serialized=True,
+                activation_scheme=activation_scheme,
+                ignored_layers=self.ignored_layers,
+                weight_block_size=(
+                    list(block_structure) if block_structure is not None else None
+                ),
+            )
+            return Fp8LinearMethod(fp8_config)
+
+        layer.scheme = self._get_scheme_from_parts(
+            weight_quant=weight_quant,
+            input_quant=input_quant,
+            format=scheme_format,
+        )
+        self._check_scheme_supported(layer.scheme.get_min_capability())
+        return CompressedTensorsLinearMethod(self)
 
     def get_cache_scale(self, name: str) -> str | None:
         """

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/gptq_marlin_moe.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/gptq_marlin_moe.py
@@ -27,7 +27,11 @@ def is_activation_quantization_format(format: str) -> bool:
         CompressionFormat.naive_quantized.value,
         CompressionFormat.int_quantized.value,
         CompressionFormat.float_quantized.value,
+        CompressionFormat.pack_quantized.value,
     ]
+    nvfp4 = getattr(CompressionFormat, "nvfp4_pack_quantized", None)
+    if nvfp4 is not None:
+        _ACTIVATION_QUANTIZATION_FORMATS.append(nvfp4.value)
     return format in _ACTIVATION_QUANTIZATION_FORMATS
 
 

--- a/python/tokenspeed/runtime/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/python/tokenspeed/runtime/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -29,7 +29,6 @@ from collections.abc import Callable
 
 import torch
 from compressed_tensors.quantization import ActivationOrdering
-from tokenspeed_kernel.ops.quantization.cuda import gptq_marlin_repack
 
 # yapf conflicts with isort for this block
 # yapf: disable
@@ -244,6 +243,8 @@ class CompressedTensorsWNA16(CompressedTensorsScheme):
                 )
 
         def transform_w_q(x):
+            from tokenspeed_kernel.ops.quantization.cuda import gptq_marlin_repack
+
             assert isinstance(x, BaseWeightParameter)
             permute_param_layout_(x, input_dim=0, output_dim=1, packed_dim=0)
             x.data = gptq_marlin_repack(

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1723,6 +1723,17 @@ class DeepseekV3ForCausalLM(BaseCausalLM):
             if name in params_dict:
                 return params_dict[name]
 
+        # compressed-tensors block-FP8 stores ``weight_scale``; TokenSpeed's
+        # Fp8LinearMethod registers the same tensor as ``weight_scale_inv``.
+        if name.endswith(".weight_scale"):
+            alias = name[: -len(".weight_scale")] + ".weight_scale_inv"
+            if alias in params_dict:
+                return params_dict[alias]
+            if "language_model." in alias:
+                alias = alias.replace("language_model.", "")
+                if alias in params_dict:
+                    return params_dict[alias]
+
         if name.endswith(_OPTIONAL_MISSING_WEIGHT_SUFFIXES):
             return None
 
@@ -1849,7 +1860,7 @@ class DeepseekV3ForCausalLM(BaseCausalLM):
                         )
                         weight_loader = param.weight_loader
                         begin_size = begin_size_mp["kv_a_proj_with_mqa"]
-                    if "scale_inv" in name:
+                    if "scale_inv" in name or name.endswith(".weight_scale"):
                         begin_size //= quant_block_size
                     weight_loader(param, loaded_weight, begin_size=begin_size)
                 else:

--- a/python/tokenspeed/runtime/models/glm5.py
+++ b/python/tokenspeed/runtime/models/glm5.py
@@ -1365,7 +1365,7 @@ class GlmMoeDsaForCausalLM(DeepseekV3ForCausalLM):
             )
             return
 
-        if "weight_scale_inv" in name:
+        if "weight_scale_inv" in name or name.endswith(".weight_scale"):
             pending_fp8_wk.setdefault(module_name, {})["scale"] = loaded_weight
             self._flush_fused_indexer_fp8_wk(
                 module_name=module_name,

--- a/test/runtime/test_compressed_tensors_w4a8.py
+++ b/test/runtime/test_compressed_tensors_w4a8.py
@@ -1,0 +1,234 @@
+"""CPU coverage for mixed-precision compressed-tensors W4A8.
+
+GLM-5.3 W4A8 stores routed experts as packed INT4 group-128 + dynamic FP8
+activations and attention / shared experts as block-FP8. TokenSpeed used to
+drop ``input_activations`` whenever the top-level format was not an activation
+format, always read ``target_scheme_map["Linear"]`` for MoE kernel selection,
+and had no ``get_quant_method`` for compressed-tensors linears.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import ModuleType
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+# Importing TokenSpeed quantization configs loads ``tokenspeed_kernel`` via
+# ``quantization/__init__.py``. That package is optional for these CPU tests.
+try:
+    import tokenspeed_kernel  # noqa: F401
+except ImportError:
+    _kernel = ModuleType("tokenspeed_kernel")
+    _platform = ModuleType("tokenspeed_kernel.platform")
+    _platform.current_platform = lambda: None
+    sys.modules["tokenspeed_kernel"] = _kernel
+    sys.modules["tokenspeed_kernel.platform"] = _platform
+
+import pytest
+import torch
+
+from tokenspeed.runtime.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+
+W4A8_TARGET = "re:.*\\.mlp\\.experts\\.\\d+\\.(gate|up|down)_proj$"
+FP8_BLOCK_TARGET = "re:.*\\.mlp\\.shared_experts\\.(gate|up|down)_proj$"
+ATTN_TARGET = "re:.*\\.self_attn\\.(q_a_proj|o_proj)$"
+
+W4A8_GROUP = {
+    "format": "pack-quantized",
+    "targets": [W4A8_TARGET],
+    "weights": {
+        "num_bits": 4,
+        "type": "int",
+        "symmetric": True,
+        "strategy": "group",
+        "group_size": 128,
+        "dynamic": False,
+    },
+    "input_activations": {
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "token",
+        "dynamic": True,
+    },
+}
+
+FP8_BLOCK_GROUP = {
+    "format": "float-quantized",
+    "targets": [FP8_BLOCK_TARGET, ATTN_TARGET],
+    "weights": {
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "block",
+        "block_structure": [128, 128],
+        "dynamic": False,
+    },
+    "input_activations": {
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "group",
+        "group_size": 128,
+        "dynamic": True,
+    },
+}
+
+MXINT4_LINEAR_GROUP = {
+    "format": "pack-quantized",
+    "targets": ["Linear"],
+    "weights": {
+        "num_bits": 4,
+        "type": "int",
+        "symmetric": True,
+        "strategy": "group",
+        "group_size": 32,
+        "dynamic": False,
+    },
+    "input_activations": None,
+}
+
+
+def _config(*groups, ignore=(), top_level_format="mixed-precision"):
+    return {
+        "quant_method": "compressed-tensors",
+        "format": top_level_format,
+        "config_groups": {f"group_{i}": g for i, g in enumerate(groups)},
+        "ignore": list(ignore),
+    }
+
+
+def _glm53_w4a8_config(**kwargs):
+    """Match the published GLM-5.3 W4A8 card: top-level pack-quantized + Linear."""
+    group_0 = dict(
+        W4A8_GROUP,
+        targets=["Linear", W4A8_TARGET],
+    )
+    return _config(
+        group_0, FP8_BLOCK_GROUP, top_level_format="pack-quantized", **kwargs
+    )
+
+
+def test_input_activations_survive_mixed_precision_top_level():
+    quant_config = CompressedTensorsConfig.from_config(
+        _config(W4A8_GROUP, FP8_BLOCK_GROUP)
+    )
+    expert = quant_config.target_scheme_map[W4A8_TARGET]
+    assert expert["format"] == "pack-quantized"
+    assert expert["input_activations"] is not None
+    assert expert["input_activations"].num_bits == 8
+    assert expert["weights"].group_size == 128
+
+    fp8 = quant_config.target_scheme_map[FP8_BLOCK_TARGET]
+    assert fp8["format"] == "float-quantized"
+    assert fp8["input_activations"] is not None
+    assert fp8["weights"].block_structure == [128, 128]
+
+
+def test_input_activations_survive_pack_quantized_top_level():
+    quant_config = CompressedTensorsConfig.from_config(_glm53_w4a8_config())
+    linear = quant_config.target_scheme_map["Linear"]
+    assert linear["input_activations"] is not None
+    assert linear["input_activations"].num_bits == 8
+    fp8 = quant_config.target_scheme_map[ATTN_TARGET]
+    assert fp8["input_activations"] is not None
+
+
+def test_w4a8_moe_dtype_reads_matched_expert_group_not_linear():
+    quant_config = CompressedTensorsConfig.from_config(
+        _config(W4A8_GROUP, FP8_BLOCK_GROUP)
+    )
+    assert "Linear" not in quant_config.target_scheme_map
+    assert quant_config.is_w4a8_fp8 is True
+    assert quant_config.moe_weight_dtype("model.layers.3.mlp") == "w4a8"
+    assert quant_config.moe_group_size("model.layers.3.mlp") == 128
+    assert quant_config.weight_block_size == [128, 128]
+
+
+def test_glm53_card_selects_w4a8_even_when_linear_is_int4():
+    quant_config = CompressedTensorsConfig.from_config(_glm53_w4a8_config())
+    assert quant_config.is_w4a8_fp8 is True
+    assert quant_config.moe_weight_dtype("model.layers.3.mlp") == "w4a8"
+    assert quant_config.weight_block_size == [128, 128]
+
+
+def test_weight_block_size_ignores_non_block_linear_target():
+    groups = (dict(W4A8_GROUP, targets=["Linear"]), FP8_BLOCK_GROUP)
+    quant_config = CompressedTensorsConfig.from_config(
+        _config(*groups, top_level_format="mixed-precision")
+    )
+    assert "Linear" in quant_config.target_scheme_map
+    assert quant_config.weight_block_size == [128, 128]
+
+
+def test_kimi_int4_group32_still_selects_mxint4():
+    quant_config = CompressedTensorsConfig.from_config(
+        _config(MXINT4_LINEAR_GROUP, top_level_format="pack-quantized")
+    )
+    assert quant_config.is_w4a8_fp8 is False
+    assert quant_config.moe_weight_dtype("model.layers.3.mlp") == "mxint4"
+
+
+def test_block_fp8_linears_match_fp8_scheme_not_w4a8():
+    quant_config = CompressedTensorsConfig.from_config(_glm53_w4a8_config())
+    attn = quant_config._scheme_dict_for_name("model.layers.0.self_attn.q_a_proj")
+    assert attn is not None
+    assert quant_config._is_fp8_w8a8(attn["weights"], attn["input_activations"])
+    assert not quant_config._is_wint4afp8(
+        attn["weights"], attn["input_activations"], attn.get("format")
+    )
+
+    shared = quant_config._scheme_dict_for_name(
+        "model.layers.3.mlp.shared_experts.gate_proj"
+    )
+    assert shared is not None
+    assert quant_config._is_fp8_w8a8(shared["weights"], shared["input_activations"])
+
+
+def test_dense_w4a8_linear_is_rejected():
+    quant_config = CompressedTensorsConfig.from_config(_glm53_w4a8_config())
+    expert = quant_config._scheme_dict_for_name(
+        "model.layers.3.mlp.experts.0.gate_proj"
+    )
+    assert expert is not None
+    assert quant_config._is_wint4afp8(
+        expert["weights"], expert["input_activations"], expert.get("format")
+    )
+    with pytest.raises(NotImplementedError, match="Dense W4A8"):
+        quant_config.get_quant_method(
+            torch.nn.Linear(8, 8),
+            "model.layers.3.mlp.experts.0.gate_proj",
+        )
+
+
+def test_unpack_int4_dequant_matches_group_scale():
+    try:
+        from tokenspeed_kernel.ops.moe.flashinfer.w4a8 import (
+            dequant_cutlass_int4,
+            unpack_int32_uint4b8_to_cutlass_int8,
+        )
+    except Exception:
+        pytest.skip("tokenspeed_kernel W4A8 helpers require a native kernel install")
+
+    group_size = 128
+    n, k = 4, 256
+    values = torch.arange(n * k, dtype=torch.int32).remainder(16) - 8
+    values = values.view(n, k)
+    nibbles = (values + 8).view(n, k // 8, 8) & 0x0F
+    packed_words = torch.zeros(n, k // 8, dtype=torch.int32)
+    for i in range(8):
+        packed_words |= nibbles[:, :, i] << (4 * i)
+    packed = packed_words.unsqueeze(0)
+    scale = torch.full((1, n, k // group_size), 0.5, dtype=torch.bfloat16)
+
+    cutlass = unpack_int32_uint4b8_to_cutlass_int8(packed)[0]
+    restored = dequant_cutlass_int4(cutlass, scale[0], torch.float32)
+    expected = values.to(torch.float32) * 0.5
+    torch.testing.assert_close(restored, expected, atol=0, rtol=0)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/w4a8.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/w4a8.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Hopper W4A8 MoE: packed INT4 weights × dynamic per-token FP8 activations.
+
+Serves ``compressed-tensors`` mixed-precision checkpoints whose routed experts
+are symmetric INT4 group_size=128 (``pack-quantized`` uint4b8/int32) with
+dynamic FP8 activations — e.g. GLM-5.3 W4A8.
+
+The checkpoint keeps eight unsigned-offset INT4 values per ``int32`` word.
+``process_weights`` repacks them into CUTLASS signed nibbles (two INT4 per
+``int8``) without expanding VRAM. Apply prefers a CUTLASS grouped GEMM when
+``sgl_kernel.cutlass_w4a8_moe_mm`` is importable; otherwise it dequantizes one
+expert at a time into a scratch buffer (INT4 stays in memory).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import torch.nn.functional as F
+from tokenspeed_kernel.platform import (
+    ArchVersion,
+    CapabilityRequirement,
+    current_platform,
+)
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+
+logger = logging.getLogger(__name__)
+
+platform = current_platform()
+
+
+def unpack_int32_uint4b8_to_cutlass_int8(weight_packed: torch.Tensor) -> torch.Tensor:
+    """Convert compressed-tensors pack_to_int32 uint4b8 to CUTLASS int8 nibbles.
+
+    ``pack_to_int32`` stores 8 unsigned-offset int4 values per int32.
+    CUTLASS expects pairs of signed int4 packed into int8 (low nibble = even
+    index, high nibble = odd index, two's complement).
+
+    Args:
+        weight_packed: ``[E, N, K // 8]`` int32.
+
+    Returns:
+        ``[E, N, K // 2]`` int8 in CUTLASS layout.
+    """
+    num_bits = 4
+    pack_factor = 32 // num_bits
+    mask = (1 << num_bits) - 1
+    offset = 1 << (num_bits - 1)
+    pair_factor = pack_factor // 2
+
+    out = torch.empty(
+        (*weight_packed.shape[:-1], weight_packed.shape[-1], pair_factor),
+        dtype=torch.int8,
+        device=weight_packed.device,
+    )
+    for pair_idx in range(pair_factor):
+        low_shift = num_bits * (2 * pair_idx)
+        high_shift = low_shift + num_bits
+        low_nibbles = ((weight_packed >> low_shift) & mask) - offset
+        high_nibbles = ((weight_packed >> high_shift) & mask) - offset
+        out[..., pair_idx] = ((high_nibbles << 4) | (low_nibbles & 0x0F)).to(torch.int8)
+    return out.flatten(-2).contiguous()
+
+
+def interleave_w4a8_scales(scales: torch.Tensor) -> torch.Tensor:
+    """Interleave group scales in groups of 4 for the CUTLASS W4A8 epilogue."""
+    s_shape = scales.shape
+    alignment = 4 if s_shape[2] % 4 == 0 else 1
+    scales_interleaved = scales.reshape(
+        s_shape[0], s_shape[1], (s_shape[2] // alignment), alignment
+    )
+    scales_interleaved = scales_interleaved.permute(0, 2, 1, 3)
+    scales_interleaved = scales_interleaved.reshape(
+        s_shape[0], s_shape[2] // alignment, s_shape[1] * alignment
+    )
+    return scales_interleaved.contiguous()
+
+
+def dequant_cutlass_int4(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Dequantize one expert's CUTLASS-packed INT4 weights to ``dtype``.
+
+    Args:
+        packed: ``[N, K // 2]`` int8.
+        scale: ``[N, K // group_size]`` (typically bf16).
+        dtype: Output dtype.
+    """
+    n, k_half = packed.shape
+    k = k_half * 2
+    packed_i32 = packed.to(torch.int32)
+    low = packed_i32 & 0x0F
+    high = (packed_i32 >> 4) & 0x0F
+    low = torch.where(low >= 8, low - 16, low)
+    high = torch.where(high >= 8, high - 16, high)
+    weight = torch.empty(n, k, dtype=dtype, device=packed.device)
+    weight[:, 0::2] = low.to(dtype)
+    weight[:, 1::2] = high.to(dtype)
+    num_groups = scale.shape[-1]
+    group_size = k // num_groups
+    weight = weight.view(n, num_groups, group_size) * scale.to(dtype).unsqueeze(-1)
+    return weight.reshape(n, k)
+
+
+def _try_sgl_cutlass_w4a8_moe(
+    x: torch.Tensor,
+    w: torch.nn.Module,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor | None:
+    """Run SGLang's Hopper CUTLASS grouped GEMM when ``sgl_kernel`` is present."""
+    try:
+        from sgl_kernel import cutlass_w4a8_moe_mm, get_cutlass_w4a8_moe_mm_data
+    except ImportError:
+        return None
+
+    device = x.device
+    w1_q = w.w13_weight_packed
+    w2_q = w.w2_weight_packed
+    w1_scale = w.w13_weight_scale_interleaved
+    w2_scale = w.w2_weight_scale_interleaved
+    num_local_experts = w1_q.size(0)
+    m = x.size(0)
+    k = w1_q.size(2) * 2
+    n = w2_q.size(2) * 2
+    topk = topk_ids.size(1)
+
+    a_strides1 = torch.full((num_local_experts, 3), k, device=device, dtype=torch.int64)
+    c_strides1 = torch.full(
+        (num_local_experts, 3), 2 * n, device=device, dtype=torch.int64
+    )
+    a_strides2 = torch.full((num_local_experts, 3), n, device=device, dtype=torch.int64)
+    c_strides2 = torch.full((num_local_experts, 3), k, device=device, dtype=torch.int64)
+    expert_offsets = torch.empty(
+        num_local_experts + 1, dtype=torch.int32, device=device
+    )
+    problem_sizes1 = torch.empty(
+        (num_local_experts, 3), dtype=torch.int32, device=device
+    )
+    problem_sizes2 = torch.empty(
+        (num_local_experts, 3), dtype=torch.int32, device=device
+    )
+    a_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
+    c_map = torch.empty((topk_ids.numel()), dtype=torch.int32, device=device)
+    get_cutlass_w4a8_moe_mm_data(
+        topk_ids,
+        expert_offsets,
+        problem_sizes1,
+        problem_sizes2,
+        a_map,
+        c_map,
+        num_local_experts,
+        n,
+        k,
+    )
+
+    a_fp8 = x.to(torch.float8_e4m3fn)
+    a1_scale = torch.ones(1, dtype=torch.float32, device=device)
+    c1 = torch.empty((m * topk, n * 2), device=device, dtype=torch.bfloat16)
+    cutlass_w4a8_moe_mm(
+        c1,
+        a_fp8,
+        w1_q,
+        a1_scale,
+        w1_scale,
+        expert_offsets[:-1],
+        problem_sizes1,
+        a_strides1,
+        a_strides1,
+        c_strides1,
+        c_strides1,
+        128,
+        topk,
+    )
+    gate, up = c1.chunk(2, dim=-1)
+    intermediate = F.silu(gate) * up
+    intermediate_fp8 = intermediate.to(torch.float8_e4m3fn)
+    a2_scale = torch.ones(1, dtype=torch.float32, device=device)
+    c2 = torch.empty((m * topk, k), device=device, dtype=torch.bfloat16)
+    cutlass_w4a8_moe_mm(
+        c2,
+        intermediate_fp8,
+        w2_q,
+        a2_scale,
+        w2_scale,
+        expert_offsets[:-1],
+        problem_sizes2,
+        a_strides2,
+        a_strides2,
+        c_strides2,
+        c_strides2,
+        128,
+        topk,
+    )
+    routed = c2.view(m, topk, k) * topk_weights.to(c2.dtype).unsqueeze(-1)
+    return routed.sum(dim=1).to(x.dtype)
+
+
+def _torch_w4a8_moe_apply(
+    x: torch.Tensor,
+    w: torch.nn.Module,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Per-expert INT4 dequant + SiLU-and-mul GEMM. Keeps packed weights in VRAM."""
+    output = torch.zeros_like(x)
+    unique_experts = torch.unique(topk_ids)
+    for expert_id in unique_experts.tolist():
+        expert_id = int(expert_id)
+        if expert_id < 0 or expert_id >= w.w13_weight_packed.shape[0]:
+            continue
+        token_mask = topk_ids == expert_id
+        if not bool(token_mask.any()):
+            continue
+        token_index, slot = torch.where(token_mask)
+        tokens = x.index_select(0, token_index)
+        w13 = dequant_cutlass_int4(
+            w.w13_weight_packed[expert_id],
+            w.w13_weight_scale[expert_id],
+            x.dtype,
+        )
+        w2 = dequant_cutlass_int4(
+            w.w2_weight_packed[expert_id],
+            w.w2_weight_scale[expert_id],
+            x.dtype,
+        )
+        gate_up = F.linear(tokens, w13)
+        gate, up = gate_up.chunk(2, dim=-1)
+        down = F.linear(F.silu(gate) * up, w2)
+        scaled = down * topk_weights[token_index, slot].to(down.dtype).unsqueeze(-1)
+        output.index_add_(0, token_index, scaled.to(output.dtype))
+    return output
+
+
+def flashinfer_cutlass_w4a8_moe_weights(plan: dict, w: torch.nn.Module):
+    """Repack uint4b8/int32 expert weights into CUTLASS signed int8 nibbles."""
+    del plan
+    if getattr(w, "is_w4a8_converted", False):
+        return None
+    if w.w13_weight_packed.dtype == torch.int32:
+        w.w13_weight_packed = torch.nn.Parameter(
+            unpack_int32_uint4b8_to_cutlass_int8(w.w13_weight_packed.data),
+            requires_grad=False,
+        )
+        w.w2_weight_packed = torch.nn.Parameter(
+            unpack_int32_uint4b8_to_cutlass_int8(w.w2_weight_packed.data),
+            requires_grad=False,
+        )
+    w.w13_weight_scale = torch.nn.Parameter(
+        w.w13_weight_scale.data.to(torch.bfloat16), requires_grad=False
+    )
+    w.w2_weight_scale = torch.nn.Parameter(
+        w.w2_weight_scale.data.to(torch.bfloat16), requires_grad=False
+    )
+    w.w13_weight_scale_interleaved = interleave_w4a8_scales(w.w13_weight_scale.data)
+    w.w2_weight_scale_interleaved = interleave_w4a8_scales(w.w2_weight_scale.data)
+    for shape_name in ("w13_weight_shape", "w2_weight_shape"):
+        if hasattr(w, shape_name):
+            delattr(w, shape_name)
+    w.is_w4a8_converted = True
+    return None
+
+
+if platform.is_nvidia:
+
+    @register_kernel(
+        "moe",
+        "apply",
+        name="cutlass_w4a8_moe_apply",
+        solution="flashinfer_cutlass",
+        weight_preprocessor=flashinfer_cutlass_w4a8_moe_weights,
+        capability=CapabilityRequirement(
+            vendors=frozenset({"nvidia"}),
+            min_arch_version=ArchVersion(9, 0),
+            max_arch_version=ArchVersion(9, 0),
+        ),
+        signatures=format_signatures(
+            "x",
+            "dense",
+            {torch.float16, torch.bfloat16},
+        ),
+        traits={
+            "weight_dtype": frozenset({"w4a8"}),
+            "activation": frozenset({"silu", "swiglu"}),
+            "routing_mode": frozenset({"precomputed_topk"}),
+            "supports_deferred_finalize": frozenset({False}),
+            "supports_ep": frozenset({True}),
+            "supports_all_to_all_ep": frozenset({False}),
+            "ispp_alignment": frozenset({128}),
+            "internal_activation_dtype": frozenset({"fp8"}),
+            "supports_bias": frozenset({False}),
+        },
+        priority=Priority.PERFORMANT,
+    )
+    def cutlass_w4a8_moe_apply(
+        plan: dict,
+        x: torch.Tensor,
+        w: torch.nn.Module,
+        router_logits: torch.Tensor,
+        topk_weights: torch.Tensor | None = None,
+        topk_ids: torch.Tensor | None = None,
+        num_tokens_global: int | None = None,
+        max_num_tokens_per_gpu: int | None = None,
+        do_finalize: bool = True,
+        enable_pdl: bool = False,
+    ):
+        del plan, num_tokens_global, max_num_tokens_per_gpu, do_finalize, enable_pdl
+        if x.shape[0] == 0:
+            return x
+        if topk_weights is None or topk_ids is None:
+            scores = torch.softmax(router_logits.float(), dim=-1)
+            topk_weights, topk_ids = torch.topk(
+                scores, k=getattr(w, "top_k"), dim=-1, sorted=False
+            )
+            topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+            topk_weights = topk_weights.to(x.dtype)
+        cutlass_out = _try_sgl_cutlass_w4a8_moe(x, w, topk_weights, topk_ids)
+        if cutlass_out is not None:
+            return cutlass_out
+        return _torch_w4a8_moe_apply(x, w, topk_weights, topk_ids)


### PR DESCRIPTION
## Summary

- Parse mixed-precision / pack-quantized compressed-tensors configs **per `config_group`**, so GLM-5.3 W4A8 keeps packed INT4 group-128 + dynamic FP8 activations on routed experts and block-FP8 on attention / shared experts. TokenSpeed previously dropped `input_activations` when the top-level format was not an activation format, and `moe_weight_dtype()` always read `target_scheme_map["Linear"]`.
- Add Hopper `quant_kind=w4a8` MoE weight buffers and an apply kernel. Packed INT4 stays in VRAM (no load-time dequant to FP8). Apply uses `sgl_kernel.cutlass_w4a8_moe_mm` when that extra is present; otherwise it falls back to per-expert torch dequant + SiLU GEMM (correctness / bring-up, not a production prefill path).
- Map compressed-tensors `weight_scale` onto TokenSpeed's `weight_scale_inv` for DeepSeek/GLM DSA loaders. Dense W4A8 linears raise `NotImplementedError`; block-FP8 linears reuse `Fp8LinearMethod`. Kimi INT4 group-32 weight-only still selects `mxint4`.

This is a larger feature than a one-line bugfix. Happy to follow up with an RFC if maintainers prefer that process.

## Test Plan

- [x] CPU unit tests in `test/runtime/test_compressed_tensors_w4a8.py` (registered on `runtime-1gpu`): mixed-precision `input_activations` survive; GLM-5.3 card selects `w4a8` + `weight_block_size=[128,128]`; Kimi g32 still `mxint4`; block-FP8 vs W4A8 matching; dense W4A8 `get_quant_method` is rejected. 8 passed; the unpack helper test skips without a native kernel install.
- [ ] Not claimed: serving the ~372GB GLM-5.3 W4A8 checkpoint at production speed. That needs the Hopper CUTLASS grouped GEMM (`sgl_kernel` or an in-tree equivalent). The torch path keeps INT4 in memory but is slow for prefill.
