### PR TITLE
perf(k3): time the MoE tactic sweep by graph replay and floor it at auto-tune

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/moe_tactic_sweep.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/benchmark/moe_tactic_sweep.py
@@ -75,10 +75,8 @@ from tokenspeed_kernel.ops.tuning import (
 SITU_TUNE_MAX_NUM_TOKENS = get_autotune_max_num_tokens()
 
 SF_BLOCK = 32
-# Buckets below this are left on the autotuner's own choice: the enumeration
-# and profiling problems only bite once tokens-per-expert crosses tile
-# boundaries, and measured decode-range picks were already optimal.
-DEFAULT_SWEEP_MIN_BUCKET = 128
+# With the heuristic floor every bucket is safe to sweep; kept for opt-outs.
+DEFAULT_SWEEP_MIN_BUCKET = 1
 STAGE1_CONFIGS_PER_FAMILY = 3
 STAGE2_MAX_CONFIGS = 64
 
@@ -129,18 +127,35 @@ def _make_tokens(
     return x_q, x_scale, topk_ids, topk_weights
 
 
-def _time_call(fn, iters: int, warmup: int = 3) -> float:
+def _time_call(fns, iters: int, warmup: int = 3) -> float:
+    """Time CUDA-graph replays of one pass over every weight copy.
+
+    Replay keeps the host out of the timed region (at small buckets the op's
+    GPU work is ~17us against ~300us of host path, so host-inclusive timing
+    ranks host jitter instead of tactics), and cycling copies keeps every
+    call streaming cold weights, both matching how serving runs the op.
+    """
+    if not isinstance(fns, (list, tuple)):
+        fns = [fns]
+    n = len(fns)
+    for i in range(max(warmup, n)):
+        fns[i % n]()
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        for fn in fns:
+            fn()
+    g.replay()
+    torch.cuda.synchronize()
     start = torch.cuda.Event(enable_timing=True)
     stop = torch.cuda.Event(enable_timing=True)
-    for _ in range(warmup):
-        fn()
-    torch.cuda.synchronize()
+    reps = max(1, iters // n)
     start.record()
-    for _ in range(iters):
-        fn()
+    for _ in range(reps):
+        g.replay()
     stop.record()
     torch.cuda.synchronize()
-    return start.elapsed_time(stop) * 1000.0 / iters  # us
+    return start.elapsed_time(stop) * 1000.0 / (reps * n)
 
 
 def _candidate_tactics(args) -> list[tuple[int, int]]:
@@ -185,7 +200,7 @@ def _run(args, W, tokens, tactic_setter, tactic, iters, do_finalize=True):
     from flashinfer.tllm_enums import ActivationType
 
     x_q, x_scale, topk_ids, topk_weights = tokens
-    w13, w13_scale, w2, w2_scale = W
+    W_list = W if isinstance(W, list) else [W]
     # The cache key carries the output shape, so the modes need separate sweeps.
     output = (
         torch.zeros(
@@ -201,43 +216,46 @@ def _run(args, W, tokens, tactic_setter, tactic, iters, do_finalize=True):
         (args.local_experts,), args.situ_beta, dtype=torch.float32, device=x_q.device
     )
 
-    def call():
-        trtllm_fp4_block_scale_routed_moe(
-            topk_ids=(topk_ids, topk_weights),
-            routing_bias=None,
-            hidden_states=x_q,
-            hidden_states_scale=x_scale,
-            gemm1_weights=w13,
-            gemm1_weights_scale=w13_scale,
-            gemm1_bias=None,
-            gemm1_alpha=alpha,
-            gemm1_beta=beta,
-            gemm1_clamp_limit=None,
-            gemm2_weights=w2,
-            gemm2_weights_scale=w2_scale,
-            gemm2_bias=None,
-            output1_scale_scalar=None,
-            output1_scale_gate_scalar=None,
-            output2_scale_scalar=None,
-            num_experts=args.num_experts,
-            top_k=args.top_k,
-            n_group=None,
-            topk_group=None,
-            intermediate_size=args.intermediate_size,
-            local_expert_offset=0,
-            local_num_experts=args.local_experts,
-            routed_scaling_factor=None,
-            routing_method_type=1,
-            do_finalize=do_finalize,
-            enable_pdl=False,
-            activation_type=10,  # ActivationType.Situ; probed at startup
-            tune_max_num_tokens=SITU_TUNE_MAX_NUM_TOKENS,
-            output=output,
-        )
+    def _mk(w13, w13_scale, w2, w2_scale):
+        def call():
+            trtllm_fp4_block_scale_routed_moe(
+                topk_ids=(topk_ids, topk_weights),
+                routing_bias=None,
+                hidden_states=x_q,
+                hidden_states_scale=x_scale,
+                gemm1_weights=w13,
+                gemm1_weights_scale=w13_scale,
+                gemm1_bias=None,
+                gemm1_alpha=alpha,
+                gemm1_beta=beta,
+                gemm1_clamp_limit=None,
+                gemm2_weights=w2,
+                gemm2_weights_scale=w2_scale,
+                gemm2_bias=None,
+                output1_scale_scalar=None,
+                output1_scale_gate_scalar=None,
+                output2_scale_scalar=None,
+                num_experts=args.num_experts,
+                top_k=args.top_k,
+                n_group=None,
+                topk_group=None,
+                intermediate_size=args.intermediate_size,
+                local_expert_offset=0,
+                local_num_experts=args.local_experts,
+                routed_scaling_factor=None,
+                routing_method_type=1,
+                do_finalize=do_finalize,
+                enable_pdl=False,
+                activation_type=10,  # ActivationType.Situ; probed at startup
+                tune_max_num_tokens=SITU_TUNE_MAX_NUM_TOKENS,
+                output=output,
+            )
+
+        return call
 
     assert ActivationType.Situ.value == 10
     tactic_setter(tactic)
-    return _time_call(call, iters=iters)
+    return _time_call([_mk(*w) for w in W_list], iters=iters)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -283,7 +301,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--min-bucket",
         type=int,
-        default=DEFAULT_SWEEP_MIN_BUCKET,
+        default=1,
         help="Sweep buckets >= this; smaller buckets keep the autotuner's pick",
     )
     parser.add_argument(
@@ -296,6 +314,13 @@ def main(argv: list[str] | None = None) -> int:
             "misses every deferred-finalize call (K3 decode, where the MoE "
             "tail owns finalize)"
         ),
+    )
+    parser.add_argument("--weight-copies", type=int, default=8)
+    parser.add_argument(
+        "--floor-margin",
+        type=float,
+        default=1.04,
+        help="Ship a tuned tactic only if it beats the untuned heuristic by this",
     )
     parser.add_argument("--coarse-iters", type=int, default=8)
     parser.add_argument("--fine-iters", type=int, default=50)
@@ -318,9 +343,16 @@ def main(argv: list[str] | None = None) -> int:
             cudnn_version,
         )
         print(f"generated output path: {output}")
-    W = _make_weights(
-        args.local_experts, args.hidden_size, args.intermediate_size, device, seed=1
-    )
+    W = [
+        _make_weights(
+            args.local_experts,
+            args.hidden_size,
+            args.intermediate_size,
+            device,
+            seed=1 + c,
+        )
+        for c in range(args.weight_copies)
+    ]
 
     modes = (
         (True, False)
@@ -407,11 +439,23 @@ def main(argv: list[str] | None = None) -> int:
             best_time, best_tactic = min(timed)
             if native_time <= best_time:
                 best_time, best_tactic = native_time, tuple(native_tactic)
-            set_tactic(best_tactic)
+            # Floor: a tuned tactic must clear the untuned heuristic; else
+            # the entry pins -1 (a cache miss to the runner), so the table
+            # can never be slower than no table and every bucket is safe.
+            saved = tuner.profiling_cache.pop(key)
+            heuristic_time = run(None, args.fine_iters)
+            tuner.profiling_cache[key] = saved
+            if best_time * args.floor_margin <= heuristic_time:
+                set_tactic(best_tactic)
+                verdict = "tuned"
+            else:
+                best_time, best_tactic = heuristic_time, (-1, -1)
+                set_tactic(best_tactic)
+                verdict = "heuristic floor"
             print(
-                f"bucket {bucket:>5} ({label}): tactic {best_tactic} "
+                f"bucket {bucket:>5} ({label}): {verdict} {best_tactic} "
                 f"{best_time:7.1f}us (native {tuple(native_tactic)} "
-                f"{native_time:7.1f}us)"
+                f"{native_time:7.1f}us, heuristic {heuristic_time:7.1f}us)"
             )
 
     tuner.save_configs(output)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_GB300,flashinfer=0.6.18,cudnn=92000.json
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/tactics/kimi-k3,ep=1,tp=8,device_name=NVIDIA_GB300,flashinfer=0.6.18,cudnn=92000.json
@@ -1,158 +1,305 @@
 {
-  "_metadata": {
-    "flashinfer_version": "0.6.18",
-    "cuda_version": "13.0",
-    "cublas_version": "13.1.1",
-    "cudnn_version": "92000",
-    "cudnn_frontend_version": "1.26.0",
-    "gpu": "NVIDIA GB300"
-  },
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1, 3584), (0,), (1, 16), (1, 16), (1, 3584), (1, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      8,
-      380
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1024, 3584), (0,), (1024, 16), (1024, 16), (1024, 3584), (1024, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      0
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((128, 3584), (0,), (128, 16), (128, 16), (128, 3584), (128, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      16,
-      783
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1280, 3584), (0,), (1280, 16), (1280, 16), (1280, 3584), (1280, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      2
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1536, 3584), (0,), (1536, 16), (1536, 16), (1536, 3584), (1536, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      0
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((16, 3584), (0,), (16, 16), (16, 16), (16, 3584), (16, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      8,
-      231
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1792, 3584), (0,), (1792, 16), (1792, 16), (1792, 3584), (1792, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      0
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2, 3584), (0,), (2, 16), (2, 16), (2, 3584), (2, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      8,
-      221
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2048, 3584), (0,), (2048, 16), (2048, 16), (2048, 3584), (2048, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      8
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((256, 3584), (0,), (256, 16), (256, 16), (256, 3584), (256, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      32,
-      569
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2560, 3584), (0,), (2560, 16), (2560, 16), (2560, 3584), (2560, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      8
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3072, 3584), (0,), (3072, 16), (3072, 16), (3072, 3584), (3072, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      8
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((32, 3584), (0,), (32, 16), (32, 16), (32, 3584), (32, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      8,
-      231
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3584, 3584), (0,), (3584, 16), (3584, 16), (3584, 3584), (3584, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      128,
-      8
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4, 3584), (0,), (4, 16), (4, 16), (4, 3584), (4, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      8,
-      231
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4096, 3584), (0,), (4096, 16), (4096, 16), (4096, 3584), (4096, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      128,
-      24
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((512, 3584), (0,), (512, 16), (512, 16), (512, 3584), (512, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      0
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((64, 3584), (0,), (64, 16), (64, 16), (64, 3584), (64, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      8,
-      221
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((768, 3584), (0,), (768, 16), (768, 16), (768, 3584), (768, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      64,
-      0
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8, 3584), (0,), (8, 16), (8, 16), (8, 3584), (8, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      8,
-      221
-    ]
-  ],
-  "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8192, 3584), (0,), (8192, 16), (8192, 16), (8192, 3584), (8192, 112), (0,), (0,)), ())": [
-    "MoERunner",
-    [
-      192,
-      11
-    ]
-  ],
-  "_generation": "c7b987b6154341c7edd43457cb83817d3011597a32b889fa841f0931648dd183"
+ "_metadata": {
+  "flashinfer_version": "0.6.18",
+  "cuda_version": "13.0",
+  "cublas_version": "13.1.1",
+  "cudnn_version": "92000",
+  "cudnn_frontend_version": "1.26.0",
+  "gpu": "NVIDIA GB300"
+ },
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1, 0), (0,), (1, 16), (1, 16), (1, 3584), (1, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1, 3584), (0,), (1, 16), (1, 16), (1, 3584), (1, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1024, 0), (0,), (1024, 16), (1024, 16), (1024, 3584), (1024, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   12
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1024, 3584), (0,), (1024, 16), (1024, 16), (1024, 3584), (1024, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   12
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((128, 0), (0,), (128, 16), (128, 16), (128, 3584), (128, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   16,
+   377
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((128, 3584), (0,), (128, 16), (128, 16), (128, 3584), (128, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   16,
+   769
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1280, 0), (0,), (1280, 16), (1280, 16), (1280, 3584), (1280, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   12
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1280, 3584), (0,), (1280, 16), (1280, 16), (1280, 3584), (1280, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   12
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1536, 0), (0,), (1536, 16), (1536, 16), (1536, 3584), (1536, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   12
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1536, 3584), (0,), (1536, 16), (1536, 16), (1536, 3584), (1536, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   4
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((16, 0), (0,), (16, 16), (16, 16), (16, 3584), (16, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((16, 3584), (0,), (16, 16), (16, 16), (16, 3584), (16, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1792, 0), (0,), (1792, 16), (1792, 16), (1792, 3584), (1792, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   4
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((1792, 3584), (0,), (1792, 16), (1792, 16), (1792, 3584), (1792, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   4
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2, 0), (0,), (2, 16), (2, 16), (2, 3584), (2, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2, 3584), (0,), (2, 16), (2, 16), (2, 3584), (2, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2048, 0), (0,), (2048, 16), (2048, 16), (2048, 3584), (2048, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   4
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2048, 3584), (0,), (2048, 16), (2048, 16), (2048, 3584), (2048, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   4
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((256, 0), (0,), (256, 16), (256, 16), (256, 3584), (256, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   32,
+   569
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((256, 3584), (0,), (256, 16), (256, 16), (256, 3584), (256, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   32,
+   569
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2560, 0), (0,), (2560, 16), (2560, 16), (2560, 3584), (2560, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   8
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((2560, 3584), (0,), (2560, 16), (2560, 16), (2560, 3584), (2560, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   8
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3072, 0), (0,), (3072, 16), (3072, 16), (3072, 3584), (3072, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   8
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3072, 3584), (0,), (3072, 16), (3072, 16), (3072, 3584), (3072, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   8
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((32, 0), (0,), (32, 16), (32, 16), (32, 3584), (32, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((32, 3584), (0,), (32, 16), (32, 16), (32, 3584), (32, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3584, 0), (0,), (3584, 16), (3584, 16), (3584, 3584), (3584, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   0
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((3584, 3584), (0,), (3584, 16), (3584, 16), (3584, 3584), (3584, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   64,
+   8
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4, 0), (0,), (4, 16), (4, 16), (4, 3584), (4, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4, 3584), (0,), (4, 16), (4, 16), (4, 3584), (4, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4096, 0), (0,), (4096, 16), (4096, 16), (4096, 3584), (4096, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   128,
+   16
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((4096, 3584), (0,), (4096, 16), (4096, 16), (4096, 3584), (4096, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   128,
+   16
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((512, 0), (0,), (512, 16), (512, 16), (512, 3584), (512, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   128,
+   16
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((512, 3584), (0,), (512, 16), (512, 16), (512, 3584), (512, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   128,
+   16
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((64, 0), (0,), (64, 16), (64, 16), (64, 3584), (64, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((64, 3584), (0,), (64, 16), (64, 16), (64, 3584), (64, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((768, 0), (0,), (768, 16), (768, 16), (768, 3584), (768, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   128,
+   16
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((768, 3584), (0,), (768, 16), (768, 16), (768, 3584), (768, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   128,
+   16
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8, 0), (0,), (8, 16), (8, 16), (8, 3584), (8, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8, 3584), (0,), (8, 16), (8, 16), (8, 3584), (8, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8192, 0), (0,), (8192, 16), (8192, 16), (8192, 3584), (8192, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "('flashinfer::trtllm_fp4_block_scale_moe', 'MoERunner', ((8192, 3584), (0,), (8192, 16), (8192, 16), (8192, 3584), (8192, 112), (0,), (0,)), ())": [
+  "MoERunner",
+  [
+   -1,
+   -1
+  ]
+ ],
+ "_generation": "51708cac2700f266eac95e28ad2e68f23493c1913003896e38a7ffd833b224a1"
 }


### PR DESCRIPTION
The sweep timed whole Python calls: at small buckets the op's GPU work is ~17us against ~300us of host path, so CUDA-event timing ranked host jitter instead of tactics. Small-bucket picks were effectively random draws -- one shipped the statically-scheduled gemm2 variant (+45% on that kernel), another a 192-wide tile pair at M=1 (31.2us vs 10.9 on gemm1 alone), costing +5% and +28% end-to-end at bs=1.

- Time CUDA-graph replays of one pass over rotated weight copies: the host leaves the timed region and every call streams cold weights, both matching how serving runs the op. Replay of bucket 1 now reads 17.0us, matching the profiled GPU work exactly.
- Measure the untuned heuristic as a candidate and ship a tuned tactic only if it clears it by 4%; otherwise the entry pins tactic -1, which the runner treats as a cache miss. The table can then never be slower than no table, so every bucket is safe to sweep and the min-bucket skip is retired (default 1).
- Regenerate the GB300 TP8/EP1 table across both finalize modes: 42 entries, 16 pinned to the heuristic floor (buckets <= 64 in both modes, where the heuristic already sits within 1% of the best, plus 8192 where tuning only ties).

Validated on a 2-node TP8 GB300 pair with the startup autotune window disabled, since its in-memory cache shadows file configs: bs=1 decode sits exactly on the no-table baseline (8.72 ms/token, the floor), and bs=32 speculative decode (256-token buckets) gains +1.6% normalized throughput with both interleaved pairs agreeing. Large-bucket isolated wins did not reproduce in prefill TTFT and ship only behind the floor.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
