### PR TITLE
perf(k3): fuse MLA prefill preparation on gfx950

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/mla.py
@@ -181,17 +181,14 @@ class MLATokenToKVPool(CachePool):
             self.kv_buffer[layer_id][1][loc] = scale
             self.kv_buffer[layer_id][2][loc] = k_rope
         else:
+            kv_buffer = self.kv_buffer[layer_id]
             if self.store_dtype != self.dtype:
-                # Bitwise-viewed pool: pre-cast and re-view for the raw word copy.
-                if cache_k_nope.dtype != self.dtype:
-                    cache_k_nope = cache_k_nope.to(self.dtype)
-                    cache_k_rope = cache_k_rope.to(self.dtype)
-                cache_k_nope = cache_k_nope.view(self.store_dtype)
-                cache_k_rope = cache_k_rope.view(self.store_dtype)
-            # else: the write kernel casts to the buffer dtype on store.
+                # The arena stores FP8 rows as bytes. Give the scatter kernel an
+                # FP8 view so its stores quantize mixed-dtype sources in place.
+                kv_buffer = kv_buffer.view(self.dtype)
 
             set_mla_kv_buffer_triton(
-                self.kv_buffer[layer_id],
+                kv_buffer,
                 loc,
                 cache_k_nope,
                 cache_k_rope,

--- a/python/tokenspeed/runtime/models/deepseek_v3.py
+++ b/python/tokenspeed/runtime/models/deepseek_v3.py
@@ -1132,13 +1132,12 @@ class DeepseekV3AttentionMLA(nn.Module):
 
             v_fp8 = fp8_quantize(v)
 
-            # Write FP8 KV cache directly (skip BF16→FP8 conversion in pool)
+            # The cache scatter converts the compressed BF16 latent directly to FP8.
             k_pe_for_cache = k_fp8[:, 0:1, self.qk_nope_head_dim :]
-            kv_a_fp8 = fp8_quantize(kv_a)
             ctx.token_to_kv_pool.set_mla_kv_buffer(
                 self.attn_mha,
                 out_cache_loc,
-                cache_k_nope=kv_a_fp8.unsqueeze(1),
+                cache_k_nope=kv_a.unsqueeze(1),
                 cache_k_rope=k_pe_for_cache,
             )
 

--- a/test/runtime/cache/test_mla_kv_buffer.py
+++ b/test/runtime/cache/test_mla_kv_buffer.py
@@ -173,6 +173,67 @@ def test_set_casts_bf16_sources_into_fp8_buffer(n_loc, pattern):
 
 
 @pytest.mark.parametrize("n_loc", [4, 600])
+@pytest.mark.parametrize(
+    ("nope_dtype", "rope_dtype"),
+    [
+        (torch.bfloat16, torch.float8_e4m3fn),
+        (torch.float8_e4m3fn, torch.bfloat16),
+    ],
+)
+def test_set_casts_mixed_sources_into_fp8_buffer(n_loc, nope_dtype, rope_dtype):
+    """Both dispatch branches accept independently typed cache components."""
+    loc, k_nope, _ = _make_inputs(n_loc, nope_dtype, "rand")
+    _, _, k_rope = _make_inputs(n_loc, rope_dtype, "rand", seed=1)
+    kv = _empty_kv(torch.float8_e4m3fn)
+    ref = _torch_set_reference(
+        kv,
+        loc,
+        k_nope.to(torch.float8_e4m3fn),
+        k_rope.to(torch.float8_e4m3fn),
+    )
+
+    set_mla_kv_buffer_triton(kv, loc, k_nope, k_rope)
+    torch.cuda.synchronize()
+
+    assert _bitwise_equal(kv, ref)
+
+
+def test_pool_scatter_quantizes_without_materializing_fp8_sources(monkeypatch):
+    import tokenspeed.runtime.layers.attention.kv_cache.mla as mla_pool_module
+
+    pool = object.__new__(MLATokenToKVPool)
+    pool.quant_method = "none"
+    pool.dtype = torch.float8_e4m3fn
+    pool.store_dtype = torch.uint8
+    pool.latent_write_sanitizes = False
+    storage = torch.empty(8, TOTAL_DIM, device="cuda", dtype=torch.uint8)
+    pool.kv_buffer = [storage]
+    k_nope = torch.randn(2, 1, NOPE_DIM, device="cuda", dtype=torch.bfloat16)
+    k_rope = torch.randn(2, 1, ROPE_DIM, device="cuda", dtype=torch.bfloat16)
+    loc = torch.tensor([1, 3], device="cuda", dtype=torch.int64)
+    captured = {}
+
+    def capture(kv_buffer, cache_loc, cache_k_nope, cache_k_rope, **kwargs):
+        captured.update(
+            kv_buffer=kv_buffer,
+            cache_loc=cache_loc,
+            cache_k_nope=cache_k_nope,
+            cache_k_rope=cache_k_rope,
+            kwargs=kwargs,
+        )
+
+    monkeypatch.setattr(mla_pool_module, "set_mla_kv_buffer_triton", capture)
+    layer = type("Layer", (), {"layer_id": 0})()
+    pool.set_mla_kv_buffer(layer, loc, k_nope, k_rope)
+
+    assert captured["kv_buffer"].dtype == torch.float8_e4m3fn
+    assert captured["kv_buffer"].untyped_storage().data_ptr() == storage.data_ptr()
+    assert captured["cache_loc"] is loc
+    assert captured["cache_k_nope"] is k_nope
+    assert captured["cache_k_rope"] is k_rope
+
+
+@pytest.mark.parametrize("n_loc", [4, 600])
 def test_set_squashes_nan_and_inf(n_loc):
     """Sanitized mixed-dtype writes stay finite in the fp8 destination."""
     loc, k_nope, k_rope = _make_inputs(n_loc, torch.bfloat16, "rand")

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/kv_pack.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/kv_pack.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Fused MLA K/V packing and FP8 quantization for gfx950."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon
+
+
+@gluon.jit
+def _mla_kv_pack_quantize_fp8_kernel(
+    k_nope,
+    k_pe,
+    v,
+    k_out,
+    v_out,
+    k_scale_inv,
+    v_scale_inv,
+    seq_len,
+    k_nope_stride_t,
+    k_nope_stride_h,
+    k_pe_stride_t,
+    v_stride_t,
+    v_stride_h,
+    k_out_stride_t,
+    k_out_stride_h,
+    v_out_stride_t,
+    v_out_stride_h,
+    QK_NOPE: gl.constexpr,
+    QK_ROPE: gl.constexpr,
+    V_HEAD: gl.constexpr,
+    BLOCK_S: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+):
+    pid_s = gl.program_id(0)
+    pid_h = gl.program_id(1)
+    layout: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NUM_WARPS, 1], [1, 0])
+    row_layout: gl.constexpr = gl.SliceLayout(1, layout)
+    col_layout: gl.constexpr = gl.SliceLayout(0, layout)
+    rows = pid_s * BLOCK_S + gl.arange(0, BLOCK_S, layout=row_layout)
+    row_mask = rows < seq_len
+
+    nope_cols = gl.arange(0, QK_NOPE, layout=col_layout)
+    nope_offsets = (
+        rows[:, None] * k_nope_stride_t + pid_h * k_nope_stride_h + nope_cols[None, :]
+    )
+    nope = gl.load(k_nope + nope_offsets, mask=row_mask[:, None]).to(gl.float32)
+    nope *= k_scale_inv
+    k_out_base = rows[:, None] * k_out_stride_t + pid_h * k_out_stride_h
+    gl.store(
+        k_out + k_out_base + nope_cols[None, :],
+        nope.to(k_out.dtype.element_ty),
+        mask=row_mask[:, None],
+    )
+
+    rope_cols = gl.arange(0, QK_ROPE, layout=col_layout)
+    rope_offsets = rows[:, None] * k_pe_stride_t + rope_cols[None, :]
+    rope = gl.load(k_pe + rope_offsets, mask=row_mask[:, None]).to(gl.float32)
+    rope *= k_scale_inv
+    gl.store(
+        k_out + k_out_base + QK_NOPE + rope_cols[None, :],
+        rope.to(k_out.dtype.element_ty),
+        mask=row_mask[:, None],
+    )
+
+    v_cols = gl.arange(0, V_HEAD, layout=col_layout)
+    v_offsets = rows[:, None] * v_stride_t + pid_h * v_stride_h + v_cols[None, :]
+    values = gl.load(v + v_offsets, mask=row_mask[:, None]).to(gl.float32)
+    values *= v_scale_inv
+    v_out_offsets = (
+        rows[:, None] * v_out_stride_t + pid_h * v_out_stride_h + v_cols[None, :]
+    )
+    gl.store(
+        v_out + v_out_offsets,
+        values.to(v_out.dtype.element_ty),
+        mask=row_mask[:, None],
+    )
+
+
+def gluon_mla_kv_pack_quantize_fp8_gfx950(
+    k_nope: torch.Tensor,
+    k_pe: torch.Tensor,
+    v: torch.Tensor,
+    k_scale_inv: float = 1.0,
+    v_scale_inv: float = 1.0,
+    k_out: torch.Tensor | None = None,
+    v_out: torch.Tensor | None = None,
+    fp8_dtype: torch.dtype = torch.float8_e4m3fn,
+    enable_pdl: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pack broadcast MLA keys and quantize K/V to FP8 in one launch.
+
+    Args:
+        k_nope: Unrotated keys with shape ``[tokens, heads, qk_nope]``.
+        k_pe: Shared rotated keys with shape ``[tokens, qk_rope]`` or
+            ``[tokens, 1, qk_rope]``.
+        v: Values with shape ``[tokens, heads, v_head]``.
+        k_scale_inv: Multiplier applied to both key components before casting.
+        v_scale_inv: Multiplier applied to values before casting.
+        k_out: Optional pre-allocated packed key output.
+        v_out: Optional pre-allocated value output.
+        fp8_dtype: FP8 output dtype.
+        enable_pdl: Accepted for compatibility with the cross-platform API.
+
+    Returns:
+        Packed FP8 keys and FP8 values in the supplied or allocated outputs.
+    """
+    del enable_pdl
+
+    if k_nope.ndim != 3:
+        raise ValueError(f"k_nope must be 3D, got shape {tuple(k_nope.shape)}")
+    if v.ndim != 3:
+        raise ValueError(f"v must be 3D, got shape {tuple(v.shape)}")
+    if k_pe.ndim not in (2, 3):
+        raise ValueError(f"k_pe must be 2D or 3D, got shape {tuple(k_pe.shape)}")
+
+    seq_len, num_heads, qk_nope = k_nope.shape
+    if v.shape[:2] != (seq_len, num_heads):
+        raise ValueError(
+            f"v shape {tuple(v.shape)} mismatches k_nope {tuple(k_nope.shape)}"
+        )
+    if k_pe.shape[0] != seq_len:
+        raise ValueError(
+            f"k_pe first dim {k_pe.shape[0]} mismatches k_nope first dim {seq_len}"
+        )
+    if k_pe.ndim == 3:
+        if k_pe.shape[1] != 1:
+            raise ValueError(f"k_pe head dim must be 1, got {k_pe.shape[1]}")
+        k_pe = k_pe.squeeze(1)
+    if fp8_dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+        raise ValueError(f"unsupported FP8 dtype: {fp8_dtype}")
+    for tensor, name in ((k_nope, "k_nope"), (k_pe, "k_pe"), (v, "v")):
+        if tensor.dtype not in (torch.bfloat16, torch.float16):
+            raise TypeError(f"{name} must be BF16 or FP16, got {tensor.dtype}")
+        if tensor.device != k_nope.device:
+            raise ValueError(f"{name} must be colocated with k_nope")
+        if tensor.stride(-1) != 1:
+            raise ValueError(f"{name} must have stride-1 inner dim")
+
+    qk_rope = k_pe.shape[-1]
+    v_head = v.shape[-1]
+    expected_k_shape = (seq_len, num_heads, qk_nope + qk_rope)
+    expected_v_shape = (seq_len, num_heads, v_head)
+    if k_out is None:
+        k_out = torch.empty(expected_k_shape, dtype=fp8_dtype, device=k_nope.device)
+    elif k_out.shape != expected_k_shape or k_out.dtype != fp8_dtype:
+        raise ValueError(f"k_out must be {expected_k_shape} with dtype {fp8_dtype}")
+    if v_out is None:
+        v_out = torch.empty(expected_v_shape, dtype=fp8_dtype, device=v.device)
+    elif v_out.shape != expected_v_shape or v_out.dtype != fp8_dtype:
+        raise ValueError(f"v_out must be {expected_v_shape} with dtype {fp8_dtype}")
+    for tensor, name in ((k_out, "k_out"), (v_out, "v_out")):
+        if tensor.device != k_nope.device or tensor.stride(-1) != 1:
+            raise ValueError(f"{name} must be colocated with stride-1 inner dim")
+
+    if seq_len == 0:
+        return k_out, v_out
+
+    if seq_len < 512:
+        block_s, num_warps = 1, 1
+    elif seq_len < 2048:
+        block_s, num_warps = 4, 2
+    else:
+        block_s, num_warps = 16, 4
+    grid_s = (seq_len + block_s - 1) // block_s
+    _mla_kv_pack_quantize_fp8_kernel[(grid_s, num_heads)](
+        k_nope,
+        k_pe,
+        v,
+        k_out,
+        v_out,
+        k_scale_inv,
+        v_scale_inv,
+        seq_len,
+        k_nope.stride(0),
+        k_nope.stride(1),
+        k_pe.stride(0),
+        v.stride(0),
+        v.stride(1),
+        k_out.stride(0),
+        k_out.stride(1),
+        v_out.stride(0),
+        v_out.stride(1),
+        QK_NOPE=qk_nope,
+        QK_ROPE=qk_rope,
+        V_HEAD=v_head,
+        BLOCK_S=block_s,
+        NUM_WARPS=num_warps,
+        num_warps=num_warps,
+        num_stages=1,
+        waves_per_eu=0,
+    )
+    return k_out, v_out
+
+
+__all__ = ["gluon_mla_kv_pack_quantize_fp8_gfx950"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py
@@ -22,41 +22,49 @@
 
 from functools import wraps
 
-from tokenspeed_kernel.platform import pdl_enabled
+from tokenspeed_kernel.ops.attention.tokenspeed_mla.fallback import (
+    mla_kv_pack_quantize_fp8 as _fallback_mla_kv_pack_quantize_fp8,
+)
+from tokenspeed_kernel.platform import current_platform, pdl_enabled
 from tokenspeed_kernel.registry import error_fn
 
-try:
-    from tokenspeed_mla import (
-        get_num_sm,
+
+def _with_pdl_default(kernel, enable_pdl_position):
+    @wraps(kernel)
+    def wrapped(*args, **kwargs):
+        if len(args) <= enable_pdl_position and "enable_pdl" not in kwargs:
+            kwargs["enable_pdl"] = pdl_enabled()
+        return kernel(*args, **kwargs)
+
+    return wrapped
+
+
+get_num_sm = error_fn
+tokenspeed_mla_decode = error_fn
+tokenspeed_mla_prefill = error_fn
+warmup_compile_prefill = error_fn
+mla_kv_pack_quantize_fp8 = _fallback_mla_kv_pack_quantize_fp8
+
+if current_platform().is_cdna4:
+    from tokenspeed_kernel_amd.ops.gfx950.attention.mla.kv_pack import (
+        gluon_mla_kv_pack_quantize_fp8_gfx950 as mla_kv_pack_quantize_fp8,
     )
-    from tokenspeed_mla import mla_kv_pack_quantize_fp8 as _mla_kv_pack_quantize_fp8
-    from tokenspeed_mla import tokenspeed_mla_decode as _tokenspeed_mla_decode
-    from tokenspeed_mla import tokenspeed_mla_prefill as _tokenspeed_mla_prefill
-    from tokenspeed_mla import warmup_compile_prefill as _warmup_compile_prefill
-except ImportError:
-    from tokenspeed_kernel.ops.attention.tokenspeed_mla.fallback import (
-        mla_kv_pack_quantize_fp8,
-    )
-
-    get_num_sm = error_fn
-    tokenspeed_mla_decode = error_fn
-    tokenspeed_mla_prefill = error_fn
-    warmup_compile_prefill = error_fn
-else:
-
-    def _with_pdl_default(kernel, enable_pdl_position):
-        @wraps(kernel)
-        def wrapped(*args, **kwargs):
-            if len(args) <= enable_pdl_position and "enable_pdl" not in kwargs:
-                kwargs["enable_pdl"] = pdl_enabled()
-            return kernel(*args, **kwargs)
-
-        return wrapped
-
-    mla_kv_pack_quantize_fp8 = _with_pdl_default(_mla_kv_pack_quantize_fp8, 8)
-    tokenspeed_mla_decode = _with_pdl_default(_tokenspeed_mla_decode, 13)
-    tokenspeed_mla_prefill = _with_pdl_default(_tokenspeed_mla_prefill, 12)
-    warmup_compile_prefill = _with_pdl_default(_warmup_compile_prefill, 3)
+elif current_platform().is_nvidia:
+    try:
+        from tokenspeed_mla import (
+            get_num_sm,
+        )
+        from tokenspeed_mla import mla_kv_pack_quantize_fp8 as _mla_kv_pack_quantize_fp8
+        from tokenspeed_mla import tokenspeed_mla_decode as _tokenspeed_mla_decode
+        from tokenspeed_mla import tokenspeed_mla_prefill as _tokenspeed_mla_prefill
+        from tokenspeed_mla import warmup_compile_prefill as _warmup_compile_prefill
+    except ImportError:
+        pass
+    else:
+        mla_kv_pack_quantize_fp8 = _with_pdl_default(_mla_kv_pack_quantize_fp8, 8)
+        tokenspeed_mla_decode = _with_pdl_default(_tokenspeed_mla_decode, 13)
+        tokenspeed_mla_prefill = _with_pdl_default(_tokenspeed_mla_prefill, 12)
+        warmup_compile_prefill = _with_pdl_default(_warmup_compile_prefill, 3)
 
 __all__ = [
     "get_num_sm",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -535,18 +535,26 @@ def _set_mla_kv_buffer_kernel(
             cache_k_nope_ptr + pid_loc * nope_stride + offs,
             mask=mask,
         )
+        if SANITIZE:
+            src = src.to(tl.float32)
+            src = tl.where(src != src, 0.0, src)
+            src = tl.where(src == float("inf"), MAX_FINITE, src)
+            src = tl.where(src == -float("inf"), -MAX_FINITE, src)
+        # Both sides of this runtime branch must produce the same Triton type.
+        # Converting here also lets the store quantize mixed-dtype cache inputs.
+        src = src.to(kv_buffer_ptr.dtype.element_ty)
     else:
         offs_rope = offs - nope_dim
         src = tl.load(
             cache_k_rope_ptr + pid_loc * rope_stride + offs_rope,
             mask=mask,
         )
-
-    if SANITIZE:
-        src = src.to(tl.float32)
-        src = tl.where(src != src, 0.0, src)
-        src = tl.where(src == float("inf"), MAX_FINITE, src)
-        src = tl.where(src == -float("inf"), -MAX_FINITE, src)
+        if SANITIZE:
+            src = src.to(tl.float32)
+            src = tl.where(src != src, 0.0, src)
+            src = tl.where(src == float("inf"), MAX_FINITE, src)
+            src = tl.where(src == -float("inf"), -MAX_FINITE, src)
+        src = src.to(kv_buffer_ptr.dtype.element_ty)
 
     tl.store(dst_ptr, src, mask=mask)
 
@@ -648,7 +656,7 @@ def set_mla_kv_buffer_triton(
     # viewed pools copy raw words, so no clamp applies to non-floating tensors.
     float_maxes = [
         torch.finfo(t.dtype).max
-        for t in (cache_k_nope, kv_buffer)
+        for t in (cache_k_nope, cache_k_rope, kv_buffer)
         if t.dtype.is_floating_point
     ]
     max_finite = min(float_maxes) if float_maxes else float("inf")

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_mla_kv_pack_gfx950.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_mla_kv_pack_gfx950.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+from tokenspeed_kernel.platform import current_platform
+
+pytestmark = pytest.mark.skipif(
+    not current_platform().is_cdna4,
+    reason="gfx950 is required",
+)
+
+
+def _reference(k_nope, k_pe, v, k_scale_inv, v_scale_inv, fp8_dtype):
+    if k_pe.ndim == 2:
+        k_pe = k_pe.unsqueeze(1)
+    k_pe = k_pe.expand(-1, k_nope.shape[1], -1)
+    return (
+        (torch.cat((k_nope, k_pe), dim=-1).float() * k_scale_inv).to(fp8_dtype),
+        (v.float() * v_scale_inv).to(fp8_dtype),
+    )
+
+
+@pytest.mark.parametrize("seq_len", [0, 7, 256, 2048])
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize("k_pe_ndim", [2, 3])
+def test_gluon_mla_kv_pack_quantize_fp8(
+    seq_len: int, fp8_dtype: torch.dtype, k_pe_ndim: int
+) -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.attention.mla.kv_pack import (
+        gluon_mla_kv_pack_quantize_fp8_gfx950,
+    )
+
+    torch.manual_seed(0)
+    heads, qk_nope, qk_rope, v_head = 4, 128, 64, 128
+    packed = torch.randn(
+        seq_len,
+        heads,
+        qk_nope + v_head,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    k_nope = packed[..., :qk_nope]
+    v = packed[..., qk_nope:]
+    k_pe = torch.randn(seq_len, 1, qk_rope, device="cuda", dtype=torch.bfloat16)
+    if k_pe_ndim == 2:
+        k_pe = k_pe.squeeze(1)
+    k_scale_inv, v_scale_inv = 0.5, 1.7
+    expected_k, expected_v = _reference(
+        k_nope, k_pe, v, k_scale_inv, v_scale_inv, fp8_dtype
+    )
+    k_out = torch.empty_like(expected_k)
+    v_out = torch.empty_like(expected_v)
+
+    actual_k, actual_v = gluon_mla_kv_pack_quantize_fp8_gfx950(
+        k_nope,
+        k_pe,
+        v,
+        k_scale_inv=k_scale_inv,
+        v_scale_inv=v_scale_inv,
+        k_out=k_out,
+        v_out=v_out,
+        fp8_dtype=fp8_dtype,
+    )
+    torch.cuda.synchronize()
+
+    assert actual_k.data_ptr() == k_out.data_ptr()
+    assert actual_v.data_ptr() == v_out.data_ptr()
+    assert torch.equal(actual_k.view(torch.uint8), expected_k.view(torch.uint8))
+    assert torch.equal(actual_v.view(torch.uint8), expected_v.view(torch.uint8))
+
+
+def test_gluon_mla_kv_pack_production_heads() -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.attention.mla.kv_pack import (
+        gluon_mla_kv_pack_quantize_fp8_gfx950,
+    )
+
+    torch.manual_seed(1)
+    seq_len, heads, qk_nope, qk_rope, v_head = 4096, 16, 128, 64, 128
+    packed = torch.randn(
+        seq_len,
+        heads,
+        qk_nope + v_head,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    k_nope = packed[..., :qk_nope]
+    v = packed[..., qk_nope:]
+    k_pe = torch.randn(seq_len, 1, qk_rope, device="cuda", dtype=torch.bfloat16)
+    expected_k, expected_v = _reference(k_nope, k_pe, v, 1.0, 1.0, torch.float8_e4m3fn)
+
+    actual_k, actual_v = gluon_mla_kv_pack_quantize_fp8_gfx950(k_nope, k_pe, v)
+    torch.cuda.synchronize()
+
+    assert torch.equal(actual_k.view(torch.uint8), expected_k.view(torch.uint8))
+    assert torch.equal(actual_v.view(torch.uint8), expected_v.view(torch.uint8))

--- a/tokenspeed-kernel/test/ops/test_tokenspeed_mla_fallback.py
+++ b/tokenspeed-kernel/test/ops/test_tokenspeed_mla_fallback.py
@@ -81,7 +81,18 @@ def test_mla_kv_pack_quantize_fp8_fallback(
 
 
 def test_non_nvidia_public_api_uses_fallback() -> None:
-    if current_platform().is_nvidia:
-        pytest.skip("NVIDIA uses the optional fused tokenspeed-mla implementation")
+    if current_platform().is_nvidia or current_platform().is_cdna4:
+        pytest.skip("this platform uses an optimized MLA pack implementation")
 
     assert kernel_mla.mla_kv_pack_quantize_fp8 is mla_kv_pack_quantize_fp8
+
+
+def test_gfx950_public_api_uses_gluon() -> None:
+    if not current_platform().is_cdna4:
+        pytest.skip("gfx950 is required")
+
+    from tokenspeed_kernel_amd.ops.gfx950.attention.mla.kv_pack import (
+        gluon_mla_kv_pack_quantize_fp8_gfx950,
+    )
+
+    assert kernel_mla.mla_kv_pack_quantize_fp8 is gluon_mla_kv_pack_quantize_fp8_gfx950


### PR DESCRIPTION
Summary:
- Fuse broadcast key packing and FP8 conversion in one gfx950 Gluon kernel.
- Convert the compressed BF16 latent while scattering it directly into the FP8 cache.
- Support independently typed MLA cache components in both scatter dispatches.

This removes seven preparation and cache-write launches from each Kimi-K3 MLA prefill layer.

Testing Plan:
- Added gfx950 fused-pack coverage for empty, short, and production sequence lengths, both FP8 dtypes, and 2D or 3D RoPE keys.
- Added production-head, caller-provided output, scale-factor, and backend-dispatch coverage.
- Added MLA cache-scatter coverage for mixed source dtypes, direct FP8 conversion, sanitization, and output-storage identity.

Benchmark:
TP8 Kimi-K3 uncached c4 prefill at M=8192. Layer times are aligned all-rank GPU wall spans, summed from per-layer medians after Tukey outlier rejection.

- 24 complete MLA layers: 225.423 -> 214.457 ms (9.393 -> 8.936 ms/layer, 4.9% faster).
- MLA component launches per rank per layer: 24 -> 17; complete-layer launches: 59 -> 52.

End-to-end prefill uses EvalScope 1.11.0 random raw completions with exact 50K input and 500 output tokens, TP8/EP1, FP8 KV, 8192-token chunks, greedy streaming, and no prefix cache or prefill graph. Each fresh process runs a complete c1-c4 warm pass before measurement. Values are the median p99 TTFT from two fresh-process runs; lower is better.

```
| b/c | Main TTFT (ms) | This change (ms) | Change |
----------------------------------------------------
| 1   | 4,545.38       | 4,482.72         | -1.38% |
| 2   | 8,894.81       | 8,762.95         | -1.48% |
| 3   | 13,241.76      | 13,063.36        | -1.35% |
| 4   | 17,563.45      | 17,327.31        | -1.34% |
```
