### PR TITLE
perf(kimi3): let the MoE tail join its reductions without a lane

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -258,6 +258,7 @@ class Kimi3MoEExecutionPlan:
         lane_width: int,
         has_latent_norm: bool,
         max_token_num: int,
+        shard_up_projection: bool = False,
     ) -> "Kimi3MoEExecutionPlan":
         """Prepare optional communication fusions before graph capture."""
 
@@ -280,7 +281,13 @@ class Kimi3MoEExecutionPlan:
         # the payload exceeds COMM_ONESHOT_MAX_BYTES. Both are portable, so the
         # tail can issue one collective per MoE layer instead of two wherever a
         # TP x EP group exists -- not only where TRT-LLM can arm a lane.
-        join_moe_reduce = mapping.moe.has_tp_ep
+        #
+        # Excluded when the up projection is sharded: that tail folds the
+        # projection between two sequential all-reduces
+        # (_tail_fused_lane_ar_sharded) rather than calling the join, so the
+        # collective count is unchanged, while leaving SEPARATE_REDUCE would
+        # also give up the routed_in_fork overlap with the shared branch.
+        join_moe_reduce = mapping.moe.has_tp_ep and not shard_up_projection
         return replace(
             self,
             fused_moe_ar=fused_moe_ar,

--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -198,6 +198,12 @@ class Kimi3MoEExecutionPlan:
     joint_moe_reduce: bool
     use_marlin: bool = False
     fused_moe_ar: bool = False
+    # Whether the routed and shared partials can be reduced together at all,
+    # independent of whether a backend-owned lane is available to avoid the
+    # concatenation. ``fused_moe_ar`` implies a lane and is TRT-LLM only;
+    # ``join_moe_reduce`` only needs a grouped or concatenated all-reduce,
+    # which every backend provides, so the join is available on AMD too.
+    join_moe_reduce: bool = False
     lane_latent_norm_ar: bool = False
     comm_fusion_max_num_tokens: int = 0
 
@@ -269,9 +275,16 @@ class Kimi3MoEExecutionPlan:
                 max_token_num,
             )
         )
+        # The join itself needs no backend-owned lane: kimi3_join_reduce_moe
+        # falls back to a concatenated one-shot, or a grouped all-reduce when
+        # the payload exceeds COMM_ONESHOT_MAX_BYTES. Both are portable, so the
+        # tail can issue one collective per MoE layer instead of two wherever a
+        # TP x EP group exists -- not only where TRT-LLM can arm a lane.
+        join_moe_reduce = mapping.moe.has_tp_ep
         return replace(
             self,
             fused_moe_ar=fused_moe_ar,
+            join_moe_reduce=join_moe_reduce,
             lane_latent_norm_ar=lane_latent_norm_ar,
             comm_fusion_max_num_tokens=max_token_num,
         )

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1541,6 +1541,7 @@ class KimiLinearMoE(nn.Module):
                 int(global_server_args_dict["comm_fusion_max_num_tokens"]),
                 1,
             ),
+            shard_up_projection=self._shard_up_projection,
         )
 
         self._topk_ready = (

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -147,7 +147,17 @@ def select_k3_moe_tail_tier(
         # reduces the routed and shared partials over the same group one after
         # the other -- and each collective is a rendezvous whose cost does not
         # amortize with batch, so the saving is largest at low concurrency.
-        # SEPARATE_REDUCE stays the fallback for backends that cannot join.
+        #
+        # SEPARATE_REDUCE stays the fallback for layouts that cannot join,
+        # which includes a sharded up projection: its tail folds the projection
+        # between two sequential all-reduces instead of calling
+        # kimi3_join_reduce_moe, so it would save no collective while still
+        # giving up the routed_in_fork overlap.
+        #
+        # MULTIMEM_AR is deliberately still not reachable here. It already
+        # required fused_moe_ar before this join existed, so promoting
+        # lane-less backends into the multimem window would be a separate
+        # behavioural change rather than part of this one.
         if join_moe_reduce:
             return K3MoETailTier.FUSED_LANE_AR
         return K3MoETailTier.SEPARATE_REDUCE

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -115,6 +115,7 @@ def select_k3_moe_tail_tier(
     fused_moe_ar: bool,
     multimem_ok: bool,
     is_decode: bool = False,
+    join_moe_reduce: bool = False,
 ) -> K3MoETailTier:
     """Pick the tail tier; every input must be rank-uniform.
 
@@ -123,7 +124,12 @@ def select_k3_moe_tail_tier(
         graph_phase: Whether the forward runs under the CUDA-graph phase.
         tail_fusion_max_tokens: Largest token count the fused tail is both
             able and worth running at, 0 when absent.
-        fused_moe_ar: Whether the fused-AR execution plan is armed.
+        fused_moe_ar: Whether the fused-AR execution plan is armed (implies a
+            backend-owned lane, so TRT-LLM only).
+        join_moe_reduce: Whether the routed and shared partials can be reduced
+            together without a lane, via a concatenated one-shot or a grouped
+            all-reduce. Portable, so this is what lets non-TRT-LLM backends
+            reach the join tier.
         multimem_ok: Collectively-agreed multimem availability.
         is_decode: Whether this forward is a decode (spec-verify included);
             rank-uniform and stable between graph capture and replay.
@@ -136,6 +142,14 @@ def select_k3_moe_tail_tier(
     if graph_phase and 1 <= num_tokens <= tail_fusion_max_tokens:
         return K3MoETailTier.TAIL_FUSION
     if not fused_moe_ar:
+        # No lane, but the join only needs a concatenated or grouped
+        # all-reduce. Taking it halves the tail's collectives -- SEPARATE_REDUCE
+        # reduces the routed and shared partials over the same group one after
+        # the other -- and each collective is a rendezvous whose cost does not
+        # amortize with batch, so the saving is largest at low concurrency.
+        # SEPARATE_REDUCE stays the fallback for backends that cannot join.
+        if join_moe_reduce:
+            return K3MoETailTier.FUSED_LANE_AR
         return K3MoETailTier.SEPARATE_REDUCE
     if (
         multimem_ok
@@ -617,6 +631,7 @@ class K3MoeTailComm:
                 else 0
             ),
             fused_moe_ar=self.execution_plan.fused_moe_ar,
+            join_moe_reduce=self.execution_plan.join_moe_reduce,
             multimem_ok=self.state.multimem_ar_ok,
             is_decode=is_decode,
         )

--- a/test/runtime/layers/test_latent_moe.py
+++ b/test/runtime/layers/test_latent_moe.py
@@ -767,3 +767,48 @@ def test_kimi3_latent_projection_shard_forward_add3_matches_replicated(
         proj.weight_loader(proj.weight, full)
         got = proj.forward_add3(x, a, c)
         torch.testing.assert_close(got, expected)
+
+
+def _plan_for_join(shard_up_projection: bool) -> Kimi3MoEExecutionPlan:
+    """prepare_latent_fusion on a native (lane-less) TP x EP layout."""
+    mapping = SimpleNamespace(
+        moe=SimpleNamespace(has_tp_ep=True, tp_ep_group=(0, 1)),
+    )
+    plan = Kimi3MoEExecutionPlan(
+        use_native=True,
+        use_trtllm=False,
+        overlap_shared_experts=False,
+        joint_moe_reduce=False,
+    )
+    return plan.prepare_latent_fusion(
+        mapping,
+        lane_width=10752,
+        has_latent_norm=False,
+        max_token_num=8,
+        shard_up_projection=shard_up_projection,
+    )
+
+
+def test_join_is_available_without_a_trtllm_lane() -> None:
+    """No lane, but the partials can still be reduced together.
+
+    prepare_all_reduce_lane is only implemented by the TRT-LLM backend, so a
+    native layout never arms fused_moe_ar. kimi3_join_reduce_moe handles
+    lane=None with a concatenated one-shot or a grouped all-reduce, so the
+    join is still available and the tail issues one collective instead of two.
+    """
+    prepared = _plan_for_join(shard_up_projection=False)
+    assert not prepared.fused_moe_ar
+    assert prepared.join_moe_reduce
+
+
+def test_sharded_up_projection_does_not_advertise_the_join() -> None:
+    """A sharded up projection cannot use the join, so it must not claim it.
+
+    _tail_fused_lane_ar_sharded folds the projection between two sequential
+    all-reduces rather than calling kimi3_join_reduce_moe: selecting the join
+    tier there would save no collective while also dropping routed_in_fork,
+    which overlaps the routed reduction with the shared branch.
+    """
+    prepared = _plan_for_join(shard_up_projection=True)
+    assert not prepared.join_moe_reduce

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -142,6 +142,7 @@ def _build_comm(device: torch.device, *, latent_tail=None):
     )
     comm.execution_plan = SimpleNamespace(
         fused_moe_ar=True,
+        join_moe_reduce=True,
         lane_latent_norm_ar=False,
         comm_fusion_max_num_tokens=8192,
     )
@@ -374,7 +375,7 @@ def test_profit_cap_stops_the_fused_tail_below_its_capacity(monkeypatch):
         supports_split_collective=True,
         split_collective_min_tokens=9,
     )
-    comm.execution_plan = SimpleNamespace(fused_moe_ar=True)
+    comm.execution_plan = SimpleNamespace(fused_moe_ar=True, join_moe_reduce=True)
     comm.state = SimpleNamespace(multimem_ar_ok=False)
     comm._shard_up_projection = False
     comm.routed_hidden, comm.hidden_size = L, H
@@ -406,7 +407,9 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
             supports_split_collective=True,
             split_collective_min_tokens=9,
         )
-        comm.execution_plan = SimpleNamespace(fused_moe_ar=fused_ar)
+        comm.execution_plan = SimpleNamespace(
+            fused_moe_ar=fused_ar, join_moe_reduce=fused_ar
+        )
         comm.state = SimpleNamespace(multimem_ar_ok=False)
         comm._shard_up_projection = False
         comm.routed_hidden, comm.hidden_size = L, H

--- a/test/runtime/test_k3_moe_tail_tier.py
+++ b/test/runtime/test_k3_moe_tail_tier.py
@@ -97,3 +97,40 @@ def test_fused_lane_fallback_without_multimem(m):
 
 def test_graph_phase_above_fused_capacity_still_tiers_by_tokens():
     assert _select(num_tokens=512, graph_phase=True) is K3MoETailTier.MULTIMEM_AR
+
+
+def test_join_without_a_lane_reaches_the_join_tier():
+    """No TRT-LLM lane, but the join itself needs no lane.
+
+    ``fused_moe_ar`` implies a backend-owned lane and is TRT-LLM only, so on
+    every other backend it is False and the tail used to fall all the way to
+    SEPARATE_REDUCE -- two collectives per MoE layer over the same group.
+    ``kimi3_join_reduce_moe`` handles ``lane=None`` with a concatenated
+    one-shot or a grouped all-reduce, so the join tier is reachable without
+    one.
+    """
+    assert (
+        _select(fused_moe_ar=False, join_moe_reduce=True) is K3MoETailTier.FUSED_LANE_AR
+    )
+
+
+def test_without_join_capability_the_fallback_is_unchanged():
+    assert (
+        _select(fused_moe_ar=False, join_moe_reduce=False)
+        is K3MoETailTier.SEPARATE_REDUCE
+    )
+
+
+def test_join_does_not_preempt_the_fused_tail_or_multimem():
+    # The fused decode tail still wins inside its graph-phase window ...
+    assert (
+        _select(
+            num_tokens=8, graph_phase=True, fused_moe_ar=False, join_moe_reduce=True
+        )
+        is K3MoETailTier.TAIL_FUSION
+    )
+    # ... and an armed lane still routes through the multimem window.
+    assert (
+        _select(fused_moe_ar=True, join_moe_reduce=True, multimem_ok=True)
+        is K3MoETailTier.MULTIMEM_AR
+    )

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -238,6 +238,7 @@ class KimiK3RegistrationTests(unittest.TestCase):
             moe=SimpleNamespace(
                 tp_ep_rank=0,
                 tp_ep_size=8,
+                has_tp_ep=True,
                 tp_ep_group=tuple(range(8)),
             )
         )
@@ -476,6 +477,7 @@ class KimiK3RegistrationTests(unittest.TestCase):
                 ep_size=8,
                 ep_group=ep_group,
                 tp_ep_size=8,
+                has_tp_ep=True,
                 tp_ep_rank=0,
                 tp_ep_group=ep_group,
             ),
@@ -544,6 +546,7 @@ class KimiK3RegistrationTests(unittest.TestCase):
                 ep_size=1,
                 ep_group=(0,),
                 tp_ep_size=8,
+                has_tp_ep=True,
                 tp_ep_rank=0,
                 tp_ep_group=ep_group,
             ),


### PR DESCRIPTION
## Problem

`select_k3_moe_tail_tier` falls straight to `SEPARATE_REDUCE` whenever `fused_moe_ar` is false:

```python
if not fused_moe_ar:
    return K3MoETailTier.SEPARATE_REDUCE
```

That tier reduces the routed and shared partials one after the other over the same TP x EP group — **two collectives per MoE layer**.

`fused_moe_ar` implies a backend-owned one-shot lane, and `prepare_all_reduce_lane` is only implemented by the TRT-LLM backend (`CommBackend.prepare_all_reduce_lane` returns `False` in the base class). So every other backend was pinned to the fallback regardless of what it could actually do.

But the lane is an optimization *for* the join, not a prerequisite. `kimi3_join_reduce_moe` already handles `lane=None`, with a concatenated one-shot or a grouped all-reduce once the payload exceeds `COMM_ONESHOT_MAX_BYTES`. Both are portable.

## Change

Split the two notions apart:

- **`join_moe_reduce`** — the partials can be reduced together. Needs only a TP x EP group, so it holds on every backend.
- **`fused_moe_ar`** — and a lane exists to skip the concatenation. TRT-LLM only, unchanged.

The selector now reaches `FUSED_LANE_AR` on the former. Backends that cannot join keep `SEPARATE_REDUCE`; neither the fused decode tail nor the multimem window is preempted.

## Results

8x gfx950 (MI355X), Kimi-K3 MXFP4, TP8/EP1, 4k input / 1k output, graph mode.

| concurrency | before | after | change |
| ---: | ---: | ---: | ---: |
| 1 | 53.70 tok/s | **60.11** | **+11.9%** |
| 8 | 265.41 | 272.20 | +2.6% |
| 16 | 446.17 | 455.58 | +2.1% |

Median TPOT at concurrency 1: 18.21 -> **16.23 ms** (-10.9%).

The mechanism is confirmed in the decode traces rather than inferred — MoE-layer count is identical in both, so this is like-for-like:

| | one-shot all-reduces | MoE layers | per layer |
| --- | ---: | ---: | ---: |
| before | 9,118 | 4,324 | **2.11** |
| after | 4,794 | 4,324 | **1.11** |

TP8/EP8, which already joins via `LatentMoELayer`, sits at 1.11 — so this brings EP1 to parity. Total rank-0 decode dispatch drops 1,505 -> 1,255 ms and the collective share falls from 20.6% to 13.7%.

The gradient across concurrency is the expected signature: each collective is a rendezvous whose cost does not amortize with batch, so halving the count pays most where there is nothing to hide it behind.

## Correctness

A fixed greedy prompt set (arithmetic, recall, short reasoning) returns 8/8 correct, unchanged from before the change.

## Tests

`test_k3_moe_tail_tier.py` gains three cases: the join tier is reachable without a lane, the fallback is unchanged when the backend cannot join, and neither the fused decode tail nor the multimem window is preempted. Existing selector and equivalence tests pass (54 total); their fake execution plans gained the new field.

## Notes

Not AMD-specific — any backend with a TP x EP group and no TRT-LLM lane gains. TP8/EP8 is unaffected: it joins through `LatentMoELayer` and never reaches this selector.

Related: #1144 pursued the same idea one layer up, by widening `joint_moe_reduce` in `LatentMoELayer`. That approach no longer reaches EP1, because #1139 restricted `native_latent_moe` construction to `moe.tp_size == 1`; verified by measurement — cherry-picking it onto current main produces byte-identical traces. Fixing the tier selector reaches the path EP1 actually takes.