### PR TITLE
perf(l2): reduce Host cache transfer and scheduling overhead

### DIFF
--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -344,7 +344,16 @@ Its responsibilities:
 * **Two tiers (Device/Host).** Device prefix publication can optionally
   stream to the Host tier (`stream_device_cache_to_host_`); a
   `pending_stores_` queue drives D2H transfers, alongside Host-side
-  acquire/contains/pin queries.
+  acquire/contains/pin queries. During prefill, each completed scheduling
+  boundary queues all newly published full-attention pages and one checkpoint
+  per snapshot-state group; the pending candidates are merged into a batched
+  writeback. The first decode admission from `PrefillDone` applies the same
+  policy to the final prompt boundary. Ordinary decode still publishes Device
+  entries but does not stream full-attention or snapshot-state entries to
+  Host. At finish or retraction, all eligible Device-resident non-state pages
+  and only the newest Device-resident checkpoint per state group are queued
+  before request ownership is released. Ordinary sliding-window entries
+  always stream when published.
 * **Reclamation and lifecycle.** `ReclaimExpired`, `Free`,
   `ClearDeviceCache`/`ClearCache`, and `NumNewlyReleasableLcmBlocks` for
   ranking retraction (preemption) victims.

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -28,7 +28,10 @@ from typing import NamedTuple
 
 import psutil
 import torch
-from tokenspeed_kernel.ops.kvcache.host_transfer import transfer_cache_ranges
+from tokenspeed_kernel.ops.kvcache.host_transfer import (
+    HostTransferWorkspace,
+    transfer_cache_ranges,
+)
 from tokenspeed_scheduler import Cache
 
 from tokenspeed.runtime.cache.l2.layerwise_load import LayerwiseLoadTracker
@@ -102,9 +105,11 @@ class L2CacheExecutor:
         host_ratio: float,
         host_size_gb: float,
         io_backend: str,
+        attn_tp_rank: int = 0,
     ):
         if io_backend not in ("direct", "kernel"):
             raise ValueError(f"unsupported KVStore IO backend {io_backend!r}")
+        self.attn_tp_rank = attn_tp_rank
         self.transfer_backend = "dma" if io_backend == "direct" else "auto"
         target_layout = device_pool.cache_transfer_layout()
         draft_layout = (
@@ -165,6 +170,8 @@ class L2CacheExecutor:
         # work) can touch them. Loads keep their own stream: their consumers
         # are fenced per layer by the tracker events.
         self.load_stream = _new_cache_stream(_load_stream_priority())
+        self._write_workspace = HostTransferWorkspace()
+        self._load_workspace = HostTransferWorkspace()
 
         # Submission runs on the forward thread and polling on the control
         # plane (event queries only), so the completion queues below are the
@@ -267,6 +274,17 @@ class L2CacheExecutor:
                 )
         return ranges
 
+    def _fill_workspace_ranges(
+        self,
+        workspace: HostTransferWorkspace,
+        transfers: Sequence[tuple[int, int, int]],
+        field_ids: set[str] | None = None,
+    ) -> tuple[int, int]:
+        ranges = self._transfer_ranges(transfers, field_ids)
+        if not ranges:
+            return 0, 0
+        return workspace.load_ranges(ranges)
+
     def _start_writing(
         self,
         op_ids: Sequence[int],
@@ -279,23 +297,30 @@ class L2CacheExecutor:
             with self._ack_lock:
                 self._ready_write_op_ids.extend(op_ids)
             return
-        logger.info(
-            "[L2] writeback started: operations=%d blocks=%d",
-            len(op_ids),
-            len(transfers),
-        )
+        if self.attn_tp_rank == 0:
+            logger.info(
+                "[L2] writeback started: operations=%d blocks=%d",
+                len(op_ids),
+                len(transfers),
+            )
         # On the caller's (forward thread's default) stream: the scheduler
         # releases -- and may re-grant -- the source pages the moment it
         # emits this op, and the single-stream FIFO is what keeps the copy
         # ahead of the pages' next writer.
         stream = device_module.current_stream()
+        num_ranges, max_bytes = self._fill_workspace_ranges(
+            self._write_workspace, transfers
+        )
         transfer_cache_ranges(
             "d2h",
             self.layout.buffers,
             self.host_storage.host_buffer,
-            self._transfer_ranges(transfers),
+            (),
             stream,
             backend=self.transfer_backend,
+            workspace=self._write_workspace,
+            num_ranges=num_ranges,
+            max_bytes=max_bytes,
         )
         finish = device_module.Event()
         finish.record(stream)
@@ -316,11 +341,12 @@ class L2CacheExecutor:
             with self._ack_lock:
                 self._ready_load_op_ids.extend(op_ids)
             return None
-        logger.info(
-            "[L2] load started: operations=%d blocks=%d",
-            len(op_ids),
-            len(transfers),
-        )
+        if self.attn_tp_rank == 0:
+            logger.info(
+                "[L2] load started: operations=%d blocks=%d",
+                len(op_ids),
+                len(transfers),
+            )
 
         # EventLoop zeroes freshly allocated Device blocks before submitting the
         # load. Recording the start event here makes every layer-wise H2D
@@ -340,13 +366,19 @@ class L2CacheExecutor:
             load_events.start_event.wait(self.load_stream)
             for layer_index in range(consumer_count):
                 consumer = self.layout.consumers[consumer_offset + layer_index]
+                num_ranges, max_bytes = self._fill_workspace_ranges(
+                    self._load_workspace, transfers, set(consumer)
+                )
                 transfer_cache_ranges(
                     "h2d",
                     self.layout.buffers,
                     self.host_storage.host_buffer,
-                    self._transfer_ranges(transfers, set(consumer)),
+                    (),
                     self.load_stream,
                     backend=self.transfer_backend,
+                    workspace=self._load_workspace,
+                    num_ranges=num_ranges,
+                    max_bytes=max_bytes,
                 )
                 finish = device_module.Event()
                 finish.record(self.load_stream)

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -171,7 +171,19 @@ class L2CacheExecutor:
         # are fenced per layer by the tracker events.
         self.load_stream = _new_cache_stream(_load_stream_priority())
         self._write_workspace = HostTransferWorkspace()
-        self._load_workspace = HostTransferWorkspace()
+        # A tracker waits for an event set's previous final-layer event before
+        # reusing its index. Aligning workspaces to those indices keeps each
+        # load's pinned and Device range tables immutable until all consumers
+        # of that table have completed.
+        load_workspace_count = len(self._load_trackers[0][0].event_sets)
+        if any(
+            len(tracker.event_sets) != load_workspace_count
+            for tracker, _ in self._load_trackers
+        ):
+            raise RuntimeError("target and draft Host-load event sets diverged")
+        self._load_workspaces = tuple(
+            HostTransferWorkspace() for _ in range(load_workspace_count)
+        )
 
         # Submission runs on the forward thread and polling on the control
         # plane (event queries only), so the completion queues below are the
@@ -353,8 +365,8 @@ class L2CacheExecutor:
         # copy wait for that zeroing; the per-layer load events then keep model
         # consumers from reading partially restored cache state.
         load_index = None
-        consumer_offset = 0
         finish = None
+        active_trackers = []
         for tracker, consumer_count in self._load_trackers:
             current_load_index = tracker.begin_load()
             if load_index is None:
@@ -364,27 +376,69 @@ class L2CacheExecutor:
             load_events = tracker.event_sets[current_load_index]
             load_events.start_event.record()
             load_events.start_event.wait(self.load_stream)
+            active_trackers.append((load_events, consumer_count))
+        if load_index is None:
+            raise RuntimeError("cache transfer layout has no layer consumers")
+
+        layer_ranges = []
+        for layer_index in range(sum(count for _, count in active_trackers)):
+            consumer = self.layout.consumers[layer_index]
+            layer_ranges.append(self._transfer_ranges(transfers, set(consumer)))
+
+        range_descriptors = None
+        workspace = None
+        device = None
+        if self.transfer_backend != "dma":
+            device = self.layout.buffers[0].device
+        if device is not None and device.type != "npu":
+            workspace = self._load_workspaces[load_index]
+            range_descriptors = workspace.load_range_batches(layer_ranges)
+            total_ranges = sum(descriptor[1] for descriptor in range_descriptors)
+            if total_ranges:
+                # All layer kernels below read slices of this one table. The
+                # indexed workspace is not refilled until this event set wraps.
+                with device_module.stream(self.load_stream):
+                    workspace.commit_ranges(
+                        total_ranges,
+                        device,
+                        non_blocking=True,
+                    )
+
+        flat_layer_index = 0
+        for load_events, consumer_count in active_trackers:
             for layer_index in range(consumer_count):
-                consumer = self.layout.consumers[consumer_offset + layer_index]
-                num_ranges, max_bytes = self._fill_workspace_ranges(
-                    self._load_workspace, transfers, set(consumer)
-                )
-                transfer_cache_ranges(
-                    "h2d",
-                    self.layout.buffers,
-                    self.host_storage.host_buffer,
-                    (),
-                    self.load_stream,
-                    backend=self.transfer_backend,
-                    workspace=self._load_workspace,
-                    num_ranges=num_ranges,
-                    max_bytes=max_bytes,
-                )
+                ranges = layer_ranges[flat_layer_index]
+                if range_descriptors is None:
+                    transfer_cache_ranges(
+                        "h2d",
+                        self.layout.buffers,
+                        self.host_storage.host_buffer,
+                        ranges,
+                        self.load_stream,
+                        backend=self.transfer_backend,
+                    )
+                else:
+                    range_offset, num_ranges, max_bytes = range_descriptors[
+                        flat_layer_index
+                    ]
+                    transfer_cache_ranges(
+                        "h2d",
+                        self.layout.buffers,
+                        self.host_storage.host_buffer,
+                        (),
+                        self.load_stream,
+                        backend=self.transfer_backend,
+                        workspace=workspace,
+                        num_ranges=num_ranges,
+                        max_bytes=max_bytes,
+                        range_offset=range_offset,
+                        ranges_committed=True,
+                    )
                 finish = device_module.Event()
                 finish.record(self.load_stream)
                 load_events.layer_done_events[layer_index] = finish
-            consumer_offset += consumer_count
-        if load_index is None or finish is None:
+                flat_layer_index += 1
+        if finish is None:
             raise RuntimeError("cache transfer layout has no layer consumers")
         with self._ack_lock:
             self._load_acks.append(_Ack(finish, op_ids))

--- a/python/tokenspeed/runtime/execution/runtime_states.py
+++ b/python/tokenspeed/runtime/execution/runtime_states.py
@@ -21,10 +21,6 @@
 
 import torch
 
-from tokenspeed.runtime.utils import get_colorful_logger
-
-logger = get_colorful_logger(__name__)
-
 
 class RuntimeStates:
     """Own runtime state tensors keyed by request-pool index."""
@@ -49,12 +45,6 @@ class RuntimeStates:
         self.remote_spec_candidate_ready = torch.zeros(
             req_pool_size + 1, dtype=torch.bool, device=device
         )
-        self.linear_penalties = torch.zeros(
-            (req_pool_size + 1, vocab_size), dtype=torch.float32, device=device
-        )
-        self.scaling_penalties = torch.ones(
-            (req_pool_size + 1, vocab_size), dtype=torch.float32, device=device
-        )
 
     def update_valid_cache_length(
         self, req_pool_indices: torch.Tensor, increment_lengths: torch.Tensor
@@ -67,8 +57,6 @@ class RuntimeStates:
         extend_prefix_lens: torch.Tensor,
     ) -> None:
         self.valid_cache_lengths[extend_request_pool_indices] = extend_prefix_lens
-        self.linear_penalties.index_fill_(0, extend_request_pool_indices, 0.0)
-        self.scaling_penalties.index_fill_(0, extend_request_pool_indices, 1.0)
         self.remote_spec_candidate_ready[extend_request_pool_indices] = False
 
     def write_remote_spec_candidate_ids(

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -181,6 +181,50 @@ class GroupAwareWireTest(unittest.TestCase):
         self.assertEqual(op_ids, [7])
         self.assertEqual(transfers, [(0, 5, 9), (1, 5, 9)])
 
+    def test_fill_workspace_ranges_uses_one_batched_load(self):
+        try:
+            from tokenspeed.runtime.cache.l2.executor import L2CacheExecutor
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs runtime dependencies: {exc}")
+
+        field = SimpleNamespace(
+            field_id="k",
+            device_buffer_index=0,
+            device_block_zero_offset_bytes=8,
+            block_stride_bytes=8,
+            payload_bytes=4,
+        )
+        executor = L2CacheExecutor.__new__(L2CacheExecutor)
+        executor.layout = SimpleNamespace(groups=(SimpleNamespace(fields=(field,)),))
+        executor.host_storage = SimpleNamespace(
+            host_field_offset=lambda group, block, index: 100 + block * 10 + index
+        )
+        workspace = Mock()
+        workspace.load_ranges.return_value = (1, 4)
+        transfers = [(0, 1, 2)]
+
+        count, max_bytes = executor._fill_workspace_ranges(workspace, transfers)
+
+        workspace.load_ranges.assert_called_once_with(
+            executor._transfer_ranges(transfers)
+        )
+        self.assertEqual((count, max_bytes), (1, 4))
+
+    def test_fill_workspace_ranges_skips_empty_batch(self):
+        try:
+            from tokenspeed.runtime.cache.l2.executor import L2CacheExecutor
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs runtime dependencies: {exc}")
+
+        executor = L2CacheExecutor.__new__(L2CacheExecutor)
+        executor.layout = SimpleNamespace(groups=(SimpleNamespace(fields=()),))
+        workspace = Mock()
+
+        count, max_bytes = executor._fill_workspace_ranges(workspace, [])
+
+        workspace.load_ranges.assert_not_called()
+        self.assertEqual((count, max_bytes), (0, 0))
+
     def test_writeback_calls_transfer_with_compact_layout(self):
         try:
             import tokenspeed.runtime.cache.l2.executor as executor_module
@@ -191,13 +235,14 @@ class GroupAwareWireTest(unittest.TestCase):
 
         executor = L2CacheExecutor.__new__(L2CacheExecutor)
         executor._ack_lock = threading.Lock()
+        executor.attn_tp_rank = 0
         executor._ready_write_op_ids = []
         executor.layout = SimpleNamespace(buffers=("device",))
         executor.host_storage = SimpleNamespace(host_buffer="host")
         executor.transfer_backend = "dma"
         executor._write_acks = []
-        ranges = [(0, 64, 128, 32)]
-        executor._transfer_ranges = Mock(return_value=ranges)
+        executor._write_workspace = object()
+        executor._fill_workspace_ranges = Mock(return_value=(3, 32))
         stream = object()
         finish = Mock()
 
@@ -217,9 +262,12 @@ class GroupAwareWireTest(unittest.TestCase):
             "d2h",
             executor.layout.buffers,
             executor.host_storage.host_buffer,
-            ranges,
+            (),
             stream,
             backend="dma",
+            workspace=executor._write_workspace,
+            num_ranges=3,
+            max_bytes=32,
         )
         finish.record.assert_called_once_with(stream)
 
@@ -233,6 +281,7 @@ class GroupAwareWireTest(unittest.TestCase):
 
         executor = L2CacheExecutor.__new__(L2CacheExecutor)
         executor._ack_lock = threading.Lock()
+        executor.attn_tp_rank = 0
         executor._ready_load_op_ids = []
         executor._load_acks = []
         executor.load_stream = object()
@@ -240,6 +289,8 @@ class GroupAwareWireTest(unittest.TestCase):
         executor.layout = SimpleNamespace(buffers=("device",), consumers=(("field",),))
         executor.host_storage = SimpleNamespace(host_buffer="host")
         executor._transfer_ranges = Mock(return_value=[(0, 64, 128, 32)])
+        executor._load_workspace = object()
+        executor._fill_workspace_ranges = Mock(return_value=(2, 32))
         load_events = SimpleNamespace(start_event=Mock(), layer_done_events=[None])
         tracker = Mock()
         tracker.begin_load.return_value = 0

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -6,8 +6,9 @@ import os
 import sys
 import threading
 import unittest
+from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
@@ -309,6 +310,96 @@ class GroupAwareWireTest(unittest.TestCase):
         log_info.assert_called_once_with(
             "[L2] load started: operations=%d blocks=%d", 1, 2
         )
+
+    def test_loadback_commits_one_immutable_table_and_launches_layer_slices(self):
+        try:
+            import tokenspeed.runtime.cache.l2.executor as executor_module
+
+            L2CacheExecutor = executor_module.L2CacheExecutor
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs runtime dependencies: {exc}")
+
+        executor = L2CacheExecutor.__new__(L2CacheExecutor)
+        executor._ack_lock = threading.Lock()
+        executor._verifier = None
+        executor.attn_tp_rank = 0
+        executor._ready_load_op_ids = []
+        executor._load_acks = []
+        executor.load_stream = object()
+        executor.transfer_backend = "auto"
+        device = SimpleNamespace(type="cuda")
+        device_buffer = SimpleNamespace(device=device)
+        executor.layout = SimpleNamespace(
+            buffers=(device_buffer,),
+            consumers=(("layer.0",), ("layer.1",)),
+        )
+        executor.host_storage = SimpleNamespace(host_buffer="host")
+        layer_ranges = [
+            [(0, 64, 128, 32), (1, 96, 160, 16)],
+            [(0, 192, 256, 48)],
+        ]
+        executor._transfer_ranges = Mock(side_effect=layer_ranges)
+        workspace = Mock()
+        workspace.load_range_batches.return_value = ((0, 2, 32), (2, 1, 48))
+        executor._load_workspaces = (workspace,)
+        load_events = SimpleNamespace(
+            start_event=Mock(), layer_done_events=[None, None]
+        )
+        tracker = Mock()
+        tracker.begin_load.return_value = 0
+        tracker.event_sets = [load_events]
+        executor._load_trackers = [(tracker, 2)]
+        finishes = [Mock(), Mock()]
+
+        with (
+            patch.object(executor_module, "get_is_capture_mode", return_value=False),
+            patch.object(
+                executor_module.device_module,
+                "stream",
+                return_value=nullcontext(),
+            ),
+            patch.object(executor_module.device_module, "Event", side_effect=finishes),
+            patch.object(executor_module, "transfer_cache_ranges") as transfer,
+        ):
+            executor._start_loading([9], [(0, 2, 1)])
+
+        workspace.load_range_batches.assert_called_once_with(layer_ranges)
+        workspace.commit_ranges.assert_called_once_with(3, device, non_blocking=True)
+        self.assertEqual(
+            transfer.call_args_list,
+            [
+                call(
+                    "h2d",
+                    executor.layout.buffers,
+                    executor.host_storage.host_buffer,
+                    (),
+                    executor.load_stream,
+                    backend="auto",
+                    workspace=workspace,
+                    num_ranges=2,
+                    max_bytes=32,
+                    range_offset=0,
+                    ranges_committed=True,
+                ),
+                call(
+                    "h2d",
+                    executor.layout.buffers,
+                    executor.host_storage.host_buffer,
+                    (),
+                    executor.load_stream,
+                    backend="auto",
+                    workspace=workspace,
+                    num_ranges=1,
+                    max_bytes=48,
+                    range_offset=2,
+                    ranges_committed=True,
+                ),
+            ],
+        )
+        finishes[0].record.assert_called_once_with(executor.load_stream)
+        finishes[1].record.assert_called_once_with(executor.load_stream)
+        self.assertIs(load_events.layer_done_events[0], finishes[0])
+        self.assertIs(load_events.layer_done_events[1], finishes[1])
 
 
 class CompactLayoutRoundTripTest(unittest.TestCase):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/host_transfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/host_transfer.py
@@ -43,6 +43,8 @@ class HostTransferWorkspace:
         self._address_table: torch.Tensor | None = None
         self._range_host: torch.Tensor | None = None
         self._range_device: torch.Tensor | None = None
+        self._num_loaded_ranges = 0
+        self._num_committed_ranges = 0
 
     def ensure_range_host(self, num_ranges: int) -> torch.Tensor:
         if num_ranges <= 0:
@@ -77,8 +79,14 @@ class HostTransferWorkspace:
             self._address_key = key
         return self._address_table
 
-    def commit_ranges(self, num_ranges: int, device: torch.device) -> torch.Tensor:
-        if self._range_host is None or self._range_host.shape[0] < num_ranges:
+    def commit_ranges(
+        self,
+        num_ranges: int,
+        device: torch.device,
+        *,
+        non_blocking: bool = False,
+    ) -> torch.Tensor:
+        if self._range_host is None or self._num_loaded_ranges < num_ranges:
             raise ValueError("range host table is smaller than num_ranges")
         if self._range_device is None or self._range_device.shape[0] < num_ranges:
             capacity = num_ranges
@@ -87,11 +95,10 @@ class HostTransferWorkspace:
             self._range_device = torch.empty(
                 (capacity, 4), dtype=torch.int64, device=device
             )
-        # Sync: layerwise load rewrites this pinned table as soon as the call
-        # returns; async HtoD would race and corrupt later small KDA restores.
         self._range_device[:num_ranges].copy_(
-            self._range_host[:num_ranges], non_blocking=False
+            self._range_host[:num_ranges], non_blocking=non_blocking
         )
+        self._num_committed_ranges = num_ranges
         return self._range_device
 
     def load_ranges(
@@ -103,12 +110,52 @@ class HostTransferWorkspace:
             return 0, 0
         host = self.ensure_range_host(num_ranges)
         host[:num_ranges].copy_(torch.as_tensor(ranges, dtype=torch.int64))
+        self._num_loaded_ranges = num_ranges
         return num_ranges, max(int(row[3]) for row in ranges)
 
-    def host_rows(self, num_ranges: int) -> torch.Tensor:
+    def load_range_batches(
+        self,
+        batches: Sequence[Sequence[tuple[int, int, int, int]]],
+    ) -> tuple[tuple[int, int, int], ...]:
+        """Load immutable range batches into one pinned table.
+
+        Args:
+            batches: Per-launch range rows. Empty launches remain represented.
+
+        Returns:
+            One ``(range_offset, num_ranges, max_bytes)`` descriptor per batch.
+        """
+
+        descriptors = []
+        flat_ranges = []
+        range_offset = 0
+        for ranges in batches:
+            num_ranges = len(ranges)
+            max_bytes = max((int(row[3]) for row in ranges), default=0)
+            descriptors.append((range_offset, num_ranges, max_bytes))
+            flat_ranges.extend(ranges)
+            range_offset += num_ranges
+        if flat_ranges:
+            host = self.ensure_range_host(len(flat_ranges))
+            host[: len(flat_ranges)].copy_(
+                torch.as_tensor(flat_ranges, dtype=torch.int64)
+            )
+        self._num_loaded_ranges = len(flat_ranges)
+        return tuple(descriptors)
+
+    def host_rows(self, num_ranges: int, range_offset: int = 0) -> torch.Tensor:
         if self._range_host is None:
             raise ValueError("range host table is empty")
-        return self._range_host[:num_ranges]
+        if range_offset < 0 or range_offset + num_ranges > self._num_loaded_ranges:
+            raise ValueError("range host slice lies outside the table")
+        return self._range_host[range_offset : range_offset + num_ranges]
+
+    def device_rows(self, range_offset: int, num_ranges: int) -> torch.Tensor:
+        if self._range_device is None:
+            raise ValueError("range device table is empty")
+        if range_offset < 0 or range_offset + num_ranges > self._num_committed_ranges:
+            raise ValueError("range device slice lies outside the table")
+        return self._range_device[range_offset : range_offset + num_ranges]
 
 
 def _triton_is_unavailable(error: Exception) -> bool:
@@ -193,6 +240,8 @@ def transfer_cache_ranges(
     num_ranges: int | None = None,
     max_bytes: int | None = None,
     grid_cap: int | None = None,
+    range_offset: int = 0,
+    ranges_committed: bool = False,
 ) -> None:
     """Copy byte ranges between cache buffers and compact pinned Host memory.
 
@@ -210,6 +259,8 @@ def transfer_cache_ranges(
             ``workspace.ensure_range_host``.
         max_bytes: Largest ``num_bytes`` among those rows.
         grid_cap: Max Triton CTAs; defaults to ``TOKENSPEED_HOST_CACHE_GRID_CAP``.
+        range_offset: First row of an immutable, pre-filled workspace batch.
+        ranges_committed: Read the Device table slice without uploading metadata.
 
     Returns:
         None. Completion is observed by recording an event on ``stream``.
@@ -219,7 +270,13 @@ def transfer_cache_ranges(
         raise ValueError(f"unknown cache transfer direction {direction!r}")
     if backend not in ("auto", "triton", "dma"):
         raise ValueError(f"unknown cache transfer backend {backend!r}")
+    if range_offset < 0:
+        raise ValueError("range_offset must be non-negative")
+    if ranges_committed and (workspace is None or num_ranges is None):
+        raise ValueError("committed ranges require workspace and num_ranges")
     if num_ranges is None:
+        if range_offset != 0:
+            raise ValueError("range_offset requires pre-filled ranges")
         _validate_ranges(device_buffers, host_buffer, ranges)
         if not ranges:
             return
@@ -249,8 +306,10 @@ def transfer_cache_ranges(
                 if prepared_ranges is not None:
                     tables.load_ranges(prepared_ranges)
                 address_table = tables.bind_addresses(device_buffers, host_buffer)
-                range_table = tables.commit_ranges(
-                    prepared_count, device_buffers[0].device
+                range_table = (
+                    tables.device_rows(range_offset, prepared_count)
+                    if ranges_committed
+                    else tables.commit_ranges(prepared_count, device_buffers[0].device)
                 )
                 _transfer_cache_ranges_triton(
                     address_table,
@@ -277,7 +336,7 @@ def transfer_cache_ranges(
         if prepared_ranges is None:
             prepared_ranges = [
                 (int(row[0]), int(row[1]), int(row[2]), int(row[3]))
-                for row in workspace.host_rows(prepared_count)
+                for row in workspace.host_rows(prepared_count, range_offset)
             ]
         _transfer_dma(
             direction,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/host_transfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/host_transfer.py
@@ -87,8 +87,10 @@ class HostTransferWorkspace:
             self._range_device = torch.empty(
                 (capacity, 4), dtype=torch.int64, device=device
             )
+        # Sync: layerwise load rewrites this pinned table as soon as the call
+        # returns; async HtoD would race and corrupt later small KDA restores.
         self._range_device[:num_ranges].copy_(
-            self._range_host[:num_ranges], non_blocking=True
+            self._range_host[:num_ranges], non_blocking=False
         )
         return self._range_device
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/host_transfer.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/host_transfer.py
@@ -30,8 +30,83 @@ import torch
 from tokenspeed_kernel.ops.kvcache.triton import (
     transfer_cache_ranges as _transfer_cache_ranges_triton,
 )
+from tokenspeed_kernel.platform import current_platform
 
 _mapped_host_triton_available: bool | None = None
+
+
+class HostTransferWorkspace:
+    """Reusable address/range tables for one Host-cache transfer stream."""
+
+    def __init__(self) -> None:
+        self._address_key: tuple[int, ...] | None = None
+        self._address_table: torch.Tensor | None = None
+        self._range_host: torch.Tensor | None = None
+        self._range_device: torch.Tensor | None = None
+
+    def ensure_range_host(self, num_ranges: int) -> torch.Tensor:
+        if num_ranges <= 0:
+            raise ValueError("num_ranges must be positive")
+        if self._range_host is None or self._range_host.shape[0] < num_ranges:
+            capacity = num_ranges
+            if self._range_host is not None:
+                capacity = max(capacity, self._range_host.shape[0] * 2)
+            self._range_host = torch.empty(
+                (capacity, 4), dtype=torch.int64, pin_memory=True
+            )
+        return self._range_host
+
+    def bind_addresses(
+        self,
+        device_buffers: Sequence[torch.Tensor],
+        host_buffer: torch.Tensor,
+    ) -> torch.Tensor:
+        device = device_buffers[0].device
+        key = tuple(int(buffer.data_ptr()) for buffer in device_buffers) + (
+            int(current_platform().device_visible_data_ptr(host_buffer)),
+            int(device.index if device.index is not None else 0),
+        )
+        if self._address_table is None or self._address_key != key:
+            addresses = [int(buffer.data_ptr()) for buffer in device_buffers]
+            addresses.append(
+                int(current_platform().device_visible_data_ptr(host_buffer))
+            )
+            self._address_table = torch.tensor(
+                addresses, dtype=torch.uint64, device=device
+            )
+            self._address_key = key
+        return self._address_table
+
+    def commit_ranges(self, num_ranges: int, device: torch.device) -> torch.Tensor:
+        if self._range_host is None or self._range_host.shape[0] < num_ranges:
+            raise ValueError("range host table is smaller than num_ranges")
+        if self._range_device is None or self._range_device.shape[0] < num_ranges:
+            capacity = num_ranges
+            if self._range_device is not None:
+                capacity = max(capacity, self._range_device.shape[0] * 2)
+            self._range_device = torch.empty(
+                (capacity, 4), dtype=torch.int64, device=device
+            )
+        self._range_device[:num_ranges].copy_(
+            self._range_host[:num_ranges], non_blocking=True
+        )
+        return self._range_device
+
+    def load_ranges(
+        self,
+        ranges: Sequence[tuple[int, int, int, int]],
+    ) -> tuple[int, int]:
+        num_ranges = len(ranges)
+        if num_ranges <= 0:
+            return 0, 0
+        host = self.ensure_range_host(num_ranges)
+        host[:num_ranges].copy_(torch.as_tensor(ranges, dtype=torch.int64))
+        return num_ranges, max(int(row[3]) for row in ranges)
+
+    def host_rows(self, num_ranges: int) -> torch.Tensor:
+        if self._range_host is None:
+            raise ValueError("range host table is empty")
+        return self._range_host[:num_ranges]
 
 
 def _triton_is_unavailable(error: Exception) -> bool:
@@ -112,6 +187,10 @@ def transfer_cache_ranges(
     stream,
     *,
     backend: Literal["auto", "triton", "dma"] = "auto",
+    workspace: HostTransferWorkspace | None = None,
+    num_ranges: int | None = None,
+    max_bytes: int | None = None,
+    grid_cap: int | None = None,
 ) -> None:
     """Copy byte ranges between cache buffers and compact pinned Host memory.
 
@@ -119,9 +198,16 @@ def transfer_cache_ranges(
         direction: ``"d2h"`` for snapshot/store or ``"h2d"`` for load/recover.
         device_buffers: Device tensors referenced by range buffer indices.
         host_buffer: Contiguous pinned uint8 Host allocation.
-        ranges: ``(device_buffer_index, device_offset, host_offset, num_bytes)`` rows.
+        ranges: ``(device_buffer_index, device_offset, host_offset, num_bytes)``
+            rows. Ignored when ``num_ranges`` is set on a pre-filled workspace.
         stream: Device stream that orders the asynchronous copies.
         backend: Prefer one mapped-Host Triton launch or use asynchronous DMA.
+        workspace: Reused address/range tables for this stream. Required when
+            ``num_ranges`` is set.
+        num_ranges: Valid leading rows already written to
+            ``workspace.ensure_range_host``.
+        max_bytes: Largest ``num_bytes`` among those rows.
+        grid_cap: Max Triton CTAs; defaults to ``TOKENSPEED_HOST_CACHE_GRID_CAP``.
 
     Returns:
         None. Completion is observed by recording an event on ``stream``.
@@ -131,9 +217,21 @@ def transfer_cache_ranges(
         raise ValueError(f"unknown cache transfer direction {direction!r}")
     if backend not in ("auto", "triton", "dma"):
         raise ValueError(f"unknown cache transfer backend {backend!r}")
-    _validate_ranges(device_buffers, host_buffer, ranges)
-    if not ranges:
-        return
+    if num_ranges is None:
+        _validate_ranges(device_buffers, host_buffer, ranges)
+        if not ranges:
+            return
+        prepared_ranges = ranges
+        prepared_count = len(ranges)
+        prepared_max_bytes = max(row[3] for row in ranges)
+    else:
+        if workspace is None or max_bytes is None:
+            raise ValueError("pre-filled ranges require workspace and max_bytes")
+        if num_ranges <= 0:
+            return
+        prepared_ranges = None
+        prepared_count = num_ranges
+        prepared_max_bytes = max_bytes
 
     global _mapped_host_triton_available
     device_module = torch.get_device_module(device_buffers[0].device)
@@ -145,11 +243,21 @@ def transfer_cache_ranges(
             and _mapped_host_triton_available is not False
         ):
             try:
+                tables = workspace or HostTransferWorkspace()
+                if prepared_ranges is not None:
+                    tables.load_ranges(prepared_ranges)
+                address_table = tables.bind_addresses(device_buffers, host_buffer)
+                range_table = tables.commit_ranges(
+                    prepared_count, device_buffers[0].device
+                )
                 _transfer_cache_ranges_triton(
-                    list(device_buffers),
-                    host_buffer,
-                    list(ranges),
+                    address_table,
+                    range_table,
                     0 if direction == "d2h" else 1,
+                    num_ranges=prepared_count,
+                    max_bytes=prepared_max_bytes,
+                    num_device_buffers=len(device_buffers),
+                    grid_cap=grid_cap,
                 )
                 _mapped_host_triton_available = True
                 return
@@ -164,9 +272,14 @@ def transfer_cache_ranges(
                 )
         if backend == "triton":
             raise RuntimeError("mapped Host Triton transfer is unavailable")
+        if prepared_ranges is None:
+            prepared_ranges = [
+                (int(row[0]), int(row[1]), int(row[2]), int(row[3]))
+                for row in workspace.host_rows(prepared_count)
+            ]
         _transfer_dma(
             direction,
             device_buffers,
             host_buffer,
-            ranges,
+            prepared_ranges,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -34,6 +34,8 @@ from tokenspeed_kernel.platform import current_platform, pdl_enabled
 
 _PER_LAYER_GRID_CAP = int(os.environ.get("TOKENSPEED_KV_GRID_CAP", "64"))
 _ALL_LAYER_GRID_CAP = int(os.environ.get("TOKENSPEED_KV_ALL_LAYER_GRID_CAP", "32"))
+_HOST_CACHE_GRID_CAP = int(os.environ.get("TOKENSPEED_HOST_CACHE_GRID_CAP", "64"))
+_HOST_CACHE_BLOCK_SIZE = 4096
 
 _is_nvidia = current_platform().is_nvidia
 
@@ -73,54 +75,65 @@ __all__ = [
 def _transfer_cache_ranges_kernel(
     buffer_addresses_ptr,
     ranges_ptr,
+    num_ranges,
+    num_chunks,
     NUM_DEVICE_BUFFERS: tl.constexpr,
     DIRECTION: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    range_id = tl.program_id(0)
-    byte_offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    range_offset = range_id * 4
-    device_buffer_index = tl.load(ranges_ptr + range_offset)
-    device_offset = tl.load(ranges_ptr + range_offset + 1)
-    host_offset = tl.load(ranges_ptr + range_offset + 2)
-    num_bytes = tl.load(ranges_ptr + range_offset + 3)
+    work_items = num_ranges * num_chunks
+    pid = tl.program_id(0)
+    nprogs = tl.num_programs(0)
+    for work_id in tl.range(pid, work_items, nprogs):
+        range_id = work_id // num_chunks
+        chunk_id = work_id - range_id * num_chunks
+        range_offset = range_id * 4
+        device_buffer_index = tl.load(ranges_ptr + range_offset)
+        device_offset = tl.load(ranges_ptr + range_offset + 1)
+        host_offset = tl.load(ranges_ptr + range_offset + 2)
+        num_bytes = tl.load(ranges_ptr + range_offset + 3)
+        byte_offsets = chunk_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
 
-    device_address = tl.load(buffer_addresses_ptr + device_buffer_index)
-    host_address = tl.load(buffer_addresses_ptr + NUM_DEVICE_BUFFERS)
-    device_ptr = tl.cast(device_address + device_offset, tl.pointer_type(tl.uint8))
-    host_ptr = tl.cast(host_address + host_offset, tl.pointer_type(tl.uint8))
-    mask = byte_offsets < num_bytes
-    if DIRECTION == 0:
-        values = tl.load(device_ptr + byte_offsets, mask=mask, cache_modifier=".cg")
-        tl.store(
-            host_ptr + byte_offsets,
-            values,
-            mask=mask,
-            cache_modifier=".cs",
-        )
-    else:
-        values = tl.load(host_ptr + byte_offsets, mask=mask, cache_modifier=".cg")
-        tl.store(device_ptr + byte_offsets, values, mask=mask)
+        device_address = tl.load(buffer_addresses_ptr + device_buffer_index)
+        host_address = tl.load(buffer_addresses_ptr + NUM_DEVICE_BUFFERS)
+        device_ptr = tl.cast(device_address + device_offset, tl.pointer_type(tl.uint8))
+        host_ptr = tl.cast(host_address + host_offset, tl.pointer_type(tl.uint8))
+        mask = byte_offsets < num_bytes
+        if DIRECTION == 0:
+            values = tl.load(device_ptr + byte_offsets, mask=mask, cache_modifier=".cg")
+            tl.store(
+                host_ptr + byte_offsets,
+                values,
+                mask=mask,
+                cache_modifier=".cs",
+            )
+        else:
+            values = tl.load(host_ptr + byte_offsets, mask=mask, cache_modifier=".cg")
+            tl.store(device_ptr + byte_offsets, values, mask=mask)
 
 
 def transfer_cache_ranges(
-    device_buffers: list[torch.Tensor],
-    host_buffer: torch.Tensor,
-    ranges: list[tuple[int, int, int, int]],
+    address_table: torch.Tensor,
+    range_table: torch.Tensor,
     direction: int,
+    *,
+    num_ranges: int,
+    max_bytes: int,
+    num_device_buffers: int,
+    grid_cap: int | None = None,
 ) -> None:
-    """Copy byte ranges between device buffers and mapped Host memory.
-
-    The Host tensor is passed indirectly through its GPU-visible UVA address;
-    Triton receives only CUDA tensors containing addresses and descriptors.
-    Argument shape, dtype, and bounds validation belongs to the public
-    transport wrapper.
+    """Copy prepared Host-cache ranges with a capped grid-stride launch.
 
     Args:
-        device_buffers: Contiguous device cache tensors.
-        host_buffer: Contiguous pinned CPU uint8 buffer.
-        ranges: ``(device_buffer_index, device_offset, host_offset, num_bytes)``.
+        address_table: Device ``uint64`` table of device-buffer pointers
+            followed by the mapped Host pointer.
+        range_table: Device ``int64`` rows
+            ``(device_buffer_index, device_offset, host_offset, num_bytes)``.
         direction: ``0`` for device-to-Host and ``1`` for Host-to-device.
+        num_ranges: Valid leading rows in ``range_table``.
+        max_bytes: Largest ``num_bytes`` among those rows.
+        num_device_buffers: Count of device pointers in ``address_table``.
+        grid_cap: Max CTAs. Defaults to ``TOKENSPEED_HOST_CACHE_GRID_CAP`` (64).
 
     Returns:
         None; the copy is enqueued on the current device stream.
@@ -128,20 +141,21 @@ def transfer_cache_ranges(
 
     if direction not in (0, 1):
         raise ValueError("direction must be 0 (D2H) or 1 (H2D)")
-    if not ranges:
+    if num_ranges <= 0:
         return
-    device = device_buffers[0].device
-    platform = current_platform()
-    addresses = [buffer.data_ptr() for buffer in device_buffers]
-    addresses.append(platform.device_visible_data_ptr(host_buffer))
-    address_table = torch.tensor(addresses, dtype=torch.uint64, device=device)
-    range_table = torch.tensor(ranges, dtype=torch.int64, device=device)
-    block_size = 4096
-    grid = (len(ranges), triton.cdiv(max(row[3] for row in ranges), block_size))
+    block_size = _HOST_CACHE_BLOCK_SIZE
+    num_chunks = triton.cdiv(max_bytes, block_size)
+    work_items = num_ranges * num_chunks
+    cap = _HOST_CACHE_GRID_CAP if grid_cap is None else int(grid_cap)
+    if cap <= 0:
+        raise ValueError("grid_cap must be positive")
+    grid = (min(cap, work_items),)
     _transfer_cache_ranges_kernel[grid](
         address_table,
         range_table,
-        NUM_DEVICE_BUFFERS=len(device_buffers),
+        num_ranges,
+        num_chunks,
+        NUM_DEVICE_BUFFERS=num_device_buffers,
         DIRECTION=direction,
         BLOCK_SIZE=block_size,
         num_warps=8,

--- a/tokenspeed-kernel/test/ops/test_host_cache_transfer.py
+++ b/tokenspeed-kernel/test/ops/test_host_cache_transfer.py
@@ -12,6 +12,29 @@ requires_cuda = pytest.mark.skipif(
 )
 
 
+def test_workspace_load_ranges_empty_is_noop():
+    from tokenspeed_kernel.ops.kvcache.host_transfer import HostTransferWorkspace
+
+    workspace = HostTransferWorkspace()
+    assert workspace.load_ranges(()) == (0, 0)
+    assert workspace._range_host is None
+
+
+def test_workspace_reuses_host_range_storage():
+    from tokenspeed_kernel.ops.kvcache.host_transfer import HostTransferWorkspace
+
+    workspace = HostTransferWorkspace()
+    first = ((0, 0, 0, 8), (1, 16, 32, 24))
+    count, max_bytes = workspace.load_ranges(first)
+    assert count == 2
+    assert max_bytes == 24
+    host_ptr = workspace._range_host.data_ptr()
+    count, max_bytes = workspace.load_ranges(((0, 8, 8, 16),))
+    assert count == 1
+    assert max_bytes == 16
+    assert workspace._range_host.data_ptr() == host_ptr
+
+
 def test_unrelated_triton_runtime_error_does_not_fall_back_to_dma():
     assert not _triton_is_unavailable(
         RuntimeError("requested kernel specialization is not available")
@@ -51,3 +74,51 @@ def test_cache_ranges_round_trip_across_multiple_device_buffers(backend):
     assert torch.equal(
         second_bytes[16:48].cpu(), torch.full((32,), 9, dtype=torch.uint8)
     )
+
+
+@requires_cuda
+def test_cache_ranges_grid_stride_and_workspace_reuse():
+    from tokenspeed_kernel.ops.kvcache.host_transfer import HostTransferWorkspace
+
+    device = torch.arange(256, dtype=torch.uint8, device="cuda")
+    host = torch.zeros(256, dtype=torch.uint8, pin_memory=True)
+    first = tuple((0, offset, offset, 8) for offset in range(0, 128, 8))
+    second = tuple((0, offset, offset, 8) for offset in range(128, 256, 8))
+    workspace = HostTransferWorkspace()
+    stream = torch.cuda.Stream()
+
+    try:
+        transfer_cache_ranges(
+            "d2h",
+            (device,),
+            host,
+            first,
+            stream,
+            backend="triton",
+            workspace=workspace,
+            grid_cap=3,
+        )
+    except RuntimeError as error:
+        message = str(error).lower()
+        if "unavailable" in message or "not device-mapped" in message:
+            pytest.skip(str(error))
+        raise
+    stream.synchronize()
+    assert torch.equal(host[0:128], device[0:128].cpu())
+    address_ptr = workspace._address_table.data_ptr()
+    range_ptr = workspace._range_device.data_ptr()
+
+    transfer_cache_ranges(
+        "d2h",
+        (device,),
+        host,
+        second,
+        stream,
+        backend="triton",
+        workspace=workspace,
+        grid_cap=3,
+    )
+    stream.synchronize()
+    assert torch.equal(host[128:256], device[128:256].cpu())
+    assert workspace._address_table.data_ptr() == address_ptr
+    assert workspace._range_device.data_ptr() == range_ptr

--- a/tokenspeed-kernel/test/ops/test_host_cache_transfer.py
+++ b/tokenspeed-kernel/test/ops/test_host_cache_transfer.py
@@ -122,3 +122,67 @@ def test_cache_ranges_grid_stride_and_workspace_reuse():
     assert torch.equal(host[128:256], device[128:256].cpu())
     assert workspace._address_table.data_ptr() == address_ptr
     assert workspace._range_device.data_ptr() == range_ptr
+
+
+@requires_cuda
+def test_layerwise_workspace_reuse_preserves_small_h2d_after_large():
+    """Layer-wise loads refill the pinned range table between launches.
+
+    A non-blocking commit of that table races the next CPU refill and has been
+    observed to drop KDA field restores after large MLA range batches.
+    """
+
+    from tokenspeed_kernel.ops.kvcache.host_transfer import HostTransferWorkspace
+
+    device = torch.zeros(1 << 20, dtype=torch.uint8, device="cuda")
+    host = torch.arange(1 << 20, dtype=torch.uint8, pin_memory=True)
+    workspace = HostTransferWorkspace()
+    stream = torch.cuda.Stream()
+    # One large MLA-like batch, then several small KDA-like (conv, recurrent)
+    # pairs that reuse the same workspace without an intervening synchronize.
+    large = tuple((0, i * 64, i * 64, 64) for i in range(400))
+    small_batches = [
+        ((0, 800 * 64, 800 * 64, 32), (0, 801 * 64, 801 * 64, 48)),
+        ((0, 802 * 64, 802 * 64, 32), (0, 803 * 64, 803 * 64, 48)),
+        ((0, 804 * 64, 804 * 64, 32), (0, 805 * 64, 805 * 64, 48)),
+    ]
+    try:
+        count, max_bytes = workspace.load_ranges(large)
+        transfer_cache_ranges(
+            "h2d",
+            (device,),
+            host,
+            (),
+            stream,
+            backend="triton",
+            workspace=workspace,
+            num_ranges=count,
+            max_bytes=max_bytes,
+            grid_cap=64,
+        )
+        for batch in small_batches:
+            count, max_bytes = workspace.load_ranges(batch)
+            transfer_cache_ranges(
+                "h2d",
+                (device,),
+                host,
+                (),
+                stream,
+                backend="triton",
+                workspace=workspace,
+                num_ranges=count,
+                max_bytes=max_bytes,
+                grid_cap=64,
+            )
+    except RuntimeError as error:
+        message = str(error).lower()
+        if "unavailable" in message or "not device-mapped" in message:
+            pytest.skip(str(error))
+        raise
+    stream.synchronize()
+    for batch in small_batches:
+        for _, device_offset, host_offset, num_bytes in batch:
+            assert torch.equal(
+                device[device_offset : device_offset + num_bytes].cpu(),
+                host[host_offset : host_offset + num_bytes],
+            )

--- a/tokenspeed-kernel/test/ops/test_host_cache_transfer.py
+++ b/tokenspeed-kernel/test/ops/test_host_cache_transfer.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 import torch
 from tokenspeed_kernel.ops.kvcache.host_transfer import (
@@ -33,6 +37,93 @@ def test_workspace_reuses_host_range_storage():
     assert count == 1
     assert max_bytes == 16
     assert workspace._range_host.data_ptr() == host_ptr
+
+
+def test_workspace_load_range_batches_flattens_rows_once():
+    from tokenspeed_kernel.ops.kvcache.host_transfer import HostTransferWorkspace
+
+    workspace = HostTransferWorkspace()
+    host = MagicMock()
+    host_rows = MagicMock()
+    host.__getitem__.return_value = host_rows
+    workspace.ensure_range_host = MagicMock(return_value=host)
+    batches = (
+        ((0, 0, 32, 8), (1, 16, 64, 24)),
+        (),
+        ((0, 8, 96, 16),),
+    )
+
+    descriptors = workspace.load_range_batches(batches)
+
+    assert descriptors == ((0, 2, 24), (2, 0, 0), (2, 1, 16))
+    workspace.ensure_range_host.assert_called_once_with(3)
+    host.__getitem__.assert_called_once_with(slice(None, 3))
+    copied = host_rows.copy_.call_args.args[0]
+    assert torch.equal(
+        copied,
+        torch.tensor(
+            ((0, 0, 32, 8), (1, 16, 64, 24), (0, 8, 96, 16)),
+            dtype=torch.int64,
+        ),
+    )
+
+
+def test_workspace_device_rows_returns_committed_slice_without_copy():
+    from tokenspeed_kernel.ops.kvcache.host_transfer import HostTransferWorkspace
+
+    workspace = HostTransferWorkspace()
+    workspace._range_device = torch.arange(24, dtype=torch.int64).reshape(6, 4)
+    workspace._num_committed_ranges = 6
+
+    rows = workspace.device_rows(2, 3)
+
+    assert torch.equal(rows, workspace._range_device[2:5])
+    assert rows.data_ptr() == workspace._range_device[2:].data_ptr()
+
+
+def test_committed_range_slice_does_not_upload_metadata_again(monkeypatch):
+    import tokenspeed_kernel.ops.kvcache.host_transfer as host_transfer
+
+    workspace = MagicMock()
+    address_table = object()
+    range_table = object()
+    workspace.bind_addresses.return_value = address_table
+    workspace.device_rows.return_value = range_table
+    device = SimpleNamespace(type="cuda")
+    device_buffer = SimpleNamespace(device=device)
+    stream = object()
+    device_module = MagicMock()
+    device_module.stream.return_value = nullcontext()
+    triton_transfer = MagicMock()
+    monkeypatch.setattr(torch, "get_device_module", lambda _: device_module)
+    monkeypatch.setattr(host_transfer, "_transfer_cache_ranges_triton", triton_transfer)
+    monkeypatch.setattr(host_transfer, "_mapped_host_triton_available", None)
+
+    host_transfer.transfer_cache_ranges(
+        "h2d",
+        (device_buffer,),
+        object(),
+        (),
+        stream,
+        backend="triton",
+        workspace=workspace,
+        num_ranges=2,
+        max_bytes=64,
+        range_offset=7,
+        ranges_committed=True,
+    )
+
+    workspace.commit_ranges.assert_not_called()
+    workspace.device_rows.assert_called_once_with(7, 2)
+    triton_transfer.assert_called_once_with(
+        address_table,
+        range_table,
+        1,
+        num_ranges=2,
+        max_bytes=64,
+        num_device_buffers=1,
+        grid_cap=None,
+    )
 
 
 def test_unrelated_triton_runtime_error_does_not_fall_back_to_dma():
@@ -126,11 +217,7 @@ def test_cache_ranges_grid_stride_and_workspace_reuse():
 
 @requires_cuda
 def test_layerwise_workspace_reuse_preserves_small_h2d_after_large():
-    """Layer-wise loads refill the pinned range table between launches.
-
-    A non-blocking commit of that table races the next CPU refill and has been
-    observed to drop KDA field restores after large MLA range batches.
-    """
+    """One immutable table keeps later KDA slices intact after a large MLA batch."""
 
     from tokenspeed_kernel.ops.kvcache.host_transfer import HostTransferWorkspace
 
@@ -139,7 +226,7 @@ def test_layerwise_workspace_reuse_preserves_small_h2d_after_large():
     workspace = HostTransferWorkspace()
     stream = torch.cuda.Stream()
     # One large MLA-like batch, then several small KDA-like (conv, recurrent)
-    # pairs that reuse the same workspace without an intervening synchronize.
+    # slices launched without an intervening synchronize.
     large = tuple((0, i * 64, i * 64, 64) for i in range(400))
     small_batches = [
         ((0, 800 * 64, 800 * 64, 32), (0, 801 * 64, 801 * 64, 48)),
@@ -147,21 +234,12 @@ def test_layerwise_workspace_reuse_preserves_small_h2d_after_large():
         ((0, 804 * 64, 804 * 64, 32), (0, 805 * 64, 805 * 64, 48)),
     ]
     try:
-        count, max_bytes = workspace.load_ranges(large)
-        transfer_cache_ranges(
-            "h2d",
-            (device,),
-            host,
-            (),
-            stream,
-            backend="triton",
-            workspace=workspace,
-            num_ranges=count,
-            max_bytes=max_bytes,
-            grid_cap=64,
-        )
-        for batch in small_batches:
-            count, max_bytes = workspace.load_ranges(batch)
+        batches = (large, *small_batches)
+        descriptors = workspace.load_range_batches(batches)
+        total_ranges = sum(count for _, count, _ in descriptors)
+        with torch.cuda.stream(stream):
+            workspace.commit_ranges(total_ranges, device.device, non_blocking=True)
+        for range_offset, count, max_bytes in descriptors:
             transfer_cache_ranges(
                 "h2d",
                 (device,),
@@ -173,6 +251,8 @@ def test_layerwise_workspace_reuse_preserves_small_h2d_after_large():
                 num_ranges=count,
                 max_bytes=max_bytes,
                 grid_cap=64,
+                range_offset=range_offset,
+                ranges_committed=True,
             )
     except RuntimeError as error:
         message = str(error).lower()

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -320,7 +320,9 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def("submit_requests",
              nb::overload_cast<const std::vector<tokenspeed::RequestSpec>&>(&tokenspeed::Scheduler::SubmitRequests),
              nb::arg("request_specs"))
-        .def("next_execution_plan", [](tokenspeed::Scheduler& s) { return s.NextExecutionPlan(); })
+        .def(
+            "next_execution_plan", [](tokenspeed::Scheduler& s) { return s.NextExecutionPlan(); },
+            nb::call_guard<nb::gil_scoped_release>())
         .def("advance", &tokenspeed::Scheduler::Advance, nb::arg("event"))
         .def("drain_kv_events",
              [](tokenspeed::Scheduler& s) {

--- a/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.cpp
+++ b/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.cpp
@@ -516,74 +516,143 @@ CacheBlockRef CacheCoordinator::AcquireDeviceCachedBlock(const CacheKey& key) co
     return groups_[key.group_id].Index().Find(pool_, key);
 }
 
-CacheBlockRef CacheCoordinator::AcquireHostBlock(std::uint32_t group_id) {
-    _assert(host_pool_ != nullptr, "AcquireHostBlock requires a host pool");
-    _assert(group_id < groups_.size(), "Host block group id out of range");
-    GroupAllocator& target = groups_[group_id].Allocator();
-    const std::int32_t packing = target.CacheBlocksPerLcmBlock();
-    if (CacheBlockRef block_ref = host_pool_->AcquireBlock(group_id, packing)) {
-        return block_ref;
-    }
+CacheCoordinator::HostAllocationBatch CacheCoordinator::AcquireHostBlocks(std::span<const std::uint32_t> group_ids) {
+    _assert(host_pool_ != nullptr, "AcquireHostBlocks requires a host pool");
+    HostAllocationBatch batch;
+    batch.blocks.resize(group_ids.size());
+    batch.stats.requested = group_ids.size();
+    _assert(group_ids.size() <= static_cast<std::size_t>(std::numeric_limits<std::int32_t>::max()),
+            "Host allocation batch request exceeds int32 range");
 
+    std::vector<std::uint32_t> group_order;
+    group_order.reserve(groups_.size());
+    std::vector<bool> seen_group(groups_.size(), false);
+    for (std::size_t i = 0; i < group_ids.size(); ++i) {
+        _assert(group_ids[i] < groups_.size(), "Host block group id out of range");
+        if (!seen_group[group_ids[i]]) {
+            seen_group[group_ids[i]] = true;
+            group_order.push_back(group_ids[i]);
+        }
+    }
+    std::vector<std::vector<std::size_t>> unresolved_by_group(groups_.size());
+    const auto assign = [&](std::span<const std::size_t> indices, std::vector<CacheBlockRef> refs) {
+        _assert(refs.size() <= indices.size(), "Host allocation returned too many blocks");
+        for (std::size_t i = 0; i < refs.size(); ++i) {
+            batch.blocks[indices[i]] = std::move(refs[i]);
+        }
+        return indices.subspan(refs.size());
+    };
+
+    std::vector<std::int32_t> cache_blocks_per_group;
+    cache_blocks_per_group.reserve(groups_.size());
+    for (const CacheGroup& group : groups_) {
+        cache_blocks_per_group.push_back(group.Allocator().CacheBlocksPerLcmBlock());
+    }
+    batch.blocks = host_pool_->AcquireAvailableBlocksInOrder(group_ids, cache_blocks_per_group);
+    for (std::size_t i = 0; i < batch.blocks.size(); ++i) {
+        if (!batch.blocks[i]) {
+            unresolved_by_group[group_ids[i]].push_back(i);
+        }
+    }
     const auto value = [&](std::uint32_t candidate_group, CacheBlockLocation location) {
         const auto metadata = groups_[candidate_group].Index().MetadataFor(*host_pool_, location);
         _assert(metadata.has_value(), "evictable Host block has no cache metadata");
         return std::tuple{metadata->was_acquired, metadata->last_access_epoch, candidate_group, location.lcm_block_id,
                           location.slot_index};
     };
-    using HostCacheValue = decltype(value(group_id, CacheBlockLocation{}));
+    using HostCacheValue = decltype(value(std::uint32_t{}, CacheBlockLocation{}));
 
-    // Reusing one child of an already-bound parent destroys less cache than
-    // rebinding a complete parent from another group.
-    std::vector<CacheBlockLocation> local_victims = groups_[group_id].Index().EvictableLocations(*host_pool_);
-    if (!local_victims.empty()) {
-        const auto victim = std::ranges::min_element(
-            local_victims, {}, [&](CacheBlockLocation location) { return value(group_id, location); });
-        _assert(groups_[group_id].Index().Evict(*host_pool_, *victim).has_value(),
-                "selected Host child is not evictable");
-        CacheBlockRef block_ref = host_pool_->AcquireBlock(group_id, packing);
-        _assert(static_cast<bool>(block_ref), "evicting a same-group Host child did not free a placement");
-        return block_ref;
-    }
-
-    std::optional<std::int32_t> victim_parent;
-    std::optional<HostCacheValue> victim_value;
-    for (std::int32_t parent_id = 1; parent_id <= host_pool_->NumLcmBlocks(); ++parent_id) {
-        const std::optional<std::uint32_t> bound_group = host_pool_->BoundGroup(parent_id);
-        if (!bound_group || !groups_[*bound_group].Index().ParentIsFullyEvictable(
-                                *host_pool_, parent_id, groups_[*bound_group].Allocator().CacheBlocksPerLcmBlock())) {
+    for (std::uint32_t group_id : group_order) {
+        std::vector<std::size_t>& unresolved = unresolved_by_group[group_id];
+        if (unresolved.empty()) {
             continue;
         }
-        std::optional<HostCacheValue> parent_value;
-        for (std::int32_t slot = 0; slot < groups_[*bound_group].Allocator().CacheBlocksPerLcmBlock(); ++slot) {
-            const CacheBlockLocation location{.lcm_block_id = parent_id, .slot_index = slot};
-            if (!host_pool_->IsOccupied(location)) {
+        ++batch.stats.same_group_scans;
+        std::vector<CacheBlockLocation> local_victims = groups_[group_id].Index().EvictableLocations(*host_pool_);
+        std::ranges::sort(local_victims, {}, [&](CacheBlockLocation location) { return value(group_id, location); });
+        const std::size_t victim_count = std::min(unresolved.size(), local_victims.size());
+        for (std::size_t i = 0; i < victim_count; ++i) {
+            _assert(groups_[group_id].Index().Evict(*host_pool_, local_victims[i]).has_value(),
+                    "selected Host child is not evictable");
+        }
+        const std::int32_t packing = groups_[group_id].Allocator().CacheBlocksPerLcmBlock();
+        std::vector<CacheBlockRef> refs =
+            host_pool_->AcquireUpToBlocks(group_id, packing, static_cast<std::int32_t>(unresolved.size()));
+        const std::span<const std::size_t> remaining = assign(unresolved, std::move(refs));
+        unresolved.erase(unresolved.begin(), unresolved.end() - static_cast<std::ptrdiff_t>(remaining.size()));
+    }
+    const bool has_unresolved = std::ranges::any_of(
+        unresolved_by_group, [](const std::vector<std::size_t>& unresolved) { return !unresolved.empty(); });
+    if (has_unresolved) {
+        ++batch.stats.cross_group_scans;
+        std::vector<std::pair<HostCacheValue, std::int32_t>> victim_parents;
+        victim_parents.reserve(static_cast<std::size_t>(host_pool_->NumLcmBlocks()));
+        for (std::int32_t parent_id = 1; parent_id <= host_pool_->NumLcmBlocks(); ++parent_id) {
+            const std::optional<std::uint32_t> bound_group = host_pool_->BoundGroup(parent_id);
+            if (!bound_group ||
+                !groups_[*bound_group].Index().ParentIsFullyEvictable(
+                    *host_pool_, parent_id, groups_[*bound_group].Allocator().CacheBlocksPerLcmBlock())) {
                 continue;
             }
-            const auto child_value = value(*bound_group, location);
-            parent_value = parent_value ? std::max(*parent_value, child_value) : child_value;
+            std::optional<HostCacheValue> parent_value;
+            for (std::int32_t slot = 0; slot < groups_[*bound_group].Allocator().CacheBlocksPerLcmBlock(); ++slot) {
+                const CacheBlockLocation location{.lcm_block_id = parent_id, .slot_index = slot};
+                if (!host_pool_->IsOccupied(location)) {
+                    continue;
+                }
+                const auto child_value = value(*bound_group, location);
+                parent_value = parent_value ? std::max(*parent_value, child_value) : child_value;
+            }
+            _assert(parent_value.has_value(), "evictable Host parent has no children");
+            victim_parents.emplace_back(*parent_value, parent_id);
         }
-        _assert(parent_value.has_value(), "evictable Host parent has no children");
-        if (!victim_value || *parent_value < *victim_value) {
-            victim_parent = parent_id;
-            victim_value = *parent_value;
-        }
-    }
-    if (!victim_parent) {
-        return {};
-    }
+        std::ranges::sort(victim_parents);
 
-    const std::uint32_t bound_group = *host_pool_->BoundGroup(*victim_parent);
-    for (std::int32_t slot = 0; slot < groups_[bound_group].Allocator().CacheBlocksPerLcmBlock(); ++slot) {
-        const CacheBlockLocation location{.lcm_block_id = *victim_parent, .slot_index = slot};
-        if (host_pool_->IsOccupied(location)) {
-            _assert(groups_[bound_group].Index().Evict(*host_pool_, location).has_value(),
-                    "selected Host parent changed before eviction");
+        std::size_t victim_index = 0;
+        for (std::size_t result_index = 0; result_index < group_ids.size() && victim_index < victim_parents.size();
+             ++result_index) {
+            if (batch.blocks[result_index]) {
+                continue;
+            }
+            const std::uint32_t target_group = group_ids[result_index];
+            std::vector<std::size_t>& unresolved = unresolved_by_group[target_group];
+            while (!unresolved.empty() && victim_index < victim_parents.size()) {
+                const std::int32_t victim_parent = victim_parents[victim_index++].second;
+                const std::optional<std::uint32_t> bound_group = host_pool_->BoundGroup(victim_parent);
+                if (!bound_group ||
+                    !groups_[*bound_group].Index().ParentIsFullyEvictable(
+                        *host_pool_, victim_parent, groups_[*bound_group].Allocator().CacheBlocksPerLcmBlock())) {
+                    continue;
+                }
+                const std::int32_t victim_packing = groups_[*bound_group].Allocator().CacheBlocksPerLcmBlock();
+                for (std::int32_t slot = 0; slot < victim_packing; ++slot) {
+                    const CacheBlockLocation location{.lcm_block_id = victim_parent, .slot_index = slot};
+                    if (host_pool_->IsOccupied(location)) {
+                        _assert(groups_[*bound_group].Index().Evict(*host_pool_, location).has_value(),
+                                "selected Host parent changed before eviction");
+                    }
+                }
+
+                const std::int32_t target_packing = groups_[target_group].Allocator().CacheBlocksPerLcmBlock();
+                std::vector<CacheBlockRef> refs = host_pool_->AcquireUpToBlocksFromEmptyParent(
+                    target_group, target_packing, victim_parent, static_cast<std::int32_t>(unresolved.size()));
+                _assert(!refs.empty(), "evicting a Host parent did not free a placement");
+                const std::span<const std::size_t> remaining = assign(unresolved, std::move(refs));
+                unresolved.erase(unresolved.begin(), unresolved.end() - static_cast<std::ptrdiff_t>(remaining.size()));
+                break;
+            }
         }
     }
-    CacheBlockRef block_ref = host_pool_->AcquireBlock(group_id, packing);
-    _assert(static_cast<bool>(block_ref), "evicting a Host parent did not free a placement");
-    return block_ref;
+    batch.stats.allocated = static_cast<std::size_t>(
+        std::ranges::count_if(batch.blocks, [](const CacheBlockRef& block) { return static_cast<bool>(block); }));
+    batch.stats.unallocated = batch.stats.requested - batch.stats.allocated;
+    return batch;
+}
+
+CacheBlockRef CacheCoordinator::AcquireHostBlock(std::uint32_t group_id) {
+    const std::array groups{group_id};
+    HostAllocationBatch batch = AcquireHostBlocks(groups);
+    return batch.blocks.empty() ? CacheBlockRef{} : std::move(batch.blocks.front());
 }
 
 bool CacheCoordinator::evictCachedBlock(std::uint32_t group_id, CacheBlockLocation location) {

--- a/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.cpp
+++ b/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.cpp
@@ -454,6 +454,9 @@ void CacheCoordinator::QueueCachedBlocksForStore(std::span<const std::string> pr
         return;
     }
     for (const CacheGroup& group : groups_) {
+        if (group.Spec().kind == AttnKind::kMambaState) {
+            continue;
+        }
         for (CacheKey& key : keysForGroup(prefix_hashes, group.Id())) {
             if (group.Index().Contains(pool_, key)) {
                 pending_stores_.push_back(StoreCandidate{.key = std::move(key)});
@@ -462,9 +465,28 @@ void CacheCoordinator::QueueCachedBlocksForStore(std::span<const std::string> pr
     }
 }
 
+void CacheCoordinator::QueueLatestSnapshotBlocksForStore(std::span<const std::string> prefix_hashes) {
+    if (host_pool_ == nullptr) {
+        return;
+    }
+    for (const CacheGroup& group : groups_) {
+        if (group.Spec().kind != AttnKind::kMambaState) {
+            continue;
+        }
+        std::vector<CacheKey> keys = keysForGroup(prefix_hashes, group.Id());
+        for (auto key = keys.rbegin(); key != keys.rend(); ++key) {
+            if (group.Index().Contains(pool_, *key)) {
+                pending_stores_.push_back(StoreCandidate{.key = std::move(*key)});
+                break;
+            }
+        }
+    }
+}
+
 void CacheCoordinator::CacheCompletedBlocks(std::span<BlockTable> tables, std::span<const std::string> prefix_hashes,
                                             std::uint64_t access_epoch, std::int32_t first_new_prefix_page,
-                                            std::int32_t num_computed_tokens, CacheBoundaryKind boundary_kind) {
+                                            std::int32_t num_computed_tokens, CacheBoundaryKind boundary_kind,
+                                            bool stream_completed_to_host) {
     _assert(tables.size() == groups_.size(), "tables/groups size mismatch");
     _assert(first_new_prefix_page >= 0 && static_cast<std::size_t>(first_new_prefix_page) < prefix_hashes.size(),
             "completed page range must be non-empty");
@@ -475,6 +497,7 @@ void CacheCoordinator::CacheCompletedBlocks(std::span<BlockTable> tables, std::s
             .new_prefix_hash_begin = first_new_prefix_page,
             .completed_boundary_kind = boundary_kind,
             .num_computed_tokens = num_computed_tokens,
+            .stream_completed_to_host = stream_completed_to_host,
         };
         cacheDeviceCompletedBlocksForGroup(i, demand, access_epoch);
     }
@@ -483,11 +506,15 @@ void CacheCoordinator::CacheCompletedBlocks(std::span<BlockTable> tables, std::s
 template <CacheTier Tier>
 void CacheCoordinator::cacheFullBlocksForGroup(std::size_t group_index, BlockTable& table,
                                                std::span<const CacheKey> keys, std::int32_t first_cache_block,
-                                               std::uint64_t access_epoch, CacheBoundaryKind boundary_kind) {
+                                               std::uint64_t access_epoch, CacheBoundaryKind boundary_kind,
+                                               bool stream_completed_to_host) {
     std::vector<std::pair<CacheKey, CacheBlockRef>> newly_cached;
+    const bool automatically_streams_to_host =
+        stream_device_cache_to_host_ &&
+        (groups_[group_index].Spec().kind == AttnKind::kSlidingWindow || stream_completed_to_host);
     auto* inserted = [&]() -> std::vector<std::pair<CacheKey, CacheBlockRef>>* {
         if constexpr (Tier == CacheTier::kDevice) {
-            return stream_device_cache_to_host_ || cache_mutation_sink_ ? &newly_cached : nullptr;
+            return automatically_streams_to_host || cache_mutation_sink_ ? &newly_cached : nullptr;
         }
         return nullptr;
     }();
@@ -500,7 +527,7 @@ void CacheCoordinator::cacheFullBlocksForGroup(std::size_t group_index, BlockTab
         if (cache_mutation_sink_) {
             cache_mutation_sink_(key, CacheMutation::kStored);
         }
-        if (!stream_device_cache_to_host_) {
+        if (!automatically_streams_to_host) {
             continue;
         }
         pending_stores_.push_back(StoreCandidate{
@@ -676,7 +703,7 @@ void CacheCoordinator::cacheCompletedBlocksForGroup(std::size_t group_index, con
                          groups_[group_index].Id());
         cacheFullBlocksForGroup<Tier>(group_index, *demand.table, keys,
                                       demand.new_prefix_hash_begin * pages_per_prefix_hash, access_epoch,
-                                      *demand.completed_boundary_kind);
+                                      *demand.completed_boundary_kind, demand.stream_completed_to_host);
         return;
     }
     if (demand.num_computed_tokens < 0) {
@@ -701,7 +728,8 @@ void CacheCoordinator::cacheCompletedBlocksForGroup(std::size_t group_index, con
     std::vector<CacheKey> keys = keysForGroup(demand.prefix_hashes, groups_[group_index].Id());
     cacheFullBlocksForGroup<Tier>(group_index, *demand.table,
                                   std::span<const CacheKey>{keys}.subspan(static_cast<std::size_t>(first_cache_block)),
-                                  first_cache_block, access_epoch, *demand.completed_boundary_kind);
+                                  first_cache_block, access_epoch, *demand.completed_boundary_kind,
+                                  demand.stream_completed_to_host);
 }
 
 void CacheCoordinator::cacheDeviceCompletedBlocksForGroup(std::size_t group_index, const GroupDemand& demand,

--- a/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.h
+++ b/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.h
@@ -164,7 +164,8 @@ public:
                          CacheBoundaryKind boundary_kind = CacheBoundaryKind::kChunk);
     void CacheCompletedBlocks(std::span<BlockTable> tables, std::span<const std::string> prefix_hashes,
                               std::uint64_t access_epoch, std::int32_t first_new_prefix_page,
-                              std::int32_t num_computed_tokens, CacheBoundaryKind boundary_kind);
+                              std::int32_t num_computed_tokens, CacheBoundaryKind boundary_kind,
+                              bool stream_completed_to_host = false);
     void ReclaimExpired(std::span<BlockTable> tables, std::int32_t num_computed_tokens);
     void ConsumeReservedTokens(std::span<BlockTable> tables, std::int32_t num_tokens);
     void Free(std::span<BlockTable> tables);
@@ -192,6 +193,10 @@ public:
     // Queue every already-published non-state Device cache entry for D2H Store.
     // Missing keys and an absent Host tier are silently skipped.
     void QueueCachedBlocksForStore(std::span<const std::string> prefix_hashes);
+    // Queue the newest Device-resident checkpoint from each snapshot-state
+    // group. State checkpoints are intentionally deferred from continuous
+    // Host streaming and persisted at request lifecycle boundaries instead.
+    void QueueLatestSnapshotBlocksForStore(std::span<const std::string> prefix_hashes);
     std::vector<StoreCandidate> TakePendingStores() { return std::exchange(pending_stores_, {}); }
     CacheBlockRef AcquireDeviceCachedBlock(const CacheKey& key) const;
     HostAllocationBatch AcquireHostBlocks(std::span<const std::uint32_t> group_ids);
@@ -233,7 +238,7 @@ private:
     template <CacheTier Tier>
     void cacheFullBlocksForGroup(std::size_t group_index, BlockTable& table, std::span<const CacheKey> keys,
                                  std::int32_t first_cache_block, std::uint64_t access_epoch,
-                                 CacheBoundaryKind boundary_kind);
+                                 CacheBoundaryKind boundary_kind, bool stream_completed_to_host = false);
     template <CacheTier Tier>
     void cacheCompletedBlocksForGroup(std::size_t group_index, const GroupDemand& demand, std::uint64_t access_epoch);
     void cacheDeviceCompletedBlocksForGroup(std::size_t group_index, const GroupDemand& demand,

--- a/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.h
+++ b/tokenspeed-scheduler/csrc/cache/coordinator/cache_coordinator.h
@@ -178,11 +178,23 @@ public:
     struct StoreCandidate {
         CacheKey key;
     };
-    // Retry ordinary D2H Store for already-published Device cache entries.
+    struct HostAllocationStats {
+        std::size_t requested{0};
+        std::size_t allocated{0};
+        std::size_t unallocated{0};
+        std::size_t same_group_scans{0};
+        std::size_t cross_group_scans{0};
+    };
+    struct HostAllocationBatch {
+        std::vector<CacheBlockRef> blocks;
+        HostAllocationStats stats;
+    };
+    // Queue every already-published non-state Device cache entry for D2H Store.
     // Missing keys and an absent Host tier are silently skipped.
     void QueueCachedBlocksForStore(std::span<const std::string> prefix_hashes);
     std::vector<StoreCandidate> TakePendingStores() { return std::exchange(pending_stores_, {}); }
     CacheBlockRef AcquireDeviceCachedBlock(const CacheKey& key) const;
+    HostAllocationBatch AcquireHostBlocks(std::span<const std::uint32_t> group_ids);
     CacheBlockRef AcquireHostBlock(std::uint32_t group_id);
     // Collection/pinning follows host-tier presence, so the slide credit flips count_uncached on this.
     bool StreamsDeviceCacheToHost() const { return stream_device_cache_to_host_; }

--- a/tokenspeed-scheduler/csrc/cache/core/block_pool.h
+++ b/tokenspeed-scheduler/csrc/cache/core/block_pool.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <deque>
 #include <optional>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -66,19 +67,8 @@ public:
             return {};
         }
 
-        std::vector<CacheBlockLocation> locations;
-        if (cache_blocks_per_lcm_block == 1) {
-            if (NumEmptyLcmBlocks() < num) {
-                return {};
-            }
-            locations.reserve(static_cast<std::size_t>(num));
-            for (std::int32_t i = 0; i < num; ++i) {
-                locations.push_back(
-                    CacheBlockLocation{.lcm_block_id = free_parent_ids_[static_cast<std::size_t>(i)], .slot_index = 0});
-            }
-        } else {
-            locations = planLocations(group_id, cache_blocks_per_lcm_block, static_cast<std::size_t>(num));
-        }
+        std::vector<CacheBlockLocation> locations =
+            planLocations(group_id, cache_blocks_per_lcm_block, static_cast<std::size_t>(num));
         if (locations.size() != static_cast<std::size_t>(num)) {
             return {};
         }
@@ -87,6 +77,113 @@ public:
         out.reserve(locations.size());
         for (CacheBlockLocation location : locations) {
             out.push_back(createBlockRef(group_id, cache_blocks_per_lcm_block, location));
+        }
+        return out;
+    }
+
+    std::vector<CacheBlockRef> AcquireUpToBlocks(std::uint32_t group_id, std::int32_t cache_blocks_per_lcm_block,
+                                                 std::int32_t max_num) {
+        _assert(cache_blocks_per_lcm_block > 0, "cache_blocks_per_lcm_block must be > 0");
+        if (max_num <= 0) {
+            return {};
+        }
+        std::vector<CacheBlockLocation> locations =
+            planLocations(group_id, cache_blocks_per_lcm_block, static_cast<std::size_t>(max_num));
+        std::vector<CacheBlockRef> out;
+        out.reserve(locations.size());
+        for (CacheBlockLocation location : locations) {
+            out.push_back(createBlockRef(group_id, cache_blocks_per_lcm_block, location));
+        }
+        return out;
+    }
+
+    std::vector<CacheBlockRef> AcquireAvailableBlocksInOrder(std::span<const std::uint32_t> group_ids,
+                                                             std::span<const std::int32_t> cache_blocks_per_group) {
+        std::vector<bool> requested_groups(cache_blocks_per_group.size(), false);
+        for (std::uint32_t group_id : group_ids) {
+            _assert(group_id < cache_blocks_per_group.size(), "group id has no packing");
+            _assert(cache_blocks_per_group[group_id] > 0, "cache_blocks_per_lcm_block must be > 0");
+            requested_groups[group_id] = true;
+        }
+
+        std::vector<std::vector<std::int32_t>> partial_parent_ids(cache_blocks_per_group.size());
+        for (std::size_t i = 0; i < lcm_blocks_.size(); ++i) {
+            const LcmBlock& parent = lcm_blocks_[i];
+            if (!parent.bound_group || *parent.bound_group >= requested_groups.size() ||
+                !requested_groups[*parent.bound_group]) {
+                continue;
+            }
+            const std::uint32_t group_id = *parent.bound_group;
+            _assert(parent.occupancy.size() == static_cast<std::size_t>(cache_blocks_per_group[group_id]),
+                    "group packing changed while LCM block is occupied");
+            if (parent.occupied_count < parent.occupancy.size()) {
+                partial_parent_ids[group_id].push_back(static_cast<std::int32_t>(i + 1));
+            }
+        }
+
+        std::vector<std::deque<CacheBlockLocation>> available_locations(cache_blocks_per_group.size());
+        for (std::size_t group_id = 0; group_id < partial_parent_ids.size(); ++group_id) {
+            std::vector<std::int32_t>& parent_ids = partial_parent_ids[group_id];
+            std::ranges::sort(parent_ids, [this](std::int32_t lhs_id, std::int32_t rhs_id) {
+                const std::uint32_t lhs_occupied = lcmBlock(lhs_id).occupied_count;
+                const std::uint32_t rhs_occupied = lcmBlock(rhs_id).occupied_count;
+                return lhs_occupied != rhs_occupied ? lhs_occupied > rhs_occupied : lhs_id < rhs_id;
+            });
+            for (std::int32_t parent_id : parent_ids) {
+                const LcmBlock& parent = lcmBlock(parent_id);
+                for (std::size_t slot = 0; slot < parent.occupancy.size(); ++slot) {
+                    if (!parent.occupancy[slot]) {
+                        available_locations[group_id].push_back(CacheBlockLocation{
+                            .lcm_block_id = parent_id,
+                            .slot_index = static_cast<std::int32_t>(slot),
+                        });
+                    }
+                }
+            }
+        }
+
+        std::vector<CacheBlockRef> out(group_ids.size());
+        for (std::size_t i = 0; i < group_ids.size(); ++i) {
+            const std::uint32_t group_id = group_ids[i];
+            const std::int32_t packing = cache_blocks_per_group[group_id];
+            std::deque<CacheBlockLocation>& available = available_locations[group_id];
+            if (available.empty()) {
+                if (free_parent_ids_.empty()) {
+                    continue;
+                }
+                const std::int32_t parent_id = free_parent_ids_.front();
+                out[i] =
+                    createBlockRef(group_id, packing, CacheBlockLocation{.lcm_block_id = parent_id, .slot_index = 0});
+                for (std::int32_t slot = 1; slot < packing; ++slot) {
+                    available.push_back(CacheBlockLocation{.lcm_block_id = parent_id, .slot_index = slot});
+                }
+                continue;
+            }
+            const CacheBlockLocation location = available.front();
+            available.pop_front();
+            out[i] = createBlockRef(group_id, packing, location);
+        }
+        return out;
+    }
+
+    std::vector<CacheBlockRef> AcquireUpToBlocksFromEmptyParent(std::uint32_t group_id,
+                                                                std::int32_t cache_blocks_per_lcm_block,
+                                                                std::int32_t lcm_block_id, std::int32_t max_num) {
+        _assert(cache_blocks_per_lcm_block > 0, "cache_blocks_per_lcm_block must be > 0");
+        if (max_num <= 0) {
+            return {};
+        }
+        const LcmBlock& parent = lcmBlock(lcm_block_id);
+        _assert(parent.occupied_count == 0 && !parent.bound_group, "directed Host parent must be empty");
+        _assert(!free_parent_ids_.empty() && free_parent_ids_.front() == lcm_block_id,
+                "directed Host parent must be the next free parent");
+
+        const std::int32_t take = std::min(max_num, cache_blocks_per_lcm_block);
+        std::vector<CacheBlockRef> out;
+        out.reserve(static_cast<std::size_t>(take));
+        for (std::int32_t slot = 0; slot < take; ++slot) {
+            out.push_back(createBlockRef(group_id, cache_blocks_per_lcm_block,
+                                         CacheBlockLocation{.lcm_block_id = lcm_block_id, .slot_index = slot}));
         }
         return out;
     }
@@ -190,6 +287,16 @@ private:
 
     std::vector<CacheBlockLocation> planLocations(std::uint32_t group_id, std::int32_t slots_per_parent,
                                                   std::size_t count) const {
+        if (slots_per_parent == 1) {
+            std::vector<CacheBlockLocation> locations;
+            const std::size_t take = std::min(count, free_parent_ids_.size());
+            locations.reserve(take);
+            for (std::size_t i = 0; i < take; ++i) {
+                locations.push_back(CacheBlockLocation{.lcm_block_id = free_parent_ids_[i], .slot_index = 0});
+            }
+            return locations;
+        }
+
         std::vector<std::int32_t> partially_filled_parent_ids;
         partially_filled_parent_ids.reserve(lcm_blocks_.size());
         for (std::size_t i = 0; i < lcm_blocks_.size(); ++i) {
@@ -243,7 +350,7 @@ private:
                 return locations;
             }
         }
-        return {};
+        return locations;
     }
 
     std::vector<LcmBlock> lcm_blocks_;

--- a/tokenspeed-scheduler/csrc/cache/core/cache_types.h
+++ b/tokenspeed-scheduler/csrc/cache/core/cache_types.h
@@ -101,6 +101,10 @@ struct GroupDemand {
     // Snapshot-state local prefill uses an absolute endpoint here; Decode-side
     // PD also uses it for latest snapshots and retained sliding tails.
     std::int32_t materialized_suffix_start{-1};
+    // Prefill publication streams newly completed history and snapshot-state
+    // blocks to Host. Decode publication leaves this false so only sliding
+    // windows keep streaming; finish/retract persist the remaining groups.
+    bool stream_completed_to_host{false};
 };
 
 struct PrefixMatch {

--- a/tokenspeed-scheduler/csrc/cache/tier/transfer_manager.cpp
+++ b/tokenspeed-scheduler/csrc/cache/tier/transfer_manager.cpp
@@ -27,8 +27,9 @@
 namespace tokenspeed {
 
 std::optional<WriteBackOperation> TierTransferManager::StartPendingStores() {
-    std::vector<CacheTransfer> transfers;
-    std::vector<StoreTicket> tickets;
+    std::vector<CacheKey> keys;
+    std::vector<CacheBlockRef> device_block_refs;
+    std::vector<std::uint32_t> group_ids;
     std::unordered_set<CacheKey, CacheKeyHash> batch_keys;
     for (auto& candidate : coordinator_.TakePendingStores()) {
         if (coordinator_.ContainsHostCachedBlock(candidate.key) || store_keys_.contains(candidate.key) ||
@@ -40,20 +41,38 @@ std::optional<WriteBackOperation> TierTransferManager::StartPendingStores() {
         if (!device_block_ref) {
             continue;
         }
-        const GroupAllocator& manager = coordinator_.Allocator(static_cast<std::int32_t>(candidate.key.group_id));
-        CacheBlockRef host_block_ref = coordinator_.AcquireHostBlock(candidate.key.group_id);
+
+        group_ids.push_back(candidate.key.group_id);
+        keys.push_back(std::move(candidate.key));
+        device_block_refs.push_back(std::move(device_block_ref));
+    }
+
+    if (keys.empty()) {
+        return std::nullopt;
+    }
+
+    CacheCoordinator::HostAllocationBatch host_allocation = coordinator_.AcquireHostBlocks(group_ids);
+    _assert(host_allocation.blocks.size() == keys.size(), "Host allocation result must stay aligned");
+
+    std::vector<CacheTransfer> transfers;
+    std::vector<StoreTicket> tickets;
+    transfers.reserve(host_allocation.stats.allocated);
+    tickets.reserve(host_allocation.stats.allocated);
+    for (std::size_t i = 0; i < keys.size(); ++i) {
+        CacheBlockRef& host_block_ref = host_allocation.blocks[i];
         if (!host_block_ref) {
             continue;
         }
         // The source page id is resolved here and not pinned: the forward
         // thread's stream orders the copy ahead of any later reuse.
+        const GroupAllocator& manager = coordinator_.Allocator(static_cast<std::int32_t>(group_ids[i]));
         transfers.push_back(CacheTransfer{
-            .group_id = candidate.key.group_id,
-            .source_page = manager.ResolveCacheBlockId(device_block_ref->Location()),
+            .group_id = group_ids[i],
+            .source_page = manager.ResolveCacheBlockId(device_block_refs[i]->Location()),
             .destination_page = manager.ResolveCacheBlockId(host_block_ref->Location()),
         });
         tickets.push_back(StoreTicket{
-            std::move(candidate.key),
+            std::move(keys[i]),
             std::move(host_block_ref),
         });
     }

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -455,6 +455,7 @@ std::optional<fsm::SchedulePrefillEvent> Scheduler::schedulePrefill(
                                      .completed_boundary_kind = completed.boundary_kind,
                                      .num_computed_tokens = num_computed_tokens,
                                      .reserve_tokens = admission_reserve,
+                                     .stream_completed_to_host = config_.StreamsDeviceCacheToHost(),
                                  });
     if (!consumes_reserved_tail) {
         makeSnapshotStatePrefillSparse(demands, config_.cache_groups, coordinator_, first_pos + tokens_this_round);
@@ -492,14 +493,16 @@ std::optional<fsm::ScheduleDecodeEvent> Scheduler::scheduleDecode(ExecutionPlan&
         canConsumeReservedTokensInPlace(coordinator_, tables, reserve_tokens, num_computed_tokens)) {
         coordinator_.ConsumeReservedTokens(tables, reserve_tokens);
     } else {
-        std::vector<GroupDemand> demands =
-            makeGroupDemands(tables, GroupDemand{
-                                         .num_tokens = reserve_tokens,
-                                         .prefix_hashes = cache_progress.prefix_hashes,
-                                         .new_prefix_hash_begin = completed.first_new_prefix_page,
-                                         .completed_boundary_kind = completed.boundary_kind,
-                                         .num_computed_tokens = num_computed_tokens,
-                                     });
+        std::vector<GroupDemand> demands = makeGroupDemands(
+            tables,
+            GroupDemand{
+                .num_tokens = reserve_tokens,
+                .prefix_hashes = cache_progress.prefix_hashes,
+                .new_prefix_hash_begin = completed.first_new_prefix_page,
+                .completed_boundary_kind = completed.boundary_kind,
+                .num_computed_tokens = num_computed_tokens,
+                .stream_completed_to_host = config_.StreamsDeviceCacheToHost() && request->Is<fsm::PrefillDone>(),
+            });
         if (!admitWithKvEventTracking(plan, feedback, *request, cache_progress, completed.first_new_prefix_page,
                                       demands)) {
             return std::nullopt;
@@ -633,6 +636,7 @@ void Scheduler::retractVictim(Request& victim, std::vector<WriteBackOperation>& 
                                               num_computed_tokens, *completed.boundary_kind);
         }
         coordinator_.QueueCachedBlocksForStore(cache_progress.prefix_hashes);
+        coordinator_.QueueLatestSnapshotBlocksForStore(cache_progress.prefix_hashes);
         if (auto write_back = tier_transfers_.StartPendingStores()) {
             write_back_operations.push_back(std::move(*write_back));
         }

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -88,33 +88,40 @@ void Scheduler::handleEvent(const forward::Finish& event) {
     }
     if (Request* request = findRequest(event.request_id)) {
         if (request->Is<fsm::PrefillDone>() || request->Is<fsm::Decoding>()) {
-            publishCompletedPages(*request);
+            if (auto store = publishCompletedPages(*request)) {
+                pending_write_back_operations_.push_back(std::move(*store));
+            }
         }
         request->Apply(fsm::FinishEvent{&coordinator_});
     }
 }
 
-void Scheduler::publishCompletedPages(Request& request) {
+std::optional<WriteBackOperation> Scheduler::publishCompletedPages(Request& request) {
     const std::vector<std::span<const std::int32_t>> stable_prefix_pages = request.FullPrefixPages(true);
     fsm::CacheProgress progress = request.CacheProgress();
     const std::int32_t first_new_prefix_page = static_cast<std::int32_t>(progress.prefix_hashes.size());
     const std::int32_t num_stable_prefix_pages = static_cast<std::int32_t>(stable_prefix_pages.size());
     _assert(first_new_prefix_page <= num_stable_prefix_pages, "cache progress exceeds completed request pages");
-    if (first_new_prefix_page == num_stable_prefix_pages) {
-        return;
+    if (first_new_prefix_page != num_stable_prefix_pages) {
+        const std::string previous_hash =
+            progress.prefix_hashes.empty() ? std::string{} : progress.prefix_hashes.back();
+        std::vector<std::string> new_hashes =
+            AdvancePrefixHashes(stable_prefix_pages, first_new_prefix_page, previous_hash, num_stable_prefix_pages);
+        progress.prefix_hashes.insert(progress.prefix_hashes.end(), std::make_move_iterator(new_hashes.begin()),
+                                      std::make_move_iterator(new_hashes.end()));
+
+        std::vector<CacheKey> event_keys =
+            registerKvEventPrefixPages(request, progress.prefix_hashes, first_new_prefix_page);
+        coordinator_.CacheCompletedBlocks(request.BlockTablesRef(), progress.prefix_hashes, progress.access_epoch,
+                                          first_new_prefix_page, request.TokenSize() - 1, CacheBoundaryKind::kEndpoint);
+        discardUncachedKvEventPages(event_keys);
     }
-
-    const std::string previous_hash = progress.prefix_hashes.empty() ? std::string{} : progress.prefix_hashes.back();
-    std::vector<std::string> new_hashes =
-        AdvancePrefixHashes(stable_prefix_pages, first_new_prefix_page, previous_hash, num_stable_prefix_pages);
-    progress.prefix_hashes.insert(progress.prefix_hashes.end(), std::make_move_iterator(new_hashes.begin()),
-                                  std::make_move_iterator(new_hashes.end()));
-
-    std::vector<CacheKey> event_keys =
-        registerKvEventPrefixPages(request, progress.prefix_hashes, first_new_prefix_page);
-    coordinator_.CacheCompletedBlocks(request.BlockTablesRef(), progress.prefix_hashes, progress.access_epoch,
-                                      first_new_prefix_page, request.TokenSize() - 1, CacheBoundaryKind::kEndpoint);
-    discardUncachedKvEventPages(event_keys);
+    if (!config_.StreamsDeviceCacheToHost()) {
+        return std::nullopt;
+    }
+    coordinator_.QueueCachedBlocksForStore(progress.prefix_hashes);
+    coordinator_.QueueLatestSnapshotBlocksForStore(progress.prefix_hashes);
+    return tier_transfers_.StartPendingStores();
 }
 
 void Scheduler::handleEvent(const forward::UpdateReserveNumTokens& event) {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -413,6 +413,7 @@ std::int32_t Scheduler::RequestTokenSize(const std::string& id) const {
 }
 
 ExecutionPlan Scheduler::NextExecutionPlan() {
+    std::vector<WriteBackOperation> write_back_operations = std::exchange(pending_write_back_operations_, {});
     std::erase_if(requests_, [this](const auto& request) {
         if (!request->template Is<fsm::Finished>()) {
             return false;
@@ -431,7 +432,6 @@ ExecutionPlan Scheduler::NextExecutionPlan() {
         }
     }
     ExecutionPlan plan;
-    std::vector<WriteBackOperation> write_back_operations;
     auto [forward_operations, load_back_operations] =
         buildForwardOperations(plan, std::move(candidates), write_back_operations);
 

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -430,11 +430,11 @@ ExecutionPlan Scheduler::NextExecutionPlan() {
             candidates.push_back(request.get());
         }
     }
-
     ExecutionPlan plan;
     std::vector<WriteBackOperation> write_back_operations;
     auto [forward_operations, load_back_operations] =
         buildForwardOperations(plan, std::move(candidates), write_back_operations);
+
     plan.With(ForwardBatch{std::move(forward_operations)});
 
     if (config_.StreamsDeviceCacheToHost()) {
@@ -442,6 +442,7 @@ ExecutionPlan Scheduler::NextExecutionPlan() {
             write_back_operations.push_back(std::move(*store));
         }
     }
+
     if (!write_back_operations.empty()) {
         plan.With(CacheOperation{WriteBackBatch{write_back_operations}});
     }

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.h
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.h
@@ -145,7 +145,7 @@ private:
                                                      std::int32_t first_page);
     void discardUncachedKvEventPages(std::span<const CacheKey> keys);
     void handleCacheMutation(const CacheKey& key, CacheCoordinator::CacheMutation mutation);
-    void publishCompletedPages(Request& request);
+    std::optional<WriteBackOperation> publishCompletedPages(Request& request);
 
     std::size_t groupIndex(const std::string& group_id) const;
     Request* findRequest(const std::string& request_id);
@@ -274,6 +274,7 @@ private:
     BlockPool host_pool_;
     CacheCoordinator coordinator_;
     TierTransferManager tier_transfers_;
+    std::vector<WriteBackOperation> pending_write_back_operations_;
     std::vector<std::string> cache_group_ids_;
     std::int32_t max_single_request_tokens_{0};
 

--- a/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
+++ b/tokenspeed-scheduler/tests/cpp/integration_test_helper.h
@@ -115,6 +115,14 @@ protected:
         scheduler_->Advance(std::move(event));
     }
 
+    void AckWriteBacks(const ExecutionPlan& plan) {
+        for (const CacheOperation& op : ExtractCacheOpsOfKind<WriteBackBatch>(plan)) {
+            for (std::uint32_t id : std::get<WriteBackBatch>(op).op_ids) {
+                SendWriteBackDone(id);
+            }
+        }
+    }
+
     void SendLoadBackDone(std::uint32_t op_id) {
         ExecutionEvent event;
         event.With(cache::LoadBackDone{
@@ -135,8 +143,8 @@ protected:
         scheduler_->Advance(std::move(event));
     }
 
-    // Send Finish (generation complete) to the scheduler.
-    // This triggers FinishEvent: Decoding → Draining (or Finished if no writeback needed).
+    // Send Finish (generation complete) to the scheduler. Finish-created
+    // transfer tickets retain writeback sources after the request reaches Finished.
     void SendFinish(const std::string& request_id) {
         ExecutionEvent event;
         event.With(forward::Finish{

--- a/tokenspeed-scheduler/tests/cpp/test_block_pool.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_block_pool.cpp
@@ -201,5 +201,37 @@ TEST(BlockPoolLcmPlacementTest, LastReleaseImmediatelyClearsParentBinding) {
     EXPECT_EQ(pool.NumEmptyLcmBlocks(), 1);
 }
 
+TEST(BlockPoolTest, AcquireUpToBlocksReturnsAvailableCompatiblePlacements) {
+    BlockPool pool(2);
+    std::vector<CacheBlockRef> first = pool.AcquireBlocks(/*group_id=*/0, /*packing=*/2, /*num=*/3);
+    ASSERT_EQ(first.size(), 3u);
+
+    std::vector<CacheBlockRef> partial = pool.AcquireUpToBlocks(/*group_id=*/0, /*packing=*/2, /*max_num=*/3);
+
+    ASSERT_EQ(partial.size(), 1u);
+    EXPECT_EQ(pool.NumOccupiedSlots(), 4);
+}
+
+TEST(BlockPoolTest, AcquireUpToBlocksWithPackingOneReturnsPartialCapacity) {
+    BlockPool pool(2);
+    CacheBlockRef occupied = pool.AcquireBlock(/*group_id=*/0, /*packing=*/1);
+    ASSERT_TRUE(occupied);
+
+    std::vector<CacheBlockRef> partial = pool.AcquireUpToBlocks(/*group_id=*/1, /*packing=*/1, /*max_num=*/2);
+
+    ASSERT_EQ(partial.size(), 1u);
+    EXPECT_EQ(pool.BoundGroup(partial.front()->Location().lcm_block_id), 1u);
+    EXPECT_EQ(pool.NumOccupiedSlots(), 2);
+}
+
+TEST(BlockPoolTest, ExactAcquireBlocksRemainsAllOrNothing) {
+    BlockPool pool(2);
+    std::vector<CacheBlockRef> first = pool.AcquireBlocks(/*group_id=*/0, /*packing=*/2, /*num=*/3);
+    ASSERT_EQ(first.size(), 3u);
+
+    EXPECT_TRUE(pool.AcquireBlocks(/*group_id=*/0, /*packing=*/2, /*num=*/2).empty());
+    EXPECT_EQ(pool.NumOccupiedSlots(), 3);
+}
+
 }  // namespace
 }  // namespace tokenspeed::test

--- a/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
@@ -2536,7 +2536,7 @@ TEST(CacheCoordinatorStoreCandidates, CollectsKeysWithoutPinningDeviceBlocks) {
     CacheFullBlocksForTest(coordinator, tables, hashes, /*first_slot=*/0);
     std::vector<CacheCoordinator::StoreCandidate> pending = coordinator.TakePendingStores();
 
-    ASSERT_EQ(pending.size(), 4u);  // 2 pages x 2 groups, group-wrapped keys
+    ASSERT_EQ(pending.size(), 2u);  // sliding-window group only; full-attention deferred
     EXPECT_EQ(pool.NumEmptyLcmBlocks(), free_before);
     for (const BlockTable& table : tables) {
         for (const CacheBlockRef& block_ref : table.Blocks()) {
@@ -2546,10 +2546,9 @@ TEST(CacheCoordinatorStoreCandidates, CollectsKeysWithoutPinningDeviceBlocks) {
     // Typed keys keep the group distinct without changing the content hash.
     std::unordered_set<CacheKey, CacheKeyHash> keys;
     for (const auto& c : pending) keys.insert(c.key);
-    EXPECT_EQ(keys.size(), 4u);
-    // Collection is group-major: 2 pages for group 0, then 2 for group 1.
+    EXPECT_EQ(keys.size(), 2u);
     for (std::size_t i = 0; i < pending.size(); ++i) {
-        EXPECT_EQ(pending[i].key, Key(hashes[i % 2], static_cast<std::uint32_t>(i / 2))) << "candidate " << i;
+        EXPECT_EQ(pending[i].key, Key(hashes[i], /*group_id=*/1)) << "candidate " << i;
     }
 
     // Re-registering the same hashes yields nothing new (IsCached skip).
@@ -2576,6 +2575,135 @@ TEST(CacheCoordinatorStoreCandidates, DisabledByDefaultCollectsNothing) {
     std::vector<std::string> hashes = ContentHashes({{1, 2}, {3, 4}});
     CacheFullBlocksForTest(coordinator, tables, hashes, 0);
     EXPECT_TRUE(coordinator.TakePendingStores().empty());
+    coordinator.Free(tables);
+}
+
+TEST(CacheCoordinatorStoreCandidates, PrefillPublicationStreamsFullAndStateDecodePublicationDoesNot) {
+    BlockPool pool(24);
+    BlockPool host_pool(24);
+    std::vector<CacheGroupSpec> specs{
+        CacheGroupSpec{
+            .kind = AttnKind::kFull,
+            .sliding_window = 0,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+        CacheGroupSpec{
+            .kind = AttnKind::kSlidingWindow,
+            .sliding_window = 8,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+        CacheGroupSpec{
+            .kind = AttnKind::kMambaState,
+            .sliding_window = 0,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, pool, &host_pool, /*stream_device_cache_to_host=*/true);
+    std::vector<BlockTable> tables(coordinator.NumGroups());
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/4));
+    std::vector<std::string> hashes = ContentHashes({{1, 2}, {3, 4}});
+
+    coordinator.CacheCompletedBlocks(tables, hashes, CacheCoordinatorTestAccess::NextAccessEpoch(coordinator),
+                                     /*first_new_prefix_page=*/0, /*num_computed_tokens=*/4, CacheBoundaryKind::kChunk,
+                                     /*stream_completed_to_host=*/true);
+    std::vector<CacheCoordinator::StoreCandidate> prefill = coordinator.TakePendingStores();
+    ASSERT_EQ(prefill.size(), 5u);
+    EXPECT_EQ(prefill[0].key, Key(hashes[0], /*group_id=*/0));
+    EXPECT_EQ(prefill[1].key, Key(hashes[1], /*group_id=*/0));
+    EXPECT_EQ(prefill[2].key, Key(hashes[0], /*group_id=*/1));
+    EXPECT_EQ(prefill[3].key, Key(hashes[1], /*group_id=*/1));
+    EXPECT_EQ(prefill[4].key, Key(hashes[1], /*group_id=*/2));
+
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/2));
+    std::vector<std::string> decode_hashes = hashes;
+    decode_hashes.push_back(ContentHashes({{5, 6}})[0]);
+    coordinator.CacheCompletedBlocks(tables, decode_hashes, CacheCoordinatorTestAccess::NextAccessEpoch(coordinator),
+                                     /*first_new_prefix_page=*/2, /*num_computed_tokens=*/6, CacheBoundaryKind::kChunk,
+                                     /*stream_completed_to_host=*/false);
+    std::vector<CacheCoordinator::StoreCandidate> decode = coordinator.TakePendingStores();
+    ASSERT_EQ(decode.size(), 1u);
+    EXPECT_EQ(decode[0].key, Key(decode_hashes[2], /*group_id=*/1));
+
+    coordinator.QueueCachedBlocksForStore(decode_hashes);
+    coordinator.QueueLatestSnapshotBlocksForStore(decode_hashes);
+    std::vector<CacheCoordinator::StoreCandidate> finish = coordinator.TakePendingStores();
+    ASSERT_EQ(finish.size(), 7u);
+    EXPECT_EQ(finish[0].key, Key(decode_hashes[0], /*group_id=*/0));
+    EXPECT_EQ(finish[1].key, Key(decode_hashes[1], /*group_id=*/0));
+    EXPECT_EQ(finish[2].key, Key(decode_hashes[2], /*group_id=*/0));
+    EXPECT_EQ(finish[3].key, Key(decode_hashes[0], /*group_id=*/1));
+    EXPECT_EQ(finish[4].key, Key(decode_hashes[1], /*group_id=*/1));
+    EXPECT_EQ(finish[5].key, Key(decode_hashes[2], /*group_id=*/1));
+    EXPECT_EQ(finish[6].key, Key(decode_hashes[2], /*group_id=*/2));
+    coordinator.Free(tables);
+}
+
+TEST(CacheCoordinatorStoreCandidates, PrefillStreamsThreeKdaGroupsDecodeFinishWritesLatestOnly) {
+    BlockPool pool(32);
+    BlockPool host_pool(32);
+    std::vector<CacheGroupSpec> specs{
+        CacheGroupSpec{
+            .kind = AttnKind::kFull,
+            .sliding_window = 0,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+        CacheGroupSpec{
+            .kind = AttnKind::kMambaState,
+            .sliding_window = 0,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+        CacheGroupSpec{
+            .kind = AttnKind::kMambaState,
+            .sliding_window = 0,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+        CacheGroupSpec{
+            .kind = AttnKind::kMambaState,
+            .sliding_window = 0,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, pool, &host_pool, /*stream_device_cache_to_host=*/true);
+    std::vector<BlockTable> tables(coordinator.NumGroups());
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/4));
+    std::vector<std::string> hashes = ContentHashes({{1, 2}, {3, 4}});
+
+    coordinator.CacheCompletedBlocks(tables, hashes, CacheCoordinatorTestAccess::NextAccessEpoch(coordinator),
+                                     /*first_new_prefix_page=*/0, /*num_computed_tokens=*/4, CacheBoundaryKind::kChunk,
+                                     /*stream_completed_to_host=*/true);
+    std::vector<CacheCoordinator::StoreCandidate> prefill = coordinator.TakePendingStores();
+    ASSERT_EQ(prefill.size(), 5u) << "2 MLA pages plus one snapshot from each of 3 KDA groups";
+    EXPECT_EQ(prefill[0].key, Key(hashes[0], /*group_id=*/0));
+    EXPECT_EQ(prefill[1].key, Key(hashes[1], /*group_id=*/0));
+    EXPECT_EQ(prefill[2].key, Key(hashes[1], /*group_id=*/1));
+    EXPECT_EQ(prefill[3].key, Key(hashes[1], /*group_id=*/2));
+    EXPECT_EQ(prefill[4].key, Key(hashes[1], /*group_id=*/3));
+
+    ASSERT_TRUE(AdmitForTest(coordinator, tables, /*num_tokens=*/2));
+    std::vector<std::string> decode_hashes = hashes;
+    decode_hashes.push_back(ContentHashes({{5, 6}})[0]);
+    coordinator.CacheCompletedBlocks(tables, decode_hashes, CacheCoordinatorTestAccess::NextAccessEpoch(coordinator),
+                                     /*first_new_prefix_page=*/2, /*num_computed_tokens=*/6, CacheBoundaryKind::kChunk,
+                                     /*stream_completed_to_host=*/false);
+    EXPECT_TRUE(coordinator.TakePendingStores().empty()) << "decode publication must not auto-stream MLA or KDA";
+
+    coordinator.QueueCachedBlocksForStore(decode_hashes);
+    coordinator.QueueLatestSnapshotBlocksForStore(decode_hashes);
+    std::vector<CacheCoordinator::StoreCandidate> finish = coordinator.TakePendingStores();
+    ASSERT_EQ(finish.size(), 6u) << "all MLA pages plus the latest snapshot per KDA group";
+    EXPECT_EQ(finish[0].key, Key(decode_hashes[0], /*group_id=*/0));
+    EXPECT_EQ(finish[1].key, Key(decode_hashes[1], /*group_id=*/0));
+    EXPECT_EQ(finish[2].key, Key(decode_hashes[2], /*group_id=*/0));
+    EXPECT_EQ(finish[3].key, Key(decode_hashes[2], /*group_id=*/1));
+    EXPECT_EQ(finish[4].key, Key(decode_hashes[2], /*group_id=*/2));
+    EXPECT_EQ(finish[5].key, Key(decode_hashes[2], /*group_id=*/3));
     coordinator.Free(tables);
 }
 

--- a/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_coordinator.cpp
@@ -2681,6 +2681,199 @@ std::int32_t HostPut(CacheCoordinator& coordinator, BlockPool& host_pool, const 
     return id;
 }
 
+TEST(CacheCoordinatorHostReplacement, BatchReusesSameGroupVictimsWithOneScan) {
+    BlockPool device_pool(4);
+    BlockPool host_pool(2);
+    const std::array specs{CacheGroupSpec{
+        .kind = AttnKind::kFull,
+        .cache_blocks_per_lcm_block = 2,
+        .block_granularity = 2,
+    }};
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+    HostPut(coordinator, host_pool, "old-0", 0);
+    HostPut(coordinator, host_pool, "old-1", 0);
+    HostPut(coordinator, host_pool, "old-2", 0);
+    HostPut(coordinator, host_pool, "old-3", 0);
+
+    const std::array<std::uint32_t, 3> groups{0, 0, 0};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    ASSERT_EQ(batch.blocks.size(), groups.size());
+    EXPECT_TRUE(std::ranges::all_of(batch.blocks, [](const CacheBlockRef& ref) { return static_cast<bool>(ref); }));
+    EXPECT_EQ(batch.stats.requested, 3u);
+    EXPECT_EQ(batch.stats.allocated, 3u);
+    EXPECT_EQ(batch.stats.unallocated, 0u);
+    EXPECT_EQ(batch.stats.same_group_scans, 1u);
+    EXPECT_EQ(batch.stats.cross_group_scans, 0u);
+}
+
+TEST(CacheCoordinatorHostReplacement, BatchPreservesEmptyRefForPinnedShortfall) {
+    BlockPool device_pool(2);
+    BlockPool host_pool(2);
+    const std::array specs{CacheGroupSpec{
+        .kind = AttnKind::kFull,
+        .cache_blocks_per_lcm_block = 1,
+        .block_granularity = 2,
+    }};
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+    CacheBlockRef pinned = host_pool.AcquireBlock(/*group_id=*/0, /*cache_blocks_per_lcm_block=*/1);
+    ASSERT_TRUE(pinned);
+    coordinator.CacheHostBlock(pinned, Key("pinned", 0));
+
+    const std::array<std::uint32_t, 2> groups{0, 0};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    ASSERT_EQ(batch.blocks.size(), groups.size());
+    EXPECT_TRUE(batch.blocks[0]);
+    EXPECT_FALSE(batch.blocks[1]);
+    EXPECT_EQ(batch.stats.requested, 2u);
+    EXPECT_EQ(batch.stats.allocated, 1u);
+    EXPECT_EQ(batch.stats.unallocated, 1u);
+    EXPECT_EQ(batch.stats.same_group_scans, 1u);
+    EXPECT_EQ(batch.stats.cross_group_scans, 1u);
+}
+
+TEST(CacheCoordinatorHostReplacement, BatchGivesScarceFreeCapacityToFirstCandidateGroup) {
+    BlockPool device_pool(2);
+    BlockPool host_pool(1);
+    const std::array specs{
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+
+    const std::array<std::uint32_t, 2> groups{1, 0};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    ASSERT_EQ(batch.blocks.size(), groups.size());
+    ASSERT_TRUE(batch.blocks[0]);
+    EXPECT_EQ(host_pool.BoundGroup(batch.blocks[0]->Location().lcm_block_id), 1u);
+    EXPECT_FALSE(batch.blocks[1]);
+    EXPECT_EQ(batch.stats.allocated, 1u);
+    EXPECT_EQ(batch.stats.unallocated, 1u);
+}
+
+TEST(CacheCoordinatorHostReplacement, BatchGivesInterleavedGroupsFreeCapacityInCandidateOrder) {
+    BlockPool device_pool(3);
+    BlockPool host_pool(2);
+    const std::array specs{
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+
+    const std::array<std::uint32_t, 3> groups{0, 1, 0};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    ASSERT_EQ(batch.blocks.size(), groups.size());
+    ASSERT_TRUE(batch.blocks[0]);
+    EXPECT_EQ(host_pool.BoundGroup(batch.blocks[0]->Location().lcm_block_id), 0u);
+    ASSERT_TRUE(batch.blocks[1]);
+    EXPECT_EQ(host_pool.BoundGroup(batch.blocks[1]->Location().lcm_block_id), 1u);
+    EXPECT_FALSE(batch.blocks[2]);
+    EXPECT_EQ(batch.stats.allocated, 2u);
+    EXPECT_EQ(batch.stats.unallocated, 1u);
+}
+
+TEST(CacheCoordinatorHostReplacement, BatchRebindsParentsOnceAcrossMixedGroups) {
+    BlockPool device_pool(4);
+    BlockPool host_pool(2);
+    const std::array specs{
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 2, .block_granularity = 2},
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 2, .block_granularity = 2},
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+    HostPut(coordinator, host_pool, "old-0", 0);
+    HostPut(coordinator, host_pool, "old-1", 0);
+    HostPut(coordinator, host_pool, "old-2", 0);
+    HostPut(coordinator, host_pool, "old-3", 0);
+
+    const std::array<std::uint32_t, 3> groups{1, 1, 0};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    ASSERT_EQ(batch.blocks.size(), groups.size());
+    ASSERT_TRUE(batch.blocks[0]);
+    ASSERT_TRUE(batch.blocks[1]);
+    ASSERT_TRUE(batch.blocks[2]);
+    EXPECT_EQ(batch.blocks[0]->Location().lcm_block_id, batch.blocks[1]->Location().lcm_block_id);
+    EXPECT_NE(batch.blocks[0]->Location().slot_index, batch.blocks[1]->Location().slot_index);
+    EXPECT_EQ(host_pool.BoundGroup(batch.blocks[0]->Location().lcm_block_id), 1u);
+    EXPECT_EQ(host_pool.BoundGroup(batch.blocks[2]->Location().lcm_block_id), 0u);
+    EXPECT_NE(batch.blocks[0]->Location().lcm_block_id, batch.blocks[2]->Location().lcm_block_id);
+    EXPECT_EQ(batch.stats.same_group_scans, 2u);
+    EXPECT_EQ(batch.stats.cross_group_scans, 1u);
+    EXPECT_EQ(batch.stats.allocated, 3u);
+    EXPECT_EQ(batch.stats.unallocated, 0u);
+}
+
+TEST(CacheCoordinatorHostReplacement, BatchCrossGroupRebindingDoesNotRescanPlacementPoolPerVictim) {
+    BlockPool device_pool(4);
+    BlockPool host_pool(2);
+    const std::array specs{
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 2, .block_granularity = 2},
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 2, .block_granularity = 2},
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+    HostPut(coordinator, host_pool, "old-0", 0);
+    HostPut(coordinator, host_pool, "old-1", 0);
+    HostPut(coordinator, host_pool, "old-2", 0);
+    HostPut(coordinator, host_pool, "old-3", 0);
+
+    const std::array<std::uint32_t, 3> groups{1, 1, 1};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    EXPECT_TRUE(std::ranges::all_of(batch.blocks, [](const CacheBlockRef& ref) { return static_cast<bool>(ref); }));
+    EXPECT_EQ(batch.stats.cross_group_scans, 1u);
+}
+
+TEST(CacheCoordinatorHostReplacement, BatchCrossGroupRebindingChoosesLowestCacheValueParent) {
+    BlockPool device_pool(3);
+    BlockPool host_pool(2);
+    const std::array specs{
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+    const std::int32_t older_parent = HostPut(coordinator, host_pool, "older", 0);
+    const std::int32_t newer_parent = HostPut(coordinator, host_pool, "newer", 1);
+
+    const std::array<std::uint32_t, 1> groups{2};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    ASSERT_TRUE(batch.blocks[0]);
+    EXPECT_EQ(batch.blocks[0]->Location().lcm_block_id, older_parent);
+    EXPECT_FALSE(coordinator.ContainsHostCachedBlock(Key("older", 0)));
+    EXPECT_TRUE(coordinator.ContainsHostCachedBlock(Key("newer", 1)));
+    EXPECT_EQ(host_pool.BoundGroup(newer_parent), 1u);
+}
+
+TEST(CacheCoordinatorHostReplacement, BatchDoesNotRebindPinnedParent) {
+    BlockPool device_pool(2);
+    BlockPool host_pool(1);
+    const std::array specs{
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 2, .block_granularity = 2},
+        CacheGroupSpec{.kind = AttnKind::kFull, .cache_blocks_per_lcm_block = 1, .block_granularity = 2},
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, 2, device_pool, &host_pool);
+    HostPut(coordinator, host_pool, "old-0", 0);
+    HostPut(coordinator, host_pool, "old-1", 0);
+    CacheBlockRef pinned = coordinator.GroupPrefixIndex(0).Find(host_pool, Key("old-0", 0));
+    ASSERT_TRUE(pinned);
+
+    const std::array<std::uint32_t, 1> groups{1};
+    CacheCoordinator::HostAllocationBatch batch = coordinator.AcquireHostBlocks(groups);
+
+    ASSERT_EQ(batch.blocks.size(), groups.size());
+    EXPECT_FALSE(batch.blocks[0]);
+    EXPECT_EQ(host_pool.BoundGroup(1), 0u);
+    EXPECT_TRUE(coordinator.ContainsHostCachedBlock(Key("old-0", 0)));
+    EXPECT_TRUE(coordinator.ContainsHostCachedBlock(Key("old-1", 0)));
+    EXPECT_EQ(batch.stats.cross_group_scans, 1u);
+    EXPECT_EQ(batch.stats.allocated, 0u);
+    EXPECT_EQ(batch.stats.unallocated, 1u);
+}
+
 // Cache slots [0, blocks) in the DEVICE pool for every group, so the merged MatchPrefix's
 // device boundary lands exactly there (SWA's bottom-clamped run accepts any such floor).
 void SeedDeviceFloor(BlockPool& pool, CacheCoordinator& coord, std::span<const std::string> ch, std::int32_t blocks) {

--- a/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
@@ -174,6 +174,48 @@ TEST(CacheOperationTest, RetractionStoreIsBestEffortAndUsesOrdinaryTransferPins)
     EXPECT_TRUE(coordinator.ContainsHostCachedBlock(CacheKey{.group_id = 0, .content_hash = "h0"}));
 }
 
+TEST(CacheOperationTest, HostDestinationCannotBeReusedBeforeWriteBackAck) {
+    BlockPool device_pool{2};
+    BlockPool host_pool{1};
+    const std::array specs{CacheGroupSpec{
+        .kind = AttnKind::kFull,
+        .cache_blocks_per_lcm_block = 1,
+        .block_granularity = 2,
+    }};
+    CacheCoordinator coordinator = MakeCoordinator(specs, /*prefix_granularity=*/2, device_pool, &host_pool,
+                                                   /*stream_device_cache_to_host=*/false);
+    TierTransferManager transfers{coordinator};
+    const auto cache_device = [&](const CacheKey& key) {
+        CacheBlockRef block = device_pool.AcquireBlock(key.group_id, /*packing=*/1);
+        ASSERT_TRUE(block);
+        coordinator.GroupPrefixIndex(static_cast<std::int32_t>(key.group_id))
+            .Register(device_pool, block, key, /*access_epoch=*/1);
+    };
+
+    const CacheKey first_key{.group_id = 0, .content_hash = "first"};
+    cache_device(first_key);
+    const std::array first_hashes{first_key.content_hash};
+    coordinator.QueueCachedBlocksForStore(first_hashes);
+    auto first = transfers.StartPendingStores();
+    ASSERT_TRUE(first);
+    ASSERT_EQ(first->transfers.size(), 1u);
+    const std::int32_t destination = first->transfers.front().destination_page;
+
+    const CacheKey second_key{.group_id = 0, .content_hash = "second"};
+    cache_device(second_key);
+    const std::array second_hashes{second_key.content_hash};
+    coordinator.QueueCachedBlocksForStore(second_hashes);
+    EXPECT_FALSE(transfers.StartPendingStores());
+
+    transfers.CompleteWriteBack(first->op_id);
+    coordinator.QueueCachedBlocksForStore(second_hashes);
+    auto second = transfers.StartPendingStores();
+    ASSERT_TRUE(second);
+    ASSERT_EQ(second->transfers.size(), 1u);
+    EXPECT_EQ(second->transfers.front().destination_page, destination);
+    transfers.CompleteWriteBack(second->op_id);
+}
+
 TEST(CacheOperationTest, RetractionStoreSkipsWhenHostHasNoPlacement) {
     BlockPool device_pool{2};
     BlockPool host_pool{1};
@@ -199,6 +241,66 @@ TEST(CacheOperationTest, RetractionStoreSkipsWhenHostHasNoPlacement) {
     EXPECT_FALSE(transfers.StartPendingStores());
     coordinator.Free(tables);
     EXPECT_TRUE(coordinator.ClearDeviceCache());
+}
+
+TEST(CacheOperationTest, PendingStoresUseBatchHostAllocation) {
+    BlockPool device_pool{3};
+    BlockPool host_pool{1};
+    const std::array specs{
+        CacheGroupSpec{
+            .kind = AttnKind::kFull,
+            .cache_blocks_per_lcm_block = 2,
+            .block_granularity = 2,
+        },
+        CacheGroupSpec{
+            .kind = AttnKind::kFull,
+            .cache_blocks_per_lcm_block = 1,
+            .block_granularity = 2,
+        },
+    };
+    CacheCoordinator coordinator = MakeCoordinator(specs, /*prefix_granularity=*/2, device_pool, &host_pool,
+                                                   /*stream_device_cache_to_host=*/false);
+    TierTransferManager transfers{coordinator};
+
+    const auto cache_block = [&](BlockPool& pool, const CacheKey& key) {
+        GroupAllocator& allocator = coordinator.Allocator(static_cast<std::int32_t>(key.group_id));
+        CacheBlockRef block = pool.AcquireBlock(key.group_id, allocator.CacheBlocksPerLcmBlock());
+        EXPECT_TRUE(block);
+        const std::int32_t page = allocator.ResolveCacheBlockId(block->Location());
+        coordinator.GroupPrefixIndex(static_cast<std::int32_t>(key.group_id))
+            .Register(pool, block, key, /*access_epoch=*/1);
+        block.reset();
+        return page;
+    };
+
+    cache_block(host_pool, CacheKey{.group_id = 0, .content_hash = "old-0"});
+    cache_block(host_pool, CacheKey{.group_id = 0, .content_hash = "old-1"});
+
+    const CacheKey group_one{.group_id = 1, .content_hash = "new-1"};
+    cache_block(device_pool, group_one);
+    const std::array group_one_hashes{group_one.content_hash};
+    coordinator.QueueCachedBlocksForStore(group_one_hashes);
+
+    const CacheKey group_zero_first{.group_id = 0, .content_hash = "new-0"};
+    const CacheKey group_zero_second{.group_id = 0, .content_hash = "new-2"};
+    const std::int32_t first_source = cache_block(device_pool, group_zero_first);
+    const std::int32_t second_source = cache_block(device_pool, group_zero_second);
+    const std::array group_zero_hashes{group_zero_first.content_hash, group_zero_second.content_hash};
+    coordinator.QueueCachedBlocksForStore(group_zero_hashes);
+
+    auto write_back = transfers.StartPendingStores();
+
+    ASSERT_TRUE(write_back);
+    ASSERT_EQ(write_back->transfers.size(), 2u);
+    EXPECT_EQ(write_back->transfers[0].group_id, 0u);
+    EXPECT_EQ(write_back->transfers[0].source_page, first_source);
+    EXPECT_EQ(write_back->transfers[1].group_id, 0u);
+    EXPECT_EQ(write_back->transfers[1].source_page, second_source);
+
+    transfers.CompleteWriteBack(write_back->op_id);
+    EXPECT_FALSE(coordinator.ContainsHostCachedBlock(group_one));
+    EXPECT_TRUE(coordinator.ContainsHostCachedBlock(group_zero_first));
+    EXPECT_TRUE(coordinator.ContainsHostCachedBlock(group_zero_second));
 }
 
 TEST(CacheOperationTest, RetractionReleaseEstimateExcludesBlocksOwnedByAnotherRequest) {

--- a/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
@@ -1301,7 +1301,7 @@ TEST_F(PrefillSlideAdmissionSuite, InFlightStoreDoesNotDeferAdmission) {
     ASSERT_EQ(wb1.size(), 1u);
     const auto op1 = std::get<WriteBackBatch>(wb1.front());
     ASSERT_EQ(op1.op_ids.size(), 1u);
-    EXPECT_EQ(op1.src_pages.at(0).size(), 4u);
+    EXPECT_EQ(op1.src_pages.at(0).size(), 4u) << "the first completed Full+SWA pages stream together";
     ASSERT_EQ(scheduler_->PoolFreeBlocks(), 4);
 
     ExecutionPlan c3 = PlanOnce();  // slide credit 2: admitted with op1 in flight; emits op2
@@ -1317,7 +1317,7 @@ TEST_F(PrefillSlideAdmissionSuite, InFlightStoreDoesNotDeferAdmission) {
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 4);
 
     SendForwardDone("r1", {99});
-    ExecutionPlan decode = PlanOnce();  // finalize registers pages 4,5: emits op3
+    ExecutionPlan decode = PlanOnce();  // last prefill pages stream on PrefillDone
     ASSERT_NE(FindForwardBatch(decode), nullptr);
     ASSERT_EQ(FindForwardBatch(decode)->request_ids.size(), 1u);
     EXPECT_EQ(scheduler_->DecodingSize(), 1u);
@@ -1331,7 +1331,6 @@ TEST_F(PrefillSlideAdmissionSuite, InFlightStoreDoesNotDeferAdmission) {
     SendFinish("r1");
     PlanOnce();  // reap: no device pins, the pool balances immediately
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
-
     SendWriteBackDone(op2.op_ids.at(0));
     SendWriteBackDone(op3.op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 12);
@@ -3816,7 +3815,7 @@ protected:
     }
 
     // Prefill -> finalize; the finalize round registers the prompt's page
-    // hashes, so it is the round whose plan carries the streaming write-back.
+    // hashes and streams every completed Full+SWA page.
     ExecutionPlan RunToFinalize(const RequestSpec& spec) {
         Submit(spec);
         PlanOnce();  // prefill
@@ -3824,10 +3823,10 @@ protected:
         return PlanOnce();  // PrefillDone -> Decoding: registration + drain
     }
 
-    void FinishAndReap(const std::string& id) {
+    ExecutionPlan FinishAndReap(const std::string& id) {
         SendForwardDone(id, {9002});
         SendFinish(id);
-        PlanOnce();  // reap
+        return PlanOnce();  // leftover decode pages + latest snapshots, if any
     }
 
     static std::optional<WriteBackBatch> FindWriteBack(const ExecutionPlan& plan) {
@@ -3844,20 +3843,21 @@ TEST_F(StreamingSinkSuite, RegisteredPagesEmitWriteBackAndIndexOnDone) {
     const std::int32_t free_at_start = scheduler_->PoolFreeBlocks();
 
     ExecutionPlan finalize = RunToFinalize(MakeRequestSpec("r1", /*num_pages=*/4));
-    auto wb = FindWriteBack(finalize);
-    ASSERT_TRUE(wb.has_value()) << "finalize-registered pages must emit a streaming write-back";
-    ASSERT_EQ(wb->op_ids.size(), 1u);
-    EXPECT_EQ(wb->src_pages.at(0).size(), 6u) << "4 Full pages + the 2-page SWA resume tail";
-    EXPECT_EQ(wb->dst_pages.at(0).size(), 6u);
+    auto stream_wb = FindWriteBack(finalize);
+    ASSERT_TRUE(stream_wb.has_value()) << "finalize must stream the 4 Full + 2 SWA completed pages";
+    ASSERT_EQ(stream_wb->op_ids.size(), 1u);
+    EXPECT_EQ(stream_wb->src_pages.at(0).size(), 6u);
+    EXPECT_EQ(stream_wb->dst_pages.at(0).size(), 6u);
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 0) << "nothing indexed until WriteBackDone";
-    EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 0) << "all 6 host pages held in flight";
+    EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 0);
 
-    FinishAndReap("r1");
+    ExecutionPlan finish = FinishAndReap("r1");
+    EXPECT_FALSE(FindWriteBack(finish).has_value()) << "already-streamed prefill pages must not rewrite at finish";
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start)
         << "sources are not pinned: the forward thread's stream orders the copy before any reuse";
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 0);
 
-    SendWriteBackDone(wb->op_ids.at(0));
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     PlanOnce();
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
@@ -3867,17 +3867,18 @@ TEST_F(StreamingSinkSuite, DuplicateRegistrationsAreDroppedAtDrain) {
     const std::int32_t free_at_start = scheduler_->PoolFreeBlocks();
 
     ExecutionPlan finalize1 = RunToFinalize(MakeRequestSpec("r1", /*num_pages=*/4));
-    auto wb1 = FindWriteBack(finalize1);
-    ASSERT_TRUE(wb1.has_value());
-    FinishAndReap("r1");
-    SendWriteBackDone(wb1->op_ids.at(0));
+    auto stream_wb1 = FindWriteBack(finalize1);
+    ASSERT_TRUE(stream_wb1.has_value());
+    EXPECT_FALSE(FindWriteBack(FinishAndReap("r1")).has_value());
+    SendWriteBackDone(stream_wb1->op_ids.at(0));
     PlanOnce();
     ASSERT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     ASSERT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
 
     ExecutionPlan finalize2 = RunToFinalize(MakeRequestSpec("r2", /*num_pages=*/4));  // identical tokens
     EXPECT_FALSE(FindWriteBack(finalize2).has_value()) << "already-indexed keys must not re-emit a write-back";
-    FinishAndReap("r2");
+    ExecutionPlan finish2 = FinishAndReap("r2");
+    EXPECT_FALSE(FindWriteBack(finish2).has_value()) << "finish must also dedupe already-indexed keys";
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start)
         << "duplicate candidates are unpinned at drain, pool back to baseline";
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
@@ -3887,38 +3888,41 @@ TEST_F(StreamingSinkSuite, HostPoolExhaustionSkipsSilently) {
     const std::int32_t free_at_start = scheduler_->PoolFreeBlocks();
 
     ExecutionPlan finalize1 = RunToFinalize(MakeRequestSpec("r1", /*num_pages=*/4));
-    auto wb1 = FindWriteBack(finalize1);
-    ASSERT_TRUE(wb1.has_value());
-    FinishAndReap("r1");
+    auto stream_wb1 = FindWriteBack(finalize1);
+    ASSERT_TRUE(stream_wb1.has_value());
+    EXPECT_FALSE(FindWriteBack(FinishAndReap("r1")).has_value());
     ASSERT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
     ASSERT_EQ(scheduler_->HostPoolFreeBlocks(), 0) << "r1 holds all 6 host pages in flight";
 
     ExecutionPlan finalize2 = RunToFinalize(MakeRequestSpec("r2", /*num_pages=*/4, /*start=*/501));
     EXPECT_FALSE(FindWriteBack(finalize2).has_value())
         << "a fully-consumed host pool drops every candidate: no op at all";
-    FinishAndReap("r2");
+    ExecutionPlan finish2 = FinishAndReap("r2");
+    EXPECT_FALSE(FindWriteBack(finish2).has_value())
+        << "finish-created candidates must also skip a fully-consumed host pool";
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
 
-    SendWriteBackDone(wb1->op_ids.at(0));
+    SendWriteBackDone(stream_wb1->op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "everything balances after r1's commit";
 }
 
 TEST_F(StreamingSinkSuite, CommittedColdEntriesAreReplacedWhenHostPoolIsFull) {
     ExecutionPlan finalize1 = RunToFinalize(MakeRequestSpec("r1", /*num_pages=*/4));
-    auto wb1 = FindWriteBack(finalize1);
-    ASSERT_TRUE(wb1.has_value());
-    FinishAndReap("r1");
-    SendWriteBackDone(wb1->op_ids.at(0));
+    auto stream_wb1 = FindWriteBack(finalize1);
+    ASSERT_TRUE(stream_wb1.has_value());
+    EXPECT_FALSE(FindWriteBack(FinishAndReap("r1")).has_value());
+    SendWriteBackDone(stream_wb1->op_ids.at(0));
     ASSERT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     ASSERT_EQ(scheduler_->HostPoolFreeBlocks(), 0);
 
     ExecutionPlan finalize2 = RunToFinalize(MakeRequestSpec("r2", /*num_pages=*/4, /*start=*/501));
-    auto wb2 = FindWriteBack(finalize2);
-    ASSERT_TRUE(wb2.has_value()) << "committed, unpinned Host entries are replaceable";
-    EXPECT_EQ(wb2->src_pages.at(0).size(), 6u);
+    auto stream_wb2 = FindWriteBack(finalize2);
+    ASSERT_TRUE(stream_wb2.has_value()) << "committed, unpinned Host entries are replaceable";
+    EXPECT_EQ(stream_wb2->src_pages.at(0).size(), 6u);
+    EXPECT_FALSE(FindWriteBack(FinishAndReap("r2")).has_value());
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 0) << "old keys are removed before replacement D2H";
-    SendWriteBackDone(wb2->op_ids.at(0));
+    SendWriteBackDone(stream_wb2->op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
 }
 
@@ -3935,20 +3939,20 @@ TEST_F(StreamingSinkSuite, SameRoundDuplicateKeysDedupeAtDrain) {
     PlanOnce();  // both prefill (batch 2 <= max_batch_size 8, 16 tokens <= budget 64)
     SendForwardDone("r1", {9001});
     SendForwardDone("r2", {9001});
-    ExecutionPlan finalize = PlanOnce();  // both register, one merged drain
-    auto wb = FindWriteBack(finalize);
-    ASSERT_TRUE(wb.has_value());
-    ASSERT_EQ(wb->op_ids.size(), 1u);
-    EXPECT_EQ(wb->src_pages.at(0).size(), 6u) << "each key must be emitted at most once across both requests";
-    EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 6) << "duplicates must not consume host pages";
+    ExecutionPlan finalize = PlanOnce();  // both register the same completed pages, one merged drain
+    auto stream_wb = FindWriteBack(finalize);
+    ASSERT_TRUE(stream_wb.has_value());
+    ASSERT_EQ(stream_wb->op_ids.size(), 1u);
+    EXPECT_EQ(stream_wb->src_pages.at(0).size(), 6u) << "each Full+SWA key must be emitted at most once";
+    EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 6) << "duplicates must not consume extra host pages";
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 0);
 
-    FinishAndReap("r1");
-    FinishAndReap("r2");
+    EXPECT_FALSE(FindWriteBack(FinishAndReap("r1")).has_value());
+    EXPECT_FALSE(FindWriteBack(FinishAndReap("r2")).has_value()) << "same-round duplicates must be dropped";
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start)
         << "no source pins: the forward thread's stream orders the copies before any reuse";
 
-    SendWriteBackDone(wb->op_ids.at(0));
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 6) << "the six cached host pages remain occupied";
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
@@ -3962,31 +3966,33 @@ TEST_F(StreamingSinkSuite, MidDrainPoolFillEmitsPartialOp) {
     const std::int32_t free_at_start = scheduler_->PoolFreeBlocks();
 
     ExecutionPlan finalize = RunToFinalize(MakeRequestSpec("r1", /*num_pages=*/4));
-    auto wb = FindWriteBack(finalize);
-    ASSERT_TRUE(wb.has_value());
-    EXPECT_EQ(wb->src_pages.at(0).size(), 4u) << "4 of 6 candidates fit";
+    auto stream_wb = FindWriteBack(finalize);
+    ASSERT_TRUE(stream_wb.has_value());
+    EXPECT_EQ(stream_wb->src_pages.at(0).size(), 4u) << "the drain emits the 4 Full pages that fit first";
     EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 0);
 
-    FinishAndReap("r1");
-    SendWriteBackDone(wb->op_ids.at(0));
+    ExecutionPlan finish = FinishAndReap("r1");
+    EXPECT_FALSE(FindWriteBack(finish).has_value())
+        << "in-flight Full pages still occupy the host pool, so leftover SWA must skip";
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 4);
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "dropped candidates unpinned at drain";
 }
 
 TEST_F(StreamingSinkSuite, DuplicateWriteBackDoneIsIgnored) {
     ExecutionPlan finalize = RunToFinalize(MakeRequestSpec("r1", /*num_pages=*/4));
-    auto wb = FindWriteBack(finalize);
-    ASSERT_TRUE(wb.has_value());
-    FinishAndReap("r1");
+    auto stream_wb = FindWriteBack(finalize);
+    ASSERT_TRUE(stream_wb.has_value());
+    EXPECT_FALSE(FindWriteBack(FinishAndReap("r1")).has_value());
     const std::int32_t free_after_reap = scheduler_->PoolFreeBlocks();
 
-    SendWriteBackDone(wb->op_ids.at(0));
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     ASSERT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     const std::int32_t free_after_ack = scheduler_->PoolFreeBlocks();
     EXPECT_EQ(free_after_ack, free_after_reap) << "the ack publishes host entries; no device pins to return";
 
     // A replayed ack must be a no-op (the ledger already retired the op).
-    SendWriteBackDone(wb->op_ids.at(0));
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_after_ack);
 }
@@ -4020,27 +4026,38 @@ protected:
         return std::get<LoadBackBatch>(ops.front());
     }
 
-    // Full sink lifecycle: prefill -> finalize (registration + drain) -> reap;
-    // returns the write-back the finalize emitted.
-    std::optional<WriteBackBatch> RunSinkLifecycle(const RequestSpec& spec) {
+    // Full sink lifecycle: completed Full+SWA pages stream at finalize; finish
+    // only emits leftover decode pages or latest snapshots.
+    std::vector<WriteBackBatch> RunSinkLifecycle(const RequestSpec& spec) {
         ExecutionPlan finalize = RunToFinalize(spec);
-        FinishAndReap(spec.request_id);
-        return FindWriteBack(finalize);
+        ExecutionPlan finish = FinishAndReap(spec.request_id);
+        std::vector<WriteBackBatch> write_backs;
+        if (auto wb = FindWriteBack(finalize)) {
+            write_backs.push_back(*wb);
+        }
+        if (auto wb = FindWriteBack(finish)) {
+            write_backs.push_back(*wb);
+        }
+        return write_backs;
     }
 
     // r1 (tokens 1..8) indexes 6 host entries (4 Full + 2 SWA); the churn request
     // then floods the free list so r1's pages survive ONLY on the host tier.
     void SeedHostThenEvictDevice() {
         auto wb1 = RunSinkLifecycle(MakeRequestSpec("r1", /*num_pages=*/4));
-        ASSERT_TRUE(wb1.has_value());
-        SendWriteBackDone(wb1->op_ids.at(0));
+        ASSERT_EQ(wb1.size(), 1u);
+        for (const auto& wb : wb1) {
+            SendWriteBackDone(wb.op_ids.at(0));
+        }
         ASSERT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
         // Host cache entries retain their host blocks until host eviction.
         ASSERT_EQ(scheduler_->HostPoolFreeBlocks(), 26);
 
         auto wb3 = RunSinkLifecycle(MakeRequestSpec("churn", /*num_pages=*/5, /*start=*/501));
-        ASSERT_TRUE(wb3.has_value());
-        SendWriteBackDone(wb3->op_ids.at(0));
+        ASSERT_EQ(wb3.size(), 1u);
+        for (const auto& wb : wb3) {
+            SendWriteBackDone(wb.op_ids.at(0));
+        }
         ASSERT_EQ(scheduler_->HostPoolCachedBlocks(), 13);
         ASSERT_EQ(scheduler_->PoolFreeBlocks(), 12) << "both seeding requests fully retired";
     }
@@ -4097,12 +4114,13 @@ TEST_F(HostHitSuite, HostHitLoadsBackAfterDeviceEviction) {
 
     SendForwardDone("r2", {9001});
     ExecutionPlan finalize = PlanOnce();
-    auto wb = FindWriteBack(finalize);
-    ASSERT_TRUE(wb.has_value()) << "r2's extended endpoint must be persisted";
-    SendWriteBackDone(wb->op_ids.at(0));
+    auto stream_wb = FindWriteBack(finalize);
+    ASSERT_TRUE(stream_wb.has_value()) << "r2's newly completed prefill pages must stream";
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     SendForwardDone("r2", {9002});
     SendFinish("r2");
-    PlanOnce();  // reap
+    AckWriteBacks(PlanOnce());
+    PlanOnce();
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "pool balances after the host-hit request";
 }
 
@@ -4136,11 +4154,16 @@ TEST_F(HostHitSuite, AbandonedAdmissionUnpins) {
     EXPECT_EQ(scheduler_->WaitingSize(), 1u);
 
     // Free the filler (its write-back pins included) -> r2 admits with the load-back.
+    SendWriteBackDone(filler_wb->op_ids.at(0));
     SendForwardDone("filler", {9002});
     SendFinish("filler");
-    SendWriteBackDone(filler_wb->op_ids.at(0));
-    ExecutionPlan plan = PlanOnce();
-    auto lb = FindLoadBack(plan);
+    ExecutionPlan after_finish = PlanOnce();
+    AckWriteBacks(after_finish);
+    auto lb = FindLoadBack(after_finish);
+    if (!lb.has_value()) {
+        after_finish = PlanOnce();
+        lb = FindLoadBack(after_finish);
+    }
     ASSERT_TRUE(lb.has_value());
     EXPECT_EQ(lb->src_pages.at(0).size(), 6u);
     EXPECT_EQ(scheduler_->HostPoolPinnedBlocks(), 6);
@@ -4150,11 +4173,12 @@ TEST_F(HostHitSuite, AbandonedAdmissionUnpins) {
     EXPECT_EQ(scheduler_->HostPoolPinnedBlocks(), 0);
     SendForwardDone("r2", {9001});
     ExecutionPlan finalize = PlanOnce();
-    auto wb = FindWriteBack(finalize);
-    ASSERT_TRUE(wb.has_value()) << "r2's extended endpoint must be persisted";
-    SendWriteBackDone(wb->op_ids.at(0));
+    auto stream_wb = FindWriteBack(finalize);
+    ASSERT_TRUE(stream_wb.has_value()) << "r2's newly completed prefill pages must stream";
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     SendForwardDone("r2", {9002});
     SendFinish("r2");
+    AckWriteBacks(PlanOnce());
     PlanOnce();
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "pool balances after the deferred host hit";
 }
@@ -4243,11 +4267,12 @@ TEST_F(HostHitSuite, DuplicateLoadBackDoneIsIgnored) {
 
     SendForwardDone("r2", {9001});
     ExecutionPlan finalize = PlanOnce();
-    auto wb = FindWriteBack(finalize);
-    ASSERT_TRUE(wb.has_value()) << "r2's extended endpoint must be persisted";
-    SendWriteBackDone(wb->op_ids.at(0));
+    auto stream_wb = FindWriteBack(finalize);
+    ASSERT_TRUE(stream_wb.has_value()) << "r2's newly completed prefill pages must stream";
+    SendWriteBackDone(stream_wb->op_ids.at(0));
     SendForwardDone("r2", {9002});
     SendFinish("r2");
+    AckWriteBacks(PlanOnce());
     PlanOnce();
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "pool balances despite the duplicate event";
 }
@@ -4271,16 +4296,8 @@ protected:
         return cfg;
     }
 
-    void AckWriteBacks(const ExecutionPlan& plan) {
-        for (const CacheOperation& op : ExtractCacheOpsOfKind<WriteBackBatch>(plan)) {
-            for (std::uint32_t id : std::get<WriteBackBatch>(op).op_ids) {
-                SendWriteBackDone(id);
-            }
-        }
-    }
-
-    // Chunked twin of RunSinkLifecycle: drives prefill round by round, acking every
-    // streaming write-back so no sink pin outlives the seeding.
+    // Chunked twin of RunSinkLifecycle: ACK prefill Full+SWA streams round by round,
+    // then ACK any leftover finish write-back.
     void RunChunkedSinkLifecycle(const RequestSpec& spec, std::int32_t prefill_rounds) {
         Submit(spec);
         for (std::int32_t i = 0; i < prefill_rounds; ++i) {
@@ -4291,7 +4308,7 @@ protected:
         }
         SendForwardDone(spec.request_id, {9001});
         AckWriteBacks(PlanOnce());  // finalize: registration + drain
-        FinishAndReap(spec.request_id);
+        AckWriteBacks(FinishAndReap(spec.request_id));
     }
 
     // r1 (4 pages) indexes 8 host entries over 2 chunks; the churn request must pop
@@ -4356,7 +4373,7 @@ TEST_F(ChunkedHostHitSuite, ChunkedPrefillAfterHostHit) {
     AckWriteBacks(finalize);
     SendForwardDone("r2", {9002});
     SendFinish("r2");
-    PlanOnce();  // reap
+    AckWriteBacks(PlanOnce());  // any remaining decode write-back + reap
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "pool balances after the chunked host hit";
 }
 

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -51,6 +51,123 @@ inline std::int32_t FindRequestIndex(const ForwardBatch* fwd, const std::string&
     return -1;
 }
 
+class FinishOnlyWriteBackTestSuite : public SchedulerTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = SchedulerTestSuite::MakeConfig();
+        cfg.device_allocator.total_pages = 8;
+        cfg.host_allocator.total_pages = 8;
+        cfg.cache_groups.front().total_pages = cfg.device_allocator.total_pages;
+        return cfg;
+    }
+};
+
+TEST_F(FinishOnlyWriteBackTestSuite, PrefillStreamsMlaPagesDecodeDefersUntilFinish) {
+    Submit(MakeRequestSpec("r0", /*num_pages=*/2, /*start=*/1));
+    const ExecutionPlan prefill = PlanOnce();
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(prefill).empty())
+        << "the first prefill admit has no completed pages yet";
+    SendForwardDone("r0", {42});
+
+    const ExecutionPlan after_prefill = PlanOnce();
+    std::vector<CacheOperation> prefill_stores = ExtractCacheOpsOfKind<WriteBackBatch>(after_prefill);
+    ASSERT_EQ(prefill_stores.size(), 1u) << "completed prompt pages stream when leaving prefill";
+    const auto& prefill_write_back = std::get<WriteBackBatch>(prefill_stores.front());
+    ASSERT_EQ(prefill_write_back.op_ids.size(), 1u);
+    ASSERT_EQ(prefill_write_back.group_ids.size(), 1u);
+    EXPECT_EQ(prefill_write_back.group_ids.front(), (std::vector<std::uint32_t>{0, 0}));
+    SendWriteBackDone(prefill_write_back.op_ids.front());
+    EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 2);
+
+    SendForwardDone("r0", {43});
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(PlanOnce()).empty());
+    SendForwardDone("r0", {44});
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(PlanOnce()).empty())
+        << "ordinary decode must not stream a newly completed MLA page";
+    SendForwardDone("r0", {45});
+    SendFinish("r0");
+
+    const ExecutionPlan finish_plan = PlanOnce();
+    const std::vector<CacheOperation> finish_stores = ExtractCacheOpsOfKind<WriteBackBatch>(finish_plan);
+    ASSERT_EQ(finish_stores.size(), 1u);
+    const auto& finish_write_back = std::get<WriteBackBatch>(finish_stores.front());
+    ASSERT_EQ(finish_write_back.group_ids.size(), 1u);
+    EXPECT_EQ(finish_write_back.group_ids.front(), (std::vector<std::uint32_t>{0}))
+        << "finish writes only the new decode MLA page";
+    SendWriteBackDone(finish_write_back.op_ids.front());
+    EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 3);
+}
+
+TEST_F(FinishOnlyWriteBackTestSuite, FinishWithoutEligiblePageEmitsNoStore) {
+    Submit(RequestSpec{.request_id = "r0", .tokens = {1}});
+    PlanOnce();
+    SendForwardDone("r0", {42});
+    SendFinish("r0");
+
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(PlanOnce()).empty());
+}
+
+TEST_F(FinishOnlyWriteBackTestSuite, AbortEmitsNoStore) {
+    Submit(MakeRequestSpec("r0", /*num_pages=*/2, /*start=*/1));
+    PlanOnce();
+    SendForwardDone("r0", {42});
+    PlanOnce();
+    SendForwardDone("r0", {43});
+    SendAbortEvent("r0");
+
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(PlanOnce()).empty());
+}
+
+class FinishOnlyHybridWriteBackTestSuite : public FinishOnlyWriteBackTestSuite {
+protected:
+    SchedulerConfig MakeConfig() override {
+        SchedulerConfig cfg = FinishOnlyWriteBackTestSuite::MakeConfig();
+        cfg.device_allocator.total_pages = 16;
+        cfg.host_allocator.total_pages = 16;
+        cfg.cache_groups.front().total_pages = cfg.device_allocator.total_pages;
+        for (std::int32_t i = 0; i < 3; ++i) {
+            CacheGroupConfig state = cfg.cache_groups.front();
+            state.group_id = "state_" + std::to_string(i);
+            state.family = CacheGroupFamily::State;
+            cfg.cache_groups.push_back(std::move(state));
+        }
+        return cfg;
+    }
+};
+
+TEST_F(FinishOnlyHybridWriteBackTestSuite, FinishStoresAllMlaPagesAndLatestKdaSnapshot) {
+    Submit(MakeRequestSpec("r0", /*num_pages=*/2, /*start=*/1));
+    const ExecutionPlan prefill = PlanOnce();
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(prefill).empty());
+    SendForwardDone("r0", {42});
+
+    const ExecutionPlan after_prefill = PlanOnce();
+    std::vector<CacheOperation> prefill_stores = ExtractCacheOpsOfKind<WriteBackBatch>(after_prefill);
+    ASSERT_EQ(prefill_stores.size(), 1u);
+    const auto& prefill_write_back = std::get<WriteBackBatch>(prefill_stores.front());
+    ASSERT_EQ(prefill_write_back.group_ids.size(), 1u);
+    EXPECT_EQ(prefill_write_back.group_ids.front(), (std::vector<std::uint32_t>{0, 0, 1, 2, 3}))
+        << "prefill publication streams every MLA page plus one snapshot for each of three KDA groups";
+    SendWriteBackDone(prefill_write_back.op_ids.front());
+    EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 5);
+
+    SendForwardDone("r0", {43});
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(PlanOnce()).empty());
+    SendForwardDone("r0", {44});
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(PlanOnce()).empty())
+        << "ordinary decode must not stream the new MLA page or KDA snapshots";
+    SendForwardDone("r0", {45});
+    SendFinish("r0");
+    const std::vector<CacheOperation> finish_stores = ExtractCacheOpsOfKind<WriteBackBatch>(PlanOnce());
+    ASSERT_EQ(finish_stores.size(), 1u);
+    const auto& finish_write_back = std::get<WriteBackBatch>(finish_stores.front());
+    ASSERT_EQ(finish_write_back.group_ids.size(), 1u);
+    EXPECT_EQ(finish_write_back.group_ids.front(), (std::vector<std::uint32_t>{0, 1, 2, 3}))
+        << "finish writes one decode MLA page and only the latest snapshot from each KDA group";
+    SendWriteBackDone(finish_write_back.op_ids.front());
+    EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 9);
+}
+
 class LoadBackDoneTestSuite : public SchedulerTestSuite {
 protected:
     SchedulerConfig MakeConfig() override {
@@ -66,35 +183,20 @@ protected:
         Submit(MakeRequestSpec("r1", /*num_pages=*/2, /*start=*/1));
         PlanOnce();
         SendForwardDone("r1", {42});
-        auto plan_wb = PlanOnce();
+        const ExecutionPlan seed_stream = PlanOnce();
+        ASSERT_FALSE(ExtractCacheOpsOfKind<WriteBackBatch>(seed_stream).empty())
+            << "SetupHostCache: expected WriteBack op for r1";
+        AckWriteBacks(seed_stream);
         SendFinish("r1");
-        const WriteBackBatch* wb = nullptr;
-        for (const auto& op : plan_wb.Operations()) {
-            if (auto* cop = std::get_if<CacheOperation>(&op)) {
-                if (auto* w = std::get_if<WriteBackBatch>(cop)) {
-                    wb = w;
-                    break;
-                }
-            }
-        }
-        ASSERT_NE(wb, nullptr) << "SetupHostCache: expected WriteBack op for r1";
-        ASSERT_FALSE(wb->op_ids.empty());
-        SendWriteBackDone(wb->op_ids[0]);
+        AckWriteBacks(PlanOnce());
         PlanOnce();
 
         Submit(MakeRequestSpec("r_fill", /*num_pages=*/3, /*start=*/100));
         PlanOnce();
         SendForwardDone("r_fill", {200});
-        auto plan_wb2 = PlanOnce();
+        AckWriteBacks(PlanOnce());
         SendFinish("r_fill");
-        for (const auto& op : plan_wb2.Operations()) {
-            if (auto* cop = std::get_if<CacheOperation>(&op)) {
-                if (auto* w = std::get_if<WriteBackBatch>(cop)) {
-                    if (!w->op_ids.empty()) SendWriteBackDone(w->op_ids[0]);
-                    break;
-                }
-            }
-        }
+        AckWriteBacks(PlanOnce());
         PlanOnce();
     }
 };

--- a/tokenspeed-scheduler/tests/cpp/test_scheduler_plan.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_scheduler_plan.cpp
@@ -41,35 +41,19 @@ protected:
         Submit(MakeRequestSpec("r_seed", /*num_pages=*/2, /*start=*/1));
         PlanOnce();
         SendForwardDone("r_seed", {42});
-        auto plan_wb = PlanOnce();
+        const ExecutionPlan seed_stream = PlanOnce();
+        ASSERT_FALSE(ExtractCacheOpsOfKind<WriteBackBatch>(seed_stream).empty());
+        AckWriteBacks(seed_stream);
         SendFinish("r_seed");
-        const WriteBackBatch* wb = nullptr;
-        for (const auto& op : plan_wb.Operations()) {
-            if (auto* cop = std::get_if<CacheOperation>(&op)) {
-                if (auto* w = std::get_if<WriteBackBatch>(cop)) {
-                    wb = w;
-                    break;
-                }
-            }
-        }
-        ASSERT_NE(wb, nullptr);
-        ASSERT_FALSE(wb->op_ids.empty());
-        SendWriteBackDone(wb->op_ids[0]);
+        AckWriteBacks(PlanOnce());
         PlanOnce();
 
         Submit(MakeRequestSpec("r_fill", /*num_pages=*/3, /*start=*/100));
         PlanOnce();
         SendForwardDone("r_fill", {200});
-        auto plan_wb2 = PlanOnce();
+        AckWriteBacks(PlanOnce());
         SendFinish("r_fill");
-        for (const auto& op : plan_wb2.Operations()) {
-            if (auto* cop = std::get_if<CacheOperation>(&op)) {
-                if (auto* w = std::get_if<WriteBackBatch>(cop)) {
-                    if (!w->op_ids.empty()) SendWriteBackDone(w->op_ids[0]);
-                    break;
-                }
-            }
-        }
+        AckWriteBacks(PlanOnce());
         PlanOnce();
     }
 };


### PR DESCRIPTION
## Summary
- cap mapped-Host D2H/H2D copy occupancy and reuse transfer workspaces, reducing GPU contention and per-transfer CPU metadata construction
- flatten all layer ranges into one immutable table per Host load, upload it once asynchronously, and keep workspace reuse tied to layer completion events to avoid torn metadata
- batch Host cache allocation so one writeback batch does not repeatedly scan the pool, while preserving ordered, partial best-effort placement and delayed publication until `WriteBackDone`
- stream reusable prompt KV to Host during prefill, defer low-reuse decode MLA/KDA state until finish or retraction, release the GIL during scheduler planning, and remove unused vocabulary-sized penalty state

## Correctness
- keep Host entries unpublished until `WriteBackDone`
- preserve partial best-effort Host allocation and pinned-entry protection
- prevent pinned metadata reuse until the corresponding layerwise load event set completes