### PR TITLE
fix(engine): stop profiling without a device-side rendezvous

### DIFF
--- a/python/tokenspeed/runtime/engine/request_handler.py
+++ b/python/tokenspeed/runtime/engine/request_handler.py
@@ -156,6 +156,10 @@ class RequestHandler:
             else None
         )
         self.profile_rank_tag = _profile_rank_tag(mapping.attn)
+        # Rendezvous buffer for _profile_sync. Preallocated because the stage
+        # transitions run on the control-plane thread, where allocating is what
+        # Principle 1 forbids -- see _profile_sync.
+        self._profile_sync_buf = torch.zeros(1, dtype=torch.int32, device="cpu")
 
         self.hf_eos_token_id = hf_eos_token_id
         self.max_req_len = max_req_len
@@ -533,6 +537,29 @@ class RequestHandler:
 
         return ProfileReqOutput(success=True, message="Succeeded")
 
+    def _profile_sync(self) -> None:
+        """Rendezvous the attention TP peers without touching the device.
+
+        ``torch.distributed.barrier`` cannot be used here. It prefers
+        ``group.bound_device_id`` over its CPU branch, and
+        ``DistributedInitializer`` binds ``cuda:N`` to every group -- including
+        the gloo ones -- to force eager NCCL init. A gloo barrier therefore
+        allocates ``aten.empty`` on CUDA, and these calls run on the
+        control-plane thread (stage transitions arrive through
+        ``_profile_batch_predicate``), where ``_NoDeviceWork`` rejects exactly
+        that. The result was every rank dying mid-profile with "control-plane
+        thread ran CUDA factory".
+
+        An all-reduce over a preallocated CPU tensor rendezvouses identically
+        and allocates nothing, matching how the loop's other in-round
+        collectives are written.
+        """
+        if self.attn_tp_size == 1:
+            return
+        torch.distributed.all_reduce(
+            self._profile_sync_buf, group=self.attn_tp_cpu_group
+        )
+
     def stop_profile(self, stage: ForwardMode | None = None) -> ProfileReqOutput | None:
         if not self.profile_in_progress:
             return ProfileReqOutput(
@@ -553,7 +580,7 @@ class RequestHandler:
                     f"{self.profile_id}-{self.profile_rank_tag}{stage_suffix}.trace.json.gz",
                 )
             )
-            torch.distributed.barrier(self.attn_tp_cpu_group)
+            self._profile_sync()
 
         if self.profiler_activities is not None and "MEM" in self.profiler_activities:
             memory_profile_path = os.path.join(
@@ -577,7 +604,7 @@ class RequestHandler:
                 proton_error = exc
             finally:
                 # Do not reply until every TP peer has finished writing.
-                torch.distributed.barrier(self.attn_tp_cpu_group)
+                self._profile_sync()
 
         if "VIZTRACER" in self.profiler_activities and self.viztracer is not None:
             self.viztracer.stop()

--- a/test/runtime/test_request_handler_profile.py
+++ b/test/runtime/test_request_handler_profile.py
@@ -3,6 +3,7 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import torch
 from tokenspeed_kernel import profiling
 
 from tokenspeed.runtime.engine import request_handler as request_handler_mod
@@ -29,6 +30,10 @@ def _make_handler(attn_mapping: SimpleNamespace | None = None) -> RequestHandler
     attn_mapping = attn_mapping or _attn_mapping()
     handler.attn_tp_rank = attn_mapping.tp_rank
     handler.attn_tp_cpu_group = None
+    # __init__ is bypassed here, so mirror the state _profile_sync needs: the
+    # peer count it short-circuits on and the preallocated rendezvous buffer.
+    handler.attn_tp_size = getattr(attn_mapping, "tp_size", 2)
+    handler._profile_sync_buf = torch.zeros(1, dtype=torch.int32, device="cpu")
     handler.profile_rank_tag = request_handler_mod._profile_rank_tag(attn_mapping)
     handler.init_profiler()
     return handler
@@ -50,13 +55,16 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
         self.output_dir = tempfile.mkdtemp()
         profiling.ProfilingState.reset()
         self.addCleanup(profiling.ProfilingState.reset)
-        # stop_profile barriers the attn-TP CPU group; there is no real
-        # process group in unit tests.
-        barrier_patcher = mock.patch.object(
-            request_handler_mod.torch.distributed, "barrier"
+        # stop_profile rendezvouses the attn-TP CPU group through
+        # _profile_sync, which all-reduces a preallocated CPU tensor rather
+        # than calling barrier (barrier would allocate on the bound CUDA
+        # device and trip the control-plane guard). No real process group
+        # exists in unit tests.
+        sync_patcher = mock.patch.object(
+            request_handler_mod.torch.distributed, "all_reduce"
         )
-        self.barrier = barrier_patcher.start()
-        self.addCleanup(barrier_patcher.stop)
+        self.profile_sync = sync_patcher.start()
+        self.addCleanup(sync_patcher.stop)
 
     def test_init_fails_when_proton_unavailable(self):
         with mock.patch.object(
@@ -215,7 +223,7 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
         self.assertTrue(outputs[0].endswith("test-profile-DP0-TP0.proton"))
         self.assertTrue(outputs[1].endswith("test-profile-DP1-TP0.proton"))
 
-    def test_stop_profile_barriers_tp_peers_after_proton_finalize(self):
+    def test_stop_profile_syncs_tp_peers_after_proton_finalize(self):
         # Only attn-TP rank 0 replies to /stop_profile; the reply must wait
         # until every TP peer has finalized its Proton file.
         self.handler.attn_tp_cpu_group = object()
@@ -225,14 +233,43 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
         ), mock.patch.object(request_handler_mod, "start_profiling"), mock.patch.object(
             request_handler_mod, "stop_profiling"
         ) as stop_profiling:
-            self.barrier.side_effect = lambda group: self.assertTrue(
+            self.profile_sync.side_effect = lambda tensor, group: self.assertTrue(
                 stop_profiling.called
             )
             self.handler.profile(_start_req(self.output_dir))
             result = self.handler.profile(ProfileReq(type=ProfileReqType.STOP_PROFILE))
 
         self.assertTrue(result.success)
-        self.barrier.assert_called_once_with(self.handler.attn_tp_cpu_group)
+        self.profile_sync.assert_called_once_with(
+            self.handler._profile_sync_buf, group=self.handler.attn_tp_cpu_group
+        )
+
+    def test_profile_sync_never_touches_the_device(self):
+        """The rendezvous must not allocate, and must not be a barrier.
+
+        stop_profile runs on the control-plane thread, where _NoDeviceWork
+        rejects CUDA factories. torch.distributed.barrier prefers
+        group.bound_device_id over its CPU branch, and every group is bound to
+        cuda:N for eager NCCL init, so a barrier here allocated on CUDA and
+        killed all ranks mid-profile. Pin both halves: no barrier, and a CPU
+        rendezvous tensor.
+        """
+        self.handler.attn_tp_cpu_group = object()
+
+        with mock.patch.object(
+            request_handler_mod.torch.distributed, "barrier"
+        ) as barrier:
+            self.handler._profile_sync()
+
+        barrier.assert_not_called()
+        self.profile_sync.assert_called_once()
+        tensor = self.profile_sync.call_args.args[0]
+        self.assertEqual(tensor.device.type, "cpu")
+
+    def test_profile_sync_is_a_noop_without_peers(self):
+        self.handler.attn_tp_size = 1
+        self.handler._profile_sync()
+        self.profile_sync.assert_not_called()
 
     def test_stop_profile_reports_proton_finalize_failure(self):
         self.handler.attn_tp_cpu_group = object()
@@ -250,7 +287,9 @@ class TestRequestHandlerProtonProfile(unittest.TestCase):
         self.assertFalse(result.success)
         self.assertIn("Failed to finalize Proton profiling", result.message)
         self.assertFalse(self.handler.profile_in_progress)
-        self.barrier.assert_called_once_with(self.handler.attn_tp_cpu_group)
+        self.profile_sync.assert_called_once_with(
+            self.handler._profile_sync_buf, group=self.handler.attn_tp_cpu_group
+        )
 
     def test_num_steps_window_finalizes_proton(self):
         with mock.patch.object(


### PR DESCRIPTION
## Problem

Any `/start_profile` kills the engine on AMD, and `--profile-by-stage` never produces a decode trace. Every rank dies with:

```
RuntimeError: control-plane thread ran CUDA factory aten.empty.memory_format;
device work crosses only through DeviceHandle — see docs/design/event-loop.md Principle 1
  at request_handler.py:556 in stop_profile
     torch.distributed.barrier(self.attn_tp_cpu_group)
```

The EXTEND traces are written, then the process dies at the stage transition, before DECODE begins.

## Cause

Three separately-reasonable things compose badly:

1. `DistributedInitializer` passes `device_id=torch.device("cuda", gpu_id)` to `init_process_group`, deliberately — to force eager NCCL init and mute the c10d `barrier(): using the device under current context` warning. This sets `bound_device_id` on **every** group, including the gloo CPU ones.

2. `torch.distributed.barrier` checks `bound_device_id` **before** its CPU branch:

```python
device = torch._C._get_accelerator()
if isinstance(device_ids, list): ...
elif getattr(group, "bound_device_id", None) is not None:
    opts.device = group.bound_device_id          # <- taken, cuda:N
elif device.type == "cpu" or _get_object_coll_device(group) == "cpu":
    opts.device = torch.device("cpu")            # <- never reached
```

So a *gloo* barrier allocates `aten.empty` on CUDA.

3. Stage transitions arrive via `_profile_batch_predicate`, called from `_commit_forward_results` — the control-plane thread, where `_NoDeviceWork` correctly rejects CUDA factories per Principle 1.

Confirmed in isolation: with `bound_device_id` set, `dist.barrier(gloo_group)` raises under `_NoDeviceWork`; the same barrier on a group without it passes.

## Fix

Rendezvous over a preallocated CPU tensor. It synchronizes identically, allocates nothing, and matches how the loop's other in-round collectives are written (see the `all_gather_into_tensor` over preallocated `_dp_local_info` / `_dp_global_info` in `event_loop.py`).

The design doc already sanctions gloo collectives on the control plane — this only avoids the incidental device allocation inside `barrier()`.

## Verification

8x gfx950 (MI355X), Kimi-K3 MXFP4, TP8/EP1:

| | before | after |
| --- | --- | --- |
| `profile_by_stage` run | engine dies on all 8 ranks | completes |
| server health after profiling | dead | `200` |
| traces written | EXTEND only | EXTEND + DECODE, all 8 ranks |
| decode kernel events | none | 27,076 |

## Note

Not caught earlier because no CI job calls `/start_profile` — the same blind spot as #1287, which fixed a different profiling regression from the same refactor series. Worth considering a smoke test that starts a profile and asserts the server is still healthy; it would have caught both.