### PR TITLE
perf(k3): optimize MXFP4 MoE prefill on gfx950

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
@@ -30,6 +30,7 @@ The fused dispatch policy (`fused/moe.py`) is the top of the funnel: it calls
 | `moe_sorting.py` | Block-aligned expert sort feeding the package prefill stages. |
 | `situ_decode.py` / `situ_grouped.py` | A16W4 in-situ expert-parallel paths that read the unshuffled MXFP4 weights directly: route-direct warp decode and a contiguous-EP grouped GEMM. |
 | `latent_shared_decode.py` | Latent shared-expert decode entry. |
+| `quantize_gluon.py` | Leaf Gluon helpers for MXFP4 tile quantization and CDNA4 scale stores shared by staged and fused kernels. |
 | `scale_layout.py` | Single source of truth for the CDNA4 MXFP4 scale swizzle (constants, swizzle/predicate/allocator helpers). Leaf module: torch only. |
 | `scale.py` | Activation-scale gather into sorted-route order for the package stages. |
 | `preprocess.py` / `weight_preprocess.py` | Offline weight interleave, scale swizzle, gdot128 preshuffle, package-prefill aliases. |

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/moe.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/moe.py
@@ -1009,6 +1009,19 @@ def _maybe_route_owned_mxfp4_mfma_decode(
 _PACKAGE_PREFILL_MIN_M = 9
 
 
+def _select_package_prefill_block_m(
+    num_tokens: int,
+    top_k: int,
+    num_experts: int,
+) -> int:
+    """Use 64 rows when average route density makes 128 over-pad."""
+
+    routed_rows = num_tokens * top_k
+    if 128 * num_experts < routed_rows <= 192 * num_experts:
+        return 64
+    return 128
+
+
 def _maybe_gluon_package_mxfp4_prefill(
     hidden_states: torch.Tensor,
     router_logits: torch.Tensor,
@@ -1156,12 +1169,13 @@ def _maybe_gluon_package_mxfp4_prefill(
         gather_package_cdna4_scale,
     )
 
-    sort_block_m = 128
-    # In-house block-aligned sort: runs on the caller's stream with no
-    # device-to-host sync. The worst-case padded route buffers are kept at full
-    # length -- padding blocks carry the ``-1`` expert sentinel (stage1
-    # early-exits) and stage2 skips tiles past ``num_valid_ids[0]`` on-device,
-    # so no host-side trim is needed.
+    sort_block_m = _select_package_prefill_block_m(
+        n_tokens,
+        top_k,
+        n_experts,
+    )
+    # The stable, chunked sort preserves source-token locality for the stage-1
+    # activation gather while keeping all metadata on the current stream.
     sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, out = (
         gluon_moe_sorting(
             topk_ids,
@@ -1184,9 +1198,19 @@ def _maybe_gluon_package_mxfp4_prefill(
         top_k=top_k,
         flatten_topk=False,
     )
-    inter = torch.empty(
-        (n_tokens, top_k, inter_dim),
-        dtype=torch.bfloat16,
+    stage2_k = int(package_w2.shape[2]) * 2
+    stage2_k_scale = stage2_k // MXFP4_BLOCK
+    stage2_scale_rows = triton.cdiv(int(sorted_ids.shape[0]), 32) * 32
+    # Stage 1 writes the activated intermediate directly as sorted MXFP4,
+    # including the zero K-padding required by the physical W2 shard.
+    q_inter = torch.empty(
+        (sorted_ids.shape[0], stage2_k // 2),
+        dtype=torch.uint8,
+        device=hidden_states.device,
+    )
+    stage2_scale = torch.empty(
+        (stage2_scale_rows, stage2_k_scale),
+        dtype=torch.uint8,
         device=hidden_states.device,
     )
     invoke_gluon_mxfp4_moe_stage1(
@@ -1196,49 +1220,31 @@ def _maybe_gluon_package_mxfp4_prefill(
         sorted_ids,
         sorted_expert_ids,
         num_valid_ids,
-        inter,
+        q_inter,
         top_k,
         w1_scale=package_w13_scale.view(torch.uint8),
         a1_scale=stage1_scale,
-        sorted_weights=None,
+        block_m=sort_block_m,
         b_preshuffled=True,
         b_gdot128=True,
         swiglu_alpha=float(swiglu_alpha),
         swiglu_limit=float(swiglu_limit),
         swiglu_beta=float(swiglu_beta),
         situ_linear_beta=situ_linear_beta,
+        output_sorted=True,
+        output_quantized=True,
+        out_scale=stage2_scale,
+        output_k=stage2_k,
     )
-    inter_flat = inter.view(n_tokens * top_k, inter_dim)
-    stage2_k = int(package_w2.shape[2]) * 2
-    if stage2_k != inter_dim:
-        inter_flat = torch.nn.functional.pad(inter_flat, (0, stage2_k - inter_dim))
 
-    q_inter, q_inter_scale = _quantize_mxfp4_activation(inter_flat)
-
-    # Stage 2 down-projection block size. A smaller block reduces per-expert
-    # 128-row sort padding (top-8 over 384 experts), but on gfx950 the
-    # MFMA-utilization win of the 128-row tile dominates that padding cost.
-    # Sweep-tuned on the Kimi TP4 shard (E=384, D=7168, I=512, topk=8),
-    # BLOCK_M=128 is 10-17% faster than the old 32/64 tiers at M<=1024 and is
-    # fastest at every M; on the gpt-oss shape (E=128, topk=4) it is within ~1%
-    # of the old tiers (no regression). Forcing sort_block_m<128 at large M also
-    # overflows the routed buffers (illegal access), so a flat 128 is both
-    # faster and safer. It also matches ``sort_block_m``, so stage 2 reuses the
-    # stage-1 sort directly (no second moe_sorting pass).
-    stage2_block_m = 128
+    # Both stages consume the same route blocking so the lower-padding choice
+    # does not require a second sort or any metadata conversion.
+    stage2_block_m = sort_block_m
     s2_sorted_ids = sorted_ids
     s2_sorted_weights = sorted_weights
     s2_sorted_expert_ids = sorted_expert_ids
     s2_num_valid_ids = num_valid_ids
 
-    stage2_scale = gather_package_cdna4_scale(
-        q_inter_scale,
-        s2_sorted_ids,
-        source_rows=n_tokens * top_k,
-        cols=stage2_k,
-        top_k=top_k,
-        flatten_topk=True,
-    )
     invoke_gluon_mxfp4_moe_stage2_1x2(
         q_inter,
         None,
@@ -1256,6 +1262,7 @@ def _maybe_gluon_package_mxfp4_prefill(
         block_m=stage2_block_m,
         sort_block_m=stage2_block_m,
         force_reduce=True,
+        input_sorted=True,
     )
     return out
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/pipelined_kernel.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/pipelined_kernel.py
@@ -53,92 +53,10 @@ from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.fused.pipelined_program import (
     _preshuffled_w_copy_layout,
     _preshuffled_w_read_layout,
 )
-
-
-@gluon.jit
-def _mxfp4_quantize_tile(out):
-    max_normal: gl.constexpr = 6.0
-    min_normal: gl.constexpr = 1.0
-    BLOCK_M: gl.constexpr = out.shape[0]
-    OUT_BLOCK_N: gl.constexpr = out.shape[1]
-    Q_GROUPS: gl.constexpr = OUT_BLOCK_N // 32
-    gl.static_assert(OUT_BLOCK_N % 32 == 0)
-
-    vals = out.to(gl.bfloat16).to(gl.float32).reshape((BLOCK_M, Q_GROUPS, 32))
-    raw_abs = vals.to(gl.uint32, bitcast=True) & 0x7FFFFFFF
-    abs_vals = raw_abs.to(gl.float32, bitcast=True)
-    amax = gl.max(abs_vals, axis=2, keep_dims=True)
-    amax_bits = amax.to(gl.uint32, bitcast=True)
-    rounded_bits = (amax_bits + 0x200000) & 0x7F800000
-    exp_biased = (rounded_bits >> 23).to(gl.int32)
-    scale_i = gl.minimum(gl.maximum(exp_biased - 2, 0), 254)
-    scale_byte = scale_i.to(gl.uint8).reshape((BLOCK_M, Q_GROUPS))
-
-    inv_scale_bits = ((254 - scale_i) << 23).to(gl.uint32)
-    inv_scale = inv_scale_bits.to(gl.float32, bitcast=True)
-    qx = vals * inv_scale
-    qx_bits = qx.to(gl.uint32, bitcast=True)
-
-    sign = qx_bits & 0x80000000
-    qx_mag = qx_bits ^ sign
-    qx_fp32 = qx_mag.to(gl.float32, bitcast=True)
-    saturate_mask = qx_fp32 >= max_normal
-    denormal_mask = (not saturate_mask) & (qx_fp32 < min_normal)
-    normal_mask = not (saturate_mask | denormal_mask)
-
-    denorm_mask_int: gl.constexpr = ((127 - 1) + (23 - 1) + 1) << 23
-    denorm_mask_float: gl.constexpr = gl.cast(denorm_mask_int, gl.float32, bitcast=True)
-    denormal_x = qx_fp32 + denorm_mask_float
-    denormal_x = denormal_x.to(gl.uint32, bitcast=True)
-    denormal_x -= denorm_mask_int
-    denormal_x = denormal_x.to(gl.uint8)
-
-    normal_x = qx_mag
-    mant_odd = (normal_x >> (23 - 1)) & 1
-    normal_x += 0xC11FFFFF
-    normal_x += mant_odd
-    normal_x = normal_x >> (23 - 1)
-    normal_x = normal_x.to(gl.uint8)
-
-    e2m1 = gl.full(vals.shape, 0x7, gl.uint8, layout=vals.type.layout)
-    e2m1 = gl.where(normal_mask, normal_x, e2m1)
-    e2m1 = gl.where(denormal_mask, denormal_x, e2m1)
-    sign_lp = (sign >> (23 + 8 - 1 - 2)).to(gl.uint8)
-    e2m1 = e2m1 | sign_lp
-    e2m1 = e2m1.reshape((BLOCK_M, Q_GROUPS, 16, 2))
-    evens, odds = gl.split(e2m1)
-    packed = evens | (odds << 4)
-    return packed, scale_byte
-
-
-@gluon.jit
-def _mxfp4_store_cdna4_scale(
-    scale_ptr,
-    scale_byte,
-    scale_m,
-    scale_k,
-    stride_kswizzled,
-    stride_mblock,
-    mask,
-    M_SWIZZLE: gl.constexpr,
-    K_SWIZZLE: gl.constexpr,
-):
-    m_in_block = scale_m % M_SWIZZLE
-    m_hi = m_in_block // 16
-    m_lo = m_in_block % 16
-    k_block = scale_k // K_SWIZZLE
-    k_in_block = scale_k % K_SWIZZLE
-    k_hi = k_in_block // 4
-    k_lo = k_in_block % 4
-    swizzled_k = (((k_block * 4 + k_lo) * 16 + m_lo) * 2 + k_hi) * 2 + m_hi
-    m_block = scale_m // M_SWIZZLE
-    gl.store(
-        scale_ptr
-        + swizzled_k.to(gl.int64) * stride_kswizzled
-        + m_block.to(gl.int64) * stride_mblock,
-        scale_byte,
-        mask=mask,
-    )
+from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (
+    _mxfp4_quantize_tile,
+    _mxfp4_store_cdna4_scale,
+)
 
 
 @gluon.jit

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/moe_sorting.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/moe_sorting.py
@@ -26,29 +26,28 @@ kernels consume. It launches entirely on the *caller's* CUDA stream and
 performs **no** device-to-host synchronization, so the whole prefill path is
 CUDA-graph capturable.
 
-The routing buffers are sized to the worst case and padding is marked with
-sentinels: ``sorted_expert_ids`` padding blocks are ``-1`` and
-``sorted_token_ids`` padding slots are ``(topk << 24) | M``. The stage kernels
-self-skip padding on-device (expert ``-1`` early-exits; token field ``>= M`` is
-masked), so the launcher sizes its grid from the deterministic worst-case shape
-with no host readback.
+The routing buffers are sized to the worst case. Valid expert blocks and every
+slot within their padded ranges are written by the scatter stage; padding token
+IDs use ``(topk << 24) | M``. The stage kernels use the device-side valid count
+and mask token fields ``>= M``, so launch grids remain deterministic with no
+host readback.
 
 Implemented in Triton Gluon (``@gluon.jit``) to match the AMD-kernel convention
-for this package and to leave room for manual layout/scheduling optimization
-later. The algorithm is a four-stage block-aligned sort: a per-program expert
-histogram, a column prefix sum, block-padded per-expert offsets, and a
-race-free scatter -- scalar/scan control code with no MFMA. The vectorized
-prefix sums use ``gl.associative_scan``; the histogram and scatter use scalar
-dynamic-index loops.
+for this package. The algorithm is a four-stage block-aligned sort: vectorized
+per-chunk expert histograms, a column prefix sum, block-padded per-expert
+offsets, and a vectorized scatter. Chunk prefix sums preserve source-token
+locality across chunks; atomics assign ranks only among routes in the same
+chunk.
 
 Output contract::
 
-    max_num_tokens_padded = M * TOPK + E * B - TOPK
+    max_num_tokens_padded = floor((R + min(E, R) * (B - 1)) / B) * B
+                            where R = M * TOPK
     max_num_m_blocks      = ceil(max_num_tokens_padded / B)
     sorted_ids            (max_num_tokens_padded,) int32
         low 24 bits = token_id, high bits = topk slot; padding = (TOPK << 24) | M
-    sorted_weights        (max_num_tokens_padded,) float32; padding = 0.0
-    sorted_expert_ids     (max_num_m_blocks,)       int32; padding block = -1
+    sorted_weights        (max_num_tokens_padded,) float32; padding is unused
+    sorted_expert_ids     (max_num_m_blocks,)       int32; valid blocks are written
     num_valid_ids         (2,) int32; [0] = total padded slots, [1] = M
     out                   (M, model_dim) uninitialized ``out_dtype`` buffer
                           (stage2 overwrites/zeros it; see wrapper note)
@@ -66,6 +65,24 @@ from tokenspeed_kernel_amd._triton import gl, gluon, triton
 _SCAN_NUM_WARPS = 4
 
 
+def _max_padded_route_capacity(
+    num_routes: int,
+    num_experts: int,
+    block_size: int,
+) -> int:
+    """Bound block-padded routes by the maximum number of nonempty experts."""
+
+    if num_routes < 0 or num_experts < 0 or block_size <= 0:
+        raise ValueError(
+            "route/expert counts must be nonnegative and block_size positive"
+        )
+    max_nonempty_experts = min(num_routes, num_experts)
+    upper_bound = num_routes + max_nonempty_experts * (block_size - 1)
+    # The actual padded extent is block-aligned, so the largest multiple no
+    # greater than the per-expert padding bound is sufficient.
+    return upper_bound // block_size * block_size
+
+
 @gluon.jit
 def _add(a, b):
     return a + b
@@ -74,35 +91,57 @@ def _add(a, b):
 @gluon.jit
 def _moe_sorting_stage1_kernel(
     topk_ids_ptr,  # (numel,) int32, row-major (M, TOPK)
-    tokens_cnts_ptr,  # (E + 1, E) int32, zero-initialized
+    tokens_cnts_ptr,  # (num_programs + 1, E) int32
     num_experts: gl.constexpr,
     numel: gl.constexpr,
-    tokens_per_thread: gl.constexpr,
+    tokens_per_program: gl.constexpr,
+    ROUTE_BLOCK: gl.constexpr,
+    EXPERT_PAD: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
 ):
-    """Per-program expert histogram.
+    """Vectorized per-program expert histogram.
 
     Program ``pid`` counts the experts appearing in flat token slice
-    ``[pid * tokens_per_thread, (pid + 1) * tokens_per_thread)`` and writes them
+    ``[pid * tokens_per_program, (pid + 1) * tokens_per_program)`` and writes them
     to row ``pid + 1`` of ``tokens_cnts`` (row 0 is reserved as the zero base
-    for the stage-2 column scan). Scalar uniform loads/stores -- no tile math.
+    for the stage-2 column scan).
     """
     pid = gl.program_id(0)
-    start_idx = pid * tokens_per_thread
+    route_layout: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+    expert_layout: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+    route = gl.arange(0, ROUTE_BLOCK, layout=route_layout)
+    idx = pid * tokens_per_program + route
+    valid = (route < tokens_per_program) & (idx < numel)
+    expert_id = gl.load(topk_ids_ptr + idx, mask=valid, other=num_experts)
+    valid &= (expert_id >= 0) & (expert_id < num_experts)
+    safe_expert = gl.where(valid, expert_id, num_experts)
+    histogram = gl.histogram(
+        safe_expert,
+        EXPERT_PAD,
+        mask=valid,
+        layout=expert_layout,
+    ).to(gl.int32)
+    expert = gl.arange(0, EXPERT_PAD, layout=expert_layout)
     off_c = (pid + 1) * num_experts
-
-    for i in range(tokens_per_thread):
-        if start_idx + i < numel:
-            expert_id = gl.load(topk_ids_ptr + start_idx + i)
-            if (expert_id >= 0) and (expert_id < num_experts):
-                cnt = gl.load(tokens_cnts_ptr + off_c + expert_id)
-                gl.store(tokens_cnts_ptr + off_c + expert_id, cnt + 1)
+    if pid == 0:
+        gl.store(
+            tokens_cnts_ptr + expert,
+            gl.zeros([EXPERT_PAD], gl.int32, layout=expert_layout),
+            mask=expert < num_experts,
+        )
+    gl.store(
+        tokens_cnts_ptr + off_c + expert,
+        histogram,
+        mask=expert < num_experts,
+    )
 
 
 @gluon.jit
 def _moe_sorting_stage2_kernel(
-    tokens_cnts_ptr,  # (E + 1, E) int32
+    tokens_cnts_ptr,  # (num_programs + 1, E) int32
     num_experts: gl.constexpr,
-    E_PAD: gl.constexpr,
+    num_programs: gl.constexpr,
+    PROGRAM_PAD: gl.constexpr,
 ):
     """Column-wise inclusive prefix sum over programs (vectorized).
 
@@ -113,8 +152,8 @@ def _moe_sorting_stage2_kernel(
     """
     pid = gl.program_id(0)
     layout: gl.constexpr = gl.BlockedLayout([1], [64], [4], [0])
-    rows = gl.arange(0, E_PAD, layout=layout)  # maps to source rows 1..num_experts
-    mask = rows < num_experts
+    rows = gl.arange(0, PROGRAM_PAD, layout=layout)
+    mask = rows < num_programs
     offs = (rows + 1) * num_experts + pid
     cnt = gl.load(tokens_cnts_ptr + offs, mask=mask, other=0)
     inclusive = gl.associative_scan(cnt, 0, _add)
@@ -124,10 +163,11 @@ def _moe_sorting_stage2_kernel(
 @gluon.jit
 def _moe_sorting_stage3_kernel(
     num_valid_ids_ptr,  # (2,) int32
-    tokens_cnts_ptr,  # (E + 1, E) int32
+    tokens_cnts_ptr,  # (num_programs + 1, E) int32
     cumsum_ptr,  # (E + 1,) int32
     m_total,  # python int -> int32 scalar
     num_experts: gl.constexpr,
+    num_programs: gl.constexpr,
     block_size: gl.constexpr,
     E_PAD: gl.constexpr,
 ):
@@ -142,10 +182,11 @@ def _moe_sorting_stage3_kernel(
     layout: gl.constexpr = gl.BlockedLayout([1], [64], [4], [0])
     e = gl.arange(0, E_PAD, layout=layout)
     mask = e < num_experts
-    off_last = num_experts * num_experts  # row E == total count per expert
+    off_last = num_programs * num_experts
     cnt = gl.load(tokens_cnts_ptr + off_last + e, mask=mask, other=0)
     padded = ((cnt + block_size - 1) // block_size) * block_size
     inclusive = gl.associative_scan(padded, 0, _add)
+    gl.store(cumsum_ptr, 0)
     gl.store(cumsum_ptr + 1 + e, inclusive, mask=mask)
     gl.store(num_valid_ids_ptr + 0, gl.sum(padded))
     gl.store(num_valid_ids_ptr + 1, m_total)
@@ -155,49 +196,70 @@ def _moe_sorting_stage3_kernel(
 def _moe_sorting_stage4_kernel(
     topk_ids_ptr,  # (numel,) int32
     topk_weights_ptr,  # (numel,) float32
-    sorted_ids_ptr,  # (max_num_tokens_padded,) int32, pre-filled with sentinel
-    sorted_weights_ptr,  # (max_num_tokens_padded,) float32, pre-filled with 0
-    expert_ids_ptr,  # (max_num_m_blocks,) int32, pre-filled with -1
-    tokens_cnts_ptr,  # (E + 1, E) int32
+    sorted_ids_ptr,  # (max_num_tokens_padded,) int32
+    sorted_weights_ptr,  # (max_num_tokens_padded,) float32
+    expert_ids_ptr,  # (max_num_m_blocks,) int32
+    tokens_cnts_ptr,  # (num_programs + 1, E) int32
     cumsum_ptr,  # (E + 1,) int32
     num_experts: gl.constexpr,
+    num_programs: gl.constexpr,
     block_size: gl.constexpr,
     numel: gl.constexpr,
-    tokens_per_thread: gl.constexpr,
+    tokens_per_program: gl.constexpr,
     TOPK: gl.constexpr,
+    ROUTE_BLOCK: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
 ):
     """Fill ``expert_ids`` block map and scatter routed rows + weights.
 
-    Program ``pid`` writes ``expert_ids`` for expert ``pid``'s block range and
-    scatters the routed rows in its own token slice. Because each program owns a
-    disjoint token slice *and* a disjoint sub-range of every expert's slots
-    (via the stage-2 offsets), the scatter is race-free with no atomics.
+    Expert programs write their block maps and padding, while route programs
+    scatter one input chunk. Stage 2 gives each chunk a disjoint sub-range of
+    every expert, so atomics assign ranks only within a chunk and retain stable
+    ordering between chunks.
     """
     pid = gl.program_id(0)
 
-    # Block map: mark every block owned by expert ``pid``.
-    start_slot = gl.load(cumsum_ptr + pid)
-    end_slot = gl.load(cumsum_ptr + pid + 1)
-    for slot in range(start_slot, end_slot, block_size):
-        gl.store(expert_ids_ptr + slot // block_size, pid)
+    if pid < num_experts:
+        # Initialize only padding so these writes never overlap real routes.
+        start_slot = gl.load(cumsum_ptr + pid)
+        end_slot = gl.load(cumsum_ptr + pid + 1)
+        padding_layout: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+        block_offsets = gl.arange(0, block_size, layout=padding_layout)
+        padding_id: gl.constexpr = (TOPK << 24) | (numel // TOPK)
+        for slot in range(start_slot, end_slot, block_size):
+            gl.store(expert_ids_ptr + slot // block_size, pid)
+        total_count = gl.load(tokens_cnts_ptr + num_programs * num_experts + pid)
+        padding_start = start_slot + total_count
+        padding_slots = padding_start + block_offsets
+        gl.store(
+            sorted_ids_ptr + padding_slots,
+            padding_id,
+            mask=padding_slots < end_slot,
+        )
 
-    # Scatter this program's token slice into per-expert padded slots.
-    start_idx = pid * tokens_per_thread
-    off_t = pid * num_experts
-    for i in range(tokens_per_thread):
-        idx = start_idx + i
-        if idx < numel:
-            expert_id = gl.load(topk_ids_ptr + idx)
-            if (expert_id >= 0) and (expert_id < num_experts):
-                cursor = gl.load(tokens_cnts_ptr + off_t + expert_id)
-                rank = cursor + gl.load(cumsum_ptr + expert_id)
-                token_id = idx // TOPK
-                topk_id = idx % TOPK
-                packed = (topk_id << 24) | token_id
-                gl.store(sorted_ids_ptr + rank, packed)
-                weight = gl.load(topk_weights_ptr + idx)
-                gl.store(sorted_weights_ptr + rank, weight)
-                gl.store(tokens_cnts_ptr + off_t + expert_id, cursor + 1)
+    if pid < num_programs:
+        route_layout: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+        route = gl.arange(0, ROUTE_BLOCK, layout=route_layout)
+        idx = pid * tokens_per_program + route
+        valid = (route < tokens_per_program) & (idx < numel)
+        expert_id = gl.load(topk_ids_ptr + idx, mask=valid, other=0)
+        valid &= (expert_id >= 0) & (expert_id < num_experts)
+        safe_expert = gl.where(valid, expert_id, 0)
+        one = gl.full([ROUTE_BLOCK], 1, gl.int32, layout=route_layout)
+        cursor = gl.atomic_add(
+            tokens_cnts_ptr + pid * num_experts + safe_expert,
+            one,
+            mask=valid,
+            sem="relaxed",
+            scope="gpu",
+        )
+        rank = cursor + gl.load(cumsum_ptr + safe_expert, mask=valid, other=0)
+        token_id = idx // TOPK
+        topk_id = idx % TOPK
+        packed = (topk_id << 24) | token_id
+        gl.store(sorted_ids_ptr + rank, packed, mask=valid)
+        weight = gl.load(topk_weights_ptr + idx, mask=valid, other=0.0)
+        gl.store(sorted_weights_ptr + rank, weight, mask=valid)
 
 
 def gluon_moe_sorting(
@@ -236,25 +298,23 @@ def gluon_moe_sorting(
     E = int(num_experts)
     B = int(block_size)
 
-    # Worst-case allocation: every routed slot could land in its own
-    # partially-filled per-expert block.
-    max_num_tokens_padded = numel + E * B - topk
+    # Only experts receiving at least one route contribute a padding block.
+    # Bounding that count by min(E, routes) avoids scaling activation-sized
+    # consumers with every expert when a small prefill touches only a few.
+    max_num_tokens_padded = _max_padded_route_capacity(numel, E, B)
     max_num_m_blocks = triton.cdiv(max_num_tokens_padded, B)
 
     topk_ids = topk_ids.to(torch.int32).contiguous()
     topk_weights = topk_weights.to(torch.float32).contiguous()
 
-    # Padding sentinels let the stage kernels self-skip padding on-device
-    # (token field >= M is masked; expert -1 early-exits).
-    init_sorted_id = (int(topk) << 24) | int(M)
-    sorted_ids = torch.full(
-        (max_num_tokens_padded,), init_sorted_id, dtype=torch.int32, device=device
-    )
-    sorted_weights = torch.zeros(
+    # Stage 4 writes every routed/padding ID and every valid expert block.
+    # Padding weights are masked before stores by the consumers.
+    sorted_ids = torch.empty((max_num_tokens_padded,), dtype=torch.int32, device=device)
+    sorted_weights = torch.empty(
         (max_num_tokens_padded,), dtype=torch.float32, device=device
     )
-    sorted_expert_ids = torch.full(
-        (max_num_m_blocks,), -1, dtype=torch.int32, device=device
+    sorted_expert_ids = torch.empty(
+        (max_num_m_blocks,), dtype=torch.int32, device=device
     )
     num_valid_ids = torch.empty((2,), dtype=torch.int32, device=device)
     # ``out`` does not need zeroing: stage2's reduce epilogue overwrites every
@@ -262,28 +322,52 @@ def gluon_moe_sorting(
     # here would redundantly clear up to tens of MB at large M.
     out = torch.empty((M, model_dim), dtype=out_dtype, device=device)
 
-    # Scratch: (E+1, E) histogram + (E+1,) padded prefix sums.
-    tokens_cnts = torch.zeros((E + 1, E), dtype=torch.int32, device=device)
-    cumsum = torch.zeros((E + 1,), dtype=torch.int32, device=device)
-    tokens_per_thread = triton.cdiv(numel, E)
-    e_pad = triton.next_power_of_2(E)
+    # Keep route chunks at a practical vector width. The chunk prefix scan
+    # preserves their source order even when there are fewer experts than
+    # required route programs.
+    max_routes_per_program = 1024
+    num_programs = max(E, triton.cdiv(numel, max_routes_per_program))
+    tokens_per_program = triton.cdiv(numel, num_programs)
+    route_block = triton.next_power_of_2(tokens_per_program)
+    expert_pad = triton.next_power_of_2(E + 1)
+    program_pad = triton.next_power_of_2(num_programs)
 
-    grid = (E,)
-    _moe_sorting_stage1_kernel[grid](
-        topk_ids, tokens_cnts, E, numel, tokens_per_thread, num_warps=1
+    # Scratch: per-chunk histograms + per-expert padded prefix sums.
+    tokens_cnts = torch.empty((num_programs + 1, E), dtype=torch.int32, device=device)
+    cumsum = torch.empty((E + 1,), dtype=torch.int32, device=device)
+
+    route_grid = (num_programs,)
+    _moe_sorting_stage1_kernel[route_grid](
+        topk_ids,
+        tokens_cnts,
+        E,
+        numel,
+        tokens_per_program,
+        ROUTE_BLOCK=route_block,
+        EXPERT_PAD=expert_pad,
+        NUM_WARPS=_SCAN_NUM_WARPS,
+        num_warps=_SCAN_NUM_WARPS,
     )
-    _moe_sorting_stage2_kernel[grid](tokens_cnts, E, e_pad, num_warps=_SCAN_NUM_WARPS)
+    expert_grid = (E,)
+    _moe_sorting_stage2_kernel[expert_grid](
+        tokens_cnts,
+        E,
+        num_programs,
+        program_pad,
+        num_warps=_SCAN_NUM_WARPS,
+    )
     _moe_sorting_stage3_kernel[(1,)](
         num_valid_ids,
         tokens_cnts,
         cumsum,
         int(M),
         E,
+        num_programs,
         B,
-        e_pad,
+        expert_pad,
         num_warps=_SCAN_NUM_WARPS,
     )
-    _moe_sorting_stage4_kernel[grid](
+    _moe_sorting_stage4_kernel[(max(E, num_programs),)](
         topk_ids,
         topk_weights,
         sorted_ids,
@@ -292,11 +376,14 @@ def gluon_moe_sorting(
         tokens_cnts,
         cumsum,
         E,
+        num_programs,
         B,
         numel,
-        tokens_per_thread,
+        tokens_per_program,
         int(topk),
-        num_warps=1,
+        ROUTE_BLOCK=route_block,
+        NUM_WARPS=_SCAN_NUM_WARPS,
+        num_warps=_SCAN_NUM_WARPS,
     )
 
     return sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage1.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage1.py
@@ -32,10 +32,9 @@ by walking the ``sorted_token_ids`` / ``sorted_expert_ids`` arrays
 produced by the upstream routing kernel.
 
 Kernel shape:
-  BLOCK_M = BLOCK_N = 128, BLOCK_K = 256, num_warps = 4,
-  warps_per_cta = [1, 4]. ``BLOCK_M`` rows split into 4 quarters of
-  ``GROUP_MFMA_M = 32`` so each K-tile fires 4 (quarter) x 2 (gate/up)
-  = 8 ``mfma_scaled`` instructions on the production K = 7168 shape.
+  BLOCK_M in {64, 128}, BLOCK_N = 128, BLOCK_K = 256, with one wave
+  per 32-row quarter. Each K-tile fires one gate/up MFMA pair for every
+  quarter.
   K-loop pipelining: 2-slot LDS ping-pong for A data and A scale, and
   2-slot VGPR ping-pong for B data and B scale; B[k+1] is issued at
   the top of tile k so its VMEM latency hides behind tile k's MFMAs.
@@ -61,11 +60,10 @@ Layout contract:
   w1             (E, 2 * I_r, K_packed)      uint8, (16, 16) shuffled
   a1_scale       (M_padded_aligned, K // 32) uint8, e8m0
   w1_scale       (E, 2 * I_r, K // 32)       uint8, e8m0 (shuffled)
-  out            (EM, I_r) or (token_num, topk, I_r)  bf16
+  out            unsorted BF16 or sorted packed MXFP4 activation rows
+  out_scale      sorted CDNA4-swizzled e8m0 scales for quantized output
   sorted_token_ids    (EM,)             int32; low 24 bits = token_id
-  sorted_expert_ids   (EM // BLOCK_M,)  int32; -1 marks a padding block
-  sorted_weights      (EM,)             fp32  (REQUIRED to be empty here;
-                                               stage 1 doesn't fold weights)
+  sorted_expert_ids   (EM // BLOCK_M,)  int32; valid blocks only
 
 Stage 1 output is post-SwiGLU at ``I_r`` columns (half of the un-fused
 gate||up width). ``N = 2 * I_r`` is the B-operand column count and is
@@ -78,6 +76,13 @@ from typing import Optional  # noqa: F401  (kept for downstream type hints)
 
 import torch
 from tokenspeed_kernel_amd._triton import cdna4_async_copy, gl, gluon, triton
+from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (
+    _mxfp4_quantize_tile,
+    _mxfp4_store_cdna4_scale,
+)
+from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.scale_layout import (
+    CDNA4_SCALE_K_BLOCK,
+)
 
 
 def _b_preshuffle_3d(b: torch.Tensor) -> torch.Tensor:
@@ -246,6 +251,7 @@ def _apply_gate_activation(
 def _store_swiglu_tile_group(
     acc_swiglu,
     c_ptr,
+    c_scale_ptr,
     sorted_token_ids_ptr,
     pid_m,
     pid_n,
@@ -260,8 +266,10 @@ def _store_swiglu_tile_group(
     BLOCK_M: gl.constexpr,
     BLOCK_N: gl.constexpr,
     I_r: gl.constexpr,
+    OUTPUT_K: gl.constexpr,
+    OUTPUT_SORTED: gl.constexpr,
+    OUTPUT_QUANTIZED: gl.constexpr,
 ):
-    c_val = acc_swiglu.to(c_ptr.type.element_ty)
     cm_layout: gl.constexpr = gl.SliceLayout(1, mfma_layout)
     cn_layout: gl.constexpr = gl.SliceLayout(0, mfma_layout)
     offs_cm = (
@@ -275,15 +283,88 @@ def _store_swiglu_tile_group(
     )
     token_id_cm = offs_token_cm & 0xFFFFFF
     topk_id_cm = offs_token_cm >> 24
-    dst_row_cm = token_id_cm * top_k + topk_id_cm
-    c_ptrs = (
-        c_ptr
-        + dst_row_cm[:, None].to(gl.int64) * stride_cm
-        + offs_cn[None, :].to(gl.int64) * stride_cn
-    )
-    token_mask_cm = token_id_cm < num_tokens
-    c_mask = token_mask_cm[:, None] & (offs_cn[None, :] < I_r)
-    gl.store(c_ptrs, c_val, mask=c_mask)
+    if OUTPUT_SORTED:
+        dst_row_cm = offs_cm
+    else:
+        dst_row_cm = token_id_cm * top_k + topk_id_cm
+    token_mask_cm = (offs_cm < EM) if OUTPUT_SORTED else (token_id_cm < num_tokens)
+    if OUTPUT_QUANTIZED:
+        packed, scale_byte = _mxfp4_quantize_tile(acc_swiglu)
+        packed = packed.reshape((GROUP_M, BLOCK_N // 2))
+        packed_layout: gl.constexpr = packed.type.layout
+        packed_m = gl.arange(0, GROUP_M, gl.SliceLayout(1, packed_layout))
+        packed_n = gl.arange(0, BLOCK_N // 2, gl.SliceLayout(0, packed_layout))
+        packed_rows = pid_m * BLOCK_M + GROUP_IDX * GROUP_M + packed_m
+        packed_cols = pid_n * (BLOCK_N // 2) + packed_n
+        packed_ptrs = (
+            c_ptr
+            + packed_rows[:, None].to(gl.int64) * stride_cm
+            + packed_cols[None, :].to(gl.int64) * stride_cn
+        )
+        packed_mask = (packed_rows[:, None] < EM) & (packed_cols[None, :] < I_r // 2)
+        gl.store(packed_ptrs, packed, mask=packed_mask)
+
+        scale_layout: gl.constexpr = scale_byte.type.layout
+        scale_m = (
+            pid_m * BLOCK_M
+            + GROUP_IDX * GROUP_M
+            + gl.arange(0, GROUP_M, gl.SliceLayout(1, scale_layout))
+        )
+        scale_k = pid_n * (BLOCK_N // 32) + gl.arange(
+            0, BLOCK_N // 32, gl.SliceLayout(0, scale_layout)
+        )
+        _mxfp4_store_cdna4_scale(
+            c_scale_ptr,
+            scale_byte,
+            scale_m[:, None],
+            scale_k[None, :],
+            1,
+            (OUTPUT_K // 32) * 32,
+            (scale_m[:, None] < EM) & (scale_k[None, :] < I_r // 32),
+            M_SWIZZLE=32,
+            K_SWIZZLE=8,
+        )
+        if OUTPUT_K > I_r and pid_n == gl.cdiv(I_r, BLOCK_N) - 1:
+            gl.static_assert(OUTPUT_K - I_r <= BLOCK_N)
+            tail_packed_cols = I_r // 2 + packed_n
+            tail_packed_ptrs = (
+                c_ptr
+                + packed_rows[:, None].to(gl.int64) * stride_cm
+                + tail_packed_cols[None, :].to(gl.int64) * stride_cn
+            )
+            tail_packed_mask = (packed_rows[:, None] < EM) & (
+                tail_packed_cols[None, :] < OUTPUT_K // 2
+            )
+            gl.store(tail_packed_ptrs, gl.zeros_like(packed), mask=tail_packed_mask)
+
+            tail_scale_k = I_r // 32 + gl.arange(
+                0, BLOCK_N // 32, gl.SliceLayout(0, scale_layout)
+            )
+            _mxfp4_store_cdna4_scale(
+                c_scale_ptr,
+                gl.full(
+                    scale_byte.shape,
+                    127,
+                    gl.uint8,
+                    layout=scale_byte.type.layout,
+                ),
+                scale_m[:, None],
+                tail_scale_k[None, :],
+                1,
+                (OUTPUT_K // 32) * 32,
+                (scale_m[:, None] < EM) & (tail_scale_k[None, :] < OUTPUT_K // 32),
+                M_SWIZZLE=32,
+                K_SWIZZLE=8,
+            )
+    else:
+        c_val = acc_swiglu.to(c_ptr.type.element_ty)
+        c_ptrs = (
+            c_ptr
+            + dst_row_cm[:, None].to(gl.int64) * stride_cm
+            + offs_cn[None, :].to(gl.int64) * stride_cn
+        )
+        c_mask = token_mask_cm[:, None] & (offs_cn[None, :] < I_r)
+        gl.store(c_ptrs, c_val, mask=c_mask)
 
 
 @gluon.jit
@@ -291,12 +372,12 @@ def gluon_mxfp4_moe_stage1_kernel(
     a_ptr,
     b_ptr,
     c_ptr,
+    c_scale_ptr,
     a_scales_ptr,
     b_scales_ptr,
     sorted_token_ids_ptr,
     sorted_expert_ids_ptr,
     num_tokens_post_padded_ptr,
-    sorted_weights_ptr,
     N,
     K,
     EM,
@@ -305,15 +386,9 @@ def gluon_mxfp4_moe_stage1_kernel(
     stride_am,
     stride_ak,
     stride_be,
-    stride_bn,
-    stride_bk,
     stride_cm,
     stride_cn,
-    stride_ase_m,
-    stride_ase_k,
     stride_bse_e,
-    stride_bse_n,
-    stride_bse_k,
     stride_se_n_pad,
     K_PACKED_TOTAL: gl.constexpr,
     BLOCK_M: gl.constexpr,
@@ -322,18 +397,20 @@ def gluon_mxfp4_moe_stage1_kernel(
     GROUP_SIZE_M: gl.constexpr,
     NUM_WARPS: gl.constexpr,
     I_r: gl.constexpr,
+    OUTPUT_K: gl.constexpr,
     B_GDOT128: gl.constexpr,
     SWIGLU_ALPHA: gl.constexpr,
     SWIGLU_LIMIT: gl.constexpr,
     SWIGLU_BETA: gl.constexpr,
     DO_SITU: gl.constexpr,
     SITU_LINEAR_BETA: gl.constexpr,
+    OUTPUT_SORTED: gl.constexpr,
+    OUTPUT_QUANTIZED: gl.constexpr,
 ):
-    """Stage 1 kernel: per-token A gather + 4-deep A LDS ring + 4-deep
-    A_scale LDS ring + per-quarter MFMA K-loop with fused SwiGLU.
+    """Stage 1 kernel with per-token A gather and fused SwiGLU.
 
-    Tile config (fixed): ``128 x 128 x 256`` (M x N x K), ``num_warps=4``,
-    ``warps_per_cta=[1, 4]``. MFMA target:
+    Tile config: ``BLOCK_M x 128 x 256`` (M x N x K), with ``BLOCK_M``
+    in ``{64, 128}`` and one wave per 32 output rows. MFMA target:
     ``v_mfma_scale_f32_16x16x128_f8f6f4`` (gfx950, AMDMFMALayout
     version=4). The launch grid covers ``num_pid_m * (I_r / BLOCK_N)``
     programs (i.e. ``num_pid_n = I_r / BLOCK_N``, NOT ``N / BLOCK_N``);
@@ -341,26 +418,26 @@ def gluon_mxfp4_moe_stage1_kernel(
     output and computes the corresponding gate and up contributions
     itself.
 
-    Each K tile fires EIGHT ``mfma_scaled`` calls (4 quarters x 2 accs);
-    the four quarter-pairs share ``cur_b_gate`` / ``cur_b_up`` /
-    ``b_scale_gate`` / ``b_scale_up`` loaded inline at the tile head
-    (4 buffer_loads per tile). The 4x unroll matches the 4-deep A LDS
-    ring depth, so each Python iter of the steady-state body cycles the
-    ring back to its starting state. The K-loop opens with a 3-tile
-    prologue (3 ``buffer_load_to_shared`` for A data + 3 for A_scale,
-    each followed by ``commit_group``) and closes with a 3-tile drain
-    epilogue (``wait_group(2)``, ``wait_group(1)``, ``wait_group(0)``).
-    Mirrors dense reference lines 376 to 1305.
+    Each K tile fires two ``mfma_scaled`` calls per 32-row quarter. The
+    K loop alternates two A-data LDS slots while loading A scales and B
+    operands directly into VGPRs.
 
-    Epilogue: ``silu(gate_acc_groupX) * up_acc_groupX`` for X in 0..3,
+    Epilogue: ``silu(gate_acc_groupX) * up_acc_groupX`` for each quarter,
     cast to bf16, stored at sorted-row positions over ``BLOCK_N`` cols
     starting at ``pid_n * BLOCK_N`` of the ``[EM, I_r]`` output buffer.
     """
 
-    gl.static_assert(BLOCK_M == 128, "stage1 kernel requires BLOCK_M=128")
+    gl.static_assert(
+        BLOCK_M == 64 or BLOCK_M == 128,
+        "stage1 kernel requires BLOCK_M in {64, 128}",
+    )
     gl.static_assert(BLOCK_N == 128, "stage1 kernel requires BLOCK_N=128")
     gl.static_assert(BLOCK_K == 256, "stage1 kernel requires BLOCK_K=256")
-    gl.static_assert(NUM_WARPS == 4, "stage1 kernel requires NUM_WARPS=4")
+    gl.static_assert(
+        NUM_WARPS == BLOCK_M // 32,
+        "stage1 kernel requires one wave per 32 output rows",
+    )
+    gl.static_assert(not OUTPUT_QUANTIZED or OUTPUT_SORTED)
 
     SCALE_GROUP: gl.constexpr = 32
     DIV: gl.constexpr = 2
@@ -416,30 +493,52 @@ def gluon_mxfp4_moe_stage1_kernel(
     gload_a_layout: gl.constexpr = gl.BlockedLayout(
         [1, 16],
         [8, 8],
-        [4, 1],
+        [NUM_WARPS, 1],
         [1, 0],
     )
-    shared_a: gl.constexpr = gl.PaddedSharedLayout(
-        [[4096, 128]],
-        [
-            [0, 1],
-            [0, 2],
-            [0, 4],
-            [0, 8],
-            [0, 16],
-            [0, 32],
-            [0, 64],
-            [1, 0],
-            [2, 0],
-            [4, 0],
-            [8, 0],
-            [16, 0],
-            [32, 0],
-            [64, 0],
-        ],
-        [],
-        [BLOCK_M, BLOCK_K_PACKED],
-    )
+    if BLOCK_M == 64:
+        shared_a: gl.constexpr = gl.PaddedSharedLayout(
+            [[4096, 128]],
+            [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+                [16, 0],
+                [32, 0],
+            ],
+            [],
+            [BLOCK_M, BLOCK_K_PACKED],
+        )
+    else:
+        shared_a: gl.constexpr = gl.PaddedSharedLayout(
+            [[4096, 128]],
+            [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+                [16, 0],
+                [32, 0],
+                [64, 0],
+            ],
+            [],
+            [BLOCK_M, BLOCK_K_PACKED],
+        )
 
     # ---- per-token A row gather -----------------------------------------
     # ``sorted_token_ids`` packs ``(topk_id << 24) | token_id`` per
@@ -462,34 +561,9 @@ def gluon_mxfp4_moe_stage1_kernel(
     token_mask = (offs_token & 0xFFFFFF) < num_tokens
     a_row = offs_token & 0xFFFFFF
 
-    # ---- expert id (per-pid_m scalar; sentinel-checked) ----------------
-    # Stage 1 writes zeros and returns when this block has no expert
-    # assigned (``off_experts == -1``).
+    # The valid-count guard above excludes every unwritten tail block, so the
+    # sort contract guarantees a valid expert for each program reaching here.
     off_experts = gl.load(sorted_expert_ids_ptr + pid_m)
-    if off_experts == -1:
-        cm_layout_zero: gl.constexpr = gl.SliceLayout(1, mfma_layout)
-        cn_layout_zero: gl.constexpr = gl.SliceLayout(0, mfma_layout)
-        offs_cm_zero = pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=cm_layout_zero)
-        offs_cn_zero = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=cn_layout_zero)
-        zero_token = gl.load(
-            sorted_token_ids_ptr + offs_cm_zero,
-            mask=offs_cm_zero < EM,
-            other=num_tokens,
-        )
-        zero_token_id = zero_token & 0xFFFFFF
-        zero_topk_id = zero_token >> 24
-        zero_dst_row = zero_token_id * top_k + zero_topk_id
-        zero_c_ptrs = (
-            c_ptr
-            + zero_dst_row[:, None].to(gl.int64) * stride_cm
-            + offs_cn_zero[None, :].to(gl.int64) * stride_cn
-        )
-        zero_mask = (zero_token_id < num_tokens)[:, None] & (
-            offs_cn_zero[None, :] < I_r
-        )
-        zero_val = gl.zeros([BLOCK_M, BLOCK_N], dtype=gl.bfloat16, layout=mfma_layout)
-        gl.store(zero_c_ptrs, zero_val, mask=zero_mask)
-        return
 
     # ---- A data-load offsets (consumed by per-tile prefetch) ----------
     offs_ak = gl.arange(0, BLOCK_K_PACKED, layout=k_layout)
@@ -739,17 +813,11 @@ def gluon_mxfp4_moe_stage1_kernel(
         A_SCALE_K_STEP,
     )
 
-    # ---- 8 per-quarter accumulators (gate + up x 4 quarters) ----------
+    # ---- Per-quarter accumulators (gate + up) -------------------------
     gate_acc_group0 = gl.zeros(
         (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
     )
     gate_acc_group1 = gl.zeros(
-        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
-    )
-    gate_acc_group2 = gl.zeros(
-        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
-    )
-    gate_acc_group3 = gl.zeros(
         (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
     )
     up_acc_group0 = gl.zeros(
@@ -758,12 +826,19 @@ def gluon_mxfp4_moe_stage1_kernel(
     up_acc_group1 = gl.zeros(
         (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
     )
-    up_acc_group2 = gl.zeros(
-        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
-    )
-    up_acc_group3 = gl.zeros(
-        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
-    )
+    if BLOCK_M == 128:
+        gate_acc_group2 = gl.zeros(
+            (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+        )
+        gate_acc_group3 = gl.zeros(
+            (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+        )
+        up_acc_group2 = gl.zeros(
+            (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+        )
+        up_acc_group3 = gl.zeros(
+            (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+        )
 
     num_k_iter = gl.cdiv(K, BLOCK_K)
     # Steady tiles: 0 .. num_k_iter-2 (last tile handled in drain).
@@ -841,67 +916,70 @@ def gluon_mxfp4_moe_stage1_kernel(
             mask=token_mask[:, None],
         )
 
-        # Read remaining A[k] groups from current LDS slot0.
-        cur_a_group2 = _read_a_lds_group(
-            smem_a_slot0,
-            GROUP2_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group2 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP2_IDX,
-            tile0_k,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
-        cur_a_group3 = _read_a_lds_group(
-            smem_a_slot0,
-            GROUP3_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group3 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP3_IDX,
-            tile0_k,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
+        # The 128-row variant consumes the remaining two A[k] quarters while
+        # the next A tile is in flight. The 64-row variant has already consumed
+        # its complete tile above.
+        if BLOCK_M == 128:
+            cur_a_group2 = _read_a_lds_group(
+                smem_a_slot0,
+                GROUP2_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group2 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP2_IDX,
+                tile0_k,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
+            cur_a_group3 = _read_a_lds_group(
+                smem_a_slot0,
+                GROUP3_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group3 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP3_IDX,
+                tile0_k,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
 
         cdna4_async_copy.commit_group()
 
-        # MFMA groups 2,3 with current A[k] + current B[k].
-        gate_acc_group2 = _compute_mxfp4_group(
-            cur_a_group2,
-            a_scale_group2,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group2,
-        )
-        up_acc_group2 = _compute_mxfp4_group(
-            cur_a_group2,
-            a_scale_group2,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group2,
-        )
-        gate_acc_group3 = _compute_mxfp4_group(
-            cur_a_group3,
-            a_scale_group3,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group3,
-        )
-        up_acc_group3 = _compute_mxfp4_group(
-            cur_a_group3,
-            a_scale_group3,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group3,
-        )
+        if BLOCK_M == 128:
+            gate_acc_group2 = _compute_mxfp4_group(
+                cur_a_group2,
+                a_scale_group2,
+                cur_b_gate,
+                b_scale_gate,
+                gate_acc_group2,
+            )
+            up_acc_group2 = _compute_mxfp4_group(
+                cur_a_group2,
+                a_scale_group2,
+                cur_b_up,
+                b_scale_up,
+                up_acc_group2,
+            )
+            gate_acc_group3 = _compute_mxfp4_group(
+                cur_a_group3,
+                a_scale_group3,
+                cur_b_gate,
+                b_scale_gate,
+                gate_acc_group3,
+            )
+            up_acc_group3 = _compute_mxfp4_group(
+                cur_a_group3,
+                a_scale_group3,
+                cur_b_up,
+                b_scale_up,
+                up_acc_group3,
+            )
 
         # Drain A[k+1] prefetch; B[k+1] should also be done by now.
         cdna4_async_copy.wait_group(0)
@@ -1005,65 +1083,67 @@ def gluon_mxfp4_moe_stage1_kernel(
             mask=token_mask[:, None],
         )
 
-        cur_a_group2 = _read_a_lds_group(
-            smem_a_slot0,
-            GROUP2_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group2 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP2_IDX,
-            tile1_k,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
-        cur_a_group3 = _read_a_lds_group(
-            smem_a_slot0,
-            GROUP3_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group3 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP3_IDX,
-            tile1_k,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
+        if BLOCK_M == 128:
+            cur_a_group2 = _read_a_lds_group(
+                smem_a_slot0,
+                GROUP2_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group2 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP2_IDX,
+                tile1_k,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
+            cur_a_group3 = _read_a_lds_group(
+                smem_a_slot0,
+                GROUP3_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group3 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP3_IDX,
+                tile1_k,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
 
         cdna4_async_copy.commit_group()
 
-        gate_acc_group2 = _compute_mxfp4_group(
-            cur_a_group2,
-            a_scale_group2,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group2,
-        )
-        up_acc_group2 = _compute_mxfp4_group(
-            cur_a_group2,
-            a_scale_group2,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group2,
-        )
-        gate_acc_group3 = _compute_mxfp4_group(
-            cur_a_group3,
-            a_scale_group3,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group3,
-        )
-        up_acc_group3 = _compute_mxfp4_group(
-            cur_a_group3,
-            a_scale_group3,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group3,
-        )
+        if BLOCK_M == 128:
+            gate_acc_group2 = _compute_mxfp4_group(
+                cur_a_group2,
+                a_scale_group2,
+                cur_b_gate,
+                b_scale_gate,
+                gate_acc_group2,
+            )
+            up_acc_group2 = _compute_mxfp4_group(
+                cur_a_group2,
+                a_scale_group2,
+                cur_b_up,
+                b_scale_up,
+                up_acc_group2,
+            )
+            gate_acc_group3 = _compute_mxfp4_group(
+                cur_a_group3,
+                a_scale_group3,
+                cur_b_gate,
+                b_scale_gate,
+                gate_acc_group3,
+            )
+            up_acc_group3 = _compute_mxfp4_group(
+                cur_a_group3,
+                a_scale_group3,
+                cur_b_up,
+                b_scale_up,
+                up_acc_group3,
+            )
 
         cdna4_async_copy.wait_group(0)
 
@@ -1164,65 +1244,67 @@ def gluon_mxfp4_moe_stage1_kernel(
             mask=token_mask[:, None],
         )
 
-        cur_a_group2 = _read_a_lds_group(
-            smem_a_slot0,
-            GROUP2_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group2 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP2_IDX,
-            pk,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
-        cur_a_group3 = _read_a_lds_group(
-            smem_a_slot0,
-            GROUP3_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group3 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP3_IDX,
-            pk,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
+        if BLOCK_M == 128:
+            cur_a_group2 = _read_a_lds_group(
+                smem_a_slot0,
+                GROUP2_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group2 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP2_IDX,
+                pk,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
+            cur_a_group3 = _read_a_lds_group(
+                smem_a_slot0,
+                GROUP3_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group3 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP3_IDX,
+                pk,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
 
         cdna4_async_copy.commit_group()
 
-        gate_acc_group2 = _compute_mxfp4_group(
-            cur_a_group2,
-            a_scale_group2,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group2,
-        )
-        up_acc_group2 = _compute_mxfp4_group(
-            cur_a_group2,
-            a_scale_group2,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group2,
-        )
-        gate_acc_group3 = _compute_mxfp4_group(
-            cur_a_group3,
-            a_scale_group3,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group3,
-        )
-        up_acc_group3 = _compute_mxfp4_group(
-            cur_a_group3,
-            a_scale_group3,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group3,
-        )
+        if BLOCK_M == 128:
+            gate_acc_group2 = _compute_mxfp4_group(
+                cur_a_group2,
+                a_scale_group2,
+                cur_b_gate,
+                b_scale_gate,
+                gate_acc_group2,
+            )
+            up_acc_group2 = _compute_mxfp4_group(
+                cur_a_group2,
+                a_scale_group2,
+                cur_b_up,
+                b_scale_up,
+                up_acc_group2,
+            )
+            gate_acc_group3 = _compute_mxfp4_group(
+                cur_a_group3,
+                a_scale_group3,
+                cur_b_gate,
+                b_scale_gate,
+                gate_acc_group3,
+            )
+            up_acc_group3 = _compute_mxfp4_group(
+                cur_a_group3,
+                a_scale_group3,
+                cur_b_up,
+                b_scale_up,
+                up_acc_group3,
+            )
 
         cdna4_async_copy.wait_group(0)
 
@@ -1264,34 +1346,35 @@ def gluon_mxfp4_moe_stage1_kernel(
 
     # ---- 1-tile drain (last K tile, no prefetch) ---------------------
     # cur_a_group0/1 and cur_b_* hold the last tile's data.
-    cur_a_group2 = _read_a_lds_group(
-        smem_a_slot0,
-        GROUP2_IDX,
-        dot_a_layout,
-        GROUP_MFMA_M,
-    )
-    a_scale_group2 = _load_a_scale_vgpr(
-        a_scales_ptr,
-        a_scale_base_offsets,
-        GROUP2_IDX,
-        num_k_iter - 1,
-        a_scale_group_stride,
-        A_SCALE_K_STEP,
-    )
-    cur_a_group3 = _read_a_lds_group(
-        smem_a_slot0,
-        GROUP3_IDX,
-        dot_a_layout,
-        GROUP_MFMA_M,
-    )
-    a_scale_group3 = _load_a_scale_vgpr(
-        a_scales_ptr,
-        a_scale_base_offsets,
-        GROUP3_IDX,
-        num_k_iter - 1,
-        a_scale_group_stride,
-        A_SCALE_K_STEP,
-    )
+    if BLOCK_M == 128:
+        cur_a_group2 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP2_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group2 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP2_IDX,
+            num_k_iter - 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
+        cur_a_group3 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP3_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group3 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP3_IDX,
+            num_k_iter - 1,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
 
     gate_acc_group0 = _compute_mxfp4_group(
         cur_a_group0,
@@ -1321,34 +1404,35 @@ def gluon_mxfp4_moe_stage1_kernel(
         b_scale_up,
         up_acc_group1,
     )
-    gate_acc_group2 = _compute_mxfp4_group(
-        cur_a_group2,
-        a_scale_group2,
-        cur_b_gate,
-        b_scale_gate,
-        gate_acc_group2,
-    )
-    up_acc_group2 = _compute_mxfp4_group(
-        cur_a_group2,
-        a_scale_group2,
-        cur_b_up,
-        b_scale_up,
-        up_acc_group2,
-    )
-    gate_acc_group3 = _compute_mxfp4_group(
-        cur_a_group3,
-        a_scale_group3,
-        cur_b_gate,
-        b_scale_gate,
-        gate_acc_group3,
-    )
-    up_acc_group3 = _compute_mxfp4_group(
-        cur_a_group3,
-        a_scale_group3,
-        cur_b_up,
-        b_scale_up,
-        up_acc_group3,
-    )
+    if BLOCK_M == 128:
+        gate_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group2,
+        )
+        up_acc_group2 = _compute_mxfp4_group(
+            cur_a_group2,
+            a_scale_group2,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group2,
+        )
+        gate_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_gate,
+            b_scale_gate,
+            gate_acc_group3,
+        )
+        up_acc_group3 = _compute_mxfp4_group(
+            cur_a_group3,
+            a_scale_group3,
+            cur_b_up,
+            b_scale_up,
+            up_acc_group3,
+        )
 
     acc_swiglu_group0 = _apply_gate_activation(
         gate_acc_group0,
@@ -1368,28 +1452,30 @@ def gluon_mxfp4_moe_stage1_kernel(
         SWIGLU_BETA,
         SITU_LINEAR_BETA,
     )
-    acc_swiglu_group2 = _apply_gate_activation(
-        gate_acc_group2,
-        up_acc_group2,
-        DO_SITU,
-        SWIGLU_ALPHA,
-        SWIGLU_LIMIT,
-        SWIGLU_BETA,
-        SITU_LINEAR_BETA,
-    )
-    acc_swiglu_group3 = _apply_gate_activation(
-        gate_acc_group3,
-        up_acc_group3,
-        DO_SITU,
-        SWIGLU_ALPHA,
-        SWIGLU_LIMIT,
-        SWIGLU_BETA,
-        SITU_LINEAR_BETA,
-    )
+    if BLOCK_M == 128:
+        acc_swiglu_group2 = _apply_gate_activation(
+            gate_acc_group2,
+            up_acc_group2,
+            DO_SITU,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+            SWIGLU_BETA,
+            SITU_LINEAR_BETA,
+        )
+        acc_swiglu_group3 = _apply_gate_activation(
+            gate_acc_group3,
+            up_acc_group3,
+            DO_SITU,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+            SWIGLU_BETA,
+            SITU_LINEAR_BETA,
+        )
 
     _store_swiglu_tile_group(
         acc_swiglu_group0,
         c_ptr,
+        c_scale_ptr,
         sorted_token_ids_ptr,
         pid_m,
         pid_n,
@@ -1404,10 +1490,14 @@ def gluon_mxfp4_moe_stage1_kernel(
         BLOCK_M,
         BLOCK_N,
         I_r,
+        OUTPUT_K,
+        OUTPUT_SORTED,
+        OUTPUT_QUANTIZED,
     )
     _store_swiglu_tile_group(
         acc_swiglu_group1,
         c_ptr,
+        c_scale_ptr,
         sorted_token_ids_ptr,
         pid_m,
         pid_n,
@@ -1422,43 +1512,55 @@ def gluon_mxfp4_moe_stage1_kernel(
         BLOCK_M,
         BLOCK_N,
         I_r,
+        OUTPUT_K,
+        OUTPUT_SORTED,
+        OUTPUT_QUANTIZED,
     )
-    _store_swiglu_tile_group(
-        acc_swiglu_group2,
-        c_ptr,
-        sorted_token_ids_ptr,
-        pid_m,
-        pid_n,
-        EM,
-        num_tokens,
-        top_k,
-        stride_cm,
-        stride_cn,
-        mfma_layout,
-        GROUP2_IDX,
-        GROUP_MFMA_M,
-        BLOCK_M,
-        BLOCK_N,
-        I_r,
-    )
-    _store_swiglu_tile_group(
-        acc_swiglu_group3,
-        c_ptr,
-        sorted_token_ids_ptr,
-        pid_m,
-        pid_n,
-        EM,
-        num_tokens,
-        top_k,
-        stride_cm,
-        stride_cn,
-        mfma_layout,
-        GROUP3_IDX,
-        GROUP_MFMA_M,
-        BLOCK_M,
-        BLOCK_N,
-        I_r,
-    )
+    if BLOCK_M == 128:
+        _store_swiglu_tile_group(
+            acc_swiglu_group2,
+            c_ptr,
+            c_scale_ptr,
+            sorted_token_ids_ptr,
+            pid_m,
+            pid_n,
+            EM,
+            num_tokens,
+            top_k,
+            stride_cm,
+            stride_cn,
+            mfma_layout,
+            GROUP2_IDX,
+            GROUP_MFMA_M,
+            BLOCK_M,
+            BLOCK_N,
+            I_r,
+            OUTPUT_K,
+            OUTPUT_SORTED,
+            OUTPUT_QUANTIZED,
+        )
+        _store_swiglu_tile_group(
+            acc_swiglu_group3,
+            c_ptr,
+            c_scale_ptr,
+            sorted_token_ids_ptr,
+            pid_m,
+            pid_n,
+            EM,
+            num_tokens,
+            top_k,
+            stride_cm,
+            stride_cn,
+            mfma_layout,
+            GROUP3_IDX,
+            GROUP_MFMA_M,
+            BLOCK_M,
+            BLOCK_N,
+            I_r,
+            OUTPUT_K,
+            OUTPUT_SORTED,
+            OUTPUT_QUANTIZED,
+        )
 
 
 def invoke_gluon_mxfp4_moe_stage1(
@@ -1473,7 +1575,7 @@ def invoke_gluon_mxfp4_moe_stage1(
     kernelName="",
     w1_scale=None,
     a1_scale=None,
-    block_m=32,
+    block_m=128,
     sorted_weights=None,
     quant_type=None,
     activation=None,
@@ -1486,6 +1588,10 @@ def invoke_gluon_mxfp4_moe_stage1(
     swiglu_limit: float = 0.0,
     swiglu_beta: float = 0.0,
     situ_linear_beta: float | None = None,
+    output_sorted: bool = False,
+    output_quantized: bool = False,
+    out_scale: torch.Tensor | None = None,
+    output_k: int | None = None,
 ):
     """Host-side launcher for Gluon MXFP4 MoE stage 1.
 
@@ -1495,18 +1601,23 @@ def invoke_gluon_mxfp4_moe_stage1(
                   * (hidden_states_e @ w1_e[I_r:, :].T)
 
     When ``situ_linear_beta`` is provided, the same GEMM body instead uses the
-    SiTU-v2 epilogue.
-
-    in one kernel launch over all experts. The grid is one CTA per
+    SiTU-v2 epilogue. Both modes run in one kernel launch over all experts.
+    The grid is one CTA per
     (M-tile, N-tile); each CTA owns one ``BLOCK_M`` x ``BLOCK_N``
     output region for the expert ``sorted_expert_ids[pid_m]``.
+
+    ``output_sorted`` writes rows in routing order rather than restoring
+    token/slot order. ``output_quantized`` additionally writes packed MXFP4
+    values to ``out`` and CDNA4-swizzled e8m0 scales to ``out_scale``;
+    ``output_k`` is the physical, padding-inclusive output width. The function
+    returns the same ``out`` tensor supplied by the caller.
 
     Steps below correspond to the ``# Step N:`` comments in the body:
       1. Validate dtypes / shapes; reject unsupported options.
       2. Permute ``w1`` to the (16, 16) MFMA-tile layout (see
          :func:`_b_preshuffle_3d`), or skip if the caller already did.
-      3. Materialise ``num_valid_ids`` / ``sorted_weights`` as device
-         tensors when the caller passed a Python scalar / ``None``.
+      3. Materialise ``num_valid_ids`` as a device tensor when the caller
+         passed a Python scalar.
       4. Launch the GEMM kernel.
 
     Layout contract: see the module docstring.
@@ -1516,9 +1627,8 @@ def invoke_gluon_mxfp4_moe_stage1(
       ``splitk not in {0, 1, None}``, non-empty ``sorted_weights``,
       ``dst_type != bfloat16``.
 
-    Accepted-but-ignored, kept for signature compatibility with
-    upstream dispatchers: ``kernelName``, ``block_m`` (kernel hardcodes
-    128), ``w2``, ``use_non_temporal_load``.
+    Accepted-but-ignored, kept for signature compatibility with upstream
+    dispatchers: ``kernelName``, ``w2``, ``use_non_temporal_load``.
     """
     # Step 1: validate inputs and reject unsupported modes.
     del quant_type, activation  # only per-1x32 MXFP4 + SwiGLU is implemented
@@ -1529,16 +1639,15 @@ def invoke_gluon_mxfp4_moe_stage1(
         )
     if sorted_weights is not None and sorted_weights.numel() > 0:
         raise NotImplementedError(
-            "invoke_gluon_mxfp4_moe_stage1: do_weight_stage1 (a non-empty "
-            "sorted_weights tensor) is not implemented; pass None or a "
-            "0-element placeholder"
+            "invoke_gluon_mxfp4_moe_stage1: stage-1 route weighting is not "
+            "implemented; pass sorted_weights=None or an empty tensor"
         )
     if dst_type is not None and dst_type != torch.bfloat16:
         raise NotImplementedError(
             "invoke_gluon_mxfp4_moe_stage1: only dst_type=torch.bfloat16 is "
             f"supported, got dst_type={dst_type!r}"
         )
-    del kernelName, block_m, use_non_temporal_load, w2
+    del kernelName, use_non_temporal_load, w2
 
     assert (
         hidden_states.dtype == torch.uint8
@@ -1557,7 +1666,15 @@ def invoke_gluon_mxfp4_moe_stage1(
         "a1_scale must be a uint8 e8m0 tensor, got "
         f"{None if a1_scale is None else a1_scale.dtype}"
     )
-    assert out.dtype == torch.bfloat16, f"out must be bfloat16, got {out.dtype}"
+    if output_quantized:
+        if not output_sorted:
+            raise ValueError("quantized stage1 output requires sorted row order")
+        if out.dtype != torch.uint8:
+            raise TypeError(f"quantized stage1 out must be uint8, got {out.dtype}")
+        if out_scale is None or out_scale.dtype != torch.uint8:
+            raise TypeError("quantized stage1 out_scale must be a uint8 tensor")
+    elif out.dtype != torch.bfloat16:
+        raise TypeError(f"stage1 out must be bfloat16, got {out.dtype}")
     assert (
         sorted_token_ids.dtype == torch.int32
     ), f"sorted_token_ids must be int32, got {sorted_token_ids.dtype}"
@@ -1583,7 +1700,37 @@ def invoke_gluon_mxfp4_moe_stage1(
     I_r = two_Ir // 2
     N = 2 * I_r
     EM = sorted_token_ids.shape[0]
-    if out.dim() == 3:
+    output_k = I_r if output_k is None else int(output_k)
+    if output_k < I_r or output_k - I_r > 128 or output_k % 32:
+        raise ValueError(
+            "stage1 output_k must be a multiple of 32 in "
+            f"[{I_r}, {I_r + 128}], got {output_k}"
+        )
+    if output_quantized:
+        output_scale_cols = output_k // 32
+        if output_scale_cols % CDNA4_SCALE_K_BLOCK:
+            raise ValueError(
+                "quantized stage1 output_k must be divisible by "
+                f"{32 * CDNA4_SCALE_K_BLOCK} for complete CDNA4 scale panels; "
+                f"got {output_k}"
+            )
+        if out.dim() != 2 or out.shape[0] < EM or out.shape[1] != output_k // 2:
+            raise ValueError(
+                "quantized stage1 out must have shape "
+                f"(>= {EM}, {output_k // 2}), got {tuple(out.shape)}"
+            )
+        assert out_scale is not None
+        if (
+            out_scale.dim() != 2
+            or out_scale.shape[0] < EM
+            or out_scale.shape[1] != output_k // 32
+        ):
+            raise ValueError(
+                "quantized stage1 out_scale must have shape "
+                f"(>= {EM}, {output_k // 32}), got {tuple(out_scale.shape)}"
+            )
+        out_2d = out
+    elif out.dim() == 3:
         token_num, top_k_dim, I_r_dim = out.shape
         assert top_k_dim == topk, f"out top_k mismatch: {top_k_dim} vs topk={topk}"
         assert I_r_dim == I_r, f"out I_r mismatch: {I_r_dim} vs {I_r}"
@@ -1603,6 +1750,7 @@ def invoke_gluon_mxfp4_moe_stage1(
             "out must be 2-D (EM, I_r) or 3-D (token_num, topk, I_r); "
             f"got shape {tuple(out.shape)}"
         )
+    out_scale_ptr = out_scale if output_quantized else a1_scale
     K_scale = K // 32
     assert a1_scale.dim() == 2 and a1_scale.shape[1] == K_scale, (
         f"a1_scale.shape {tuple(a1_scale.shape)} must be "
@@ -1623,16 +1771,13 @@ def invoke_gluon_mxfp4_moe_stage1(
         num_valid_ids_ptr = torch.tensor(
             [int(num_valid_ids)], dtype=torch.int32, device=hidden_states.device
         )
-    if sorted_weights is None:
-        sw_ptr = torch.zeros(1, dtype=torch.float32, device=hidden_states.device)
-    else:
-        sw_ptr = sorted_weights
-
-    BLOCK_M = 128
+    BLOCK_M = int(block_m)
+    if BLOCK_M not in (64, 128):
+        raise ValueError(f"stage1 block_m must be 64 or 128; got {BLOCK_M}")
     BLOCK_N = 128
     BLOCK_K = 256
     GROUP_SIZE_M = 1
-    NUM_WARPS = 4
+    NUM_WARPS = BLOCK_M // 32
     num_pid_m = triton.cdiv(EM, BLOCK_M)
     num_pid_n = triton.cdiv(I_r, BLOCK_N)
     grid = (num_pid_m * num_pid_n,)
@@ -1640,15 +1785,9 @@ def invoke_gluon_mxfp4_moe_stage1(
     stride_am = hidden_states.stride(0)
     stride_ak = hidden_states.stride(1)
     stride_be = w1.stride(0)
-    stride_bn = w1.stride(1)
-    stride_bk = w1.stride(2)
     stride_cm = out_2d.stride(0)
     stride_cn = out_2d.stride(1)
-    stride_ase_m = a1_scale.stride(0)
-    stride_ase_k = a1_scale.stride(1)
     stride_bse_e = w1_scale.stride(0)
-    stride_bse_n = w1_scale.stride(1)
-    stride_bse_k = w1_scale.stride(2)
     stride_se_n_pad = a1_scale.shape[1]
     K_packed_total = K // 2
 
@@ -1659,12 +1798,12 @@ def invoke_gluon_mxfp4_moe_stage1(
         hidden_states,
         w1,
         out_2d,
+        out_scale_ptr,
         a1_scale,
         w1_scale,
         sorted_token_ids,
         sorted_expert_ids,
         num_valid_ids_ptr,
-        sw_ptr,
         N,
         K,
         EM,
@@ -1673,15 +1812,9 @@ def invoke_gluon_mxfp4_moe_stage1(
         stride_am,
         stride_ak,
         stride_be,
-        stride_bn,
-        stride_bk,
         stride_cm,
         stride_cn,
-        stride_ase_m,
-        stride_ase_k,
         stride_bse_e,
-        stride_bse_n,
-        stride_bse_k,
         stride_se_n_pad,
         K_PACKED_TOTAL=K_packed_total,
         BLOCK_M=BLOCK_M,
@@ -1690,12 +1823,15 @@ def invoke_gluon_mxfp4_moe_stage1(
         GROUP_SIZE_M=GROUP_SIZE_M,
         NUM_WARPS=NUM_WARPS,
         I_r=I_r,
+        OUTPUT_K=output_k,
         B_GDOT128=bool(b_gdot128),
         SWIGLU_ALPHA=float(swiglu_alpha),
         SWIGLU_LIMIT=float(swiglu_limit),
         SWIGLU_BETA=float(swiglu_beta),
         DO_SITU=situ_linear_beta is not None,
         SITU_LINEAR_BETA=(1.0 if situ_linear_beta is None else float(situ_linear_beta)),
+        OUTPUT_SORTED=bool(output_sorted),
+        OUTPUT_QUANTIZED=bool(output_quantized),
         num_warps=NUM_WARPS,
     )
     return out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage2.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage2.py
@@ -162,6 +162,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
     COALESCE_SCALES: gl.constexpr = False,
     DIRECT_SCALE_LAYOUT: gl.constexpr = False,
     DEFER_EPILOGUE: gl.constexpr = True,
+    INPUT_SORTED: gl.constexpr = False,
 ):
     """Stage 2 1x2 kernel: 2 waves/CTA, BLOCK_N=256, 2-stage v3 pipeline.
 
@@ -378,7 +379,10 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
             )
             token_id = offs_token & 0xFFFFFF
             topk_id = offs_token >> 24
-            inter_row = token_id * top_k + topk_id
+            if INPUT_SORTED:
+                inter_row = offs_sorted_slot
+            else:
+                inter_row = token_id * top_k + topk_id
             token_mask = token_id < token_num
 
             offs_ak = gl.arange(0, BLOCK_K_PACKED, layout=k_layout)
@@ -925,17 +929,12 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 # convert + LDS-shuffle + store of chunk i hides behind the
                 # MFMA of chunk i+1.
                 #
-                # ``store_layout`` shape per chunk = [128, 64] across
-                # the 4-wave CTA. We choose ``warps_per_cta=[4, 1]``
-                # (waves split M, not N like the MFMA layout) so the
-                # convert_layout LDS shuffle redistributes data such
-                # that within one wave the N axis is contiguous and
-                # each lane can own 8 N-cols = one dwordx4. Per wave:
-                # 32 M-rows x 64 N-cols, with 8 M-lanes x 8 N-lanes,
-                # each lane owning [4 M, 8 N] = 4 dwordx4 stores per
-                # chunk. Per simultaneous-store iteration: 8 M-rows hit
-                # 16 cache lines (8 rows x 2 lines per 64-col row),
-                # vs the 32+ rows the in-place wide layouts hit.
+                # Split M across the four waves while keeping each
+                # wave's N axis contiguous. Scaling the rows per thread
+                # with BLOCK_M makes the four waves cover exactly the
+                # compute tile: [32, 64] per wave at BM128, [16, 64] at
+                # BM64, and [8, 64] at BM32. A fixed four-row ownership
+                # would alias rows for the smaller tiles.
                 if MFMA_STORE_LAYOUT:
                     # Small-M atomic A/B path: keep the accumulator's MFMA
                     # layout through the store to avoid the convert_layout
@@ -945,7 +944,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     store_layout: gl.constexpr = mfma_layout
                 else:
                     store_layout: gl.constexpr = gl.BlockedLayout(
-                        size_per_thread=[4, 8],
+                        size_per_thread=[BLOCK_M // 32, 8],
                         threads_per_warp=[8, 8],
                         warps_per_cta=[4, 1],
                         order=[1, 0],
@@ -1451,6 +1450,7 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
     b_preshuffled: bool = False,
     b_gdot128: bool = False,
     force_reduce: bool | None = None,
+    input_sorted: bool = False,
 ):
     """Host-side launcher for Gluon MXFP4 MoE stage 2.
 
@@ -1544,6 +1544,10 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
     N = D
     assert I_r_packed_w == I_r_packed
     EM = sorted_token_ids.shape[0]
+    if input_sorted and M_padded < EM:
+        raise ValueError(
+            f"sorted stage2 input has {M_padded} rows but routing requires {EM}"
+        )
     K_scale = K // 32
     assert a2_scale.dim() == 2 and a2_scale.shape[1] == K_scale
     assert w2_scale.shape == (E_w, N, K_scale)
@@ -1709,6 +1713,7 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
         COALESCE_SCALES=COALESCE_SCALES,
         DIRECT_SCALE_LAYOUT=DIRECT_SCALE_LAYOUT,
         DEFER_EPILOGUE=DEFER_EPILOGUE,
+        INPUT_SORTED=bool(input_sorted),
         # ``CU_NUM`` is the divisor for ``tiles_per_block`` in the
         # persistent path. When PERSISTENT=False it is unused inside
         # the kernel (branch is constexpr-pruned), so we keep it at the

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/quantize_gluon.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/quantize_gluon.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Gluon device helpers shared by staged and fused MXFP4 MoE kernels."""
+
+from tokenspeed_kernel_amd._triton import gl, gluon
+
+
+@gluon.jit
+def _mxfp4_quantize_tile(out):
+    max_normal: gl.constexpr = 6.0
+    min_normal: gl.constexpr = 1.0
+    BLOCK_M: gl.constexpr = out.shape[0]
+    OUT_BLOCK_N: gl.constexpr = out.shape[1]
+    Q_GROUPS: gl.constexpr = OUT_BLOCK_N // 32
+    gl.static_assert(OUT_BLOCK_N % 32 == 0)
+
+    vals = out.to(gl.bfloat16).to(gl.float32).reshape((BLOCK_M, Q_GROUPS, 32))
+    raw_abs = vals.to(gl.uint32, bitcast=True) & 0x7FFFFFFF
+    abs_vals = raw_abs.to(gl.float32, bitcast=True)
+    amax = gl.max(abs_vals, axis=2, keep_dims=True)
+    amax_bits = amax.to(gl.uint32, bitcast=True)
+    rounded_bits = (amax_bits + 0x200000) & 0x7F800000
+    exp_biased = (rounded_bits >> 23).to(gl.int32)
+    scale_i = gl.minimum(gl.maximum(exp_biased - 2, 0), 254)
+    scale_byte = scale_i.to(gl.uint8).reshape((BLOCK_M, Q_GROUPS))
+
+    inv_scale_bits = ((254 - scale_i) << 23).to(gl.uint32)
+    inv_scale = inv_scale_bits.to(gl.float32, bitcast=True)
+    qx = vals * inv_scale
+    qx_bits = qx.to(gl.uint32, bitcast=True)
+
+    sign = qx_bits & 0x80000000
+    qx_mag = qx_bits ^ sign
+    qx_fp32 = qx_mag.to(gl.float32, bitcast=True)
+    saturate_mask = qx_fp32 >= max_normal
+    denormal_mask = (not saturate_mask) & (qx_fp32 < min_normal)
+    normal_mask = not (saturate_mask | denormal_mask)
+
+    denorm_mask_int: gl.constexpr = ((127 - 1) + (23 - 1) + 1) << 23
+    denorm_mask_float: gl.constexpr = gl.cast(
+        denorm_mask_int,
+        gl.float32,
+        bitcast=True,
+    )
+    denormal_x = qx_fp32 + denorm_mask_float
+    denormal_x = denormal_x.to(gl.uint32, bitcast=True)
+    denormal_x -= denorm_mask_int
+    denormal_x = denormal_x.to(gl.uint8)
+
+    normal_x = qx_mag
+    mant_odd = (normal_x >> (23 - 1)) & 1
+    normal_x += 0xC11FFFFF
+    normal_x += mant_odd
+    normal_x = normal_x >> (23 - 1)
+    normal_x = normal_x.to(gl.uint8)
+
+    e2m1 = gl.full(vals.shape, 0x7, gl.uint8, layout=vals.type.layout)
+    e2m1 = gl.where(normal_mask, normal_x, e2m1)
+    e2m1 = gl.where(denormal_mask, denormal_x, e2m1)
+    sign_lp = (sign >> (23 + 8 - 1 - 2)).to(gl.uint8)
+    e2m1 = e2m1 | sign_lp
+    e2m1 = e2m1.reshape((BLOCK_M, Q_GROUPS, 16, 2))
+    evens, odds = gl.split(e2m1)
+    packed = evens | (odds << 4)
+    return packed, scale_byte
+
+
+@gluon.jit
+def _mxfp4_store_cdna4_scale(
+    scale_ptr,
+    scale_byte,
+    scale_m,
+    scale_k,
+    stride_kswizzled,
+    stride_mblock,
+    mask,
+    M_SWIZZLE: gl.constexpr,
+    K_SWIZZLE: gl.constexpr,
+):
+    m_in_block = scale_m % M_SWIZZLE
+    m_hi = m_in_block // 16
+    m_lo = m_in_block % 16
+    k_block = scale_k // K_SWIZZLE
+    k_in_block = scale_k % K_SWIZZLE
+    k_hi = k_in_block // 4
+    k_lo = k_in_block % 4
+    swizzled_k = (((k_block * 4 + k_lo) * 16 + m_lo) * 2 + k_hi) * 2 + m_hi
+    m_block = scale_m // M_SWIZZLE
+    gl.store(
+        scale_ptr
+        + swizzled_k.to(gl.int64) * stride_kswizzled
+        + m_block.to(gl.int64) * stride_mblock,
+        scale_byte,
+        mask=mask,
+    )

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -721,6 +721,233 @@ def test_tp_situ_selects_a8w4_and_matches_reference_gfx950(
         torch.testing.assert_close(captured, expected, atol=2e-3, rtol=8e-2)
 
 
+@pytest.mark.parametrize(
+    ("num_tokens", "num_experts", "top_k"),
+    [(257, 17, 4), (4097, 3, 1)],
+)
+def test_package_prefill_sort_contract_gfx950(
+    num_tokens: int,
+    num_experts: int,
+    top_k: int,
+) -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.moe_sorting import (
+        _max_padded_route_capacity,
+        gluon_moe_sorting,
+    )
+
+    generator = torch.Generator().manual_seed(20260829 + num_tokens)
+    topk_ids_cpu = torch.randint(
+        num_experts,
+        (num_tokens, top_k),
+        dtype=torch.int32,
+        generator=generator,
+    )
+    topk_ids_cpu.view(-1)[::13] = -1
+    topk_weights_cpu = torch.arange(
+        num_tokens * top_k,
+        dtype=torch.float32,
+    ).view(num_tokens, top_k)
+    topk_ids = topk_ids_cpu.to("cuda")
+    topk_weights = topk_weights_cpu.to("cuda")
+    block_m = 64
+
+    sorted_ids, sorted_weights, sorted_experts, num_valid, _ = gluon_moe_sorting(
+        topk_ids,
+        topk_weights,
+        num_experts,
+        1,
+        torch.bfloat16,
+        block_m,
+    )
+    valid_extent, reported_tokens = num_valid.cpu().tolist()
+    assert reported_tokens == num_tokens
+    assert sorted_ids.numel() == _max_padded_route_capacity(
+        num_tokens * top_k,
+        num_experts,
+        block_m,
+    )
+    expected_extent = sum(
+        ((int((topk_ids_cpu == expert).sum()) + block_m - 1) // block_m) * block_m
+        for expert in range(num_experts)
+    )
+    assert valid_extent == expected_extent
+
+    ids = sorted_ids[:valid_extent].cpu()
+    weights = sorted_weights[:valid_extent].cpu()
+    experts = sorted_experts[: valid_extent // block_m].cpu()
+    expected_routes = {
+        (slot << 24) | token
+        for token in range(num_tokens)
+        for slot in range(top_k)
+        if int(topk_ids_cpu[token, slot]) >= 0
+    }
+    actual_routes: set[int] = set()
+    actual_route_count = 0
+    for row, packed_tensor in enumerate(ids):
+        packed = int(packed_tensor)
+        token = packed & 0xFFFFFF
+        if token == num_tokens:
+            continue
+        slot = packed >> 24
+        expert = int(experts[row // block_m])
+        assert int(topk_ids_cpu[token, slot]) == expert
+        assert float(weights[row]) == float(topk_weights_cpu[token, slot])
+        actual_routes.add(packed)
+        actual_route_count += 1
+    assert actual_route_count == len(expected_routes)
+    assert actual_routes == expected_routes
+
+
+def test_package_prefill_low_density_route_capacity_gfx950() -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.moe_sorting import (
+        _max_padded_route_capacity,
+        gluon_moe_sorting,
+    )
+
+    num_tokens, top_k, num_experts, block_m = 9, 16, 896, 128
+    topk_ids = torch.arange(
+        num_tokens * top_k,
+        dtype=torch.int32,
+        device="cuda",
+    ).view(num_tokens, top_k)
+    topk_weights = torch.ones_like(topk_ids, dtype=torch.float32)
+    sorted_ids, _, sorted_experts, num_valid, _ = gluon_moe_sorting(
+        topk_ids,
+        topk_weights,
+        num_experts,
+        1,
+        torch.bfloat16,
+        block_m,
+    )
+
+    expected_capacity = _max_padded_route_capacity(
+        num_tokens * top_k,
+        num_experts,
+        block_m,
+    )
+    assert expected_capacity == 18_432
+    assert sorted_ids.numel() == expected_capacity
+    assert sorted_experts.numel() == expected_capacity // block_m
+    assert int(num_valid[0].cpu()) == expected_capacity
+
+
+def test_stage1_quantized_output_rejects_partial_scale_panel_gfx950() -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.prefill_stage1 import (
+        invoke_gluon_mxfp4_moe_stage1,
+    )
+
+    hidden_states = torch.empty((64, 64), dtype=torch.uint8, device="cuda")
+    w1 = torch.empty((1, 256, 64), dtype=torch.uint8, device="cuda")
+    sorted_ids = torch.zeros(64, dtype=torch.int32, device="cuda")
+    sorted_experts = torch.zeros(1, dtype=torch.int32, device="cuda")
+    num_valid = torch.tensor([64, 64], dtype=torch.int32, device="cuda")
+    out = torch.empty((64, 64), dtype=torch.uint8, device="cuda")
+    out_scale = torch.empty((64, 4), dtype=torch.uint8, device="cuda")
+    a_scale = torch.empty((64, 4), dtype=torch.uint8, device="cuda")
+    w_scale = torch.empty((1, 256, 4), dtype=torch.uint8, device="cuda")
+
+    with pytest.raises(ValueError, match="complete CDNA4 scale panels"):
+        invoke_gluon_mxfp4_moe_stage1(
+            hidden_states,
+            w1,
+            None,
+            sorted_ids,
+            sorted_experts,
+            num_valid,
+            out,
+            1,
+            w1_scale=w_scale,
+            a1_scale=a_scale,
+            block_m=64,
+            sorted_weights=None,
+            b_preshuffled=True,
+            output_sorted=True,
+            output_quantized=True,
+            out_scale=out_scale,
+            output_k=128,
+        )
+
+
+@pytest.mark.parametrize(
+    ("num_tokens", "expected"),
+    [(128, 128), (129, 64), (192, 64), (193, 128)],
+)
+def test_package_prefill_block_m_selection_gfx950(
+    num_tokens: int,
+    expected: int,
+) -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.fused.moe import (
+        _select_package_prefill_block_m,
+    )
+
+    assert _select_package_prefill_block_m(num_tokens, 16, 16) == expected
+
+
+def test_tp_situ_package_prefill_block64_matches_block128_gfx950(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.fused import moe as fused_moe
+
+    generator = torch.Generator(device="cuda").manual_seed(20260828)
+    num_tokens, num_experts, top_k = 160, 16, 16
+    latent_size, intermediate_size = 3584, 384
+    module, _ = _make_mxfp4_module(
+        num_experts=num_experts,
+        latent_size=latent_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        generator=generator,
+    )
+    hidden_states = torch.randn(
+        num_tokens,
+        latent_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    topk_weights, topk_ids = make_round_robin_topk(
+        num_tokens,
+        num_experts,
+        top_k,
+    )
+    router_logits = torch.empty((num_tokens, 0), dtype=torch.float32, device="cuda")
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="situ",
+        routing_mode="precomputed_topk",
+        ep_size=1,
+        ispp=intermediate_size,
+        internal_activation_dtype="input",
+        solution="gluon",
+    )
+    tokenspeed_kernel.moe_process_weights(plan, module)
+
+    block64 = tokenspeed_kernel.moe_apply(
+        plan,
+        hidden_states,
+        module,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+    monkeypatch.setattr(
+        fused_moe,
+        "_select_package_prefill_block_m",
+        lambda *_args: 128,
+    )
+    block128 = tokenspeed_kernel.moe_apply(
+        plan,
+        hidden_states,
+        module,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+    torch.testing.assert_close(block64, block128, atol=0.0, rtol=0.0)
+
+
 @pytest.mark.parametrize("num_tokens", [1, 2, 3, 4])
 def test_tp_situ_joint_shared_projection_gfx950(num_tokens: int) -> None:
     generator = torch.Generator(device="cuda").manual_seed(20260818 + num_tokens)


### PR DESCRIPTION
Summary:
- Select 64-row grouped tiles when 128-row blocks over-pad routed rows.
- Vectorize the stable routing sort and initialize route padding in the sorting kernels.
- Quantize stage-1 SiTU output directly into the sorted MXFP4/CDNA4 layout consumed by stage 2.

This removes the intermediate BF16 padding, quantization, and scale-gather launches from Kimi-K3 TP8 prefill.

Testing Plan:
- Added gfx950 coverage for stable routing metadata, low-density route capacity, and sorted-row padding.
- Added block-size selection and bit-exact block64 versus block128 output coverage.
- Added validation of the stage-1 quantized-output scale-panel contract.

Benchmark:
TP8 Kimi-K3 uncached c4 prefill at M=8192. Layer times are aligned all-rank GPU wall spans, summed from per-layer medians after Tukey outlier rejection.

- 69 complete KDA layers: 485.042 -> 448.271 ms (7.030 -> 6.497 ms/layer, 7.6% faster).
- 24 complete MLA layers: 225.423 -> 212.257 ms (9.393 -> 8.844 ms/layer, 5.8% faster).
- MoE launches per rank per layer: 32 -> 22.

End-to-end prefill uses EvalScope 1.11.0 random raw completions with exact 50K input and 500 output tokens, TP8/EP1, FP8 KV, 8192-token chunks, greedy streaming, and no prefix cache or prefill graph. Each fresh process runs a complete c1-c4 warm pass before measurement. Values are the median p99 TTFT from two fresh-process runs; lower is better.

```
| b/c | Main TTFT (ms) | This change (ms) | Change |
| ---: | ---: | ---: | ---: |
| 1 | 4,545.38 | 4,218.39 | -7.19% |
| 2 | 8,894.81 | 8,244.61 | -7.31% |
| 3 | 13,241.76 | 12,267.31 | -7.36% |
| 4 | 17,563.45 | 16,251.78 | -7.47% |
```
