### PR TITLE
perf(k3): 256-bit skinny GEMV configs for the measured decode shapes

### DIFF
--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -21,7 +21,10 @@
 """Measure decode-GEMV backends at the served models' real shapes, cold-cache.
 
 Run as ``tune_route.py [shape_set] [route.json]``; the set names a key of
-SHAPE_SETS and defaults to K3's TP16 table.
+SHAPE_SETS and defaults to K3's TP16 table. ``tune_route.py skinny-configs``
+instead sweeps per-shape skinny configs (vector-width-16 geometries against
+the served config) over every shape MEASURED_ROUTE sends to skinny, emitting
+the full SKINNY_CONFIG_ROUTE literal to paste wholesale.
 
 The shapes are the exact (N, K) that the decode path hands the routed GEMV,
 extracted from a trace of the serving path (rowcta's launch grid is ``(N,)``,
@@ -95,7 +98,10 @@ SHAPE_SETS = {
         [1, 2, 4, 8],
     ),
 }
-SHAPES, MS = SHAPE_SETS[sys.argv[1] if len(sys.argv) > 1 else "k3_tp16"]
+_SKINNY_CONFIG_MODE = sys.argv[1:2] == ["skinny-configs"]
+SHAPES, MS = SHAPE_SETS[
+    sys.argv[1] if len(sys.argv) > 1 and not _SKINNY_CONFIG_MODE else "k3_tp16"
+]
 NUM_COPIES = 8
 # 41-round medians repeat within ~1-2%, so 4% clears noise without excluding
 # the consistent 6-11% skinny wins.
@@ -163,7 +169,11 @@ def candidates(m: int, n: int, k: int):
     )
 
     if skinny.is_available():
-        cfg = skinny.default_config(m, n, k)
+        # Rank the config serving would run, not the bare heuristic, so a
+        # re-sweep cannot demote a shape whose win lives in SKINNY_CONFIG_ROUTE.
+        from tokenspeed_kernel.ops.gemm.routed_gemv import _skinny_config
+
+        cfg = _skinny_config(m, n, k, torch.cuda.current_device())
         if skinny.supports(cfg, m, n, k):
 
             def sk(i):
@@ -194,6 +204,129 @@ def candidates(m: int, n: int, k: int):
 
         yield "ll_bf16", [ll(i) for i in range(NUM_COPIES)], o, ref
 
+
+def sweep_skinny_configs() -> None:
+    """Emit the full SKINNY_CONFIG_ROUTE literal, revalidating tuned entries.
+
+    A candidate earns an entry only by beating what will serve after this
+    sweep (the tuned entry while it holds, else the heuristic) by MARGIN,
+    cold-L2. A tuned entry keeps while it is not worse than the heuristic
+    -- MARGIN gates admission only, so marginal entries do not flap -- and
+    the block is a valid wholesale replacement, never a ratchet.
+    """
+    from tokenspeed_kernel.ops.gemm.routed_gemv import (
+        MEASURED_ROUTE,
+        SKINNY_CONFIG_ROUTE,
+        _is_skinny_config_arch,
+        _skinny_config,
+    )
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        SkinnyGemmConfig,
+    )
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        shape_dynamic_skinny_gemm as skinny,
+    )
+
+    if not _is_skinny_config_arch(torch.cuda.current_device()):
+        sys.exit("skinny-configs was swept on sm100; refusing to emit elsewhere")
+
+    block_sizes = {
+        1536: (96,),
+        2560: (160,),
+        7168: (448, 224, 64),
+        14336: (448, 224, 128),
+    }
+    winners: dict[tuple[int, int, int], tuple[int, int, int, int]] = {}
+    for (m, n, k), backend in sorted(MEASURED_ROUTE.items(), key=lambda e: e[0][::-1]):
+        if backend != "skinny":
+            continue
+        xs = [
+            torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+            for _ in range(NUM_COPIES)
+        ]
+        ws = [
+            torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+            for _ in range(NUM_COPIES)
+        ]
+        o = torch.empty(m, n, device="cuda", dtype=torch.bfloat16)
+        ref = xs[0].float() @ ws[0].float().t()
+        served = _skinny_config(m, n, k, torch.cuda.current_device())
+        heuristic = skinny.default_config(m, n, k)
+        t_served = timed(
+            [
+                (lambda i, c: lambda: skinny(xs[i], ws[i], c, out=o))(i, served)
+                for i in range(NUM_COPIES)
+            ]
+        )
+        t_heuristic = t_served
+        if served != heuristic:
+            t_heuristic = timed(
+                [
+                    (lambda i, c: lambda: skinny(xs[i], ws[i], c, out=o))(i, heuristic)
+                    for i in range(NUM_COPIES)
+                ]
+            )
+        best: tuple[float, SkinnyGemmConfig] | None = None
+        for block in block_sizes.get(k, ()):
+            for outputs in (1, 2, 4, 8):
+                config = SkinnyGemmConfig(m, block, outputs, 1, 16)
+                if config == served or not skinny.supports(config, m, n, k):
+                    continue
+                try:
+                    skinny(xs[0], ws[0], config, out=o)
+                    torch.cuda.synchronize()
+                except Exception:  # noqa: BLE001
+                    continue
+                if (o.float() - ref).abs().max().item() > 1.5:
+                    continue
+                t = timed(
+                    [
+                        (lambda i, c: lambda: skinny(xs[i], ws[i], c, out=o))(i, config)
+                        for i in range(NUM_COPIES)
+                    ]
+                )
+                if best is None or t < best[0]:
+                    best = (t, config)
+        # Decide keep/demote first, then admit candidates against what will
+        # actually serve, so a candidate cannot lose to a config that is
+        # itself being demoted. MARGIN is for admission only: a tuned entry
+        # keeps while it is not worse than the heuristic, so marginal wins
+        # do not flap in and out across re-sweeps.
+        keep = (m, n, k) in SKINNY_CONFIG_ROUTE and t_served <= t_heuristic
+        bar = t_served if keep else t_heuristic
+        if best and best[0] * MARGIN <= bar:
+            winner = best[1]
+            print(
+                f"({m}, {n}, {k}) served={t_served:.3f}us "
+                f"vw16={best[0]:.3f}us {t_served / best[0]:.2f}x"
+            )
+        elif keep:
+            winner = served
+            print(f"({m}, {n}, {k}) served={t_served:.3f}us (keep tuned entry)")
+        else:
+            winner = None
+            demoted = (m, n, k) in SKINNY_CONFIG_ROUTE
+            print(
+                f"({m}, {n}, {k}) served={t_served:.3f}us "
+                f"({'DEMOTE to heuristic' if demoted else 'keep heuristic'})"
+            )
+        if winner is not None:
+            winners[(m, n, k)] = (
+                winner.block_size,
+                winner.outputs_per_block,
+                winner.k_unroll,
+                winner.vector_width,
+            )
+    print("\nSKINNY_CONFIG_ROUTE entries:")
+    for shape, tuned in winners.items():
+        print(f"        {shape}: {tuned},")
+
+
+if _SKINNY_CONFIG_MODE:
+    if len(sys.argv) > 2:
+        sys.exit("skinny-configs takes no further arguments and writes no file")
+    sweep_skinny_configs()
+    sys.exit(0)
 
 route: dict[str, str] = {}
 per_step_gain: dict[int, float] = dict.fromkeys(MS, 0.0)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -331,12 +331,68 @@ def _mark_warmed(backend: str, dev: int, m: int, n: int, k: int) -> None:
             _warmed.add((backend, dev, m, n, k))
 
 
-@functools.lru_cache(maxsize=32)
-def _skinny_config(m: int, n: int, k: int):
+# Measured skinny configs that beat ``default_config`` by >=4% under the
+# tune_route.py methodology (cold L2: 8 weight copies cycled in-graph,
+# 41-round medians, GB200/sm100 -- hence the ``_is_skinny_config_arch`` pin):
+# (m, n, k) -> (block_size, outputs_per_block, k_unroll, vector_width).
+# All use 256-bit loads (vector_width 16), which nvidia-cutlass-dsl accepts
+# from 4.7; the heuristic predates that option. Wins are 4.2%-49.8%, biggest
+# where one block tile covers K (96x16 == 1536, 160x16 == 2560). The K=7168
+# and K=14336 families lost cold -- an L2-warm sweep had them ahead -- and
+# keep the heuristic, except the 1536x7168 shard at M == 5 and 6.
+SKINNY_CONFIG_ROUTE: MappingProxyType[
+    tuple[int, int, int], tuple[int, int, int, int]
+] = MappingProxyType(
+    {
+        (2, 768, 1536): (96, 2, 1, 16),
+        (3, 768, 1536): (96, 2, 1, 16),
+        (4, 768, 1536): (96, 2, 1, 16),
+        (2, 1152, 1536): (96, 4, 1, 16),
+        (3, 1152, 1536): (96, 4, 1, 16),
+        (4, 1152, 1536): (96, 4, 1, 16),
+        (5, 1152, 1536): (96, 4, 1, 16),
+        (2, 1536, 1536): (96, 4, 1, 16),
+        (3, 1536, 1536): (96, 4, 1, 16),
+        (4, 1536, 1536): (96, 2, 1, 16),
+        (2, 2304, 1536): (96, 4, 1, 16),
+        (1, 320, 2560): (160, 2, 1, 16),
+        (2, 320, 2560): (160, 2, 1, 16),
+        (1, 512, 2560): (160, 2, 1, 16),
+        (2, 512, 2560): (160, 2, 1, 16),
+        (1, 640, 2560): (160, 4, 1, 16),
+        (2, 640, 2560): (160, 2, 1, 16),
+        (4, 640, 2560): (160, 2, 1, 16),
+        (2, 12800, 2560): (160, 4, 1, 16),
+        (5, 1536, 7168): (224, 2, 1, 16),
+        (6, 1536, 7168): (64, 2, 1, 16),
+    }
+)
+
+
+@functools.lru_cache(maxsize=8)
+def _is_skinny_config_arch(device_index: int) -> bool:
+    """SKINNY_CONFIG_ROUTE's arch pin: its configs were only swept on sm100."""
+    from tokenspeed_kernel.platform import current_platform
+
+    platform = current_platform()
+    if platform.vendor != "nvidia":
+        return False
+    return torch.cuda.get_device_capability(device_index) == (10, 0)
+
+
+# Unbounded is safe: the sole hot caller admits only MEASURED_ROUTE skinny
+# shapes, so the key space is that table times the device count.
+@functools.lru_cache(maxsize=None)
+def _skinny_config(m: int, n: int, k: int, device_index: int):
     from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        SkinnyGemmConfig,
         shape_dynamic_skinny_gemm,
     )
 
+    if _is_skinny_config_arch(device_index):
+        tuned = SKINNY_CONFIG_ROUTE.get((m, n, k))
+        if tuned is not None:
+            return SkinnyGemmConfig(m, *tuned)
     return shape_dynamic_skinny_gemm.default_config(m, n, k)
 
 
@@ -370,9 +426,13 @@ def skinny_gemv(
         or not _usable_in_capture("skinny", dev, m, n, k)
     ):
         return _torch_decode_gemv(x, weight, out)
-    config = _skinny_config(m, n, k)
+    config = _skinny_config(m, n, k, dev)
     # default_config can emit a config supports() rejects; fall back, don't raise.
     if not shape_dynamic_skinny_gemm.supports(config, m, n, k):
+        return _torch_decode_gemv(x, weight, out)
+    # supports() cannot see pointer alignment; the kernel asserts it at launch.
+    align = config.vector_width * x.element_size()
+    if x.data_ptr() % align or weight.data_ptr() % align:
         return _torch_decode_gemv(x, weight, out)
     # DLPack refuses requires_grad tensors; detach is a zero-copy view.
     result = shape_dynamic_skinny_gemm(x.detach(), weight.detach(), config, out=out)

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -353,5 +353,126 @@ def test_measured_route_source_has_no_duplicate_keys():
     assert not dupes, f"duplicate MEASURED_ROUTE keys in source: {dupes}"
     # Parsed size must match source count, else a duplicate collapsed.
     assert len(routed_gemv.MEASURED_ROUTE) == len(keys)
+    # Tuple-valued tables need their own pattern, scanned per table: the two
+    # config tables are independent key spaces, so a shared key is legal.
+    for name, table in (
+        ("SKINNY_CONFIG_ROUTE", routed_gemv.SKINNY_CONFIG_ROUTE),
+        ("ADD3_ROUTE", routed_gemv.ADD3_ROUTE),
+    ):
+        start = src.index(f"{name}: MappingProxyType")
+        span = src[start : src.index(")", src.index("}", start))]
+        cfg_keys = re.findall(r"\((\d+), (\d+), (\d+)\): \(", span)
+        cfg_dupes = [k for k, n in collections.Counter(cfg_keys).items() if n > 1]
+        assert not cfg_dupes, f"duplicate {name} keys in source: {cfg_dupes}"
+        assert len(table) == len(cfg_keys), name
     # Exact-M keying: entries may only exist in the gap-free swept range.
     assert all(m <= 32 for m, _, _ in routed_gemv.MEASURED_ROUTE)
+
+
+def test_skinny_config_route_entries_are_valid():
+    """Every tuned skinny config must target a shape the route actually sends
+    to skinny, and must satisfy the kernel's geometry contract; a typo here
+    would otherwise fall back (wrong M) or crash at compile time."""
+    from tokenspeed_kernel.ops.gemm.routed_gemv import SKINNY_CONFIG_ROUTE
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        SkinnyGemmConfig,
+        shape_dynamic_skinny_gemm,
+    )
+
+    for (m, n, k), tuned in SKINNY_CONFIG_ROUTE.items():
+        assert MEASURED_ROUTE.get((m, n, k)) == "skinny", (m, n, k)
+        # supports() does not know the kernel's warp-multiple block rule.
+        assert tuned[0] % 32 == 0, (m, n, k)
+        config = SkinnyGemmConfig(m, *tuned)
+        assert shape_dynamic_skinny_gemm.supports(config, m, n, k), (m, n, k)
+
+
+def test_skinny_config_consults_the_table_only_on_the_pinned_arch():
+    """The tuned tile shapes were swept on sm100; a widened pin would run
+    them unmeasured elsewhere, the hazard _is_add3_arch documents."""
+    from unittest.mock import patch
+
+    from tokenspeed_kernel.ops.gemm import routed_gemv
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        shape_dynamic_skinny_gemm,
+    )
+
+    m, n, k = 2, 768, 1536
+    # A failed assert must not leave patched-state configs cached for later
+    # tests; clear on every exit path.
+    try:
+        routed_gemv._skinny_config.cache_clear()
+        with patch.object(routed_gemv, "_is_skinny_config_arch", return_value=True):
+            config = routed_gemv._skinny_config(m, n, k, 0)
+        assert (
+            config.block_size,
+            config.outputs_per_block,
+            config.k_unroll,
+            config.vector_width,
+        ) == (96, 2, 1, 16)
+        routed_gemv._skinny_config.cache_clear()
+        with patch.object(routed_gemv, "_is_skinny_config_arch", return_value=False):
+            config = routed_gemv._skinny_config(m, n, k, 0)
+        assert config == shape_dynamic_skinny_gemm.default_config(m, n, k)
+        # The pin is exact: sm103 swept nothing, so it must say no there.
+        routed_gemv._is_skinny_config_arch.cache_clear()
+        with patch.object(torch.cuda, "get_device_capability", return_value=(10, 3)):
+            assert not routed_gemv._is_skinny_config_arch(0)
+    finally:
+        routed_gemv._skinny_config.cache_clear()
+        routed_gemv._is_skinny_config_arch.cache_clear()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_routed_arch(),
+    reason="route is registered for sm100 and up",
+)
+@pytest.mark.parametrize("misalign", ["x", "weight"])
+def test_under_aligned_input_falls_back_to_torch(monkeypatch, misalign):
+    """vw-16 raises the kernel's pointer requirement to 32 bytes; supports()
+    cannot see alignment, so the guard must fall back instead of launching."""
+    from tokenspeed_kernel.ops.gemm import routed_gemv
+    from tokenspeed_kernel.thirdparty.cute_dsl import skinny_gemm
+
+    m, n, k = 2, 768, 1536  # SKINNY_CONFIG_ROUTE entry (vector_width 16)
+    # An 8-byte offset under-aligns every vector width the route can pick
+    # (vw 8 needs 16B, vw 16 needs 32B), so the fallback must fire on every
+    # routed arch -- the tuned-config pin only holds on sm100.
+    xbuf = torch.randn(m * k + 4, device="cuda", dtype=torch.bfloat16)
+    wbuf = torch.randn(n * k + 4, device="cuda", dtype=torch.bfloat16)
+    x = xbuf[4:].view(m, k) if misalign == "x" else xbuf[:-4].view(m, k)
+    w = wbuf[4:].view(n, k) if misalign == "weight" else wbuf[:-4].view(n, k)
+    assert (x if misalign == "x" else w).data_ptr() % 16
+    monkeypatch.setattr(
+        skinny_gemm.ShapeDynamicSkinnyGemm,
+        "__call__",
+        lambda *a, **kw: pytest.fail("under-aligned input must not launch"),
+    )
+    got = routed_gemv.skinny_gemv(x, w)
+    assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_routed_arch(),
+    reason="route is registered for sm100 and up",
+)
+def test_vw16_alignment_threshold_is_32_bytes(monkeypatch):
+    """A 16-byte-aligned view satisfies vw-8 but not vw-16; on the pinned
+    arch the tuned config must reject it, pinning align = vw * elem_size."""
+    from tokenspeed_kernel.ops.gemm import routed_gemv
+    from tokenspeed_kernel.thirdparty.cute_dsl import skinny_gemm
+
+    if not routed_gemv._is_skinny_config_arch(0):
+        pytest.skip("SKINNY_CONFIG_ROUTE is pinned to sm100")
+    m, n, k = 2, 768, 1536  # tuned entry (96, 2, 1, 16)
+    xbuf = torch.randn(m * k + 8, device="cuda", dtype=torch.bfloat16)
+    x = xbuf[8:].view(m, k)
+    assert x.data_ptr() % 32 == 16
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+    monkeypatch.setattr(
+        skinny_gemm.ShapeDynamicSkinnyGemm,
+        "__call__",
+        lambda *a, **kw: pytest.fail("16B-aligned input must not launch vw-16"),
+    )
+    got = routed_gemv.skinny_gemv(x, w)
+    assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)


### PR DESCRIPTION
## What

`nvidia-cutlass-dsl` 4.7 accepts 256-bit copy atoms, which 4.6 rejected at IR
verification — so every measured skinny GEMV config in the route table predates
`vector_width=16` as an option. This re-tunes the 62 skinny-routed shapes and
adds `SKINNY_CONFIG_ROUTE`, a measured `(m, n, k) -> (block_size,
outputs_per_block, k_unroll, vector_width)` table consulted before the vLLM
heuristic, mirroring how `ADD3_ROUTE` already works.

21 shapes earn an entry, winning **4.2%–49.8%**, concentrated where one block
tile covers K (96x16 = 1536, 160x16 = 2560).

## How the entries were measured

Under `tune_route.py`'s cold-L2 methodology — 8 weight copies cycled inside a
96-iteration CUDA graph, 41-round medians — because decode streams a different
layer's weight on every launch.

This mattered: an L2-**warm** sweep put the K=7168 and K=14336 families ahead by
17–47%, and those same configs *lose* cold. Warm-sweep entries for the hot
`(1, 3584, 7168)` / `(1, 6288, 7168)` decode shapes would have cost roughly
170us/step. They keep the heuristic here; the only K=7168 entries that survived
are the 1536x7168 shard at M = 5 and 6.

## Supporting changes

- **Arch pin.** `_is_skinny_config_arch` gates the table at capability exactly
  `(10, 0)` — the arch the sweep ran on. `ADD3_ROUTE`'s pin is a floor; this one
  is exact, since nothing was measured above it.
- **Alignment fallback.** `vector_width=16` raises the kernel's pointer
  requirement from 16 to 32 bytes, which `supports()` cannot see. `skinny_gemv`
  now falls back instead of letting an under-aligned view raise at launch.
- **Tuner.** `candidates()` ranks the config serving would actually run, so a
  backend re-sweep can't demote a shape whose win lives in this table. New
  `tune_route.py skinny-configs` mode re-emits the whole table, revalidating
  existing entries against the heuristic (and printing `DEMOTE` when one no
  longer holds), so its output is a wholesale replacement rather than a ratchet.

## Testing

- `tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py`: 409 passed, 1 skipped
  on GB200. The pre-existing `MEASURED_ROUTE` parametrization compiles and
  numerically checks all 21 tuned configs on the pinned arch.
- New tests cover the arch pin (both the consult branch and the capability
  comparison), the alignment fallback on every routed arch plus the exact
  32-byte vw-16 threshold, table validity including the warp-multiple block rule
  that `supports()` misses, and per-table duplicate keys.
- End-to-end DSPARK bs=1 decode is unchanged within noise (medians 484.9 vs
  480.4 tok/s over paired boots), as expected: the per-call wins are a few us
  against a ~12ms step, and K3 bs=1 does not hit most of the tuned shapes. The
  wins land on drafter shapes at bs>=2 and on the Qwen TP4 table.

## Follow-up

GB300 (sm103) can extend the table by running `tune_route.py skinny-configs`
there and widening the pin — nothing was measured on it, so it deliberately
keeps the heuristic today.
