### PR TITLE
docs: use --prefix-granularity instead of deprecated --block-size

### DIFF
--- a/docs/configuration/compatible-parameters.md
+++ b/docs/configuration/compatible-parameters.md
@@ -31,7 +31,7 @@ TokenSpeed-specific behavior explicitly.
 | `--chat-template` | Chat template name or path. |
 | `--gpu-memory-utilization` | GPU memory fraction used for weights and KV cache. |
 | `--max-num-seqs` | Maximum concurrent sequences. |
-| `--block-size` | KV cache block size. |
+| `--prefix-granularity` | Scheduler prefix granularity in tokens. `--block-size` is a deprecated alias. |
 | `--enable-prefix-caching` | Enable prefix cache reuse. |
 | `--no-enable-prefix-caching` | Disable prefix cache reuse. |
 | `--enforce-eager` | Disable device-graph execution (CUDA Graph on CUDA, ACL Graph on NPU). |

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -103,7 +103,7 @@ distributed update mode until that implementation is added.
 | `--chunked-prefill-size` | Token budget the scheduler may issue in one iteration. Defaults to `8192`. Set `-1` to disable chunked prefill. |
 | `--max-prefill-tokens` | Prefill token budget used when chunked prefill is disabled. Defaults to `8192`. |
 | `--max-total-tokens` | Override the automatically calculated token pool size. |
-| `--block-size` | KV cache block size. |
+| `--prefix-granularity` | Scheduler prefix granularity in tokens: the identity boundary of cache reuse. `--block-size` is a deprecated alias. |
 | `--enable-prefix-caching` / `--no-enable-prefix-caching` | Enable or disable prefix cache reuse. |
 | `--enforce-eager` | Disable device-graph execution (CUDA Graph on CUDA, ACL Graph on NPU). |
 | `--disable-prefill-graph` | Keep prefill eager while leaving decode device graphs enabled. |
@@ -196,7 +196,7 @@ startup rather than silently drafting a wrong-width block. A checkpoint with
 --speculative-num-steps 7`.
 
 A block drafter writes its KV at the target's cache locations, so it shares the
-target's page table: `--block-size` is a target-side choice and the draft
+target's page table: `--prefix-granularity` is a target-side choice and the draft
 follows it. Any sliding window the draft checkpoint declares is an attention
 mask applied by the draft's own layers, never a cache-retention policy of its
 own.

--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -36,7 +36,7 @@ ts serve \
     --moe-backend flashinfer_trtllm \
     --enable-prefix-caching \
     --disable-kvstore \
-    --block-size 128 \
+    --prefix-granularity 128 \
     --enable-cache-report \
     --speculative-algorithm MTP \
     --speculative-num-steps 3 \
@@ -57,7 +57,7 @@ ts serve \
     --trust-remote-code \
     --enable-prefix-caching \
     --disable-kvstore \
-    --block-size 128 \
+    --prefix-granularity 128 \
     --enable-cache-report \
     --speculative-algorithm MTP \
     --speculative-num-steps 3 \
@@ -91,7 +91,7 @@ tokenspeed serve nvidia/MiniMax-M3-NVFP4 \
     --speculative-eagle-topk 1 \
     --speculative-num-draft-tokens 4 \
     --disable-kvstore \
-    --block-size 128 \
+    --prefix-granularity 128 \
     --trust-remote-code \
     --host 0.0.0.0 \
     --port 8000
@@ -121,7 +121,7 @@ tokenspeed serve nvidia/MiniMax-M3-NVFP4 \
     --speculative-eagle-topk 1 \
     --speculative-num-draft-tokens 8 \
     --disable-kvstore \
-    --block-size 128 \
+    --prefix-granularity 128 \
     --trust-remote-code \
     --host 0.0.0.0 \
     --port 8000
@@ -134,7 +134,7 @@ Notes:
   draft queries, and the step count is always the verify width minus one. The
   width is checked against the checkpoint's `block_size` at startup, so a
   mismatched launch fails fast instead of drafting a wrong-width block.
-- `--block-size 128` is the target's MSA page size. The draft writes its KV at
+- `--prefix-granularity 128` is the target's MSA page size. The draft writes its KV at
   the target's cache locations and shares the target's page table, so it
   inherits that page size; do not set a separate draft block size.
 - The draft's 1024-token sliding window is an attention mask its own layers
@@ -745,8 +745,8 @@ tokenspeed serve openai/gpt-oss-120b \
 
 DeepSeek V4 needs FP8 KV cache, the DeepGEMM `mega_moe` experts, and the FP4
 indexer cache. `tokenspeed serve` auto-selects `--reasoning-parser deepseek_v31`
-and `--tool-call-parser deepseek_v4`, and auto-sets `block_size=256` (pass
-`--block-size N` with `N != 64` to override). Requires
+and `--tool-call-parser deepseek_v4`, and auto-sets `prefix_granularity=256` (pass
+`--prefix-granularity N` with `N != 64` to override). Requires
 `tokenspeed-deepgemm>=2.5.0.post20260629` and `tokenspeed-flashmla`.
 
 **V4-Flash** — 4× B200 (SM100), data-parallel + expert-parallel:


### PR DESCRIPTION
## Summary

Docs still presented `--block-size` as the current `tokenspeed serve` flag. Argparse exposes `--prefix-granularity` as the real option and keeps `--block-size` only as a deprecated alias. Update the server, compatible-parameters, and model-recipe docs to the current flag. Alias is mentioned where this repo already documents deprecations that way (parameter tables). Launch recipes use `--prefix-granularity` only. Checkpoint `block_size` (DFLASH/DSPARK verify width) is left unchanged.

`docs/design/cache-concepts.md` already names `--prefix-granularity` and the alias; skipped.

## Reproduce

CLI definition (`python/tokenspeed/runtime/utils/server_args.py`):

```python
parser.add_argument(
    "--prefix-granularity",
    "--block-size",  # deprecated alias
    dest="prefix_granularity",
    metavar="PREFIX_GRANULARITY",
    type=int,
    default=ServerArgs.prefix_granularity,
    help="Scheduler prefix granularity in tokens: the identity "
    "boundary of cache reuse. (--block-size is a deprecated alias.)",
)
```

Docs on `main` still treated the alias as current:

- `docs/configuration/server.md`: `| `--block-size` | KV cache block size. |`
- `docs/configuration/compatible-parameters.md`: `| `--block-size` | KV cache block size. |`
- `docs/recipes/models.md`: launch lines `--block-size 128` and DeepSeek V4 `auto-sets `block_size=256` (pass `--block-size N` ...)`

One recipe already used `--prefix-granularity 128` (Qwen path).

## Test Plan

- [x] Quoted argparse dest/flags vs the three docs files on `ba1b1c71`
- [x] Replaced CLI `--block-size` with `--prefix-granularity` in recipes and flag tables
- [x] Left checkpoint `block_size` / event payload `block_size` alone
- [x] Alias noted only in the parameter tables, matching cache-concepts.md / CLI help