### PR TITLE
docs: document --disable-kvstore in server parameter tables

### DIFF
--- a/docs/configuration/compatible-parameters.md
+++ b/docs/configuration/compatible-parameters.md
@@ -34,6 +34,7 @@ TokenSpeed-specific behavior explicitly.
 | `--block-size` | KV cache block size. |
 | `--enable-prefix-caching` | Enable prefix cache reuse. |
 | `--no-enable-prefix-caching` | Disable prefix cache reuse. |
+| `--disable-kvstore` | Disable host KVStore (enabled by default). |
 | `--enforce-eager` | Disable device-graph execution (CUDA Graph on CUDA, ACL Graph on NPU). |
 | `--max-cudagraph-capture-size` | Largest decode device-graph capture size. |
 | `--tensor-parallel-size`, `--tp` | Set attention tensor parallel size. |
@@ -62,4 +63,4 @@ TokenSpeed-specific behavior explicitly.
 - Pass the model path positionally, then keep `--trust-remote-code`, `--max-model-len`, `--kv-cache-dtype`, `--gpu-memory-utilization`, `--max-num-seqs`, `--tensor-parallel-size`, `--reasoning-parser`, and `--tool-call-parser` when the model needs them.
 - Review `--max-num-batched-tokens` before copying it. TokenSpeed usually wants `--chunked-prefill-size` for per-iteration scheduling.
 - Review backend names. TokenSpeed backends are optimized for its runtime and kernel packages.
-- Keep TokenSpeed-specific `--attn-tp-size`, `--moe-tp-size`, `--disaggregation-*`, and `--kvstore-*` only when the deployment needs those features.
+- Keep TokenSpeed-specific `--attn-tp-size`, `--moe-tp-size`, `--disaggregation-*`, and `--kvstore-*` / `--disable-kvstore` only when the deployment needs those features.

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -105,6 +105,7 @@ distributed update mode until that implementation is added.
 | `--max-total-tokens` | Override the automatically calculated token pool size. |
 | `--block-size` | KV cache block size. |
 | `--enable-prefix-caching` / `--no-enable-prefix-caching` | Enable or disable prefix cache reuse. |
+| `--disable-kvstore` | Disable host KVStore. KVStore is enabled by default; several model recipes and same-checkpoint DSPARK require this flag. |
 | `--enforce-eager` | Disable device-graph execution (CUDA Graph on CUDA, ACL Graph on NPU). |
 | `--disable-prefill-graph` | Keep prefill eager while leaving decode device graphs enabled. |
 | `--max-cudagraph-capture-size` | Largest decode batch size to capture as a device graph. |
@@ -286,7 +287,7 @@ features directly:
 - `--attn-tp-size`
 - `--dense-tp-size`
 - `--moe-tp-size`
-- `--kvstore-*`
+- `--disable-kvstore` and `--kvstore-*`
 - `--kv-events-config`
 - `--mla-chunk-multiplier`
 - `--disaggregation-*`


### PR DESCRIPTION
## Summary

`--disable-kvstore` is a real `tokenspeed serve` flag (`server_args.py`) and is already required by several recipes in `docs/recipes/models.md` (and by same-checkpoint DSPARK). The configuration docs only listed the `--kvstore-*` family and never named `--disable-kvstore`, so operators could not discover the opt-out from the parameter tables.

## Changes

- `docs/configuration/server.md`: add `--disable-kvstore` to the Scheduler And Memory table; list it next to `--kvstore-*` under TokenSpeed-specific knobs.
- `docs/configuration/compatible-parameters.md`: add the same flag to the Directly Aligned table and mention it in the recipe translation notes.

## Reproduce

```bash
# Flag is registered
rg -n 'disable-kvstore|disable_kvstore' python/tokenspeed/runtime/utils/server_args.py

# Recipes already use it
rg -n -- '--disable-kvstore' docs/recipes/models.md

# Parameter tables previously omitted the flag name (before this PR)
rg -n -- '--disable-kvstore' docs/configuration/server.md docs/configuration/compatible-parameters.md
```

On `main` the third command is empty for the named flag (only `--kvstore-*` appears). After this PR both tables document `--disable-kvstore`.