### PR TITLE
perf(gemm): 256-bit skinny GEMV configs for the measured decode shapes

### DIFF
--- a/test/gemm_tuning/tune_route.py
+++ b/test/gemm_tuning/tune_route.py
@@ -22,7 +22,6 @@
 
 Run as ``tune_route.py [shape_set] [route.json]``; the set names a key of
 SHAPE_SETS and defaults to K3's TP16 table.
-
 The shapes are the exact (N, K) that the decode path hands the routed GEMV,
 extracted from a trace of the serving path (rowcta's launch grid is ``(N,)``,
 so gridX identifies each call site). Every measurement cycles
@@ -163,7 +162,11 @@ def candidates(m: int, n: int, k: int):
     )
 
     if skinny.is_available():
-        cfg = skinny.default_config(m, n, k)
+        # Rank the config serving would run, not the bare heuristic, so a
+        # re-sweep cannot demote a shape whose win lives in SKINNY_CONFIG_ROUTE.
+        from tokenspeed_kernel.ops.gemm.routed_gemv import _skinny_config
+
+        cfg = _skinny_config(m, n, k)
         if skinny.supports(cfg, m, n, k):
 
             def sk(i):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -331,12 +331,43 @@ def _mark_warmed(backend: str, dev: int, m: int, n: int, k: int) -> None:
             _warmed.add((backend, dev, m, n, k))
 
 
-@functools.lru_cache(maxsize=32)
+# Measured (m, n, k) -> (block_size, outputs_per_block, k_unroll, vector_width).
+SKINNY_CONFIG_ROUTE: MappingProxyType[
+    tuple[int, int, int], tuple[int, int, int, int]
+] = MappingProxyType(
+    {
+        (2, 768, 1536): (96, 2, 1, 16),
+        (3, 768, 1536): (96, 2, 1, 16),
+        (4, 768, 1536): (96, 2, 1, 16),
+        (2, 1152, 1536): (96, 4, 1, 16),
+        (3, 1152, 1536): (96, 4, 1, 16),
+        (2, 1536, 1536): (96, 4, 1, 16),
+        (3, 1536, 1536): (96, 4, 1, 16),
+        (2, 2304, 1536): (96, 4, 1, 16),
+        (1, 320, 2560): (160, 2, 1, 16),
+        (2, 320, 2560): (160, 2, 1, 16),
+        (1, 512, 2560): (160, 2, 1, 16),
+        (2, 512, 2560): (160, 2, 1, 16),
+        (1, 640, 2560): (160, 2, 1, 16),
+        (2, 640, 2560): (160, 2, 1, 16),
+        (4, 640, 2560): (160, 2, 1, 16),
+        (5, 1536, 7168): (224, 2, 1, 16),
+        (6, 1536, 7168): (64, 2, 1, 16),
+    }
+)
+
+
+@functools.lru_cache(maxsize=256)
 def _skinny_config(m: int, n: int, k: int):
+    """The measured config for this shape, else the vendor heuristic."""
     from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        SkinnyGemmConfig,
         shape_dynamic_skinny_gemm,
     )
 
+    tuned = SKINNY_CONFIG_ROUTE.get((m, n, k))
+    if tuned is not None:
+        return SkinnyGemmConfig(m, *tuned)
     return shape_dynamic_skinny_gemm.default_config(m, n, k)
 
 
@@ -373,6 +404,10 @@ def skinny_gemv(
     config = _skinny_config(m, n, k)
     # default_config can emit a config supports() rejects; fall back, don't raise.
     if not shape_dynamic_skinny_gemm.supports(config, m, n, k):
+        return _torch_decode_gemv(x, weight, out)
+    # supports() cannot see pointer alignment; the kernel asserts it at launch.
+    align = config.vector_width * x.element_size()
+    if x.data_ptr() % align or weight.data_ptr() % align:
         return _torch_decode_gemv(x, weight, out)
     # DLPack refuses requires_grad tensors; detach is a zero-copy view.
     result = shape_dynamic_skinny_gemm(x.detach(), weight.detach(), config, out=out)

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -353,5 +353,86 @@ def test_measured_route_source_has_no_duplicate_keys():
     assert not dupes, f"duplicate MEASURED_ROUTE keys in source: {dupes}"
     # Parsed size must match source count, else a duplicate collapsed.
     assert len(routed_gemv.MEASURED_ROUTE) == len(keys)
+    # Tuple-valued tables need their own pattern, scanned per table: the two
+    # config tables are independent key spaces, so a shared key is legal.
+    for name, table in (
+        ("SKINNY_CONFIG_ROUTE", routed_gemv.SKINNY_CONFIG_ROUTE),
+        ("ADD3_ROUTE", routed_gemv.ADD3_ROUTE),
+    ):
+        start = src.index(f"{name}: MappingProxyType")
+        span = src[start : src.index(")", src.index("}", start))]
+        cfg_keys = re.findall(r"\((\d+), (\d+), (\d+)\): \(", span)
+        cfg_dupes = [k for k, n in collections.Counter(cfg_keys).items() if n > 1]
+        assert not cfg_dupes, f"duplicate {name} keys in source: {cfg_dupes}"
+        assert len(table) == len(cfg_keys), name
     # Exact-M keying: entries may only exist in the gap-free swept range.
     assert all(m <= 32 for m, _, _ in routed_gemv.MEASURED_ROUTE)
+
+
+def test_skinny_config_route_entries_are_valid():
+    """Every tuned skinny config must target a shape the route actually sends
+    to skinny, and must satisfy the kernel's geometry contract; a typo here
+    would otherwise fall back (wrong M) or crash at compile time."""
+    from tokenspeed_kernel.ops.gemm.routed_gemv import SKINNY_CONFIG_ROUTE
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        SkinnyGemmConfig,
+        shape_dynamic_skinny_gemm,
+    )
+
+    for (m, n, k), tuned in SKINNY_CONFIG_ROUTE.items():
+        assert MEASURED_ROUTE.get((m, n, k)) == "skinny", (m, n, k)
+        # supports() does not know the kernel's warp-multiple block rule.
+        assert tuned[0] % 32 == 0, (m, n, k)
+        config = SkinnyGemmConfig(m, *tuned)
+        assert shape_dynamic_skinny_gemm.supports(config, m, n, k), (m, n, k)
+
+
+def test_skinny_config_prefers_the_measured_table_over_the_heuristic():
+    """Measured entries serve; unmeasured shapes fall through to the heuristic."""
+    from tokenspeed_kernel.ops.gemm import routed_gemv
+    from tokenspeed_kernel.thirdparty.cute_dsl.skinny_gemm import (
+        shape_dynamic_skinny_gemm,
+    )
+
+    routed_gemv._skinny_config.cache_clear()
+    m, n, k = 2, 768, 1536
+    config = routed_gemv._skinny_config(m, n, k)
+    assert (
+        config.block_size,
+        config.outputs_per_block,
+        config.k_unroll,
+        config.vector_width,
+    ) == routed_gemv.SKINNY_CONFIG_ROUTE[(m, n, k)]
+
+    unmeasured = (7, 768, 1536)
+    assert unmeasured not in routed_gemv.SKINNY_CONFIG_ROUTE
+    assert routed_gemv._skinny_config(*unmeasured) == (
+        shape_dynamic_skinny_gemm.default_config(*unmeasured)
+    )
+    routed_gemv._skinny_config.cache_clear()
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not _is_routed_arch(),
+    reason="route is registered for sm100 and up",
+)
+@pytest.mark.parametrize("misalign,offset", [("x", 4), ("weight", 4), ("x", 8)])
+def test_under_aligned_operands_fall_back_to_torch(monkeypatch, misalign, offset):
+    """vw-16 needs 32-byte pointers and supports() cannot see alignment, so the
+    guard falls back; offset 8 is the 16B case a vw-8 config would accept."""
+    from tokenspeed_kernel.ops.gemm import routed_gemv
+    from tokenspeed_kernel.thirdparty.cute_dsl import skinny_gemm
+
+    m, n, k = 2, 768, 1536  # tuned entry (96, 2, 1, 16)
+    xbuf = torch.randn(m * k + offset, device="cuda", dtype=torch.bfloat16)
+    wbuf = torch.randn(n * k + offset, device="cuda", dtype=torch.bfloat16)
+    x = (xbuf[offset:] if misalign == "x" else xbuf[:-offset]).view(m, k)
+    w = (wbuf[offset:] if misalign == "weight" else wbuf[:-offset]).view(n, k)
+    assert (x if misalign == "x" else w).data_ptr() % 32
+    monkeypatch.setattr(
+        skinny_gemm.ShapeDynamicSkinnyGemm,
+        "__call__",
+        lambda *a, **kw: pytest.fail("under-aligned input must not launch vw-16"),
+    )
+    got = routed_gemv.skinny_gemv(x, w)
+    assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)


### PR DESCRIPTION
nvidia-cutlass-dsl 4.7 accepts a 256-bit copy atom the vendored skinny GEMM's heuristic predates, so the config it picks never uses one. Re-tuning the skinny-routed decode shapes under tune_route.py's cold-L2 methodology (8 weight copies cycled in-graph, 41-round medians) finds 17 where a vector-width-16 geometry wins, by 4% to 28%. The gains cluster where one block tile covers K: 96x16 == 1536 and 160x16 == 2560.

Two regimes stay on the heuristic. The K=7168 and K=14336 families lead in an L2-warm sweep but lose cold, and decode streams every layer's weight, so cold is the honest regime -- only the 1536x7168 shard at M == 5 and 6 survives it. Three more shapes the sweep admitted at 1.04-1.07x did not reproduce in an independent replay-timed check.

Swept on sm100 and sm103, which agreed on every K3 shape, so the table is not arch-pinned. The two shapes that disagreed are qwen3-8B's and both take the sm103 reading: 640x2560 only moved between adjacent outputs_per_block values, and 12800x2560's vw-16 geometry did not beat the incumbent there at all.

skinny_gemv also learns to fall back when an operand pointer is under-aligned for the config's vector width -- supports() cannot see alignment, and vw-16 raises the requirement to 32 bytes. tune_route.py ranks the config serving would run rather than the bare heuristic, so a backend re-sweep cannot demote a shape whose win lives in this table.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
