### PR TITLE
ci: make the Kimi-K3 TP8/EP1 jobs dispatchable

### DIFF
--- a/.github/workflows/k8s-dispatch.yml
+++ b/.github/workflows/k8s-dispatch.yml
@@ -31,6 +31,7 @@ on:
           - test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-ocr-bench.yaml
           - test/ci/eval/kimi-k2.5-mxfp4-eagle3-evalscope-aime25-amd.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+          - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
           - test/ci/eval/minimax-m3-nvfp4-dspark-evalscope-aime26.yaml
           - test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-evalscope-ocr-bench.yaml
@@ -44,6 +45,7 @@ on:
           - test/ci/perf/gpt-oss-120b-mxfp4-evalscope-mi355.yaml
           - test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+          - test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml


### PR DESCRIPTION
Follow-up to #1283.

The two TP8/EP1 jobs added there are `manual`-trigger only, but `k8s-dispatch.yml` exposes its target as a hardcoded `type: choice` list and neither job was added to it. That combination leaves them **unreachable** — no per-commit trigger, and not selectable in the only workflow that can start them. They have never run.

Found while trying to fire the perf job by hand to confirm it works, which it turns out was not possible.

Registers both next to their TP8/EP8 counterparts:

```
  - test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+ - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
  ...
  - test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+ - test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
```

The `amd` `runner_pool` option these jobs need already exists, so no other plumbing changes are required.

Note the thresholds in both EP1 jobs are still marked provisional in-file and have never been exercised on a runner. The first dispatches should be treated as calibration runs — particularly the perf reference, which is deliberately seeded loose because EP1 is slower than EP8 at the concurrency-1 point that job measures.