### PR TITLE
perf(amd): hardcode the gfx1250 prefill occupancy cutoff

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
@@ -27,7 +27,6 @@ optional sliding window, optional sinks, and optional natural-log LSE output.
 
 from __future__ import annotations
 
-import functools
 import math
 from typing import NamedTuple
 
@@ -43,6 +42,8 @@ from tokenspeed_kernel_amd.ops.gfx1250.attention._common import (
 )
 
 gfx1250 = gl.amd.gfx1250
+
+_GFX1250_NUM_CUS = 256
 
 
 @gluon.aggregate
@@ -703,15 +704,8 @@ class LaunchConfig(NamedTuple):
     grid: tuple[int, ...]
 
 
-@functools.lru_cache(maxsize=None)
-def _num_cus(device_index: int) -> int:
-    """Cached: querying it per launch costs ~2us, which is over 10% of a short
-    prefill, and a device's CU count cannot change within a process."""
-    return torch.cuda.get_device_properties(device_index).multi_processor_count
-
-
 def _select_m_tile(
-    *, batch_size: int, n_heads: int, max_seqlen: int, num_cus: int
+    *, batch_size: int, n_heads: int, max_seqlen: int
 ) -> tuple[int, int]:
     """Pick (BLOCK_M, num_warps) for prefill, measured on gfx1250.
 
@@ -728,17 +722,13 @@ def _select_m_tile(
         sequences pay a larger fraction of it.
 
     Below either bound the narrow tile wins by up to 1.2x, so keep it there.
-
-    num_cus comes from the running device rather than a constant, so a compute
-    partition exposing a fraction of the CUs compares its grid against the CUs
-    it actually has. The measured thresholds below come from a full 256-CU part.
     """
     wide_m, wide_warps = 256, 8
     narrow_m, narrow_warps = 128, 4
     if max_seqlen < 1024:
         return narrow_m, narrow_warps
     workgroups = batch_size * n_heads * triton_cdiv(max_seqlen, wide_m)
-    if workgroups < num_cus:
+    if workgroups < _GFX1250_NUM_CUS:
         return narrow_m, narrow_warps
     return wide_m, wide_warps
 
@@ -760,14 +750,7 @@ def get_config(
     num_buffers = 2
     waves_per_eu = 1
     block_m, num_warps = _select_m_tile(
-        batch_size=batch_size,
-        n_heads=n_heads,
-        max_seqlen=max_seqlen,
-        num_cus=_num_cus(
-            q.device.index
-            if q.device.index is not None
-            else torch.cuda.current_device()
-        ),
+        batch_size=batch_size, n_heads=n_heads, max_seqlen=max_seqlen
     )
     if softmax_scale is None:
         softmax_scale = 1.0 / math.sqrt(head_dim)

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
@@ -122,29 +122,21 @@ def test_mha_prefill_tile_shapes(block_m, num_warps, head_dim, window_left):
     torch.testing.assert_close(out.float(), expected, rtol=8e-2, atol=8e-2)
 
 
-def test_select_m_tile_scales_with_device_cus():
-    """The wide tile needs both a long sequence and a grid that fills the device,
-    so the cutoff has to follow the CU count actually reported."""
+def test_select_m_tile_gates():
+    """Both gates on the wide tile are load-bearing.
+
+    Measured on gfx1250, taking the 256-row tile when either gate fails costs up
+    to 1.2x, so pin the behaviour at each boundary.
+    """
     wide = (256, 8)
     narrow = (128, 4)
 
-    # Short sequences pay too much of the causally-masked diagonal block.
-    assert (
-        prefill._select_m_tile(batch_size=8, n_heads=32, max_seqlen=512, num_cus=256)
-        == narrow
-    )
+    # Sequence too short: the causally-masked half of the diagonal block is a
+    # large fraction of the work, even though this grid fills the device.
+    assert prefill._select_m_tile(batch_size=8, n_heads=32, max_seqlen=512) == narrow
 
-    # 128 workgroups underfills 256 CUs but fills a 128-CU partition.
-    assert (
-        prefill._select_m_tile(batch_size=1, n_heads=8, max_seqlen=4096, num_cus=256)
-        == narrow
-    )
-    assert (
-        prefill._select_m_tile(batch_size=1, n_heads=8, max_seqlen=4096, num_cus=128)
-        == wide
-    )
+    # Long enough, but 128 workgroups underfills the 256 CUs.
+    assert prefill._select_m_tile(batch_size=1, n_heads=8, max_seqlen=4096) == narrow
 
-    assert (
-        prefill._select_m_tile(batch_size=4, n_heads=32, max_seqlen=4096, num_cus=256)
-        == wide
-    )
+    # Both satisfied.
+    assert prefill._select_m_tile(batch_size=4, n_heads=32, max_seqlen=4096) == wide


### PR DESCRIPTION
## Summary

Follows up review feedback on #1337, which merged before the change could be applied.

`_select_m_tile()` currently reads the CU count from the device so a compute partition would compare its grid against the CUs it actually has. gfx1250 has a fixed CU count of 256, so that case cannot arise and the query buys nothing. Comparing against a module constant instead drops a per-launch device query, an `lru_cache` wrapper and the `functools` import, and matches how `kda/decode.py` states the same constant.

Behaviour is unchanged: the query returned 256 on this architecture, so every tile decision is identical.

The selector test moves with it, pinning the two gates that remain load-bearing sequence length and grid fill rather than a CU scaling that cannot occur.

## Test Plan

No functional change to verify: the removed query returned the constant this replaces it with, so tile selection is identical for every input.

Checked that nothing else references `_num_cus`, that `functools` is no longer used in the file, and that `pre-commit run --all-files` is clean.

The kernel tests added in #1337 cover both tile shapes and both selector gates, and are unaffected apart from the selector test dropping its `num_cus` argument. They were last run green on gfx1250 hardware; this change does not touch the kernel or the launch path beyond the constant.
