### PR TITLE
docs: fix kimi_k2.5 agentic bench README cd paths

### DIFF
--- a/test/agentic_benchmark/kimi_k2.5/tokenspeed/README.md
+++ b/test/agentic_benchmark/kimi_k2.5/tokenspeed/README.md
@@ -18,7 +18,7 @@ outputs/<sweep_ts>/<config>/parallel_<P>_number_<N>/  # per-run evalscope artifa
 ## Run a sweep
 
 ```bash
-cd test/agentic_benchmark/tokenspeed
+cd test/agentic_benchmark/kimi_k2.5/tokenspeed
 ./agentic_bench.sh
 ```
 

--- a/test/agentic_benchmark/kimi_k2.5/trtllm/README.md
+++ b/test/agentic_benchmark/kimi_k2.5/trtllm/README.md
@@ -18,7 +18,7 @@ outputs/<sweep_ts>/<config>/parallel_<P>_number_<N>/  # per-run evalscope artifa
 ## Run a sweep
 
 ```bash
-cd test/agentic_benchmark/trtllm
+cd test/agentic_benchmark/kimi_k2.5/trtllm
 ./agentic_bench.sh
 ```
 


### PR DESCRIPTION
## Summary

The kimi_k2.5 agentic-bench READMEs `cd` one directory too shallow after the model-named layout (`test/agentic_benchmark/<model>/<backend>`). Those commands omit `kimi_k2.5` and point at paths that do not exist. The kimi_k3 README already uses the nested path.

## Reproduce

From the repo root, README `cd` vs actual relative path:

**tokenspeed**

- README says: `cd test/agentic_benchmark/tokenspeed`
- actual path: `test/agentic_benchmark/kimi_k2.5/tokenspeed`

**trtllm**

- README says: `cd test/agentic_benchmark/trtllm`
- actual path: `test/agentic_benchmark/kimi_k2.5/trtllm`

```bash
ls test/agentic_benchmark/tokenspeed    # missing
ls test/agentic_benchmark/trtllm        # missing
ls test/agentic_benchmark/kimi_k2.5/tokenspeed
ls test/agentic_benchmark/kimi_k2.5/trtllm
```

kimi_k3 is already correct: `cd test/agentic_benchmark/kimi_k3/tokenspeed`.

## Test Plan

- [x] Confirmed tree: `test/agentic_benchmark/kimi_k2.5/{tokenspeed,trtllm}/README.md` sit next to `agentic_bench.sh`
- [x] Compared against `kimi_k3/tokenspeed/README.md`
- [x] Each README `cd` now matches its directory