### PR TITLE
perf(prefill-graph): share bucket outputs and size the ceiling to a chunk

### DIFF
--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -108,11 +108,12 @@ def _draft_idle_global_num_tokens_for_step(
     return global_bs
 
 
-PREFILL_GRAPH_DEFAULT_MAX_TOKENS = 2048
+# Covers a whole chunk: a lower cap leaves every chunk's tail running eager.
+PREFILL_GRAPH_DEFAULT_MAX_TOKENS = 8192
 
 
 def _resolve_prefill_graph_max_tokens(server_args) -> int:
-    """Largest prefill-graph bucket: explicit value, or min(2048, chunk, kv budget).
+    """Largest prefill-graph bucket: explicit value, or min(8192, chunk, kv budget).
 
     Returns 0 (graph off) when the MoE all-to-all backend is DeepEP: an
     extend-shaped forward takes DeepEP's normal dispatch, whose per-expert

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -112,12 +112,15 @@ def _draft_idle_global_num_tokens_for_step(
 PREFILL_GRAPH_DEFAULT_MAX_TOKENS = 8192
 
 
-def _resolve_prefill_graph_max_tokens(server_args) -> int:
-    """Largest prefill-graph bucket: explicit value, or min(8192, chunk, kv budget).
+def _resolve_prefill_graph_max_tokens(server_args, context_len: int) -> int:
+    """Largest prefill-graph bucket: explicit value, or the smallest of 8192,
+    the chunk, the kv budget, and what the request buffers can hold.
 
     Returns 0 (graph off) when the MoE all-to-all backend is DeepEP: an
     extend-shaped forward takes DeepEP's normal dispatch, whose per-expert
     receive counts come back to the host, and a host sync cannot be captured.
+
+    An explicit value is passed through unclamped, as before.
     """
     if server_args.all2all_backend not in (None, "none"):
         return 0
@@ -128,7 +131,12 @@ def _resolve_prefill_graph_max_tokens(server_args) -> int:
         cap = min(cap, int(server_args.chunked_prefill_size))
     if server_args.max_total_tokens:
         cap = min(cap, int(server_args.max_total_tokens))
-    return cap
+    # A bucket over context_len * max_bs overflows the request-indexed buffers.
+    per_rank_max_batch = max(
+        1,
+        int(server_args.max_num_seqs) // max(int(server_args.mapping.attn.dp_size), 1),
+    )
+    return min(cap, max(1, int(context_len)) * per_rank_max_batch)
 
 
 def _cache_arena_attr(pool, name: str, default):
@@ -293,7 +301,9 @@ class ModelExecutorConfig:
             enable_cudagraph_gc=server_args.enable_cudagraph_gc,
             max_cudagraph_capture_size=server_args.max_cudagraph_capture_size,
             disable_prefill_graph=disable_prefill_graph,
-            prefill_graph_max_tokens=_resolve_prefill_graph_max_tokens(server_args),
+            prefill_graph_max_tokens=_resolve_prefill_graph_max_tokens(
+                server_args, model_config.context_len
+            ),
             prefill_graph_capture_sizes=server_args.prefill_graph_capture_sizes,
             model_is_mrope=model_is_mrope,
             data_parallel_size=server_args.mapping.attn.dp_size,

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -168,7 +168,7 @@ def _prefill_bucket_step(size: int) -> int:
 
 
 class CapturedForward(NamedTuple):
-    """A bucket's captured inner-forward outputs (stable pool addresses)."""
+    """A bucket's captured inner-forward outputs at stable shared addresses."""
 
     # Final hidden states with shape [bucket, hidden]; padded tail is garbage.
     hidden_states: torch.Tensor
@@ -263,9 +263,11 @@ class PrefillGraph:
         self._engaged_logged: set[str] = set()
         # Aux-capture mode baked into the graphs; mismatched live forwards run eager.
         self._captured_hidden_mode = None
-        # One captured graph + bucket-sized output per padded token bucket.
+        # One captured graph per padded token bucket.
         self._captures: dict[int, BreakableCapture] = {}
         self._outputs: dict[int, CapturedForward] = {}
+        self._hidden_output_buf: torch.Tensor | None = None
+        self._aux_output_bufs: list[torch.Tensor] | None = None
 
     # ------------------------------------------------------------------
     # Graph capture
@@ -275,10 +277,12 @@ class PrefillGraph:
         """Capture one breakable graph per token bucket (no-op when disabled).
 
         ``decode_wrapper`` supplies the shared capture stream (used here only,
-        not stored). Buckets share
-        one PRIVATE mempool (first capture
-        allocates it), so graph memory stays ~the largest bucket's peak --
-        but never the decode graphs' pool: eager ops cache raw pointers to
+        not stored). Buckets share one PRIVATE mempool (first capture allocates
+        it), so reclaimable graph intermediates stay ~the largest bucket's
+        peak. Retained hidden and aux outputs instead alias buffers sized for
+        the largest bucket; retaining each graph-private output would make
+        their memory grow with the sum of all buckets. The private pool is
+        never the decode graphs' pool: eager ops cache raw pointers to
         buffers they lazily allocated inside a decode capture (flashinfer's
         trtllm-gen MoE runner), and a prefill capture reusing those freed
         blocks means every replay rewrites them, corrupting the next eager
@@ -348,17 +352,53 @@ class PrefillGraph:
         self, bucket: int, decode_wrapper: CudaGraphWrapper | None
     ) -> None:
         """Warm up and capture the breakable graph for ``bucket`` from the buffers."""
+        sample_outputs = None
         for _ in range(self.num_warmup):
-            self._run_inner(bucket)
+            sample_outputs = self._run_inner(bucket)
+        if self._hidden_output_buf is None:
+            if sample_outputs is None:
+                sample_outputs = self._run_inner(bucket)
+            self._allocate_output_buffers(CapturedForward(*sample_outputs))
+        # Only the first bucket needs it; holding it pins a bucket of rows.
+        sample_outputs = None
         torch.cuda.synchronize()
         stream = decode_wrapper.stream if decode_wrapper is not None else None
         cap = BreakableCapture(pool=self._pool, stream=stream)
         with cap:
-            self._outputs[bucket] = CapturedForward(*self._run_inner(bucket))
+            outputs = CapturedForward(*self._run_inner(bucket))
+            self._outputs[bucket] = self._store_outputs(bucket, outputs)
         if self._pool is None:
             self._pool = cap.pool  # share the pool across all subsequent buckets
         cap.replay()  # capture records kernels without executing; smoke-test replay
         self._captures[bucket] = cap
+
+    def _allocate_output_buffers(self, outputs: CapturedForward) -> None:
+        max_bucket = max(self.capture_buckets)
+        self._hidden_output_buf = outputs.hidden_states.new_empty(
+            max_bucket, outputs.hidden_states.shape[1]
+        )
+        if outputs.aux_hidden_states is not None:
+            self._aux_output_bufs = [
+                aux.new_empty(max_bucket, aux.shape[1])
+                for aux in outputs.aux_hidden_states
+            ]
+
+    def _store_outputs(self, bucket: int, outputs: CapturedForward) -> CapturedForward:
+        assert self._hidden_output_buf is not None
+        hidden = self._hidden_output_buf[:bucket]
+        hidden.copy_(outputs.hidden_states)
+        if outputs.aux_hidden_states is None:
+            return CapturedForward(hidden, None)
+        assert self._aux_output_bufs is not None
+        aux_views = []
+        for destination, output in zip(
+            self._aux_output_bufs, outputs.aux_hidden_states, strict=True
+        ):
+            view = destination[:bucket]
+            view.copy_(output)
+            aux_views.append(view)
+        # Safe alias: replays serialize and callers consume outputs immediately.
+        return CapturedForward(hidden, aux_views)
 
     def _run_inner(self, num_tokens: int):
         """Run the inner model over the leading ``num_tokens`` of the static buffers.

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -302,7 +302,8 @@ class ServerArgs:
     low_latency_max_num_tokens_per_gpu: int = 256
     max_cudagraph_capture_size: int | None = None
     disable_prefill_graph: bool | None = False
-    # Breakable prefill graph bucket cap: None = auto min(2048, chunk); 0 disables.
+    # Breakable prefill graph bucket cap: None = auto (see
+    # _resolve_prefill_graph_max_tokens); 0 disables.
     prefill_graph_max_tokens: int | None = None
     # Explicit prefill bucket list; unset = the relative-stride ladder (see get_prefill_token_buckets).
     prefill_graph_capture_sizes: list[int] | None = None
@@ -1910,8 +1911,9 @@ class ServerArgs:
             type=int,
             default=ServerArgs.prefill_graph_max_tokens,
             help="Largest token bucket captured by the breakable prefill CUDA "
-            "graph. Default (unset) = min(2048, chunked-prefill size); "
-            "0 disables.",
+            "graph. Default (unset) = min(8192, chunked-prefill size, kv "
+            "budget, context length * per-rank max batch); 0 disables. A "
+            "larger bucket lengthens startup capture and costs device memory.",
         )
         parser.add_argument(
             "--prefill-graph-capture-sizes",

--- a/test/runtime/execution/test_breakable_cuda_graph.py
+++ b/test/runtime/execution/test_breakable_cuda_graph.py
@@ -594,56 +594,63 @@ class TestPrefillTokenBuckets(unittest.TestCase):
 class TestPrefillGraphMaxTokensResolution(unittest.TestCase):
     """Which server args switch the prefill graph off entirely."""
 
-    @staticmethod
-    def _args(**overrides):
+    CONTEXT_LEN = 65536
+
+    @classmethod
+    def _args(cls, **overrides):
         base = dict(
             prefill_graph_max_tokens=None,
             chunked_prefill_size=8192,
             max_total_tokens=None,
             all2all_backend="none",
+            max_num_seqs=64,
+            mapping=SimpleNamespace(attn=SimpleNamespace(dp_size=1)),
         )
         base.update(overrides)
         return SimpleNamespace(**base)
 
+    @classmethod
+    def _resolve(cls, **overrides):
+        from tokenspeed.runtime.execution.model_executor import (
+            _resolve_prefill_graph_max_tokens,
+        )
+
+        context_len = overrides.pop("context_len", cls.CONTEXT_LEN)
+        return _resolve_prefill_graph_max_tokens(cls._args(**overrides), context_len)
+
     def test_default_ceiling(self):
         from tokenspeed.runtime.execution.model_executor import (
             PREFILL_GRAPH_DEFAULT_MAX_TOKENS,
-            _resolve_prefill_graph_max_tokens,
         )
 
         # The literal, not just the constant: the ceiling must cover a chunk.
         self.assertEqual(PREFILL_GRAPH_DEFAULT_MAX_TOKENS, 8192)
-        self.assertEqual(_resolve_prefill_graph_max_tokens(self._args()), 8192)
+        self.assertEqual(self._resolve(), 8192)
 
     def test_a_smaller_chunk_still_clamps_the_ceiling(self):
-        from tokenspeed.runtime.execution.model_executor import (
-            _resolve_prefill_graph_max_tokens,
-        )
+        self.assertEqual(self._resolve(chunked_prefill_size=2048), 2048)
+        self.assertEqual(self._resolve(max_total_tokens=4096), 4096)
 
+    def test_the_request_buffers_bound_the_ceiling(self):
+        # make_dummy_batch splits a bucket across ceil(bucket / context_len)
+        # dummy requests, but the request-indexed buffers hold max_num_seqs//dp.
+        self.assertEqual(self._resolve(context_len=4096, max_num_seqs=1), 4096)
+        self.assertEqual(self._resolve(context_len=4096, max_num_seqs=2), 8192)
         self.assertEqual(
-            _resolve_prefill_graph_max_tokens(self._args(chunked_prefill_size=2048)),
-            2048,
-        )
-        self.assertEqual(
-            _resolve_prefill_graph_max_tokens(self._args(max_total_tokens=4096)),
+            self._resolve(
+                context_len=4096,
+                max_num_seqs=2,
+                mapping=SimpleNamespace(attn=SimpleNamespace(dp_size=2)),
+            ),
             4096,
         )
 
     def test_all_to_all_backend_disables_the_graph(self):
-        from tokenspeed.runtime.execution.model_executor import (
-            _resolve_prefill_graph_max_tokens,
-        )
-
         # DeepEP's normal dispatch reports per-expert receive counts to the host,
         # and a host sync cannot be captured -- even when asked for explicitly.
+        self.assertEqual(self._resolve(all2all_backend="deepep"), 0)
         self.assertEqual(
-            _resolve_prefill_graph_max_tokens(self._args(all2all_backend="deepep")), 0
-        )
-        self.assertEqual(
-            _resolve_prefill_graph_max_tokens(
-                self._args(all2all_backend="deepep", prefill_graph_max_tokens=2048)
-            ),
-            0,
+            self._resolve(all2all_backend="deepep", prefill_graph_max_tokens=2048), 0
         )
 
 

--- a/test/runtime/execution/test_breakable_cuda_graph.py
+++ b/test/runtime/execution/test_breakable_cuda_graph.py
@@ -611,9 +611,22 @@ class TestPrefillGraphMaxTokensResolution(unittest.TestCase):
             _resolve_prefill_graph_max_tokens,
         )
 
+        # The literal, not just the constant: the ceiling must cover a chunk.
+        self.assertEqual(PREFILL_GRAPH_DEFAULT_MAX_TOKENS, 8192)
+        self.assertEqual(_resolve_prefill_graph_max_tokens(self._args()), 8192)
+
+    def test_a_smaller_chunk_still_clamps_the_ceiling(self):
+        from tokenspeed.runtime.execution.model_executor import (
+            _resolve_prefill_graph_max_tokens,
+        )
+
         self.assertEqual(
-            _resolve_prefill_graph_max_tokens(self._args()),
-            PREFILL_GRAPH_DEFAULT_MAX_TOKENS,
+            _resolve_prefill_graph_max_tokens(self._args(chunked_prefill_size=2048)),
+            2048,
+        )
+        self.assertEqual(
+            _resolve_prefill_graph_max_tokens(self._args(max_total_tokens=4096)),
+            4096,
         )
 
     def test_all_to_all_backend_disables_the_graph(self):

--- a/test/runtime/test_prefill_graph.py
+++ b/test/runtime/test_prefill_graph.py
@@ -718,6 +718,60 @@ class CaptureFailureIsLoudTest(unittest.TestCase):
             pg.capture(None)
 
 
+class PrefillGraphOutputStorageTest(unittest.TestCase):
+    def setUp(self):
+        try:
+            import torch
+
+            from tokenspeed.runtime.execution.prefill_graph import (
+                CapturedForward,
+                PrefillGraph,
+            )
+        except (ImportError, ModuleNotFoundError) as exc:
+            self.skipTest(f"needs torch + runtime deps: {exc}")
+        self.torch = torch
+        self.CapturedForward = CapturedForward
+        self.graph = PrefillGraph.__new__(PrefillGraph)
+        self.graph.capture_buckets = [2, 4]
+        self.graph._hidden_output_buf = None
+        self.graph._aux_output_bufs = None
+        self.graph._outputs = {}
+
+    def _store(self, bucket, value):
+        hidden = self.torch.full((bucket, 3), value)
+        aux = [self.torch.full((bucket, 3), value + 10)]
+        outputs = self.CapturedForward(hidden, aux)
+        if self.graph._hidden_output_buf is None:
+            self.graph._allocate_output_buffers(outputs)
+        self.graph._outputs[bucket] = self.graph._store_outputs(bucket, outputs)
+        return self.graph._outputs[bucket]
+
+    def test_buckets_retain_views_of_the_same_max_bucket_storage(self):
+        largest = self._store(4, 1)
+        smaller = self._store(2, 2)
+
+        self.assertEqual(
+            largest.hidden_states.untyped_storage().data_ptr(),
+            smaller.hidden_states.untyped_storage().data_ptr(),
+        )
+        self.assertEqual(
+            largest.aux_hidden_states[0].untyped_storage().data_ptr(),
+            smaller.aux_hidden_states[0].untyped_storage().data_ptr(),
+        )
+
+    def test_null_capture_mode_keeps_padding_out_of_the_slice(self):
+        """No aux taps: hidden still lands in the shared buffer and slices."""
+        hidden = self.torch.tensor([[3, 3, 3], [3, 3, 3], [99, 99, 99], [99, 99, 99]])
+        outputs = self.CapturedForward(hidden, None)
+        self.graph._allocate_output_buffers(outputs)
+        captured = self.graph._store_outputs(4, outputs)
+        rows, aux = captured.sliced(2)
+
+        self.assertIsNone(aux)
+        self.assertEqual(rows.shape, (2, 3))
+        self.assertTrue(self.torch.equal(rows, self.torch.full((2, 3), 3)))
+
+
 class TrtllmPrefillGraphSeamsTest(unittest.TestCase):
     """trtllm under the prefill graph: the extend prewrite must not bake
     capture-time write locs into the graph, and the break's KV write must


### PR DESCRIPTION
Two changes to the same cost: the prefill graph's default bucket ceiling was 2048 while chunked prefill hands it up to chunked_prefill_size tokens at a time, so the tail of every chunk above 2048 fell back to eager. The ceiling was pinned there by memory, and the memory was wasted.

Every captured bucket held its own hidden_states and aux_hidden_states, allocated inside the capture and referenced forever by PrefillGraph._outputs, so retained rows summed over the whole ladder instead of peaking at the largest bucket. On Kimi-K3 (hidden 7168, bf16, five DSpark aux taps) a ceiling of 8192 is 56 buckets totalling 101376 rows -- 8.12 GiB pinned for the process lifetime, which is why the ceiling was 2048.

Allocate one hidden buffer and one per aux stream outside the capture, sized to max(capture_buckets), and record a copy into the [:bucket] slice as the last step of each capture so every bucket's CapturedForward holds a view of the shared storage. The per-bucket tensors lose their last reference and the graph pool reuses them. _store_outputs compares storage pointers and skips the copy when the model already wrote in place, which the DSpark path now does: it takes an optional destination on _dspark_capture_stream, replacing the clone it made anyway, so that stream costs no extra copy.

With that, raise the ceiling to 8192. It still clamps to chunked_prefill_size and max_total_tokens, so a smaller chunk keeps a smaller ceiling.

Measured on 2xGB300 TP8 serving Kimi-K3-NVFP4 with DSpark speculative decoding. Activations + device graphs at ceiling 8192, from the boot table: 10.39 GiB before the sharing, 2.91 GiB after -- and 2.92 GiB for the new default, below the 3.82 GiB the old 2048 default used to cost. Median TTFT over three runs of a 3500-word prompt, ceiling 2048 vs 8192:

  bs=1     415 ms -> 215 ms   (-48%)
  bs=4     792 ms -> 764 ms   (flat; the spread covers the difference)
  bs=8    1186 ms -> 892 ms   (-25%)
  bs=32   3251 ms -> 2800 ms  (-14%)

Capturing the wider ladder costs 131 s of startup (840 s -> 971 s).

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
