### PR TITLE
fix(moe): pad NVFP4 expert shards for TRT-LLM

### DIFF
--- a/docs/serving/parallelism.md
+++ b/docs/serving/parallelism.md
@@ -79,6 +79,12 @@ Start with the recipe closest to your model family, then tune:
 - `--all2all-backend`
 - `--deepep-mode`
 
+With `--moe-backend flashinfer_trtllm`, NVFP4 expert shards are automatically
+padded to a multiple of 64 along their per-rank intermediate dimension. The
+packed weights and block scales in the padded tail are zero-filled, so the
+extra dimensions do not change the MoE result. For example, a 640-wide expert
+under MoE TP4 is padded from 160 to 192 values per rank.
+
 ### DeepEP all-to-all
 
 `--all2all-backend deepep` moves expert routing off all-gather and onto DeepEP

--- a/python/tokenspeed/runtime/layers/moe/expert.py
+++ b/python/tokenspeed/runtime/layers/moe/expert.py
@@ -25,6 +25,9 @@ from dataclasses import replace
 
 import tokenspeed_kernel
 import torch
+from tokenspeed_kernel.ops.moe.flashinfer.trtllm_nvfp4 import (
+    TRTLLM_NVFP4_ISPP_ALIGNMENT,
+)
 
 from tokenspeed.runtime.distributed.process_group_manager import (
     process_group_manager as pg_manager,
@@ -205,6 +208,11 @@ class MoELayer(torch.nn.Module):
             # nothing to the MoE output.
             self._apply_trtllm_ispp_padding(
                 128, "the flashinfer_trtllm unquant kernel accepts it"
+            )
+        if self._quant_kind == "nvfp4":
+            self._apply_trtllm_ispp_padding(
+                TRTLLM_NVFP4_ISPP_ALIGNMENT,
+                "the flashinfer_trtllm NVFP4 weight layout accepts it",
             )
         if self._quant_kind == "mxfp4":
             if self.quant_config.is_w4a8_fp8:

--- a/python/tokenspeed/runtime/layers/moe/weights/nvfp4.py
+++ b/python/tokenspeed/runtime/layers/moe/weights/nvfp4.py
@@ -40,7 +40,7 @@ def create_nvfp4_weight_pair(
 ) -> None:
     ispp = spec.intermediate_size // spec.tp_size
     w13_weight = torch.nn.Parameter(
-        torch.empty(
+        torch.zeros(
             spec.num_local_experts,
             2 * ispp,
             spec.hidden_size // 2,
@@ -49,7 +49,7 @@ def create_nvfp4_weight_pair(
         requires_grad=False,
     )
     w2_weight = torch.nn.Parameter(
-        torch.empty(
+        torch.zeros(
             spec.num_local_experts,
             spec.hidden_size,
             ispp // 2,
@@ -61,7 +61,7 @@ def create_nvfp4_weight_pair(
     layer.register_parameter("w2_weight", w2_weight)
 
     w13_weight_scale = torch.nn.Parameter(
-        torch.empty(
+        torch.zeros(
             spec.num_local_experts,
             2 * ispp,
             spec.hidden_size // group_size,
@@ -70,7 +70,7 @@ def create_nvfp4_weight_pair(
         requires_grad=False,
     )
     w2_weight_scale = torch.nn.Parameter(
-        torch.empty(
+        torch.zeros(
             spec.num_local_experts,
             spec.hidden_size,
             ispp // group_size,

--- a/test/runtime/test_moe_global_padded_tp_loader.py
+++ b/test/runtime/test_moe_global_padded_tp_loader.py
@@ -24,6 +24,7 @@ import torch
 
 from tokenspeed.runtime.layers.moe.types import MoELayerSpec
 from tokenspeed.runtime.layers.moe.weights.loaders import make_weight_loader
+from tokenspeed.runtime.layers.moe.weights.nvfp4 import create_nvfp4_weight_pair
 
 _TP_SIZE = 4
 _BLOCK_SIZE = 128
@@ -141,3 +142,51 @@ def test_global_padding_precedes_w2_weight_and_scale_tp_sharding() -> None:
         torch.testing.assert_close(
             scale[0], _expected_scale_shard(down_scale, rank, dim=1)
         )
+
+
+def test_nvfp4_packed_weight_and_scale_use_the_same_padded_tp_shard() -> None:
+    group_size = 16
+    hidden_size = 16
+    padded_intermediate_size = 768
+    local_intermediate_size = padded_intermediate_size // _TP_SIZE
+    spec = MoELayerSpec(
+        top_k=2,
+        num_experts=1,
+        num_local_experts=1,
+        hidden_size=hidden_size,
+        intermediate_size=padded_intermediate_size,
+        activation="silu",
+        tp_rank=3,
+        tp_size=_TP_SIZE,
+        ep_rank=0,
+        ep_size=1,
+    )
+    layer = torch.nn.Module()
+    create_nvfp4_weight_pair(spec, layer, group_size=group_size)
+    layer.w2_weight.weight_loader(
+        layer.w2_weight,
+        torch.ones(hidden_size, _INTERMEDIATE_SIZE // 2, dtype=torch.uint8),
+        "w2",
+        local_expert_id=0,
+    )
+    layer.w2_weight_scale.weight_loader(
+        layer.w2_weight_scale,
+        torch.full(
+            (hidden_size, _INTERMEDIATE_SIZE // group_size),
+            2,
+            dtype=torch.float8_e4m3fn,
+        ),
+        shard_id="w2",
+        local_expert_id=0,
+    )
+
+    real_values = _INTERMEDIATE_SIZE - 3 * local_intermediate_size
+    assert torch.all(layer.w2_weight[..., : real_values // 2] == 1)
+    assert torch.count_nonzero(layer.w2_weight[..., real_values // 2 :]) == 0
+    assert torch.all(layer.w2_weight_scale[..., : real_values // group_size] == 2)
+    assert (
+        torch.count_nonzero(
+            layer.w2_weight_scale[..., real_values // group_size :].float()
+        )
+        == 0
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_nvfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_nvfp4.py
@@ -38,6 +38,7 @@ from tokenspeed_kernel.signature import format_signatures
 logger = logging.getLogger(__name__)
 
 platform = current_platform()
+TRTLLM_NVFP4_ISPP_ALIGNMENT = 64
 
 
 if platform.is_nvidia:
@@ -446,7 +447,7 @@ if platform.is_nvidia:
             "supports_deferred_finalize": frozenset({True}),
             "supports_ep": frozenset({True}),
             "supports_all_to_all_ep": frozenset({False}),
-            "ispp_alignment": frozenset({1}),
+            "ispp_alignment": frozenset({TRTLLM_NVFP4_ISPP_ALIGNMENT}),
             "internal_activation_dtype": frozenset({"input"}),
             "supports_bias": frozenset({False}),
         },
@@ -498,7 +499,7 @@ if platform.is_nvidia:
             "supports_deferred_finalize": frozenset({True}),
             "supports_ep": frozenset({True}),
             "supports_all_to_all_ep": frozenset({False}),
-            "ispp_alignment": frozenset({1}),
+            "ispp_alignment": frozenset({TRTLLM_NVFP4_ISPP_ALIGNMENT}),
             "internal_activation_dtype": frozenset({"input"}),
             "supports_bias": frozenset({False}),
         },
@@ -563,7 +564,7 @@ if platform.is_nvidia:
                 "supports_deferred_finalize": frozenset({True, False}),
                 "supports_ep": frozenset({True}),
                 "supports_all_to_all_ep": frozenset({False}),
-                "ispp_alignment": frozenset({1}),
+                "ispp_alignment": frozenset({TRTLLM_NVFP4_ISPP_ALIGNMENT}),
                 # NVFP4 SiTU runs w4a4: the wrapper quantizes the bf16 input
                 # to NVFP4 itself, which the registry models as "input"
                 # (unlike the MXFP4 SiTU cubins, which are w4a8/MXFP8).

--- a/tokenspeed-kernel/test/ops/moe/test_nvfp4_situ_flashinfer_trtllm.py
+++ b/tokenspeed-kernel/test/ops/moe/test_nvfp4_situ_flashinfer_trtllm.py
@@ -133,13 +133,22 @@ class _MoEWeights(torch.nn.Module):
         )
 
 
-def _make_nvfp4_moe_weights(generator: torch.Generator) -> dict[str, torch.Tensor]:
+def _make_nvfp4_moe_weights(
+    generator: torch.Generator, *, logical_ispp: int = ISPP
+) -> dict[str, torch.Tensor]:
     """K3-style [gate|up]-concatenated NVFP4 expert weights (loader layout)."""
     w13, w13_scale, w13_s2 = [], [], []
     w2, w2_scale, w2_s2 = [], [], []
     for _ in range(NUM_EXPERTS):
-        w13_bf16 = torch.randn(2 * ISPP, HIDDEN, generator=generator) * 0.5
-        w2_bf16 = torch.randn(HIDDEN, ISPP, generator=generator) * 0.5
+        w13_bf16 = torch.zeros(2, ISPP, HIDDEN)
+        w13_bf16[:, :logical_ispp] = (
+            torch.randn(2, logical_ispp, HIDDEN, generator=generator) * 0.5
+        )
+        w13_bf16 = w13_bf16.flatten(0, 1)
+        w2_bf16 = torch.zeros(HIDDEN, ISPP)
+        w2_bf16[:, :logical_ispp] = (
+            torch.randn(HIDDEN, logical_ispp, generator=generator) * 0.5
+        )
         packed, sf, s2 = _nvfp4_quantize(w13_bf16)
         w13.append(packed), w13_scale.append(sf), w13_s2.append(s2)
         packed, sf, s2 = _nvfp4_quantize(w2_bf16)
@@ -225,7 +234,10 @@ def _rel_l2(actual: torch.Tensor, expected: torch.Tensor) -> float:
 
 
 @requires_flashinfer_situ
-def test_flashinfer_nvfp4_situ_routed_moe_matches_dequant_reference() -> None:
+@pytest.mark.parametrize("logical_ispp", [ISPP, 160])
+def test_flashinfer_nvfp4_situ_routed_moe_matches_dequant_reference(
+    logical_ispp: int,
+) -> None:
     from tokenspeed_kernel.ops.moe.flashinfer.trtllm_nvfp4 import (
         flashinfer_trtllm_nvfp4_moe_weights,
         flashinfer_trtllm_nvfp4_routed_moe_apply,
@@ -236,7 +248,7 @@ def test_flashinfer_nvfp4_situ_routed_moe_matches_dequant_reference() -> None:
     generator = torch.Generator().manual_seed(20260817)
     num_tokens = 16
 
-    raw = _make_nvfp4_moe_weights(generator)
+    raw = _make_nvfp4_moe_weights(generator, logical_ispp=logical_ispp)
     hidden_states = (
         (torch.randn(num_tokens, HIDDEN, generator=generator) * 0.2).bfloat16().cuda()
     )
@@ -379,6 +391,24 @@ def test_registry_deferred_finalize_bit_matches_wiring() -> None:
     if spec is None:
         pytest.skip("nvfp4 SiTU kernel not registered on this platform")
     assert spec.traits["supports_deferred_finalize"] == frozenset({True, False})
+
+
+@pytest.mark.parametrize(
+    "kernel_name",
+    [
+        "flashinfer_trtllm_nvfp4_moe_apply",
+        "flashinfer_trtllm_nvfp4_routed_moe_apply",
+        "flashinfer_trtllm_nvfp4_situ_routed_moe_apply",
+    ],
+)
+def test_nvfp4_trtllm_registry_declares_ispp_alignment(kernel_name: str) -> None:
+    import tokenspeed_kernel.ops.moe.flashinfer.trtllm_nvfp4  # noqa: F401
+    from tokenspeed_kernel.registry import KernelRegistry
+
+    spec = KernelRegistry.get().get_by_name(kernel_name)
+    if spec is None:
+        pytest.skip("nvfp4 TRT-LLM kernel not registered on this platform")
+    assert spec.traits["ispp_alignment"] == frozenset({64})
 
 
 @requires_flashinfer_situ


### PR DESCRIPTION
## Summary

Under MoE TP, an NVFP4 expert's per-rank intermediate size may not be a multiple of 64 (e.g. a 640-wide expert under TP4 gives 160 per rank), which the `flashinfer_trtllm` NVFP4 weight layout does not accept. This PR pads NVFP4 expert shards so the kernel's ISPP alignment is always met:

- Declare `ispp_alignment = 64` (`TRTLLM_NVFP4_ISPP_ALIGNMENT`) for the three flashinfer TRT-LLM NVFP4 kernels (apply / routed apply / SiTU routed apply) in the kernel registry.
- Apply the existing TRT-LLM ISPP padding path for `_quant_kind == "nvfp4"` in the MoE expert layer, so padding happens on the global intermediate size before TP sharding.
- Allocate NVFP4 packed weights and block scales with `torch.zeros` instead of `torch.empty`, so the padded tail is zero-filled and does not change the MoE result.
- Document the behavior in `docs/serving/parallelism.md`.

Tests added:
- Runtime test that the packed NVFP4 weight and block-scale loaders share the same padded TP shard and the padded tail stays zero.
- Kernel test parametrized with `logical_ispp=160` (padded to 192) verifying the SiTU NVFP4 MoE still matches the dequant reference on a padded shard.
- Registry test asserting all three NVFP4 TRT-LLM kernels declare `ispp_alignment == 64`.

## Test Plan

- `pytest test/runtime/test_moe_global_padded_tp_loader.py`
- `pytest tokenspeed-kernel/test/ops/moe/test_nvfp4_situ_flashinfer_trtllm.py`
- E2E: qwen3.8-flash-next NVFP4 with MoE TP4, gsm8k eval