### PR TITLE
perf(kimi3): avoid shape-specialized AttnRes compilation

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/kda/attn_res.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/kda/attn_res.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel_amd._triton import gl, gluon
+from tokenspeed_kernel_amd._triton import gl, gluon, tl
 
 cdna4 = gl.amd.cdna4
 _BLOCK_H = gl.constexpr(8192)
@@ -38,14 +38,14 @@ def _load_candidate(
     hidden,
     hidden_mask,
     stride_block_t: gl.constexpr,
-    stride_block_n: gl.constexpr,
+    stride_block_n: tl.int64,
     candidate: gl.constexpr,
     N: gl.constexpr,
 ):
     if candidate == N - 1:
         return prefix
-    # Candidate offsets can exceed int32; fold the block stride into the pointer.
-    ptr = block_residual + candidate * stride_block_n
+    # The stride fits int32, but candidate * stride can exceed it at large T.
+    ptr = block_residual + candidate * stride_block_n.to(gl.int64)
     return cdna4.buffer_load(
         ptr,
         (token * stride_block_t + hidden).to(gl.int32),
@@ -66,7 +66,7 @@ def _attn_res_rmsnorm_kernel(
     stride_layer_t: gl.constexpr,
     stride_delta_t: gl.constexpr,
     stride_block_t: gl.constexpr,
-    stride_block_n: gl.constexpr,
+    stride_block_n: tl.int64,
     stride_output_t: gl.constexpr,
     H: gl.constexpr,
     N: gl.constexpr,
@@ -105,7 +105,7 @@ def _attn_res_rmsnorm_kernel(
             mask=hidden_mask,
         )
     if WRITE_BLOCK:
-        block_write_ptr = block_residual + BLOCK_WRITE_IDX * stride_block_n
+        block_write_ptr = block_residual + BLOCK_WRITE_IDX * stride_block_n.to(gl.int64)
         cdna4.buffer_store(
             prefix.to(block_residual.dtype.element_ty),
             block_write_ptr,

--- a/tokenspeed-kernel/test/ops/test_kimi3_prefill_gluon_gfx950.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_prefill_gluon_gfx950.py
@@ -241,8 +241,8 @@ def test_attn_res_first_layer_snapshot_write() -> None:
     torch.testing.assert_close(actual, expected, rtol=5e-3, atol=1.6e-2)
 
 
-@pytest.mark.parametrize("tokens", [2, 4, 8, 16, 32, 64, 128, 256, 512])
-def test_attn_res_delta_and_block_write_power_of_two_batches(tokens: int) -> None:
+@pytest.mark.parametrize("tokens", [2, 4, 8, 16, 32, 64, 65, 128, 256, 512])
+def test_attn_res_delta_and_block_write_batches(tokens: int) -> None:
     valid_blocks = 3
     score_eps, output_eps = 1e-6, 2e-6
     generator = torch.Generator(device="cuda").manual_seed(100 + tokens)


### PR DESCRIPTION
Summary:

Pass the token-dependent block-candidate stride as a dynamic 64-bit kernel argument. This prevents each irregular prefill chunk from compiling a new family of AttnRes variants while retaining 64-bit candidate offset arithmetic.

Testing Plan:

- Exercise odd token counts in the fused AttnRes numerical coverage alongside the existing power-of-two cases.
- Preserve delta, block-write, and graph-replay coverage for the fused kernel.

Benchmark:

EP8, concurrency 4, four approximately 50K-token prompts, one output token:

```
| Version                  | Wave wall time | Prompt tok/s |
| Shape-specialized stride | 46.051 s       | 4,377.87     |
| Dynamic 64-bit stride    | 16.361 s       | 12,322.51    |
```

At T=8192, steady-state AttnRes median runtime remains within 1.4% of baseline across N=1,4,8,12.