### PR TITLE
docs: document --device cuda|npu (drop CUDA-only claim)

### DIFF
--- a/docs/configuration/compatible-parameters.md
+++ b/docs/configuration/compatible-parameters.md
@@ -20,7 +20,7 @@ TokenSpeed-specific behavior explicitly.
 | `--quantization` | Weight quantization method. |
 | `--quantization-param-path` | KV cache scaling-factor file. |
 | `--max-model-len` | Maximum sequence length. |
-| `--device` | Device type. TokenSpeed currently serves CUDA. |
+| `--device` | Device type: `cuda` (default) or `npu`. |
 | `--served-model-name` | OpenAI-compatible served model name. |
 | `--revision` | Model revision. |
 | `--download-dir` | Model download directory. |

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -21,6 +21,7 @@ For a compact compatibility table, see
 | `--revision` | Model branch, tag, or commit. |
 | `--download-dir` | Hugging Face download/cache directory. |
 | `--hf-overrides` | JSON overrides for model configuration values. |
+| `--device` | Device type: `cuda` (default) or `npu`. |
 
 ## Precision And Quantization
 


### PR DESCRIPTION
## Summary

`docs/configuration/compatible-parameters.md` stated that TokenSpeed currently serves CUDA only. `ServerArgs` accepts `--device {cuda,npu}` (default `cuda`), and `docs/recipes/models.md` already documents Ascend NPU launches. Update the compatible-parameters row and list `--device` in the server parameter tables so they match the CLI.

## Test plan

- [x] Confirmed on HEAD `069354e0cea4`: `choices=["cuda", "npu"]` for `--device` in `python/tokenspeed/runtime/utils/server_args.py`
- [x] Confirmed NPU recipe exists in `docs/recipes/models.md` (`--device npu`)
- [x] Diff limited to the two configuration docs; no `--prefix-granularity` / `--block-size` changes