### PR TITLE
perf(kimi-k3): reduce the MoE tail's joined partials in symmetric memory

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_backend/auto.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/auto.py
@@ -161,6 +161,31 @@ class AutoBackend(CommBackend):
     def prepare_all_reduce_lane(self, group: Group, hidden_dim: int) -> bool:
         return self._trtllm_ar.ensure_group_lane(group, hidden_dim)
 
+    def can_acquire_all_reduce_outputs(
+        self,
+        shapes: tuple[tuple[int, ...], ...],
+        like: torch.Tensor,
+        group: Group,
+        op=None,
+    ) -> bool:
+        """Whether ``acquire_all_reduce_outputs`` returns producer-direct memory.
+
+        Mirrors the routing in ``acquire_all_reduce_outputs`` below: the cases
+        that fall through to ``super()`` there get ordinary allocations, so they
+        answer False here.
+        """
+        if (
+            self._force_deterministic_rsag()
+            or self._group_spans_nodes(group)
+            or self._trtllm_ar.has_trtllm_ar(group)
+        ):
+            return False
+        if current_platform().is_amd:
+            return self._triton_ar.can_acquire_outputs(shapes, like, group, op=op)
+        return self._triton_ar.can_acquire_all_reduce_outputs(
+            shapes, like, group, op=op
+        )
+
     def acquire_all_reduce_outputs(
         self,
         shapes: tuple[tuple[int, ...], ...],

--- a/python/tokenspeed/runtime/distributed/comm_backend/base.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/base.py
@@ -56,6 +56,29 @@ class CommBackend(ABC):
 
         return False
 
+    def can_acquire_all_reduce_outputs(
+        self,
+        shapes: tuple[tuple[int, ...], ...],
+        like: torch.Tensor,
+        group: Group,
+        op=None,
+    ) -> bool:
+        """Whether ``acquire_all_reduce_outputs`` returns producer-direct memory.
+
+        The base implementation of ``acquire_all_reduce_outputs`` always
+        succeeds, but by allocating ordinary tensors that the collective must
+        then stage. Callers that only want the buffers when the reduction can
+        consume them in place -- and would otherwise keep a persistent buffer of
+        their own -- ask here first.
+
+        Must be answerable without side effects beyond the backend's own lazy
+        setup, and must return the same answer on every rank of ``group``: a
+        caller that acquires on some ranks and not others would leave the group
+        disagreeing on which collective runs.
+        """
+
+        return False
+
     def acquire_all_reduce_outputs(
         self,
         shapes: tuple[tuple[int, ...], ...],

--- a/python/tokenspeed/runtime/distributed/comm_backend/triton_allreduce.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/triton_allreduce.py
@@ -125,6 +125,16 @@ class TritonAllReduceBackend(CommBackend):
         state = self._get_or_create(group)
         return acquire_symm_outputs(state, shapes, like.dtype)
 
+    def can_acquire_all_reduce_outputs(
+        self,
+        shapes: tuple[tuple[int, ...], ...],
+        like: torch.Tensor,
+        group: Group,
+        op=None,
+    ) -> bool:
+        """Iris returns symmetric outputs the reduction consumes in place."""
+        return self.can_acquire_outputs(shapes, like, group, op=op)
+
     def can_acquire_outputs(
         self,
         shapes: tuple[tuple[int, ...], ...],

--- a/python/tokenspeed/runtime/distributed/comm_ops.py
+++ b/python/tokenspeed/runtime/distributed/comm_ops.py
@@ -195,6 +195,28 @@ def all_reduce_latent_norm(
     )
 
 
+def can_acquire_all_reduce_outputs(
+    shapes: tuple[tuple[int, ...], ...],
+    like: torch.Tensor,
+    group: Group,
+    backend: CommBackend | None = None,
+    op: torch.distributed.ReduceOp = torch.distributed.ReduceOp.SUM,
+) -> bool:
+    """Whether ``acquire_all_reduce_outputs`` returns producer-direct memory.
+
+    ``acquire_all_reduce_outputs`` always returns writable buffers, falling
+    back to ordinary allocations the collective has to stage. Ask here when the
+    buffers are only worth taking if the reduction consumes them in place.
+
+    This is COLLECTIVE in the same sense the acquire is: every rank of
+    ``group`` must call it with identical arguments, or the group will disagree
+    on which collective the tail runs.
+    """
+    if backend is None:
+        backend = get_global_backend()
+    return backend.can_acquire_all_reduce_outputs(shapes, like, group, op=op)
+
+
 def acquire_all_reduce_outputs(
     shapes: tuple[tuple[int, ...], ...],
     like: torch.Tensor,

--- a/python/tokenspeed/runtime/layers/moe/latent.py
+++ b/python/tokenspeed/runtime/layers/moe/latent.py
@@ -75,11 +75,30 @@ def _marlin_moe_available() -> bool:
     )
 
 
+def _produced_into(
+    partials: tuple[torch.Tensor, ...],
+    destinations: tuple[torch.Tensor, ...],
+) -> bool:
+    """Whether every partial really landed in its requested destination.
+
+    The producer-direct destinations are a request, not a guarantee: a producer
+    that cannot write in place returns its own tensor instead. Comparing
+    storage addresses is what distinguishes the two, and it has to hold for
+    *both* partials -- reducing a pair where only one side was produced in
+    place would silently drop the other one's contribution.
+    """
+    return all(
+        p.data_ptr() == d.data_ptr() and p.shape == d.shape
+        for p, d in zip(partials, destinations, strict=True)
+    )
+
+
 def kimi3_join_reduce_moe(
     routed_partial: torch.Tensor,
     shared_partial: torch.Tensor,
     *,
     lane: torch.Tensor | None,
+    symm_outputs: tuple[torch.Tensor, torch.Tensor] | None = None,
     routed_hidden: int,
     routed_norm: nn.Module | None,
     group: tuple[int, ...],
@@ -88,11 +107,16 @@ def kimi3_join_reduce_moe(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Join the routed/shared partials and reduce them, owning the strategy.
 
-    Three regimes, all element-wise identical:
+    Four regimes, all element-wise identical:
 
+    * Symmetric hit: the partials were produced straight into the collective's
+      symmetric heap, so the pair reduces in place with no staging copy at all.
+      This is the only regime that reaches the symmetric kernel -- the backend
+      decides on the tuple operand, so a single concatenated tensor cannot get
+      there however its memory was allocated.
     * Lane hit (decode batch=1): the partials were produced straight into the
       persistent fused lane, one one-shot reduce with an eligible norm
-      epilogue and zero copies.
+      epilogue and zero copies, but the collective stages them first.
     * Small partials: cat into one contiguous operand and take a single
       one-shot reduce; the copy is a couple of microseconds there.
     * Partials past the one-shot window (prefill-sized chunks): the cat would
@@ -100,6 +124,14 @@ def kimi3_join_reduce_moe(
       grouped NCCL launch reduces both tensors in place with the same
       single-launch latency -- so skip the join entirely.
     """
+
+    if symm_outputs is not None and _produced_into(
+        (routed_partial, shared_partial), symm_outputs
+    ):
+        routed_out, shared_out = all_reduce(symm_outputs, group=group)
+        if routed_norm is not None:
+            routed_out = routed_norm(routed_out)
+        return routed_out, shared_out
 
     if lane is not None and routed_partial.data_ptr() == lane.data_ptr():
         fused = lane

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1892,10 +1892,17 @@ class KimiLinearMoE(nn.Module):
                 )
             ),
         )
-        if plan.lane is not None:
-            self.experts._situ_output_buffer = plan.lane[:, : self.routed_hidden]
+        # Producer-direct destinations for the routed and shared partials. The
+        # symmetric pair is preferred (the tail reduces it in place); the packed
+        # lane is the fallback, and its two halves are slices of one buffer.
+        if plan.symm_outputs is not None:
+            routed_out_buf, shared_out_buf = plan.symm_outputs
+        elif plan.lane is not None:
+            routed_out_buf = plan.lane[:, : self.routed_hidden]
+            shared_out_buf = plan.lane[:, self.routed_hidden :]
         else:
-            self.experts._situ_output_buffer = None
+            routed_out_buf = shared_out_buf = None
+        self.experts._situ_output_buffer = routed_out_buf
         prepared_shared_shard = None
         # Enable the fork for the whole graph phase, but only overlap during
         # capture. The pre-capture warmup runs with capture mode off, so gating
@@ -1922,11 +1929,7 @@ class KimiLinearMoE(nn.Module):
                     self._topk_ready.record(torch.cuda.current_stream())
                 shared_partial = self.shared_experts(
                     hidden_states,
-                    down_out=(
-                        plan.lane[:, self.routed_hidden :]
-                        if plan.lane is not None
-                        else None
-                    ),
+                    down_out=shared_out_buf,
                 )
                 if plan.split_shared_rs and fork._active:
                     prepared_shared_shard = self.comm.reduce_scatter_shared(

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -62,7 +62,9 @@ from tokenspeed_kernel.ops.moe.latent_tail import (
 from tokenspeed_kernel.platform import current_platform
 
 from tokenspeed.runtime.distributed.comm_ops import (
+    acquire_all_reduce_outputs,
     all_reduce,
+    can_acquire_all_reduce_outputs,
     prepare_all_reduce_fusion,
     prepare_all_reduce_lane,
 )
@@ -499,6 +501,9 @@ class TailPlan:
         lane: Pre-materialized fused-lane buffer, or None; when set the
             experts kernel writes its routed partial into
             ``lane[:, :routed_hidden]`` and the shared experts into the rest.
+        symm_outputs: Producer-direct (routed, shared) views of symmetric
+            memory, or None. When set the producers write into these and the
+            tail reduces the pair in place; ``lane`` is None in that case.
         routed_in_fork: Whether the routed partial must be reduced and
             projected inside the fork (SEPARATE_REDUCE overlap).
         split_shared_rs: Start the shared ReduceScatter on the auxiliary
@@ -508,6 +513,7 @@ class TailPlan:
     tier: "K3MoETailTier"
     defer_finalize: bool = False
     lane: torch.Tensor | None = None
+    symm_outputs: tuple[torch.Tensor, torch.Tensor] | None = None
     routed_in_fork: bool = False
     split_shared_rs: bool = False
 
@@ -529,6 +535,39 @@ def _tail_finalize_top_k(
     if execution_plan.fused_moe_ar and experts_supports_deferred_finalize:
         return top_k
     return None
+
+
+def _acquire_symm_join_outputs(
+    *, mapping, routed_hidden: int, hidden_size: int, like, enabled: bool
+):
+    """Acquire the routed/shared pair from symmetric memory, or None.
+
+    Returns two consecutive views of the Iris input buffer -- not fresh
+    allocations -- so the producers write where the reduction already reads and
+    the pointers stay put across graph capture.
+
+    The pair matters, not just the memory: ``AutoBackend.all_reduce`` only
+    consults ``can_reduce_outputs`` on its tuple branch, so a single
+    concatenated operand can never reach the symmetric kernel however it was
+    allocated. This is the shape ``latent_moe_expert_shared_all_reduce`` uses
+    for EP-only layouts.
+
+    Collective in the same sense the acquire is: every rank of the MoE TP x EP
+    group reaches this with rank-uniform shapes, so none can disagree about
+    whether the pair exists.
+    """
+    if not enabled or mapping.moe.tp_ep_size <= 1 or like is None:
+        return None
+    if like.ndim != 2:
+        return None
+    num_tokens = like.shape[0]
+    if num_tokens <= 0:
+        return None
+    shapes = ((num_tokens, routed_hidden), (num_tokens, hidden_size))
+    group = mapping.moe.tp_ep_group
+    if not can_acquire_all_reduce_outputs(shapes, like, group):
+        return None
+    return acquire_all_reduce_outputs(shapes, like, group)
 
 
 class K3MoeTailComm:
@@ -666,16 +705,32 @@ class K3MoeTailComm:
                 ),
             )
         # Shard mode splits the joined reduction, so it cannot use the packed lane.
-        lane = allreduce_fusion_lane(
-            hidden_states,
-            self.routed_hidden + self.hidden_size,
-            enabled=(
-                tier is K3MoETailTier.FUSED_LANE_AR and not self._shard_up_projection
-            ),
+        lane_enabled = (
+            tier is K3MoETailTier.FUSED_LANE_AR and not self._shard_up_projection
+        )
+        # Preferred: the producers write straight into symmetric memory and the
+        # join reduces them there. Falls back to the packed lane, which holds
+        # ordinary memory the collective has to stage first.
+        symm_outputs = _acquire_symm_join_outputs(
+            mapping=self.mapping,
+            routed_hidden=self.routed_hidden,
+            hidden_size=self.hidden_size,
+            like=hidden_states,
+            enabled=lane_enabled,
+        )
+        lane = (
+            None
+            if symm_outputs is not None
+            else allreduce_fusion_lane(
+                hidden_states,
+                self.routed_hidden + self.hidden_size,
+                enabled=lane_enabled,
+            )
         )
         return TailPlan(
             tier=tier,
             lane=lane,
+            symm_outputs=symm_outputs,
             routed_in_fork=tier is K3MoETailTier.SEPARATE_REDUCE,
         )
 
@@ -764,6 +819,7 @@ class K3MoeTailComm:
                 shared_partial,
                 prefix_sum,
                 plan.lane,
+                plan.symm_outputs,
                 num_tokens,
                 hidden_size,
             )
@@ -953,6 +1009,7 @@ class K3MoeTailComm:
         shared_partial: torch.Tensor,
         prefix_sum: torch.Tensor,
         lane: torch.Tensor | None,
+        symm_outputs: tuple[torch.Tensor, torch.Tensor] | None,
         num_tokens: int,
         hidden_size: int,
     ) -> torch.Tensor:
@@ -961,7 +1018,13 @@ class K3MoeTailComm:
                 routed_out, shared_partial, prefix_sum, num_tokens, hidden_size
             )
         return self._tail_fused_lane_ar_replicated(
-            routed_out, shared_partial, prefix_sum, lane, num_tokens, hidden_size
+            routed_out,
+            shared_partial,
+            prefix_sum,
+            lane,
+            symm_outputs,
+            num_tokens,
+            hidden_size,
         )
 
     def _tail_fused_lane_ar_sharded(
@@ -987,6 +1050,7 @@ class K3MoeTailComm:
         shared_partial: torch.Tensor,
         prefix_sum: torch.Tensor,
         lane: torch.Tensor | None,
+        symm_outputs: tuple[torch.Tensor, torch.Tensor] | None,
         num_tokens: int,
         hidden_size: int,
     ) -> torch.Tensor:
@@ -994,6 +1058,7 @@ class K3MoeTailComm:
             routed_out,
             shared_partial,
             lane=lane,
+            symm_outputs=symm_outputs,
             routed_hidden=self.routed_hidden,
             routed_norm=self.routed_norm,
             group=self.mapping.moe.tp_ep_group,

--- a/test/runtime/test_k3_moe_tail_equivalence.py
+++ b/test/runtime/test_k3_moe_tail_equivalence.py
@@ -97,6 +97,18 @@ def _agreed(ok: bool) -> bool:
     return bool(flag.item())
 
 
+def _mapping_stub(world: int = 1):
+    """The slice of ``mapping`` the tail and the producer-direct probe read."""
+    return SimpleNamespace(
+        moe=SimpleNamespace(
+            # tokenspeed groups are tuples of global ranks, not ProcessGroups.
+            tp_ep_group=tuple(range(world)),
+            tp_ep_size=world,
+            has_tp_ep=world > 1,
+        )
+    )
+
+
 def _build_comm(device: torch.device, *, latent_tail=None):
     """A ``K3MoeTailComm`` carrying just what the tail methods touch.
 
@@ -132,14 +144,7 @@ def _build_comm(device: torch.device, *, latent_tail=None):
     # _replicated variants, matching the full-width reference below.
     comm._shard_up_projection = up_proj.shard_group is not None
 
-    comm.mapping = SimpleNamespace(
-        moe=SimpleNamespace(
-            # tokenspeed groups are tuples of global ranks, not ProcessGroups.
-            tp_ep_group=tuple(range(world)),
-            tp_ep_size=world,
-            has_tp_ep=world > 1,
-        )
-    )
+    comm.mapping = _mapping_stub(world)
     comm.execution_plan = SimpleNamespace(
         fused_moe_ar=True,
         join_moe_reduce=True,
@@ -378,6 +383,9 @@ def test_profit_cap_stops_the_fused_tail_below_its_capacity(monkeypatch):
     comm.execution_plan = SimpleNamespace(fused_moe_ar=True, join_moe_reduce=True)
     comm.state = SimpleNamespace(multimem_ar_ok=False)
     comm._shard_up_projection = False
+    # __init__ is bypassed here; the probe declines on CPU, so no symmetric
+    # heap is reached.
+    comm.mapping = _mapping_stub()
     comm.routed_hidden, comm.hidden_size = L, H
 
     cap = mod.TAIL_FUSION_MAX_TOKENS
@@ -412,6 +420,9 @@ def test_tail_fusion_plan_defer_decision(monkeypatch):
         )
         comm.state = SimpleNamespace(multimem_ar_ok=False)
         comm._shard_up_projection = False
+        # __init__ is bypassed here; the probe declines on CPU, so no
+        # symmetric heap is reached.
+        comm.mapping = _mapping_stub()
         comm.routed_hidden, comm.hidden_size = L, H
         return comm
 
@@ -588,7 +599,48 @@ def test_fused_lane_ar_matches_reference(m):
     comm = _build_comm(dev)
     routed, shared, prefix = _inputs(rank, dev, m, seed=55)
     ref = _reference(comm, routed, shared, prefix)
-    out = comm._tail_fused_lane_ar(routed, shared, prefix, None, m, H)
+    out = comm._tail_fused_lane_ar(routed, shared, prefix, None, None, m, H)
+    torch.cuda.synchronize()
+    assert _rel_err(out, ref) < 0.05
+
+
+@collective
+@pytest.mark.parametrize("m", [1, MID_TOKENS, 1024])
+def test_fused_lane_ar_symmetric_matches_reference(m):
+    """The join tier reduces producer-direct partials to the same answer.
+
+    This regime swaps both the operand shape (a pair, not one concatenation)
+    and the kernel that sums it (an in-place symmetric reduce rather than a
+    staged one-shot), so it is the tier variant most able to disagree while
+    every other test still passes. Driving it here is also the only check that
+    the tail consumes the pair in the order it acquired them -- transposing
+    routed and shared would still produce plausibly-shaped output.
+
+    Skipped where the backend declines producer-direct memory; the vote keeps
+    the ranks from splitting over it, since one rank taking the symmetric
+    kernel while another stages would hang rather than fail.
+    """
+    from tokenspeed.runtime.distributed.comm_ops import (
+        acquire_all_reduce_outputs,
+        can_acquire_all_reduce_outputs,
+    )
+
+    rank, dev = _setup()
+    comm = _build_comm(dev)
+    routed, shared, prefix = _inputs(rank, dev, m, seed=55)
+    ref = _reference(comm, routed, shared, prefix)
+
+    group = comm.mapping.moe.tp_ep_group
+    shapes = ((m, L), (m, H))
+    if not _agreed(can_acquire_all_reduce_outputs(shapes, routed, group)):
+        pytest.skip("backend has no producer-direct all-reduce outputs here")
+
+    symm = acquire_all_reduce_outputs(shapes, routed, group)
+    # Stand in for the producers, which write their partials into these
+    # buffers rather than returning fresh ones.
+    symm[0].copy_(routed)
+    symm[1].copy_(shared)
+    out = comm._tail_fused_lane_ar(symm[0], symm[1], prefix, None, symm, m, H)
     torch.cuda.synchronize()
     assert _rel_err(out, ref) < 0.05
 
@@ -653,7 +705,7 @@ def test_tiers_agree_with_each_other():
 
     outs = {"separate_reduce": _run_separate_reduce(comm, *fresh(), m)}
     r, s, p = fresh()
-    outs["fused_lane_ar"] = comm._tail_fused_lane_ar(r, s, p, None, m, H)
+    outs["fused_lane_ar"] = comm._tail_fused_lane_ar(r, s, p, None, None, m, H)
     if _agreed(multimem_available()):
         outs["multimem_ar"] = comm._tail_multimem_ar(*fresh(), m, H)
     if tail is not None:

--- a/test/runtime/test_kimi_k3_moe_fork_warmup.py
+++ b/test/runtime/test_kimi_k3_moe_fork_warmup.py
@@ -96,6 +96,7 @@ def _make_moe(fork: _SpyFork) -> SimpleNamespace:
 
     plan = SimpleNamespace(
         lane=None,
+        symm_outputs=None,
         split_shared_rs=False,
         routed_in_fork=False,
         defer_finalize=False,


### PR DESCRIPTION
## Problem

The K3 MoE tail's join tier concatenates the routed and shared partials into one
operand and hands that to `all_reduce`. The backend can only select its
symmetric, in-place reduction on a *tuple* of tensors it allocated —
`AutoBackend.all_reduce` consults `can_reduce_outputs` on its tuple branch only —
so a single packed operand always took the staged path, copying both partials
into the collective's buffer before reducing them.

This is invisible from the call site: the staged path is correct, just slower,
and no amount of allocating the packed operand from symmetric memory changes the
selection. The operand *shape* is what routes it.

## Change

Acquire the `(routed, shared)` pair from the collective, point the producers at
it, and reduce the pair. This is the shape the EP-only layout already uses via
`latent_moe_expert_shared_all_reduce`; the TP layout now reaches the same kernel.

The packed lane remains the fallback for backends offering no producer-direct
memory. The tail verifies both partials actually landed in the acquired buffers
before reducing there — a producer that cannot write in place returns its own
tensor, and reducing a pair where only one side was produced in place would
silently drop the other's contribution.

Acquisition is gated on a new `can_acquire_all_reduce_outputs` probe, because
`acquire_all_reduce_outputs` always succeeds — it falls back to ordinary
allocations the collective must still stage — so taking those unconditionally
would cost a buffer without buying the kernel. The probe must answer identically
on every rank: a group split over which collective the tail runs would hang
rather than fail, so that requirement is documented on the base method.

## Measurements

8×MI355X, Kimi-K3 tp8/ep1, against the same commit without this change:

| | before | after |
|---|---|---|
| conc 1 | 60.41 tok/s | **64.17** |
| conc 8 | 271.74 tok/s | **291.97** |
| conc 16 | 452.96 tok/s | **489.75** |
| median TPOT @ conc 1 | 16.15 ms | **15.18** |

Decode trace, same shape both sides (63 steps, ~113.7k kernel events):

| | before | after |
|---|---|---|
| MoE-tail collective | `iris_stage_one_shot_allreduce` ×6426 | `iris_reduce_symmetric` ×5796 + 630 staged |
| mean / median | 67.91 / 45.04 µs | **24.07 / 13.16 µs** |
| total kernel dispatch | 1432.89 ms | **1146.00 ms** |

The 5796 calls that moved are exactly 92 MoE layers × 63 steps — every MoE layer
takes the symmetric path, with no silent fallbacks. The 630 remaining staged
calls are a different site, present identically in both traces.

## Tests

`test_fused_lane_ar_symmetric_matches_reference` drives the new regime against
the same reference the other tiers use. It is the tier variant most able to
disagree while everything else passes, since it swaps both the operand shape and
the summing kernel; it also pins the order the tail consumes the pair, which
transposition would otherwise leave plausibly shaped.

Run with `torchrun --standalone --nproc-per-node=8 -m pytest -q
test/runtime/test_k3_moe_tail_equivalence.py`.