### PR TITLE
perf(amd): port standard-cache DSA scorer to gfx1250

### DIFF
--- a/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
@@ -61,6 +61,10 @@ env:
     --deselect=tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py::test_dsa_prefill_topk_fp8_glm52_cases[prefill_mixed_1024]
     --deselect=tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py::test_dsa_prefill_topk_fp8_glm52_cases[prefill_persistent_2048]
     --deselect=tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py::test_dsa_with_sparse_kvcache
+    --deselect=tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py::test_standard_cache_decode_matches_weighted_relu_oracle
+    --deselect=tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py::test_standard_cache_prefill_uses_workspace_rows_not_global_slots
+    --deselect=tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py::test_standard_cache_decode_accepts_block_split_writer_output
+    --deselect=tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py::test_standard_cache_decode_logits_cover_empty_and_short_spans
     --deselect=tokenspeed-kernel/test/ops/gemm/test_per_block_quant_fp8.py::test_per_block_quant_fp8_feeds_block_scaled_gemm
     --deselect=tokenspeed-kernel/test/ops/gemm/test_per_block_quant_fp8.py::test_per_block_quant_fp8_roundtrip[130-300-block_size2]
     --deselect=tokenspeed-kernel/test/ops/gemm/test_per_block_quant_fp8.py::test_per_block_quant_fp8_roundtrip[192-256-block_size3]

--- a/tokenspeed-kernel-amd/THIRDPARTYNOTICES
+++ b/tokenspeed-kernel-amd/THIRDPARTYNOTICES
@@ -40,8 +40,9 @@ https://github.com/ROCm/aiter/blob/00b271b95f8a3405fa211e509c63441040557305/aite
 https://github.com/ROCm/aiter/blob/00b271b95f8a3405fa211e509c63441040557305/aiter/ops/triton/_gluon_kernels/gfx1250/attention/pa_decode_sparse.py
 https://github.com/ROCm/aiter/blob/00b271b95f8a3405fa211e509c63441040557305/aiter/ops/triton/_gluon_kernels/gfx1250/attention/pa_prefill_sparse.py
 
-The GFX950 standard-cache DSA scorer scheduling and FP8 matrix structure are
-informed by ROCm/AITER commit b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df.
+The GFX950 and GFX1250 standard-cache DSA scorer scheduling and FP8 matrix
+structure are informed by ROCm/AITER commit
+b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df.
 Sources:
 https://github.com/ROCm/aiter/blob/b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df/aiter/ops/triton/_gluon_kernels/gfx950/attention/fp8_mqa_logits.py
 https://github.com/ROCm/aiter/blob/b5c5912cb2bbab5d8c0cc12b08dec391a27bf8df/aiter/ops/triton/gluon/pa_mqa_logits.py

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
@@ -1132,7 +1132,7 @@ def _run_dense(
             num_kv_splits,
             kv_lora_rank,
             OUTPUT_WITHIN_2GB=_output_within_2gb(out),
-            num_warps=4,
+            num_warps=8,
         )
     return out
 
@@ -1352,7 +1352,7 @@ def gluon_dsa_decode_gfx1250(
             softmax_scale=scale,
             kv_lora_rank=kv_lora_rank,
             qk_rope_head_dim=qk_rope_head_dim,
-            block_h=16,
+            block_h=8,
             max_seqlen_k=max_seqlen_k,
             split_kv=True,
             out=out_view,
@@ -1407,8 +1407,8 @@ def gluon_dsa_prefill_gfx1250(
             qk_rope_head_dim=qk_rope_head_dim,
         )
     elif kv_cache is not None:
-        # Prefill exposes more token-level parallelism and uses a wider head
-        # tile than decode to amortize the selected-row gather.
+        # GLM-5-class prefill uses eight attention heads. A 16-head WMMA tile
+        # avoids the extra inactive rows of the wider decode-independent tile.
         result = _run_dense(
             q,
             kv_cache,
@@ -1417,7 +1417,7 @@ def gluon_dsa_prefill_gfx1250(
             softmax_scale=scale,
             kv_lora_rank=kv_lora_rank,
             qk_rope_head_dim=qk_rope_head_dim,
-            block_h=32,
+            block_h=16,
             max_seqlen_k=max_seqlen_k,
             split_kv=False,
         )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/attention.py
@@ -1132,7 +1132,7 @@ def _run_dense(
             num_kv_splits,
             kv_lora_rank,
             OUTPUT_WITHIN_2GB=_output_within_2gb(out),
-            num_warps=8,
+            num_warps=4 if kv_lora_rank == 128 else 8,
         )
     return out
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/sparse_mla.py
@@ -29,17 +29,36 @@ from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.indexing import (
     _dsa_decode_logits_fp8_kernel,
     _dsa_prefill_logits_fp8_kernel,
 )
+from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.standard_cache_logits import (
+    _dsa_standard_decode_logits_kernel,
+    _dsa_standard_prefill_logits_kernel,
+)
 
 __all__ = [
     "gluon_dsa_decode_topk_fp8_gfx1250",
+    "gluon_dsa_decode_topk_standard_gfx1250",
     "gluon_dsa_prefill_topk_fp8_gfx1250",
+    "gluon_dsa_prefill_topk_standard_gfx1250",
 ]
 
 _RADIX_BITS = (12, 12, 8)
+_RADIX0_BITS = gl.constexpr(_RADIX_BITS[0])
+_RADIX1_BITS = gl.constexpr(_RADIX_BITS[1])
+_RADIX2_BITS = gl.constexpr(_RADIX_BITS[2])
 _MAX_BUCKETS = gl.constexpr(1 << max(_RADIX_BITS))
 _TOPK_BLOCK_N = 2048
 _TOPK_NUM_WARPS = 8
 _TOPK_WAVES_PER_EU = 1
+_DECODE_TOPK_BLOCK_N = 4096
+_DECODE_TOPK_NUM_WARPS = 32
+_DECODE_TOPK_WAVES_PER_EU = 1
+_STANDARD_DECODE_BLOCK_N = 64
+_STANDARD_DECODE_CHUNK_N = 64
+_STANDARD_DECODE_NUM_WARPS = 4
+_STANDARD_DECODE_WAVES_PER_EU = 2
+_STANDARD_PREFILL_BLOCK_N = 128
+_STANDARD_PREFILL_NUM_WARPS = 8
+_STANDARD_PREFILL_WAVES_PER_EU = 1
 
 
 @gluon.constexpr_function
@@ -77,9 +96,11 @@ def _accumulate_histogram_tile(
     FIRST_PASS: gl.constexpr,
 ):
     offsets = tile_start + gl.arange(0, BLOCK_N, layout=value_layout)
+    offsets = gl.max_contiguous(gl.multiple_of(offsets.to(gl.int32), 4), 4)
     valid = offsets < candidate_len
-    values = gl.load(
-        candidate_logits + offsets,
+    values = gl.amd.gfx1250.buffer_load(
+        candidate_logits,
+        offsets,
         mask=valid,
         other=-float("inf"),
     )
@@ -100,6 +121,7 @@ def _accumulate_histogram_tile(
 @gluon.jit
 def _emit_topk_tile(
     candidate_logits,
+    block_table,
     tile_start,
     candidate_len,
     candidate_start,
@@ -109,20 +131,28 @@ def _emit_topk_tile(
     shared_output_counters,
     out,
     row,
+    req,
+    block_table_cols: gl.constexpr,
+    page_size: gl.constexpr,
     out_stride: gl.constexpr,
     value_layout: gl.constexpr,
     BLOCK_N: gl.constexpr,
+    PREFIX_SHIFT: gl.constexpr,
+    IS_DECODE: gl.constexpr,
 ):
     offsets = tile_start + gl.arange(0, BLOCK_N, layout=value_layout)
+    offsets = gl.max_contiguous(gl.multiple_of(offsets.to(gl.int32), 4), 4)
     valid = offsets < candidate_len
-    values = gl.load(
-        candidate_logits + offsets,
+    values = gl.amd.gfx1250.buffer_load(
+        candidate_logits,
+        offsets,
         mask=valid,
         other=-float("inf"),
     )
     keys = _fp32_to_topk_key(values)
-    greater = valid & (keys < threshold)
-    equal = valid & (keys == threshold)
+    compared_keys = keys if PREFIX_SHIFT == 0 else keys >> PREFIX_SHIFT
+    greater = valid & (compared_keys < threshold)
+    equal = valid & (compared_keys == threshold)
     reservation_mask = greater | equal
     counter = gl.where(greater, 0, 1).to(gl.int32)
     reservation = shared_output_counters.atomic_scatter_add(
@@ -132,14 +162,25 @@ def _emit_topk_tile(
         mask=reservation_mask,
     )
     logical_offsets = candidate_start + offsets.to(gl.int32)
+    if IS_DECODE:
+        block_idx = logical_offsets // page_size
+        block_offset = logical_offsets - block_idx * page_size
+        page = gl.load(
+            block_table + req * block_table_cols + block_idx,
+            mask=reservation_mask & (block_idx < block_table_cols),
+            other=0,
+        ).to(gl.int32)
+        output_values = page * page_size + block_offset
+    else:
+        output_values = logical_offsets
     gl.store(
         out + row * out_stride + reservation,
-        logical_offsets,
+        output_values,
         mask=greater & (reservation < count_greater),
     )
     gl.store(
         out + row * out_stride + count_greater + reservation,
-        logical_offsets,
+        output_values,
         mask=equal & (reservation < remaining),
     )
 
@@ -216,7 +257,6 @@ def _dsa_wave32_radix_topk_kernel(
     candidate_len = gl.maximum(candidate_end - candidate_start, 0)
     selected_count = gl.minimum(candidate_len, topk).to(gl.int32)
     output_offsets = gl.arange(0, topk, layout=output_layout)
-    gl.store(out + row * out_stride + output_offsets, -1)
     gl.store(lens_out + row, selected_count)
 
     if candidate_len <= topk:
@@ -243,18 +283,20 @@ def _dsa_wave32_radix_topk_kernel(
     bucket_offsets = gl.arange(0, _MAX_BUCKETS, layout=histogram_layout)
     prefix = gl.full([], 0, gl.uint32)
     remaining = gl.full([], topk, gl.int32)
+    shared_output_counters.store(counter_zeros)
+    gl.barrier()
 
-    # The three-pass 12/12/8 radix schedule follows TokenSpeed's gfx950
-    # selector, but all lane geometry and memory operations are Wave32-safe.
+    # The three-pass schedule resolves the full ordered FP32 key.
     for pass_index in gl.static_range(3):
         shared_histogram.store(histogram_zeros)
         gl.barrier()
-        radix_bits = 12
-        shift = 20
+        radix_bits = _RADIX0_BITS
+        shift = 32 - _RADIX0_BITS
         if pass_index == 1:
-            shift = 8
+            radix_bits = _RADIX1_BITS
+            shift = 32 - _RADIX0_BITS - _RADIX1_BITS
         elif pass_index == 2:
-            radix_bits = 8
+            radix_bits = _RADIX2_BITS
             shift = 0
         for tile_start in range(0, candidate_len, BLOCK_N):
             _accumulate_histogram_tile(
@@ -288,18 +330,50 @@ def _dsa_wave32_radix_topk_kernel(
         select_low = before_group + count_low >= remaining
         selected_bucket = gl.where(select_low, bucket_low, bucket_high)
         selected_greater = before_group + gl.where(select_low, 0, count_low)
+        if pass_index == 1:
+            selected_bucket_count = gl.where(select_low, count_low, count_high)
         packed = selected_bucket.to(gl.uint32) | (selected_greater.to(gl.uint32) << 12)
+        if pass_index == 1:
+            selected_bucket_complete = selected_bucket_count == (
+                remaining - selected_greater
+            )
+            packed |= selected_bucket_complete.to(gl.uint32) << 23
         packed = gl.sum(gl.where(selected_group, packed, 0), axis=0)
         prefix = (prefix << radix_bits) | (packed & 0xFFF)
-        remaining -= ((packed >> 12) & 0xFFF).to(gl.int32)
+        remaining -= ((packed >> 12) & 0x7FF).to(gl.int32)
         gl.barrier()
+        if pass_index == 1:
+            if ((packed >> 23) & 1) != 0:
+                count_greater = topk - remaining
+                for tile_start in range(0, candidate_len, BLOCK_N):
+                    _emit_topk_tile(
+                        candidate_logits,
+                        block_table,
+                        tile_start,
+                        candidate_len,
+                        candidate_start,
+                        prefix,
+                        count_greater,
+                        remaining,
+                        shared_output_counters,
+                        out,
+                        row,
+                        req,
+                        block_table_cols,
+                        page_size,
+                        out_stride,
+                        value_layout,
+                        BLOCK_N,
+                        shift,
+                        IS_DECODE,
+                    )
+                return
 
-    shared_output_counters.store(counter_zeros)
-    gl.barrier()
     count_greater = topk - remaining
     for tile_start in range(0, candidate_len, BLOCK_N):
         _emit_topk_tile(
             candidate_logits,
+            block_table,
             tile_start,
             candidate_len,
             candidate_start,
@@ -309,30 +383,14 @@ def _dsa_wave32_radix_topk_kernel(
             shared_output_counters,
             out,
             row,
+            req,
+            block_table_cols,
+            page_size,
             out_stride,
             value_layout,
             BLOCK_N,
-        )
-
-    if IS_DECODE:
-        gl.barrier()
-        logical_offsets = gl.load(
-            out + row * out_stride + output_offsets,
-        ).to(gl.int32)
-        block_idx = logical_offsets // page_size
-        block_offset = logical_offsets - block_idx * page_size
-        page = gl.load(
-            block_table + req * block_table_cols + block_idx,
-            mask=(logical_offsets >= 0) & (block_idx < block_table_cols),
-            other=0,
-        ).to(gl.int32)
-        gl.store(
-            out + row * out_stride + output_offsets,
-            gl.where(
-                logical_offsets >= 0,
-                page * page_size + block_offset,
-                -1,
-            ),
+            0,
+            IS_DECODE,
         )
 
 
@@ -347,6 +405,83 @@ def _check_score_input_contract(
         raise ValueError("q and weights must have contiguous innermost dimensions")
     if not index_k_cache.is_contiguous():
         raise ValueError("index_k_cache must be contiguous")
+
+
+def _check_standard_scorer_inputs(
+    q: torch.Tensor,
+    q_scales: torch.Tensor | None,
+    weights: torch.Tensor,
+    index_k_cache: torch.Tensor,
+    page_size: int,
+) -> tuple[int, int, bool]:
+    if q.dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise TypeError(
+            f"standard-cache DSA scorer expects BF16 or FP8 q, got {q.dtype}"
+        )
+    if weights.dtype not in (torch.bfloat16, torch.float32):
+        raise TypeError(f"DSA weights must be BF16 or FP32, got {weights.dtype}")
+    if q.dim() != 3 or q.shape[1] not in (32, 64) or q.shape[2] != 128:
+        raise ValueError(
+            "standard-cache DSA scorer requires q=[tokens, 32|64, 128], got "
+            f"{tuple(q.shape)}"
+        )
+    if weights.shape != q.shape[:2]:
+        raise ValueError(
+            f"weights must have shape {tuple(q.shape[:2])}, got {tuple(weights.shape)}"
+        )
+    if q.stride(-1) != 1 or weights.stride(-1) != 1:
+        raise ValueError("q and weights must have contiguous innermost dimensions")
+    if page_size != 64:
+        raise ValueError(
+            f"standard-cache DSA scorer requires page_size=64, got {page_size}"
+        )
+    if index_k_cache.dtype != torch.uint8:
+        raise TypeError("index_k_cache must be a uint8 tensor")
+    row_bytes = 128 + 4
+    if index_k_cache.dim() != 2:
+        raise ValueError(
+            "index_k_cache must be a packed slot matrix or page-planar matrix, "
+            f"got shape {tuple(index_k_cache.shape)}"
+        )
+    page_bytes = page_size * row_bytes
+    if index_k_cache.shape[1] == row_bytes:
+        if not index_k_cache.is_contiguous():
+            raise ValueError("packed index_k_cache must be contiguous")
+        if index_k_cache.shape[0] % page_size:
+            raise ValueError("index_k_cache slot count must be page aligned")
+        page_stride_bytes = page_bytes
+    elif (
+        index_k_cache.shape[1] >= page_bytes
+        and index_k_cache.stride(1) == 1
+        and index_k_cache.stride(0) >= page_bytes
+    ):
+        page_stride_bytes = index_k_cache.stride(0)
+    else:
+        raise ValueError(
+            "index_k_cache must be contiguous [slots, row_bytes] or page-planar "
+            f"[pages, at least {page_bytes} bytes], got "
+            f"shape={tuple(index_k_cache.shape)}, stride={index_k_cache.stride()}"
+        )
+    if index_k_cache.storage_offset() % 4 or page_stride_bytes % 4:
+        raise ValueError("index_k_cache page storage must be float32 aligned")
+    if weights.device != q.device or index_k_cache.device != q.device:
+        raise ValueError("q, weights, and index_k_cache must be on the same device")
+    q_is_fp8 = q.dtype == torch.float8_e4m3fn
+    if q_is_fp8:
+        if q_scales is None:
+            raise ValueError("FP8 q requires per-token/head q_scales")
+        if (
+            q_scales.dtype != torch.float32
+            or q_scales.shape != q.shape[:2]
+            or q_scales.device != q.device
+            or q_scales.stride(-1) != 1
+        ):
+            raise ValueError(
+                "q_scales must be FP32 [tokens, heads] with a contiguous head axis"
+            )
+    elif q_scales is not None:
+        raise ValueError("q_scales is only valid with FP8 q")
+    return row_bytes, page_stride_bytes, q_is_fp8
 
 
 def _check_topk_contract(topk: int) -> None:
@@ -375,6 +510,14 @@ def _dsa_topk_indices(
     else:
         is_decode = True
         block_table_cols = block_table.shape[1]
+    if is_decode:
+        block_n = _DECODE_TOPK_BLOCK_N
+        num_warps = min(_DECODE_TOPK_NUM_WARPS, topk // 32)
+        waves_per_eu = _DECODE_TOPK_WAVES_PER_EU
+    else:
+        block_n = _TOPK_BLOCK_N
+        num_warps = _TOPK_NUM_WARPS
+        waves_per_eu = _TOPK_WAVES_PER_EU
     rows = logits.shape[0]
     _dsa_wave32_radix_topk_kernel[(rows,)](
         logits,
@@ -390,10 +533,10 @@ def _dsa_topk_indices(
         topk=topk,
         q_len_per_req=q_len_per_req,
         IS_DECODE=is_decode,
-        BLOCK_N=_TOPK_BLOCK_N,
-        LOAD_ELEMS=_TOPK_BLOCK_N // (32 * _TOPK_NUM_WARPS),
-        num_warps=_TOPK_NUM_WARPS,
-        waves_per_eu=_TOPK_WAVES_PER_EU,
+        BLOCK_N=block_n,
+        LOAD_ELEMS=block_n // (32 * num_warps),
+        num_warps=num_warps,
+        waves_per_eu=waves_per_eu,
     )
     return out, lens_out
 
@@ -622,6 +765,273 @@ def gluon_dsa_prefill_topk_fp8_gfx1250(
             BLOCK_D=128,
             num_warps=4,
             waves_per_eu=1,
+        )
+        _dsa_topk_indices(
+            logits,
+            row_starts[start:end],
+            row_ends[start:end],
+            topk=topk,
+            out=out[start:end],
+            lens_out=lens_out[start:end],
+        )
+    return out, lens_out
+
+
+def gluon_dsa_decode_topk_standard_gfx1250(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    *,
+    page_size: int,
+    topk: int,
+    softmax_scale: float,
+    q_len_per_req: int = 1,
+    index_k_cache: torch.Tensor | None = None,
+    q_scales: torch.Tensor | None = None,
+    seq_lens_2d: torch.Tensor | None = None,
+    plan: object | None = None,
+    out: torch.Tensor | None = None,
+    lens_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Score standard FP8 index keys with Wave32 WMMA and return global slots."""
+    del plan, seq_lens_2d
+    topk = int(topk)
+    q_len_per_req = int(q_len_per_req)
+    _check_topk_contract(topk)
+    if q_len_per_req not in (1, 2, 3, 4, 5, 6):
+        raise ValueError(
+            f"DSA Gluon top-k supports q_len_per_req=1..6, got {q_len_per_req}"
+        )
+    if index_k_cache is None:
+        raise RuntimeError("standard-cache DSA scorer requires index_k_cache")
+    row_bytes, page_stride_bytes, q_is_fp8 = _check_standard_scorer_inputs(
+        q,
+        q_scales,
+        weights,
+        index_k_cache,
+        int(page_size),
+    )
+    if seq_lens.dim() != 1:
+        raise ValueError(f"seq_lens must be 1-D, got {tuple(seq_lens.shape)}")
+    expected_tokens = int(seq_lens.numel()) * q_len_per_req
+    if expected_tokens != q.shape[0]:
+        raise ValueError(
+            "q rows must equal seq_lens rows times q_len_per_req, got "
+            f"q={tuple(q.shape)}, seq_lens={tuple(seq_lens.shape)}, "
+            f"q_len_per_req={q_len_per_req}"
+        )
+    if block_table.dim() != 2 or block_table.shape[0] < seq_lens.numel():
+        raise ValueError(
+            "block_table must have at least one row per request, got "
+            f"{tuple(block_table.shape)}"
+        )
+    if seq_lens.dtype != torch.int32 or block_table.dtype != torch.int32:
+        raise TypeError("seq_lens and block_table must be int32")
+    if seq_lens.device != q.device or block_table.device != q.device:
+        raise ValueError("decode metadata must be on the same device as q")
+    if not seq_lens.is_contiguous() or not block_table.is_contiguous():
+        raise ValueError("seq_lens and block_table must be contiguous")
+    if out is None:
+        out = torch.empty((q.shape[0], topk), dtype=torch.int32, device=q.device)
+    if lens_out is None:
+        lens_out = torch.empty((q.shape[0],), dtype=torch.int32, device=q.device)
+    if q.shape[0] == 0:
+        return out, lens_out
+
+    max_candidates = int(block_table.shape[1]) * int(page_size)
+    if max_candidates == 0:
+        out.fill_(-1)
+        lens_out.zero_()
+        return out, lens_out
+    logits = torch.empty(
+        (q.shape[0], max_candidates),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    block_n = _STANDARD_DECODE_BLOCK_N
+    chunk_n = _STANDARD_DECODE_CHUNK_N
+    num_warps = _STANDARD_DECODE_NUM_WARPS
+    q_scale_arg = q_scales if q_scales is not None else weights
+    cache_span = (
+        0
+        if index_k_cache.shape[0] == 0
+        else (index_k_cache.shape[0] - 1) * index_k_cache.stride(0)
+        + index_k_cache.shape[1]
+    )
+    grid = (q.shape[0], triton.cdiv(max_candidates, chunk_n))
+    _dsa_standard_decode_logits_kernel[grid](
+        q,
+        q_scale_arg,
+        index_k_cache.view(torch.float8_e4m3fn),
+        index_k_cache.view(torch.float32),
+        weights,
+        seq_lens,
+        block_table,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        q_scale_arg.stride(0),
+        q_scale_arg.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        block_table.stride(0),
+        logits.stride(0),
+        float(softmax_scale),
+        max_candidates,
+        q_len_per_req,
+        PAGE_SIZE=int(page_size),
+        ROW_BYTES=row_bytes,
+        PAGE_STRIDE_BYTES=page_stride_bytes,
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=block_n,
+        CHUNK_N=chunk_n,
+        NUM_WARPS=num_warps,
+        Q_IS_FP8=q_is_fp8,
+        USE_BUFFER_LOAD=cache_span < 2**31,
+        USE_BUFFER_STORE=logits.nbytes < 2**31,
+        num_warps=num_warps,
+        waves_per_eu=_STANDARD_DECODE_WAVES_PER_EU,
+    )
+    return _dsa_topk_indices(
+        logits,
+        seq_lens,
+        seq_lens,
+        block_table=block_table,
+        page_size=int(page_size),
+        topk=topk,
+        q_len_per_req=q_len_per_req,
+        out=out,
+        lens_out=lens_out,
+    )
+
+
+def gluon_dsa_prefill_topk_standard_gfx1250(
+    q: torch.Tensor,
+    weights: torch.Tensor,
+    kv_workspace_slots: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    *,
+    topk: int,
+    softmax_scale: float,
+    index_k_cache: torch.Tensor | None = None,
+    page_size: int | None = None,
+    index_k_fp8: torch.Tensor | None = None,
+    index_k_scale: torch.Tensor | None = None,
+    q_scales: torch.Tensor | None = None,
+    max_logits_bytes: int | None = None,
+    out: torch.Tensor | None = None,
+    lens_out: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Score standard FP8 workspace keys with Wave32 WMMA and return row ids."""
+    del index_k_fp8, index_k_scale
+    topk = int(topk)
+    _check_topk_contract(topk)
+    if index_k_cache is None or page_size is None:
+        raise RuntimeError("standard-cache DSA scorer requires cache and page_size")
+    row_bytes, page_stride_bytes, q_is_fp8 = _check_standard_scorer_inputs(
+        q,
+        q_scales,
+        weights,
+        index_k_cache,
+        int(page_size),
+    )
+    if kv_workspace_slots.dim() != 1:
+        raise ValueError(
+            f"kv_workspace_slots must be 1-D, got {tuple(kv_workspace_slots.shape)}"
+        )
+    if row_starts.shape != (q.shape[0],) or row_ends.shape != (q.shape[0],):
+        raise ValueError("row_starts and row_ends must have one element per q row")
+    if (
+        kv_workspace_slots.dtype != torch.int64
+        or row_starts.dtype != torch.int32
+        or row_ends.dtype != torch.int32
+    ):
+        raise TypeError(
+            "kv_workspace_slots must be int64 and row_starts/row_ends must be int32"
+        )
+    if (
+        kv_workspace_slots.device != q.device
+        or row_starts.device != q.device
+        or row_ends.device != q.device
+    ):
+        raise ValueError("prefill metadata must be on the same device as q")
+    if not (
+        kv_workspace_slots.is_contiguous()
+        and row_starts.is_contiguous()
+        and row_ends.is_contiguous()
+    ):
+        raise ValueError("prefill metadata must be contiguous")
+    if out is None:
+        out = torch.empty((q.shape[0], topk), dtype=torch.int32, device=q.device)
+    if lens_out is None:
+        lens_out = torch.empty((q.shape[0],), dtype=torch.int32, device=q.device)
+    if q.shape[0] == 0:
+        return out, lens_out
+
+    workspace_rows = int(kv_workspace_slots.numel())
+    if workspace_rows == 0:
+        out.fill_(-1)
+        lens_out.zero_()
+        return out, lens_out
+    if max_logits_bytes is None:
+        max_query_rows = q.shape[0]
+    else:
+        max_query_rows = max(1, int(max_logits_bytes) // (max(workspace_rows, 1) * 4))
+
+    block_n = _STANDARD_PREFILL_BLOCK_N
+    num_warps = _STANDARD_PREFILL_NUM_WARPS
+    q_scale_arg = q_scales if q_scales is not None else weights
+    cache_span = (
+        0
+        if index_k_cache.shape[0] == 0
+        else (index_k_cache.shape[0] - 1) * index_k_cache.stride(0)
+        + index_k_cache.shape[1]
+    )
+    dummy_table = row_starts
+    for start in range(0, q.shape[0], max_query_rows):
+        end = min(start + max_query_rows, q.shape[0])
+        logits = torch.empty(
+            (end - start, workspace_rows),
+            dtype=torch.float32,
+            device=q.device,
+        )
+        _dsa_standard_prefill_logits_kernel[(end - start, 1)](
+            q[start:end],
+            q_scale_arg[start:end],
+            index_k_cache.view(torch.float8_e4m3fn),
+            index_k_cache.view(torch.float32),
+            weights[start:end],
+            kv_workspace_slots,
+            row_starts[start:end],
+            row_ends[start:end],
+            dummy_table,
+            logits,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q_scale_arg.stride(0),
+            q_scale_arg.stride(1),
+            weights.stride(0),
+            weights.stride(1),
+            logits.stride(0),
+            float(softmax_scale),
+            workspace_rows,
+            PAGE_SIZE=int(page_size),
+            ROW_BYTES=row_bytes,
+            PAGE_STRIDE_BYTES=page_stride_bytes,
+            NUM_HEADS=q.shape[1],
+            HEAD_DIM=q.shape[2],
+            BLOCK_N=block_n,
+            NUM_WARPS=num_warps,
+            Q_IS_FP8=q_is_fp8,
+            USE_BUFFER_LOAD=cache_span < 2**31,
+            USE_BUFFER_STORE=logits.nbytes < 2**31,
+            num_warps=num_warps,
+            waves_per_eu=_STANDARD_PREFILL_WAVES_PER_EU,
         )
         _dsa_topk_indices(
             logits,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/standard_cache_logits.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/dsa/standard_cache_logits.py
@@ -1,0 +1,561 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""GFX1250 matrix-core DSA logits kernels for the standard paged cache.
+
+The scorer supports 32 or 64 index heads, BF16 or scaled FP8 queries, and both
+packed-slot and page-planar FP8 key-cache storage.
+"""
+
+from tokenspeed_kernel_amd._triton import gl, gluon, tl
+
+__all__ = [
+    "_dsa_standard_decode_logits_kernel",
+    "_dsa_standard_prefill_logits_kernel",
+]
+
+
+@gluon.constexpr_function
+def _make_wmma_layout(
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+):
+    """Map Wave32 workgroups over 32 scoring heads and candidate columns."""
+    if NUM_WARPS == 2:
+        warp_bases = [[1, 0]]
+    elif NUM_WARPS == 4:
+        warp_bases = [[1, 0], [0, 1]]
+    elif NUM_WARPS == 8:
+        warp_bases = [[1, 0], [0, 1], [0, 2]]
+    else:
+        warp_bases = []
+    return gl.amd.AMDWMMALayout(
+        version=3,
+        transposed=True,
+        warp_bases=warp_bases,
+        reg_bases=[],
+        instr_shape=[16, 16, 64 if Q_IS_FP8 else 32],
+    )
+
+
+@gluon.jit
+def _candidate_slots(
+    positions,
+    valid,
+    kv_workspace_slots,
+    block_table,
+    request_id,
+    block_table_stride,
+    PAGE_SIZE: gl.constexpr,
+    IS_PREFILL: gl.constexpr,
+):
+    if IS_PREFILL:
+        return gl.amd.gfx1250.buffer_load(
+            kv_workspace_slots,
+            positions.to(gl.int32),
+            mask=valid,
+            other=0,
+        ).to(gl.int64)
+    page_indices = positions // PAGE_SIZE
+    pages = gl.amd.gfx1250.buffer_load(
+        block_table,
+        (request_id * block_table_stride + page_indices).to(gl.int32),
+        mask=valid,
+        other=0,
+    ).to(gl.int64)
+    return pages * PAGE_SIZE + positions % PAGE_SIZE
+
+
+@gluon.jit
+def _load_query(
+    q,
+    q_scales,
+    weights,
+    row_id,
+    head_offset: gl.constexpr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_qs_row,
+    stride_qs_head,
+    stride_w_row,
+    stride_w_head,
+    q_load_layout: gl.constexpr,
+    q_dot_layout: gl.constexpr,
+    wmma_layout: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+):
+    heads = gl.arange(0, 32, layout=gl.SliceLayout(1, q_load_layout))[:, None]
+    dims = gl.arange(0, HEAD_DIM, layout=gl.SliceLayout(0, q_load_layout))[None, :]
+    query = gl.amd.gfx1250.buffer_load(
+        q,
+        (
+            row_id * stride_q_row
+            + (head_offset + heads) * stride_q_head
+            + dims * stride_q_dim
+        ).to(gl.int32),
+    )
+    weight_heads = gl.arange(0, 32, layout=gl.SliceLayout(1, wmma_layout))
+    head_weights = gl.amd.gfx1250.buffer_load(
+        weights,
+        (row_id * stride_w_row + (head_offset + weight_heads) * stride_w_head).to(
+            gl.int32
+        ),
+    ).to(gl.float32)
+    if Q_IS_FP8:
+        query_scales = gl.amd.gfx1250.buffer_load(
+            q_scales,
+            (row_id * stride_qs_row + (head_offset + weight_heads) * stride_qs_head).to(
+                gl.int32
+            ),
+        ).to(gl.float32)
+        head_weights *= query_scales
+    return gl.convert_layout(query, q_dot_layout), head_weights
+
+
+@gluon.jit
+def _score_head_tile(
+    query,
+    key,
+    head_weights,
+    wmma_layout: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+):
+    accumulator = gl.zeros([32, BLOCK_N], gl.float32, layout=wmma_layout)
+    head_scores = gl.amd.gfx1250.wmma(query, key, accumulator)
+    head_scores = gl.maximum(
+        head_scores,
+        0.0,
+        propagate_nan=tl.PropagateNan.ALL,
+    )
+    return gl.sum(head_scores * head_weights[:, None], axis=0)
+
+
+@gluon.jit
+def _score_key_tile(
+    query_0,
+    weight_0,
+    query_1,
+    weight_1,
+    index_k_fp8,
+    index_k_scale,
+    kv_workspace_slots,
+    block_table,
+    request_id,
+    block_table_stride,
+    candidate_start,
+    candidate_end,
+    model_scale,
+    wmma_layout: gl.constexpr,
+    k_dot_layout: gl.constexpr,
+    PAGE_SIZE: gl.constexpr,
+    PAGE_STRIDE_BYTES: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    IS_PREFILL: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+):
+    dims = gl.arange(0, HEAD_DIM, layout=gl.SliceLayout(1, k_dot_layout))[:, None]
+    columns = gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, k_dot_layout))[None, :]
+    positions = candidate_start + columns
+    valid = positions < candidate_end
+    slots = _candidate_slots(
+        positions,
+        valid,
+        kv_workspace_slots,
+        block_table,
+        request_id,
+        block_table_stride,
+        PAGE_SIZE,
+        IS_PREFILL,
+    )
+    pages = slots // PAGE_SIZE
+    page_rows = slots - pages * PAGE_SIZE
+    key_offsets = pages * PAGE_STRIDE_BYTES + page_rows * HEAD_DIM + dims
+    if USE_BUFFER_LOAD:
+        raw_key = gl.amd.gfx1250.buffer_load(
+            index_k_fp8,
+            key_offsets.to(gl.int32),
+            mask=valid,
+            other=0.0,
+        )
+    else:
+        raw_key = gl.load(
+            index_k_fp8 + key_offsets,
+            mask=valid,
+            other=0.0,
+        )
+    key = raw_key if Q_IS_FP8 else raw_key.to(gl.bfloat16)
+    scores = _score_head_tile(
+        query_0,
+        key,
+        weight_0,
+        wmma_layout,
+        BLOCK_N,
+    )
+    if NUM_HEADS == 64:
+        scores += _score_head_tile(
+            query_1,
+            key,
+            weight_1,
+            wmma_layout,
+            BLOCK_N,
+        )
+
+    output_layout: gl.constexpr = gl.SliceLayout(0, wmma_layout)
+    scale_positions = candidate_start + gl.arange(0, BLOCK_N, layout=output_layout)
+    scale_valid = scale_positions < candidate_end
+    scale_slots = _candidate_slots(
+        scale_positions,
+        scale_valid,
+        kv_workspace_slots,
+        block_table,
+        request_id,
+        block_table_stride,
+        PAGE_SIZE,
+        IS_PREFILL,
+    )
+    scale_pages = scale_slots // PAGE_SIZE
+    scale_rows = scale_slots - scale_pages * PAGE_SIZE
+    scale_offsets = (
+        scale_pages * (PAGE_STRIDE_BYTES // 4)
+        + (PAGE_SIZE * HEAD_DIM) // 4
+        + scale_rows
+    )
+    if USE_BUFFER_LOAD:
+        key_scales = gl.amd.gfx1250.buffer_load(
+            index_k_scale,
+            scale_offsets.to(gl.int32),
+            mask=scale_valid,
+            other=0.0,
+        ).to(gl.float32)
+    else:
+        key_scales = gl.load(
+            index_k_scale + scale_offsets,
+            mask=scale_valid,
+            other=0.0,
+        ).to(gl.float32)
+    return scores * key_scales * model_scale, scale_positions, scale_valid
+
+
+@gluon.jit
+def _standard_cache_logits_body(
+    q,
+    q_scales,
+    index_k_fp8,
+    index_k_scale,
+    weights,
+    kv_workspace_slots,
+    row_starts,
+    row_ends,
+    seq_lens,
+    block_table,
+    logits,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_qs_row,
+    stride_qs_head,
+    stride_w_row,
+    stride_w_head,
+    block_table_stride,
+    logits_stride,
+    model_scale,
+    max_candidates,
+    q_len_per_req,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    PAGE_STRIDE_BYTES: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    CHUNK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    IS_PREFILL: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+    USE_BUFFER_STORE: gl.constexpr,
+):
+    row_id = gl.program_id(0)
+    split_id = gl.program_id(1)
+    if IS_PREFILL:
+        request_id = row_id
+        candidate_start = gl.maximum(gl.load(row_starts + row_id), 0)
+        candidate_end = gl.minimum(gl.load(row_ends + row_id), max_candidates)
+    else:
+        request_id = row_id // q_len_per_req
+        q_offset = row_id - request_id * q_len_per_req
+        candidate_start = split_id * CHUNK_N
+        candidate_end = gl.load(seq_lens + request_id).to(gl.int32)
+        if q_len_per_req != 1:
+            candidate_end = candidate_end - (q_len_per_req - 1) + q_offset
+        candidate_end = gl.minimum(candidate_end, candidate_start + CHUNK_N)
+        candidate_end = gl.minimum(candidate_end, max_candidates)
+    candidate_start = gl.minimum(candidate_start, candidate_end)
+
+    wmma_layout: gl.constexpr = _make_wmma_layout(NUM_WARPS, Q_IS_FP8)
+    k_width: gl.constexpr = 16 if Q_IS_FP8 else 8
+    q_dot_layout: gl.constexpr = gl.DotOperandLayout(
+        0,
+        wmma_layout,
+        k_width=k_width,
+    )
+    k_dot_layout: gl.constexpr = gl.DotOperandLayout(
+        1,
+        wmma_layout,
+        k_width=k_width,
+    )
+    q_load_layout: gl.constexpr = gl.BlockedLayout(
+        [1, k_width],
+        [4, 8],
+        [NUM_WARPS, 1],
+        [1, 0],
+    )
+    query_0, weight_0 = _load_query(
+        q,
+        q_scales,
+        weights,
+        row_id,
+        0,
+        stride_q_row,
+        stride_q_head,
+        stride_q_dim,
+        stride_qs_row,
+        stride_qs_head,
+        stride_w_row,
+        stride_w_head,
+        q_load_layout,
+        q_dot_layout,
+        wmma_layout,
+        HEAD_DIM,
+        Q_IS_FP8,
+    )
+    if NUM_HEADS == 64:
+        query_1, weight_1 = _load_query(
+            q,
+            q_scales,
+            weights,
+            row_id,
+            32,
+            stride_q_row,
+            stride_q_head,
+            stride_q_dim,
+            stride_qs_row,
+            stride_qs_head,
+            stride_w_row,
+            stride_w_head,
+            q_load_layout,
+            q_dot_layout,
+            wmma_layout,
+            HEAD_DIM,
+            Q_IS_FP8,
+        )
+    else:
+        query_1 = query_0
+        weight_1 = weight_0
+
+    tile_count = tl.cdiv(candidate_end - candidate_start, BLOCK_N)
+    for tile_id in tl.range(0, tile_count):
+        tile_start = candidate_start + tile_id * BLOCK_N
+        scores, positions, valid = _score_key_tile(
+            query_0,
+            weight_0,
+            query_1,
+            weight_1,
+            index_k_fp8,
+            index_k_scale,
+            kv_workspace_slots,
+            block_table,
+            request_id,
+            block_table_stride,
+            tile_start,
+            candidate_end,
+            model_scale,
+            wmma_layout,
+            k_dot_layout,
+            PAGE_SIZE,
+            PAGE_STRIDE_BYTES,
+            HEAD_DIM,
+            BLOCK_N,
+            NUM_HEADS,
+            Q_IS_FP8,
+            IS_PREFILL,
+            USE_BUFFER_LOAD,
+        )
+        if USE_BUFFER_STORE:
+            gl.amd.gfx1250.buffer_store(
+                scores,
+                logits,
+                (row_id * logits_stride + positions).to(gl.int32),
+                mask=valid,
+            )
+        else:
+            output_offsets = row_id.to(gl.int64) * logits_stride + positions.to(
+                gl.int64
+            )
+            gl.store(logits + output_offsets, scores, mask=valid)
+
+
+@gluon.jit
+def _dsa_standard_prefill_logits_kernel(
+    q,
+    q_scales,
+    index_k_fp8,
+    index_k_scale,
+    weights,
+    kv_workspace_slots,
+    row_starts,
+    row_ends,
+    block_table,
+    logits,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_qs_row,
+    stride_qs_head,
+    stride_w_row,
+    stride_w_head,
+    logits_stride,
+    model_scale,
+    workspace_rows,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    PAGE_STRIDE_BYTES: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+    USE_BUFFER_STORE: gl.constexpr,
+):
+    _standard_cache_logits_body(
+        q,
+        q_scales,
+        index_k_fp8,
+        index_k_scale,
+        weights,
+        kv_workspace_slots,
+        row_starts,
+        row_ends,
+        row_ends,
+        block_table,
+        logits,
+        stride_q_row,
+        stride_q_head,
+        stride_q_dim,
+        stride_qs_row,
+        stride_qs_head,
+        stride_w_row,
+        stride_w_head,
+        0,
+        logits_stride,
+        model_scale,
+        workspace_rows,
+        1,
+        PAGE_SIZE,
+        ROW_BYTES,
+        PAGE_STRIDE_BYTES,
+        NUM_HEADS,
+        HEAD_DIM,
+        BLOCK_N,
+        BLOCK_N,
+        NUM_WARPS,
+        Q_IS_FP8,
+        True,
+        USE_BUFFER_LOAD,
+        USE_BUFFER_STORE,
+    )
+
+
+@gluon.jit
+def _dsa_standard_decode_logits_kernel(
+    q,
+    q_scales,
+    index_k_fp8,
+    index_k_scale,
+    weights,
+    seq_lens,
+    block_table,
+    logits,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_qs_row,
+    stride_qs_head,
+    stride_w_row,
+    stride_w_head,
+    block_table_stride,
+    logits_stride,
+    model_scale,
+    max_candidates,
+    q_len_per_req,
+    PAGE_SIZE: gl.constexpr,
+    ROW_BYTES: gl.constexpr,
+    PAGE_STRIDE_BYTES: gl.constexpr,
+    NUM_HEADS: gl.constexpr,
+    HEAD_DIM: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    CHUNK_N: gl.constexpr,
+    NUM_WARPS: gl.constexpr,
+    Q_IS_FP8: gl.constexpr,
+    USE_BUFFER_LOAD: gl.constexpr,
+    USE_BUFFER_STORE: gl.constexpr,
+):
+    _standard_cache_logits_body(
+        q,
+        q_scales,
+        index_k_fp8,
+        index_k_scale,
+        weights,
+        block_table,
+        seq_lens,
+        seq_lens,
+        seq_lens,
+        block_table,
+        logits,
+        stride_q_row,
+        stride_q_head,
+        stride_q_dim,
+        stride_qs_row,
+        stride_qs_head,
+        stride_w_row,
+        stride_w_head,
+        block_table_stride,
+        logits_stride,
+        model_scale,
+        max_candidates,
+        q_len_per_req,
+        PAGE_SIZE,
+        ROW_BYTES,
+        PAGE_STRIDE_BYTES,
+        NUM_HEADS,
+        HEAD_DIM,
+        BLOCK_N,
+        CHUNK_N,
+        NUM_WARPS,
+        Q_IS_FP8,
+        False,
+        USE_BUFFER_LOAD,
+        USE_BUFFER_STORE,
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -146,7 +146,13 @@ if current_platform().is_amd:
         gluon_dsa_decode_topk_fp8_gfx1250 as _dsa_decode_topk_gfx1250_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.sparse_mla import (
+        gluon_dsa_decode_topk_standard_gfx1250 as _dsa_decode_topk_standard_gfx1250_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.sparse_mla import (
         gluon_dsa_prefill_topk_fp8_gfx1250 as _dsa_prefill_topk_gfx1250_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.sparse_mla import (
+        gluon_dsa_prefill_topk_standard_gfx1250 as _dsa_prefill_topk_standard_gfx1250_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx1250.attention.kda.decode import (
         gluon_kda_fused_decode_gfx1250 as _kda_fused_decode_gfx1250_impl,
@@ -1820,6 +1826,75 @@ if current_platform().is_amd:
     )
     def gluon_dsa_prefill_fp8_dense_gfx950(*args, enable_pdl: bool = False, **kwargs):
         return _dsa_prefill_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "dsa_decode_topk",
+        name="gluon_dsa_decode_topk_standard_gfx1250",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(12, 5),
+            max_arch_version=ArchVersion(12, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=frozenset(
+            {
+                format_signature(
+                    q=dense_tensor_format(q_dtype),
+                    weights=dense_tensor_format(weight_dtype),
+                )
+                for q_dtype in (torch.bfloat16, torch.float8_e4m3fn)
+                for weight_dtype in (torch.bfloat16, torch.float32)
+            }
+        ),
+        priority=Priority.SPECIALIZED + 1,
+        traits={
+            "index_heads": frozenset({32, 64}),
+            "head_dim": frozenset({128}),
+            "topk": _DSA_FULL_TOPK_WIDTHS,
+            "page_size": frozenset({64}),
+            "q_len_per_req": frozenset({1, 2, 3, 4, 5, 6}),
+            "index_k_format": frozenset({"fp8_scaled"}),
+            "index_k_layout": frozenset({"packed", "page_planar"}),
+        },
+        tags={"amd", "gfx1250"},
+    )
+    def gluon_dsa_decode_topk_standard_gfx1250(*args, **kwargs):
+        return _dsa_decode_topk_standard_gfx1250_impl(*args, **kwargs)
+
+    @register_kernel(
+        "attention",
+        "dsa_prefill_topk",
+        name="gluon_dsa_prefill_topk_standard_gfx1250",
+        solution="gluon",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(12, 5),
+            max_arch_version=ArchVersion(12, 5),
+            vendors=frozenset({"amd"}),
+        ),
+        signatures=frozenset(
+            {
+                format_signature(
+                    q=dense_tensor_format(q_dtype),
+                    weights=dense_tensor_format(weight_dtype),
+                )
+                for q_dtype in (torch.bfloat16, torch.float8_e4m3fn)
+                for weight_dtype in (torch.bfloat16, torch.float32)
+            }
+        ),
+        priority=Priority.SPECIALIZED + 1,
+        traits={
+            "index_heads": frozenset({32, 64}),
+            "head_dim": frozenset({128}),
+            "topk": _DSA_PREFILL_TOPK_WIDTHS,
+            "page_size": frozenset({64}),
+            "index_k_format": frozenset({"fp8_scaled"}),
+            "index_k_layout": frozenset({"packed", "page_planar"}),
+        },
+        tags={"amd", "gfx1250"},
+    )
+    def gluon_dsa_prefill_topk_standard_gfx1250(*args, **kwargs):
+        return _dsa_prefill_topk_standard_gfx1250_impl(*args, **kwargs)
 
     @register_kernel(
         "attention",

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py
@@ -28,8 +28,7 @@ import pytest
 import torch
 from utils import is_cdna4, is_cdna5
 
-_IS_GFX950 = is_cdna4()
-if not (_IS_GFX950 or is_cdna5()):
+if not (is_cdna4() or is_cdna5()):
     pytest.skip(
         "AMD GFX950 or GFX1250 is required for standard-cache Gluon DSA tests",
         allow_module_level=True,
@@ -39,7 +38,7 @@ from tokenspeed_kernel.ops.kvcache.triton import (  # isort: skip
     index_k_block_split_scatter,
 )
 
-if _IS_GFX950:
+if is_cdna4():
     from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.sparse_mla import (  # isort: skip
         gluon_dsa_decode_topk_standard_gfx950 as _decode_topk,
         gluon_dsa_prefill_topk_standard_gfx950 as _prefill_topk,
@@ -165,21 +164,6 @@ def _pack_standard_cache(
     fp8_pages.copy_(key_fp8.reshape(num_pages, _PAGE_SIZE, _HEAD_DIM))
     scale_pages.copy_(scales.reshape(num_pages, _PAGE_SIZE, 1))
     return packed, reference, key_fp8, scales
-
-
-def _page_planar_cache(packed: torch.Tensor) -> torch.Tensor:
-    """Copy packed page bytes into a padded page-planar allocation."""
-    page_bytes = _PAGE_SIZE * packed.shape[1]
-    num_pages = packed.shape[0] // _PAGE_SIZE
-    backing = torch.zeros(
-        (num_pages, page_bytes + 64),
-        device=packed.device,
-        dtype=packed.dtype,
-    )
-    cache = backing[:, :page_bytes]
-    cache.copy_(packed.reshape(num_pages, page_bytes))
-    assert cache.stride() == (page_bytes + 64, 1)
-    return cache
 
 
 def _weighted_relu_scores(
@@ -325,83 +309,6 @@ def test_standard_cache_decode_matches_weighted_relu_oracle(case: _DecodeCase) -
         case.q_len,
     )
 
-    _assert_topk(actual, actual_lens, expected, expected_lens)
-
-
-def test_standard_cache_page_planar_matches_oracle() -> None:
-    generator = _generator(175)
-    num_slots = 11 * _PAGE_SIZE
-    keys = (
-        torch.randn(
-            (num_slots, _HEAD_DIM),
-            device=_DEVICE,
-            dtype=torch.float32,
-            generator=generator,
-        )
-        * 0.15
-    )
-    packed, key_reference, _, _ = _pack_standard_cache(keys)
-    cache = _page_planar_cache(packed)
-    query, q_scales, query_reference = _prepared_query(
-        1,
-        64,
-        torch.float8_e4m3fn,
-        generator,
-    )
-    weights = _noncompact_weights(1, 64, torch.bfloat16, generator)
-    weights[:, :32].zero_()
-
-    seq_lens = torch.tensor((515,), device=_DEVICE, dtype=torch.int32)
-    block_table = torch.randperm(11, device=_DEVICE, generator=generator).reshape(1, 11)
-    block_table = block_table.to(torch.int32)
-    actual, actual_lens = _decode_topk(
-        query,
-        weights,
-        seq_lens,
-        block_table,
-        page_size=_PAGE_SIZE,
-        topk=_TOPK,
-        softmax_scale=_SOFTMAX_SCALE,
-        index_k_cache=cache,
-        q_scales=q_scales,
-    )
-    expected, expected_lens = _expected_decode(
-        query_reference,
-        weights,
-        key_reference,
-        seq_lens,
-        block_table,
-        1,
-    )
-    _assert_topk(actual, actual_lens, expected, expected_lens)
-
-    workspace_rows = 600
-    workspace_slots = (
-        torch.arange(workspace_rows, device=_DEVICE) * 37 + 41
-    ).remainder(num_slots)
-    workspace_slots = workspace_slots.to(torch.int64)
-    row_starts = torch.tensor((7,), device=_DEVICE, dtype=torch.int32)
-    row_ends = torch.tensor((550,), device=_DEVICE, dtype=torch.int32)
-    actual, actual_lens = _prefill_topk(
-        query,
-        weights,
-        workspace_slots,
-        row_starts,
-        row_ends,
-        topk=_TOPK,
-        softmax_scale=_SOFTMAX_SCALE,
-        index_k_cache=cache,
-        page_size=_PAGE_SIZE,
-        q_scales=q_scales,
-    )
-    expected, expected_lens = _expected_prefill(
-        query_reference,
-        weights,
-        key_reference,
-        workspace_slots,
-        row_starts,
-        row_ends,
-    )
     _assert_topk(actual, actual_lens, expected, expected_lens)
 
 
@@ -557,10 +464,7 @@ def test_standard_cache_decode_returns_empty_result_for_zero_pages() -> None:
     assert (actual_lens == 0).all()
 
 
-@pytest.mark.parametrize("use_buffer_ops", (True, False))
-def test_standard_cache_decode_logits_cover_empty_and_short_spans(
-    use_buffer_ops: bool,
-) -> None:
+def test_standard_cache_decode_logits_cover_empty_and_short_spans() -> None:
     generator = _generator(350)
     seq_lens = torch.tensor((0, 1, 63, 64, 65), device=_DEVICE, dtype=torch.int32)
     block_table = torch.tensor(
@@ -616,8 +520,8 @@ def test_standard_cache_decode_logits_cover_empty_and_short_spans(
         CHUNK_N=256,
         NUM_WARPS=2,
         Q_IS_FP8=False,
-        USE_BUFFER_LOAD=use_buffer_ops,
-        USE_BUFFER_STORE=use_buffer_ops,
+        USE_BUFFER_LOAD=True,
+        USE_BUFFER_STORE=True,
         num_warps=2,
         waves_per_eu=4,
     )

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_standard_cache.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""GFX950 integration coverage for the standard block-split DSA cache."""
+"""GFX950/GFX1250 integration coverage for the standard block-split DSA cache."""
 
 from __future__ import annotations
 
@@ -26,24 +26,35 @@ from dataclasses import dataclass
 
 import pytest
 import torch
-from utils import is_cdna4
+from utils import is_cdna4, is_cdna5
 
-if not is_cdna4():
+_IS_GFX950 = is_cdna4()
+if not (_IS_GFX950 or is_cdna5()):
     pytest.skip(
-        "AMD CDNA4 (GFX950) is required for standard-cache Gluon DSA tests",
+        "AMD GFX950 or GFX1250 is required for standard-cache Gluon DSA tests",
         allow_module_level=True,
     )
 
 from tokenspeed_kernel.ops.kvcache.triton import (  # isort: skip
     index_k_block_split_scatter,
 )
-from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.sparse_mla import (  # isort: skip
-    gluon_dsa_decode_topk_standard_gfx950,
-    gluon_dsa_prefill_topk_standard_gfx950,
-)
-from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.standard_cache_logits import (  # isort: skip
-    _dsa_standard_decode_logits_kernel,
-)
+
+if _IS_GFX950:
+    from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.sparse_mla import (  # isort: skip
+        gluon_dsa_decode_topk_standard_gfx950 as _decode_topk,
+        gluon_dsa_prefill_topk_standard_gfx950 as _prefill_topk,
+    )
+    from tokenspeed_kernel_amd.ops.gfx950.attention.dsa.standard_cache_logits import (  # isort: skip
+        _dsa_standard_decode_logits_kernel,
+    )
+else:
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.sparse_mla import (  # isort: skip
+        gluon_dsa_decode_topk_standard_gfx1250 as _decode_topk,
+        gluon_dsa_prefill_topk_standard_gfx1250 as _prefill_topk,
+    )
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.dsa.standard_cache_logits import (  # isort: skip
+        _dsa_standard_decode_logits_kernel,
+    )
 
 _DEVICE = "cuda"
 _PAGE_SIZE = 64
@@ -154,6 +165,21 @@ def _pack_standard_cache(
     fp8_pages.copy_(key_fp8.reshape(num_pages, _PAGE_SIZE, _HEAD_DIM))
     scale_pages.copy_(scales.reshape(num_pages, _PAGE_SIZE, 1))
     return packed, reference, key_fp8, scales
+
+
+def _page_planar_cache(packed: torch.Tensor) -> torch.Tensor:
+    """Copy packed page bytes into a padded page-planar allocation."""
+    page_bytes = _PAGE_SIZE * packed.shape[1]
+    num_pages = packed.shape[0] // _PAGE_SIZE
+    backing = torch.zeros(
+        (num_pages, page_bytes + 64),
+        device=packed.device,
+        dtype=packed.dtype,
+    )
+    cache = backing[:, :page_bytes]
+    cache.copy_(packed.reshape(num_pages, page_bytes))
+    assert cache.stride() == (page_bytes + 64, 1)
+    return cache
 
 
 def _weighted_relu_scores(
@@ -278,7 +304,7 @@ def test_standard_cache_decode_matches_weighted_relu_oracle(case: _DecodeCase) -
     if case.heads == 64:
         weights[:, :32].zero_()
 
-    actual, actual_lens = gluon_dsa_decode_topk_standard_gfx950(
+    actual, actual_lens = _decode_topk(
         query,
         weights,
         seq_lens,
@@ -299,6 +325,83 @@ def test_standard_cache_decode_matches_weighted_relu_oracle(case: _DecodeCase) -
         case.q_len,
     )
 
+    _assert_topk(actual, actual_lens, expected, expected_lens)
+
+
+def test_standard_cache_page_planar_matches_oracle() -> None:
+    generator = _generator(175)
+    num_slots = 11 * _PAGE_SIZE
+    keys = (
+        torch.randn(
+            (num_slots, _HEAD_DIM),
+            device=_DEVICE,
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.15
+    )
+    packed, key_reference, _, _ = _pack_standard_cache(keys)
+    cache = _page_planar_cache(packed)
+    query, q_scales, query_reference = _prepared_query(
+        1,
+        64,
+        torch.float8_e4m3fn,
+        generator,
+    )
+    weights = _noncompact_weights(1, 64, torch.bfloat16, generator)
+    weights[:, :32].zero_()
+
+    seq_lens = torch.tensor((515,), device=_DEVICE, dtype=torch.int32)
+    block_table = torch.randperm(11, device=_DEVICE, generator=generator).reshape(1, 11)
+    block_table = block_table.to(torch.int32)
+    actual, actual_lens = _decode_topk(
+        query,
+        weights,
+        seq_lens,
+        block_table,
+        page_size=_PAGE_SIZE,
+        topk=_TOPK,
+        softmax_scale=_SOFTMAX_SCALE,
+        index_k_cache=cache,
+        q_scales=q_scales,
+    )
+    expected, expected_lens = _expected_decode(
+        query_reference,
+        weights,
+        key_reference,
+        seq_lens,
+        block_table,
+        1,
+    )
+    _assert_topk(actual, actual_lens, expected, expected_lens)
+
+    workspace_rows = 600
+    workspace_slots = (
+        torch.arange(workspace_rows, device=_DEVICE) * 37 + 41
+    ).remainder(num_slots)
+    workspace_slots = workspace_slots.to(torch.int64)
+    row_starts = torch.tensor((7,), device=_DEVICE, dtype=torch.int32)
+    row_ends = torch.tensor((550,), device=_DEVICE, dtype=torch.int32)
+    actual, actual_lens = _prefill_topk(
+        query,
+        weights,
+        workspace_slots,
+        row_starts,
+        row_ends,
+        topk=_TOPK,
+        softmax_scale=_SOFTMAX_SCALE,
+        index_k_cache=cache,
+        page_size=_PAGE_SIZE,
+        q_scales=q_scales,
+    )
+    expected, expected_lens = _expected_prefill(
+        query_reference,
+        weights,
+        key_reference,
+        workspace_slots,
+        row_starts,
+        row_ends,
+    )
     _assert_topk(actual, actual_lens, expected, expected_lens)
 
 
@@ -345,7 +448,7 @@ def test_standard_cache_prefill_uses_workspace_rows_not_global_slots(
     )
     weights = _noncompact_weights(row_starts.numel(), heads, weight_dtype, generator)
 
-    actual, actual_lens = gluon_dsa_prefill_topk_standard_gfx950(
+    actual, actual_lens = _prefill_topk(
         query,
         weights,
         workspace_slots,
@@ -403,7 +506,7 @@ def test_standard_cache_decode_accepts_block_split_writer_output() -> None:
     query, _, query_reference = _prepared_query(1, 32, torch.bfloat16, generator)
     weights = _noncompact_weights(1, 32, torch.float32, generator)
 
-    actual, actual_lens = gluon_dsa_decode_topk_standard_gfx950(
+    actual, actual_lens = _decode_topk(
         query,
         weights,
         seq_lens,
@@ -435,7 +538,7 @@ def test_standard_cache_decode_returns_empty_result_for_zero_pages() -> None:
     out = torch.zeros((1, _TOPK), device=_DEVICE, dtype=torch.int32)
     lens_out = torch.full((1,), -1, device=_DEVICE, dtype=torch.int32)
 
-    actual, actual_lens = gluon_dsa_decode_topk_standard_gfx950(
+    actual, actual_lens = _decode_topk(
         query,
         weights,
         seq_lens,
@@ -454,7 +557,10 @@ def test_standard_cache_decode_returns_empty_result_for_zero_pages() -> None:
     assert (actual_lens == 0).all()
 
 
-def test_standard_cache_decode_logits_cover_empty_and_short_spans() -> None:
+@pytest.mark.parametrize("use_buffer_ops", (True, False))
+def test_standard_cache_decode_logits_cover_empty_and_short_spans(
+    use_buffer_ops: bool,
+) -> None:
     generator = _generator(350)
     seq_lens = torch.tensor((0, 1, 63, 64, 65), device=_DEVICE, dtype=torch.int32)
     block_table = torch.tensor(
@@ -510,8 +616,8 @@ def test_standard_cache_decode_logits_cover_empty_and_short_spans() -> None:
         CHUNK_N=256,
         NUM_WARPS=2,
         Q_IS_FP8=False,
-        USE_BUFFER_LOAD=True,
-        USE_BUFFER_STORE=True,
+        USE_BUFFER_LOAD=use_buffer_ops,
+        USE_BUFFER_STORE=use_buffer_ops,
         num_warps=2,
         waves_per_eu=4,
     )
@@ -557,7 +663,7 @@ def test_standard_cache_decode_cuda_graph_replays_changed_inputs(q_len: int) -> 
     lens_out = torch.empty((q_len,), device=_DEVICE, dtype=torch.int32)
 
     def invoke() -> None:
-        gluon_dsa_decode_topk_standard_gfx950(
+        _decode_topk(
             query,
             weights,
             seq_lens,

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1622,12 +1622,18 @@ def _attention_dsa_prefill_topk_bf16_weights() -> object:
 def _attention_dsa_decode_topk_standard(
     index_heads: int,
     q_dtype: torch.dtype = torch.bfloat16,
+    index_k_layout: str = "packed",
 ) -> object:
     q = torch.empty((2, index_heads, 128), dtype=q_dtype)
     q_scales = (
         torch.ones((2, index_heads), dtype=torch.float32)
         if q_dtype == torch.float8_e4m3fn
         else None
+    )
+    index_k_cache = (
+        torch.zeros((128, 132), dtype=torch.uint8)
+        if index_k_layout == "packed"
+        else torch.zeros((2, 64 * 132), dtype=torch.uint8)
     )
     return tokenspeed_kernel.dsa_decode_topk(
         q,
@@ -1637,7 +1643,7 @@ def _attention_dsa_decode_topk_standard(
         page_size=64,
         topk=512,
         softmax_scale=1.0,
-        index_k_cache=torch.zeros((128, 132), dtype=torch.uint8),
+        index_k_cache=index_k_cache,
         q_scales=q_scales,
     )
 
@@ -1645,12 +1651,18 @@ def _attention_dsa_decode_topk_standard(
 def _attention_dsa_prefill_topk_standard(
     index_heads: int,
     q_dtype: torch.dtype = torch.bfloat16,
+    index_k_layout: str = "packed",
 ) -> object:
     q = torch.empty((2, index_heads, 128), dtype=q_dtype)
     q_scales = (
         torch.ones((2, index_heads), dtype=torch.float32)
         if q_dtype == torch.float8_e4m3fn
         else None
+    )
+    index_k_cache = (
+        torch.zeros((128, 132), dtype=torch.uint8)
+        if index_k_layout == "packed"
+        else torch.zeros((2, 64 * 132), dtype=torch.uint8)
     )
     return tokenspeed_kernel.dsa_prefill_topk(
         q,
@@ -1660,7 +1672,7 @@ def _attention_dsa_prefill_topk_standard(
         torch.tensor([8, 16], dtype=torch.int32),
         topk=512,
         softmax_scale=1.0,
-        index_k_cache=torch.zeros((128, 132), dtype=torch.uint8),
+        index_k_cache=index_k_cache,
         page_size=64,
         q_scales=q_scales,
     )
@@ -3520,8 +3532,10 @@ _CASES = [
             "attention",
             operation,
             expected,
-            lambda heads=heads, dtype=dtype, invoke=invoke: invoke(heads, dtype),
-            id_suffix=f"h{heads}-{str(dtype).removeprefix('torch.')}",
+            lambda heads=heads, dtype=dtype, layout=layout, invoke=invoke: invoke(
+                heads, dtype, layout
+            ),
+            id_suffix=(f"h{heads}-{str(dtype).removeprefix('torch.')}-{layout}"),
         )
         for operation, expected, invoke in (
             (
@@ -3537,6 +3551,7 @@ _CASES = [
         )
         for heads in (32, 64)
         for dtype in (torch.bfloat16, torch.float8_e4m3fn)
+        for layout in ("packed", "page_planar")
     ),
     _case(
         _is_cdna4,
@@ -3649,6 +3664,34 @@ _CASES = [
         "dsa_prefill_fp8_packed_rank512",
         "triton_dsa_prefill",
         _attention_dsa_prefill_fp8_packed_rank512,
+    ),
+    *(
+        _case(
+            _is_cdna5,
+            "cdna5",
+            "attention",
+            operation,
+            expected,
+            lambda heads=heads, dtype=dtype, layout=layout, invoke=invoke: invoke(
+                heads, dtype, layout
+            ),
+            id_suffix=(f"h{heads}-{str(dtype).removeprefix('torch.')}-{layout}"),
+        )
+        for operation, expected, invoke in (
+            (
+                "dsa_decode_topk",
+                "gluon_dsa_decode_topk_standard_gfx1250",
+                _attention_dsa_decode_topk_standard,
+            ),
+            (
+                "dsa_prefill_topk",
+                "gluon_dsa_prefill_topk_standard_gfx1250",
+                _attention_dsa_prefill_topk_standard,
+            ),
+        )
+        for heads in (32, 64)
+        for dtype in (torch.bfloat16, torch.float8_e4m3fn)
+        for layout in ("packed", "page_planar")
     ),
     _case(
         _is_cdna5,


### PR DESCRIPTION
## Summary
- Port the corrected standard-cache DSA scorer introduced for GFX950 in [#1196](https://github.com/lightseekorg/tokenspeed/pull/1196) to GFX1250 Wave32 WMMA.
- Preserve per-head ReLU semantics while restoring scorer performance.
- Match GFX950 support for 32/64 index heads, BF16/scaled-FP8 queries, BF16/FP32 weights, and packed/page-planar caches.
- Retune GFX1250 radix top-k and selected-attention launch geometry.

## Performance
- **DSA-D1**: Decode top-k plus selected attention. B1, context 4,096, q_len 1, 32 index heads, index dimension 128, 8 attention heads, top-k 2,048, rank 512, and RoPE dimension 64.
- **DSA-P1**: Pure prefill top-k plus selected attention. B1, prefix 0, extend 4,096, 32 index heads, index dimension 128, 8 attention heads, causal top-k up to 2,048, rank 512, and RoPE dimension 64.
Both use BF16 index queries, packed FP8 index-K cache, and FP8 attention Q/KV.

| Workload | Before (µs) | After (µs) | Change |
| --- | ---: | ---: | ---: |
| DSA-D1 | 35.534 | 24.196 | -31.9% |
| DSA-P1 | 5,925.391 | 894.020 | -84.9% |