### PR TITLE
perf(kimi3): port dynamic AttnRes stride handling to gfx1250

### DIFF
--- a/.github/workflows/run-pr-test-stage.yml
+++ b/.github/workflows/run-pr-test-stage.yml
@@ -43,7 +43,7 @@ jobs:
     name: ${{ matrix.name }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     # Leave setup and reporting headroom around the simulator's 60-minute run.
-    timeout-minutes: ${{ matrix.runner == 'amd-mi450-sim' && 75 || inputs.timeout_minutes }}
+    timeout-minutes: ${{ matrix.runner == 'amd-mi450-sim' && inputs.timeout_minutes == 60 && 75 || inputs.timeout_minutes }}
     continue-on-error: ${{ matrix.optional }}
     env:
       INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ inputs.install_tokenspeed_mla_from_source }}

--- a/.github/workflows/run-pr-test-stage.yml
+++ b/.github/workflows/run-pr-test-stage.yml
@@ -41,11 +41,9 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(inputs.matrix) }}
     name: ${{ matrix.name }} (${{ matrix.runner }})
-    # `runner` is the platform a task targets, and carries its vendor
-    # classification. `runs_on` is the machine that hosts it, and differs
-    # whenever the target platform is not the host's own hardware.
-    runs-on: ${{ matrix.runs_on || matrix.runner }}
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    runs-on: ${{ matrix.runner }}
+    # Leave setup and reporting headroom around the simulator's 60-minute run.
+    timeout-minutes: ${{ matrix.runner == 'amd-mi450-sim' && 75 || inputs.timeout_minutes }}
     continue-on-error: ${{ matrix.optional }}
     env:
       INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ inputs.install_tokenspeed_mla_from_source }}

--- a/.github/workflows/run-pr-test-stage.yml
+++ b/.github/workflows/run-pr-test-stage.yml
@@ -42,7 +42,8 @@ jobs:
       matrix: ${{ fromJson(inputs.matrix) }}
     name: ${{ matrix.name }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    # Leave setup and reporting headroom around the simulator's 60-minute run.
+    timeout-minutes: ${{ matrix.runner == 'amd-mi450-sim' && 75 || inputs.timeout_minutes }}
     continue-on-error: ${{ matrix.optional }}
     env:
       INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ inputs.install_tokenspeed_mla_from_source }}

--- a/.github/workflows/run-pr-test-stage.yml
+++ b/.github/workflows/run-pr-test-stage.yml
@@ -42,8 +42,7 @@ jobs:
       matrix: ${{ fromJson(inputs.matrix) }}
     name: ${{ matrix.name }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    # Leave setup and reporting headroom around the simulator's 60-minute run.
-    timeout-minutes: ${{ matrix.runner == 'amd-mi450-sim' && inputs.timeout_minutes == 60 && 75 || inputs.timeout_minutes }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     continue-on-error: ${{ matrix.optional }}
     env:
       INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ inputs.install_tokenspeed_mla_from_source }}

--- a/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
@@ -13,6 +13,7 @@ env:
   BUILD_AND_DOWNLOAD_PARALLEL: "4"
   CI: "true"
   GFX_ARCH: gfx1250
+  MI450_SIM_RUN_TIMEOUT: "3600"
   MI450_SIM_WORKERS: "6"
   TEST_DESELECTS: |
     # Iris symmetric heaps require physical KFD/ARSMI peer topology. rocJITsu

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -326,11 +326,6 @@ def resolve_runner_labels(labels: Iterable[str]) -> List[str]:
     return [resolve_runner_label(label) for label in labels]
 
 
-def resolve_runs_on(runner: str) -> str:
-    """Resolve the Actions label that executes a logical CI runner."""
-    return runner
-
-
 def find_task_files(root: Path) -> List[Path]:
     return sorted(root.rglob("*.yaml"))
 
@@ -414,9 +409,6 @@ def build_matrix(
                 "priority": effective,
                 "optional": is_optional,
             }
-            runs_on = resolve_runs_on(runner)
-            if runs_on != runner:
-                entry["runs_on"] = runs_on
             if task_workflow_stage is not None:
                 entry["workflow_stage"] = task_workflow_stage
             include.append(entry)
@@ -836,7 +828,7 @@ def setup_runner(
             dry_run=dry_run,
         )
 
-    if is_amd_runner(runner) and resolve_runs_on(runner) == runner:
+    if is_amd_runner(runner):
         # Best-effort: kill any GPU-holding processes left over by a
         # previous pod scheduled on the same node. Cluster admins flagged
         # a known race where the device plugin releases a GPU back to the

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -92,6 +92,10 @@ def is_amd_runner(runner: str) -> bool:
     return runner.startswith(AMD_RUNNER_PREFIXES)
 
 
+def should_run_amd_gpu_cleanup(runner: str) -> bool:
+    return is_amd_runner(runner) and runner != "amd-mi450-sim"
+
+
 def is_nvidia_arm_runner(runner: str) -> bool:
     return runner.startswith(NVIDIA_ARM_RUNNER_PREFIXES)
 
@@ -829,19 +833,20 @@ def setup_runner(
         )
 
     if is_amd_runner(runner):
-        # Best-effort: kill any GPU-holding processes left over by a
-        # previous pod scheduled on the same node. Cluster admins flagged
-        # a known race where the device plugin releases a GPU back to the
-        # pool before the previous pod's processes have actually
-        # relinquished VRAM, so we can land in a pod with ~0 GiB free
-        # VRAM. Cleanup script never fails the task.
-        shell_run(
-            "bash test/ci_system/cleanup_amd_gpu_state.sh",
-            env=local_env,
-            cwd=cwd,
-            dry_run=dry_run,
-            check=False,
-        )
+        if should_run_amd_gpu_cleanup(runner):
+            # Best-effort: kill any GPU-holding processes left over by a
+            # previous pod scheduled on the same node. Cluster admins flagged
+            # a known race where the device plugin releases a GPU back to the
+            # pool before the previous pod's processes have actually
+            # relinquished VRAM, so we can land in a pod with ~0 GiB free
+            # VRAM. Cleanup script never fails the task.
+            shell_run(
+                "bash test/ci_system/cleanup_amd_gpu_state.sh",
+                env=local_env,
+                cwd=cwd,
+                dry_run=dry_run,
+                check=False,
+            )
         return local_env, pgm
     if dry_run:
         return local_env, pgm

--- a/test/ci_system/pipeline.py
+++ b/test/ci_system/pipeline.py
@@ -92,10 +92,6 @@ def is_amd_runner(runner: str) -> bool:
     return runner.startswith(AMD_RUNNER_PREFIXES)
 
 
-def should_run_amd_gpu_cleanup(runner: str) -> bool:
-    return is_amd_runner(runner) and runner != "amd-mi450-sim"
-
-
 def is_nvidia_arm_runner(runner: str) -> bool:
     return runner.startswith(NVIDIA_ARM_RUNNER_PREFIXES)
 
@@ -833,7 +829,7 @@ def setup_runner(
         )
 
     if is_amd_runner(runner):
-        if should_run_amd_gpu_cleanup(runner):
+        if runner != "amd-mi450-sim":
             # Best-effort: kill any GPU-holding processes left over by a
             # previous pod scheduled on the same node. Cluster admins flagged
             # a known race where the device plugin releases a GPU back to the

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -639,17 +639,6 @@ def test_nvidia_arm_model_tests_allow_runner_wait_time():
     assert workflow["jobs"]["model-test"]["with"]["timeout_minutes"] >= 120
 
 
-def test_mi450_sim_uses_direct_runner_and_preserves_timeout_overrides():
-    workflow = load_yaml(REPO_ROOT / ".github/workflows/run-pr-test-stage.yml")
-    job = workflow["jobs"]["test"]
-
-    assert job["runs-on"] == "${{ matrix.runner }}"
-    assert job["timeout-minutes"] == (
-        "${{ matrix.runner == 'amd-mi450-sim' && "
-        "inputs.timeout_minutes == 60 && 75 || inputs.timeout_minutes }}"
-    )
-
-
 def test_mi450_sim_has_one_hour_internal_timeout():
     task = load_yaml(REPO_ROOT / "test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml")
 

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -637,3 +637,20 @@ def test_nvidia_arm_model_tests_allow_runner_wait_time():
     workflow = load_yaml(REPO_ROOT / ".github/workflows/pr-test-nvidia-arm.yml")
 
     assert workflow["jobs"]["model-test"]["with"]["timeout_minutes"] >= 120
+
+
+def test_mi450_sim_uses_direct_runner_and_preserves_timeout_overrides():
+    workflow = load_yaml(REPO_ROOT / ".github/workflows/run-pr-test-stage.yml")
+    job = workflow["jobs"]["test"]
+
+    assert job["runs-on"] == "${{ matrix.runner }}"
+    assert job["timeout-minutes"] == (
+        "${{ matrix.runner == 'amd-mi450-sim' && "
+        "inputs.timeout_minutes == 60 && 75 || inputs.timeout_minutes }}"
+    )
+
+
+def test_mi450_sim_has_one_hour_internal_timeout():
+    task = load_yaml(REPO_ROOT / "test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml")
+
+    assert task["env"]["MI450_SIM_RUN_TIMEOUT"] == "3600"

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -639,6 +639,16 @@ def test_nvidia_arm_model_tests_allow_runner_wait_time():
     assert workflow["jobs"]["model-test"]["with"]["timeout_minutes"] >= 120
 
 
+def test_mi450_sim_uses_direct_runner_and_extended_timeout():
+    workflow = load_yaml(REPO_ROOT / ".github/workflows/run-pr-test-stage.yml")
+    job = workflow["jobs"]["test"]
+
+    assert job["runs-on"] == "${{ matrix.runner }}"
+    assert job["timeout-minutes"] == (
+        "${{ matrix.runner == 'amd-mi450-sim' && 75 || inputs.timeout_minutes }}"
+    )
+
+
 def test_mi450_sim_has_one_hour_internal_timeout():
     task = load_yaml(REPO_ROOT / "test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml")
 

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -31,7 +31,6 @@ from pipeline import (
     resolve_score_threshold_for_runner,
     runner_matches_group,
     setup_runner,
-    should_run_amd_gpu_cleanup,
     should_run_nvidia_gpu_cleanup,
     validate_task,
     wrap_command_with_log,
@@ -168,7 +167,7 @@ def test_nvidia_runner_groups_split_arm_from_x86():
     assert not runner_matches_group("amd-mi35x-1gpu-test", "nvidia-x86")
 
 
-def test_gpu_cleanup_runner_prefixes():
+def test_nvidia_gpu_cleanup_runner_prefixes_cover_gb200_and_b300():
     assert is_gb200_runner("gb200-1gpu")
     assert is_gb200_runner("gb200-4gpu-perf")
     assert is_gb200_runner("slurm-gb200-4node-4gpu")
@@ -184,11 +183,6 @@ def test_gpu_cleanup_runner_prefixes():
     assert not should_run_nvidia_gpu_cleanup("amd-mi35x-2gpu-test")
     assert not should_run_nvidia_gpu_cleanup("amd-mi355-1gpu-bench")
     assert not should_run_nvidia_gpu_cleanup("amd-mi350-1gpu-bench")
-
-    assert should_run_amd_gpu_cleanup("amd-mi35x-2gpu-test")
-    assert should_run_amd_gpu_cleanup("amd-mi355-1gpu-bench")
-    assert not should_run_amd_gpu_cleanup("amd-mi450-sim")
-    assert not should_run_amd_gpu_cleanup("b200-4gpu")
 
 
 def test_b200v2_setup_forces_all_apt_invocations_to_ipv4(tmp_path, capsys):

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -106,24 +106,6 @@ def test_amd_runner_prefixes_cover_legacy_and_arc_labels():
     assert not is_amd_runner("gb200-4gpu-perf")
 
 
-def test_mi450_sim_uses_self_hosted_cpu_runner(tmp_path):
-    _write_task_yaml(
-        tmp_path,
-        "mi450-sim.yaml",
-        _default_body("mi450-sim", ["amd-mi450-sim"]),
-    )
-
-    matrix = build_matrix(
-        tmp_path,
-        tmp_path,
-        trigger="per-commit",
-        runner_group="amd",
-    )
-
-    assert matrix["include"][0]["runner"] == "amd-mi450-sim"
-    assert "runs_on" not in matrix["include"][0]
-
-
 @pytest.mark.parametrize(
     ("declared", "effective"),
     [

--- a/test/ci_system/test_pipeline.py
+++ b/test/ci_system/test_pipeline.py
@@ -31,6 +31,7 @@ from pipeline import (
     resolve_score_threshold_for_runner,
     runner_matches_group,
     setup_runner,
+    should_run_amd_gpu_cleanup,
     should_run_nvidia_gpu_cleanup,
     validate_task,
     wrap_command_with_log,
@@ -167,7 +168,7 @@ def test_nvidia_runner_groups_split_arm_from_x86():
     assert not runner_matches_group("amd-mi35x-1gpu-test", "nvidia-x86")
 
 
-def test_nvidia_gpu_cleanup_runner_prefixes_cover_gb200_and_b300():
+def test_gpu_cleanup_runner_prefixes():
     assert is_gb200_runner("gb200-1gpu")
     assert is_gb200_runner("gb200-4gpu-perf")
     assert is_gb200_runner("slurm-gb200-4node-4gpu")
@@ -183,6 +184,11 @@ def test_nvidia_gpu_cleanup_runner_prefixes_cover_gb200_and_b300():
     assert not should_run_nvidia_gpu_cleanup("amd-mi35x-2gpu-test")
     assert not should_run_nvidia_gpu_cleanup("amd-mi355-1gpu-bench")
     assert not should_run_nvidia_gpu_cleanup("amd-mi350-1gpu-bench")
+
+    assert should_run_amd_gpu_cleanup("amd-mi35x-2gpu-test")
+    assert should_run_amd_gpu_cleanup("amd-mi355-1gpu-bench")
+    assert not should_run_amd_gpu_cleanup("amd-mi450-sim")
+    assert not should_run_amd_gpu_cleanup("b200-4gpu")
 
 
 def test_b200v2_setup_forces_all_apt_invocations_to_ipv4(tmp_path, capsys):

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/attn_res.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/kda/attn_res.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel_amd._triton import gl, gluon
+from tokenspeed_kernel_amd._triton import gl, gluon, tl
 
 gfx1250 = gl.amd.gfx1250
 _BLOCK_H = gl.constexpr(8192)
@@ -38,14 +38,14 @@ def _load_candidate(
     hidden,
     hidden_mask,
     stride_block_t: gl.constexpr,
-    stride_block_n: gl.constexpr,
+    stride_block_n: tl.int64,
     candidate: gl.constexpr,
     N: gl.constexpr,
 ):
     if candidate == N - 1:
         return prefix
-    # Candidate offsets can exceed int32; fold the block stride into the pointer.
-    ptr = block_residual + candidate * stride_block_n
+    # The stride fits int32, but candidate * stride can exceed it at large T.
+    ptr = block_residual + candidate * stride_block_n.to(gl.int64)
     return gfx1250.buffer_load(
         ptr,
         (token * stride_block_t + hidden).to(gl.int32),
@@ -66,7 +66,7 @@ def _attn_res_rmsnorm_kernel(
     stride_layer_t: gl.constexpr,
     stride_delta_t: gl.constexpr,
     stride_block_t: gl.constexpr,
-    stride_block_n: gl.constexpr,
+    stride_block_n: tl.int64,
     stride_output_t: gl.constexpr,
     H: gl.constexpr,
     N: gl.constexpr,
@@ -105,7 +105,7 @@ def _attn_res_rmsnorm_kernel(
             mask=hidden_mask,
         )
     if WRITE_BLOCK:
-        block_write_ptr = block_residual + BLOCK_WRITE_IDX * stride_block_n
+        block_write_ptr = block_residual + BLOCK_WRITE_IDX * stride_block_n.to(gl.int64)
         gfx1250.buffer_store(
             prefix.to(block_residual.dtype.element_ty),
             block_write_ptr,

--- a/tokenspeed-kernel/test/ops/test_kimi3_prefill_gluon_amd.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_prefill_gluon_amd.py
@@ -18,17 +18,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Correctness tests for Kimi K3 prefill Gluon kernels."""
+"""Correctness tests for Kimi K3 prefill Gluon kernels on AMD CDNA4/CDNA5."""
 
 from __future__ import annotations
 
 import pytest
 import torch
-from utils import is_cdna4
+from utils import is_cdna4, is_cdna5
 
-if not is_cdna4():
+if not (is_cdna4() or is_cdna5()):
     pytest.skip(
-        "AMD CDNA4 is required for Kimi K3 prefill Gluon tests",
+        "AMD CDNA4 or CDNA5 is required for Kimi K3 prefill Gluon tests",
         allow_module_level=True,
     )
 
@@ -40,9 +40,15 @@ from tokenspeed_kernel.ops.attn_res import (  # noqa: E402
 )
 from tokenspeed_kernel.ops.moe import moe_sigmoid_bias_topk  # noqa: E402
 from tokenspeed_kernel.ops.moe.sigmoid_topk import _gluon_eligible  # noqa: E402
-from tokenspeed_kernel_amd.ops.gfx950.attention.kda.attn_res import (  # noqa: E402
-    attn_res_rmsnorm_gfx950,
-)
+
+if is_cdna4():
+    from tokenspeed_kernel_amd.ops.gfx950.attention.kda.attn_res import (  # noqa: E402
+        attn_res_rmsnorm_gfx950 as attn_res_rmsnorm_amd,
+    )
+else:
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.kda.attn_res import (  # noqa: E402
+        attn_res_rmsnorm_gfx1250 as attn_res_rmsnorm_amd,
+    )
 
 
 def _attn_res_reference(
@@ -65,6 +71,11 @@ def _attn_res_reference(
         * torch.rsqrt(mixed.square().mean(-1, keepdim=True) + output_eps)
         * output_weight
     ).to(torch.bfloat16)
+
+
+def _bf16_add_rne(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    """Match the fused kernel's FP32 add followed by BF16 rounding."""
+    return (lhs.float() + rhs.float()).to(torch.bfloat16)
 
 
 def test_attn_res_public_block_major_dispatch_matches_reference() -> None:
@@ -166,7 +177,7 @@ def test_attn_res_amd_entrypoint_accepts_legacy_keywords() -> None:
         7168, device="cuda", dtype=torch.bfloat16, generator=generator
     )
 
-    actual = attn_res_rmsnorm_gfx950(
+    actual = attn_res_rmsnorm_amd(
         layer_residual=layer,
         block_residual=history,
         res_weight=res_weight,
@@ -297,7 +308,7 @@ def test_attn_res_delta_and_block_write_batches(tokens: int) -> None:
         block_write_idx=valid_blocks,
     )
 
-    updated_prefix = (original_prefix + delta).to(torch.bfloat16)
+    updated_prefix = _bf16_add_rne(original_prefix, delta)
     expected = _attn_res_reference(
         updated_prefix,
         original_blocks.transpose(0, 1),
@@ -388,7 +399,12 @@ def test_attn_res_model_update_modes_graph_replay(
     prefix = torch.randn(
         tokens, 7168, device="cuda", dtype=torch.bfloat16, generator=generator
     )
-    delta = torch.randn_like(prefix)
+    delta = torch.randn(
+        prefix.shape,
+        device=prefix.device,
+        dtype=prefix.dtype,
+        generator=generator,
+    )
     blocks = torch.randn(
         valid_blocks + 1,
         tokens,
@@ -411,10 +427,12 @@ def test_attn_res_model_update_modes_graph_replay(
     call_delta = delta if use_delta else None
     block_write_idx = valid_blocks if write_block else -1
 
-    # Compile before capture so the graph contains only the steady-state launch.
-    attn_res_fwd(
-        prefix.clone(),
-        blocks.clone(),
+    # Compile before capture and retain the eager result as the replay oracle.
+    eager_prefix = original_prefix.clone()
+    eager_blocks = original_blocks.clone()
+    eager_output = attn_res_fwd(
+        eager_prefix,
+        eager_blocks,
         res_weight,
         score_weight,
         out_norm_weight=output_weight,
@@ -440,25 +458,12 @@ def test_attn_res_model_update_modes_graph_replay(
     graph.replay()
     torch.cuda.synchronize()
 
-    updated_prefix = (
-        (original_prefix + delta).to(torch.bfloat16) if use_delta else original_prefix
-    )
-    expected = _attn_res_reference(
-        updated_prefix,
-        original_blocks.transpose(0, 1),
-        res_weight,
-        score_weight,
-        output_weight,
-        valid_blocks,
-        1e-6,
-        1e-6,
-    )
-    torch.testing.assert_close(prefix, updated_prefix, rtol=0, atol=0)
-    expected_block = updated_prefix if write_block else original_blocks[valid_blocks]
-    torch.testing.assert_close(blocks[valid_blocks], expected_block, rtol=0, atol=0)
-    torch.testing.assert_close(actual, expected, rtol=5e-3, atol=1.6e-2)
+    torch.testing.assert_close(prefix, eager_prefix, rtol=0, atol=0)
+    torch.testing.assert_close(blocks, eager_blocks, rtol=0, atol=0)
+    torch.testing.assert_close(actual, eager_output, rtol=0, atol=0)
 
 
+@pytest.mark.skipif(not is_cdna4(), reason="Gluon sigmoid top-k is gfx950-only")
 @pytest.mark.parametrize("tokens", [1, 17, 8192])
 def test_kimi_topk_prefill_matches_reference(tokens: int) -> None:
     generator = torch.Generator(device="cuda").manual_seed(41 + tokens)
@@ -480,6 +485,7 @@ def test_kimi_topk_prefill_matches_reference(tokens: int) -> None:
     torch.testing.assert_close(actual_weights, expected_weights, rtol=2e-6, atol=2e-7)
 
 
+@pytest.mark.skipif(not is_cdna4(), reason="Gluon sigmoid top-k is gfx950-only")
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
 def test_kimi_topk_prefill_scales_beyond_8k(dtype: torch.dtype) -> None:
     tokens = 16384
@@ -509,6 +515,7 @@ def test_kimi_topk_prefill_scales_beyond_8k(dtype: torch.dtype) -> None:
     )
 
 
+@pytest.mark.skipif(not is_cdna4(), reason="Gluon sigmoid top-k is gfx950-only")
 def test_kimi_topk_prefill_ties_choose_smaller_expert_id() -> None:
     logits = torch.zeros(3, 896, device="cuda")
     bias = torch.zeros(896, device="cuda")

--- a/tokenspeed-kernel/test/ops/test_kimi3_prefill_gluon_amd.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_prefill_gluon_amd.py
@@ -427,12 +427,10 @@ def test_attn_res_model_update_modes_graph_replay(
     call_delta = delta if use_delta else None
     block_write_idx = valid_blocks if write_block else -1
 
-    # Compile before capture and retain the eager result as the replay oracle.
-    eager_prefix = original_prefix.clone()
-    eager_blocks = original_blocks.clone()
-    eager_output = attn_res_fwd(
-        eager_prefix,
-        eager_blocks,
+    # Compile before capture so the graph contains only the steady-state launch.
+    attn_res_fwd(
+        prefix.clone(),
+        blocks.clone(),
         res_weight,
         score_weight,
         out_norm_weight=output_weight,
@@ -458,9 +456,23 @@ def test_attn_res_model_update_modes_graph_replay(
     graph.replay()
     torch.cuda.synchronize()
 
-    torch.testing.assert_close(prefix, eager_prefix, rtol=0, atol=0)
-    torch.testing.assert_close(blocks, eager_blocks, rtol=0, atol=0)
-    torch.testing.assert_close(actual, eager_output, rtol=0, atol=0)
+    updated_prefix = (
+        _bf16_add_rne(original_prefix, delta) if use_delta else original_prefix
+    )
+    expected = _attn_res_reference(
+        updated_prefix,
+        original_blocks.transpose(0, 1),
+        res_weight,
+        score_weight,
+        output_weight,
+        valid_blocks,
+        1e-6,
+        1e-6,
+    )
+    torch.testing.assert_close(prefix, updated_prefix, rtol=0, atol=0)
+    expected_block = updated_prefix if write_block else original_blocks[valid_blocks]
+    torch.testing.assert_close(blocks[valid_blocks], expected_block, rtol=0, atol=0)
+    torch.testing.assert_close(actual, expected, rtol=5e-3, atol=1.6e-2)
 
 
 @pytest.mark.skipif(not is_cdna4(), reason="Gluon sigmoid top-k is gfx950-only")


### PR DESCRIPTION
## Summary
- Port the gfx950 AttnRes optimization from #1336 to gfx1250.
- Extend the existing Gluon AttnRes tests from gfx950-only coverage to both gfx950 and gfx1250.
- Increase the MI450 rocJITsu run budget for the added coverage and remove the hosted-runner indirection made obsolete by #1319.