### PR TITLE
perf(pd): pack dest-contiguous CachePD fragments before Mooncake WRITE

### DIFF
--- a/docs/design/event-loop.md
+++ b/docs/design/event-loop.md
@@ -239,7 +239,9 @@ SMG startup handshake lives in `zmq_msgpack.connect_msgpack_engine_for_loop`
 `multimodal/inputs.py::multimodal_context_for_forward` (which also snapshots
 each request's multimodal inputs, per Principle 1's capture contract), and
 P-side layerwise KV streaming setup, which happens inside the device builder
-(the step counter is backend surgery; the sender just receives it).
+(the step counter is backend surgery; the sender just receives it). Dest-
+contiguous CachePD fragments are 2D-packed in the Prefill transfer path
+before Mooncake WRITE — that CUDA copy is data-plane work, not loop work.
 
 All hooks obey Principle 3: they return events or decisions; they never call
 `advance_scheduler`.

--- a/python/tokenspeed/runtime/execution/device.py
+++ b/python/tokenspeed/runtime/execution/device.py
@@ -978,7 +978,7 @@ def _build_kv_transfer(
         ),
         kv_args=get_kv_args(
             global_rank,
-            global_rank,
+            gpu_id,  # local CUDA index; new threads do not inherit current_device
             server_args.disaggregation_ib_device,
             executor.token_to_kv_pool,
             model_config=model_config,

--- a/python/tokenspeed/runtime/pd/base/mooncake_engine.py
+++ b/python/tokenspeed/runtime/pd/base/mooncake_engine.py
@@ -46,6 +46,12 @@ class MooncakeTransferEngine:
         self.session_id = f"{self.hostname}:{self.engine.get_rpc_port()}"
 
     def register(self, ptr, length):
+        """Register ``ptr`` with Mooncake.
+
+        Returns:
+            0 on success, nonzero on failure. KV-arena registration may ignore
+            the result; pack scratch must check it before swapping buffers.
+        """
         try:
             ret_value = self.engine.register_memory(ptr, length)
         except Exception:
@@ -54,6 +60,7 @@ class MooncakeTransferEngine:
 
         if ret_value != 0:
             logger.debug("Mooncake memory registration %s failed.", ptr)
+        return ret_value
 
     def deregister(self, ptr):
         try:

--- a/python/tokenspeed/runtime/pd/mooncake/pack.py
+++ b/python/tokenspeed/runtime/pd/mooncake/pack.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Pack strided Prefill KV rows into contiguous SGEs before Mooncake WRITE.
+
+Heterogeneous TP partitions heads, so a page is ``rows_per_page`` rows of
+``bytes_per_row`` with a larger source pitch. Decode's local layout is often
+already contiguous (``dst_stride == bytes_per_row``). Expanding each row into
+its own 1KB SGE dominates RDMA submit time; a device-side 2D copy plus one
+SGE matches equal-TP descriptor counts.
+
+Destination-strided fragments still expand to per-row SGEs: a contiguous
+WRITE would land on the wrong Decode layout without a remote unpack.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+_PACK_ALIGN = 256
+
+Sge = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class PackedCopy:
+    """One dest-contiguous, src-strided page fragment to pack before WRITE."""
+
+    src: int
+    dst: int
+    width: int
+    src_pitch: int
+    rows: int
+
+    def __post_init__(self) -> None:
+        if self.width <= 0 or self.src_pitch < self.width or self.rows <= 0:
+            raise ValueError(
+                f"invalid PackedCopy width={self.width} src_pitch={self.src_pitch} "
+                f"rows={self.rows}"
+            )
+
+    @property
+    def nbytes(self) -> int:
+        return self.width * self.rows
+
+
+def expand_packed_copy(copy: PackedCopy) -> list[Sge]:
+    """Row-wise SGEs used when 2D pack is unavailable. Dest is contiguous."""
+    return [
+        (
+            copy.src + row * copy.src_pitch,
+            copy.dst + row * copy.width,
+            copy.width,
+        )
+        for row in range(copy.rows)
+    ]
+
+
+def flatten_transfer_blocks(blocks: Iterable[object]) -> Iterator[Sge]:
+    """Yield row SGEs for PackedCopy entries; pass 3-tuples through.
+
+    Expansion is lazy so the WRITE path can flush every 4096 descriptors
+    even when a packed page becomes many rows.
+    """
+    for block in blocks:
+        if isinstance(block, PackedCopy):
+            yield from expand_packed_copy(block)
+            continue
+        src, dst, length = block
+        yield (int(src), int(dst), int(length))
+
+
+def _aligned(nbytes: int) -> int:
+    return (nbytes + _PACK_ALIGN - 1) & ~(_PACK_ALIGN - 1)
+
+
+def scratch_device(gpu_id: int | None):
+    """CUDA device for pack staging. Index-less ``"cuda"`` is device 0 on new threads."""
+    import torch
+
+    if gpu_id is None:
+        return torch.device("cuda")
+    return torch.device("cuda", int(gpu_id))
+
+
+class PrefillPackScratch:
+    """Reusable registered CUDA buffer for dest-contiguous 2D packs."""
+
+    def __init__(self, engine, gpu_id: int | None = None) -> None:
+        self.engine = engine
+        self._gpu_id = None if gpu_id is None else int(gpu_id)
+        self._tensor = None
+        self._nbytes = 0
+        self._ptr = 0
+        self._stream = None
+
+    def materialize(self, blocks: Iterable[object]) -> Iterable[Sge]:
+        items = list(blocks)
+        if not any(isinstance(item, PackedCopy) for item in items):
+            return flatten_transfer_blocks(items)
+        try:
+            return self._pack_cuda(items)
+        except Exception:
+            logger.exception("CachePD 2D pack failed; falling back to per-row SGEs")
+            return flatten_transfer_blocks(items)
+
+    def _pack_cuda(self, items: list[object]) -> Iterable[Sge]:
+        import torch
+        from tokenspeed_kernel.platform import current_platform
+
+        if not torch.cuda.is_available() or not current_platform().is_nvidia:
+            return flatten_transfer_blocks(items)
+
+        from tokenspeed_kernel.ops.copy.cuda import memcpy_2d_async
+
+        packed_bytes = 0
+        for item in items:
+            if isinstance(item, PackedCopy):
+                packed_bytes += _aligned(item.nbytes)
+        self._ensure(packed_bytes)
+
+        stream = self._stream
+        assert stream is not None
+        sges: list[Sge] = []
+        offset = 0
+        for item in items:
+            if not isinstance(item, PackedCopy):
+                src, dst, length = item
+                sges.append((int(src), int(dst), int(length)))
+                continue
+            scratch = self._ptr + offset
+            memcpy_2d_async(
+                dst=scratch,
+                dst_pitch=item.width,
+                src=item.src,
+                src_pitch=item.src_pitch,
+                width=item.width,
+                height=item.rows,
+                stream_ptr=int(stream.cuda_stream),
+            )
+            sges.append((scratch, item.dst, item.nbytes))
+            offset += _aligned(item.nbytes)
+        stream.synchronize()
+        return sges
+
+    def _ensure(self, nbytes: int) -> None:
+        import torch
+
+        if nbytes <= self._nbytes and self._tensor is not None:
+            return
+        alloc = max(nbytes, 1)
+        device = scratch_device(self._gpu_id)
+        tensor = torch.empty(alloc, dtype=torch.uint8, device=device)
+        ptr = int(tensor.data_ptr())
+        ret = self.engine.register(ptr, alloc)
+        if ret:
+            raise RuntimeError(
+                f"Mooncake scratch registration failed: ptr={ptr} nbytes={alloc} "
+                f"ret={ret}"
+            )
+        old_ptr = self._ptr
+        self._tensor = tensor
+        self._ptr = ptr
+        self._nbytes = alloc
+        if self._stream is None:
+            self._stream = torch.cuda.Stream(device=device)
+        if old_ptr:
+            self.engine.deregister(old_ptr)

--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -47,6 +47,11 @@ from tokenspeed.runtime.pd.mooncake.entities import (
     TransferInfo,
     TransferKVChunk,
 )
+from tokenspeed.runtime.pd.mooncake.pack import (
+    PackedCopy,
+    PrefillPackScratch,
+    flatten_transfer_blocks,
+)
 from tokenspeed.runtime.pd.transfer_plan import (
     CacheTransferFragment,
     CacheTransferPlanner,
@@ -340,10 +345,34 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 "Cache-transfer room destination ranks disagree with the typed route plan"
             )
 
-    def _transfer_data(self, mooncake_session_id, transfer_blocks):
-        block_iter = iter(transfer_blocks)
+    def _transfer_data(self, mooncake_session_id, transfer_blocks, packer=None):
+        """WRITE descriptors in bounded batches, packing PackedCopy items per batch."""
+        pending: list[object] = []
+        for item in transfer_blocks:
+            pending.append(item)
+            if len(pending) >= _TRANSFER_DESCRIPTOR_BATCH_SIZE:
+                ret = self._write_sge_batch(mooncake_session_id, pending, packer)
+                pending = []
+                if ret != 0:
+                    return ret
+        if pending:
+            return self._write_sge_batch(mooncake_session_id, pending, packer)
+        return 0
+
+    def _write_sge_batch(self, mooncake_session_id, pending, packer) -> int:
+        if packer is not None:
+            sges = packer.materialize(pending)
+        else:
+            sges = flatten_transfer_blocks(pending)
+        started = time.monotonic()
+        n_sge = 0
+        n_bytes = 0
+        ret = 0
+        block_iter = iter(sges)
         while batch := tuple(islice(block_iter, _TRANSFER_DESCRIPTOR_BATCH_SIZE)):
             src_addrs, dst_addrs, lengths = zip(*batch, strict=True)
+            n_sge += len(batch)
+            n_bytes += sum(lengths)
             ret = self.engine.batch_transfer_sync(
                 mooncake_session_id,
                 list(src_addrs),
@@ -351,8 +380,15 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 list(lengths),
             )
             if ret != 0:
-                return ret
-        return 0
+                break
+        logger.info(
+            "CachePD WRITE n_sge=%d bytes=%d wait_ms=%.1f ret=%s",
+            n_sge,
+            n_bytes,
+            (time.monotonic() - started) * 1e3,
+            ret,
+        )
+        return ret
 
     def _cache_transfer_blocks(
         self,
@@ -364,7 +400,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         dst_cache_layout: CacheTransferContract,
         block_selection: CachePDLayerwiseBlockSelection | None = None,
         field_ids: frozenset[str] | None = None,
-    ) -> Iterator[tuple[int, int, int]]:
+    ) -> Iterator[PackedCopy | tuple[int, int, int]]:
         layout = self.kv_args.cache_layout
 
         cache_fragments = tuple(transfer_fragments)
@@ -439,11 +475,27 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                             + int(dst_page) * dst_segment.page_stride_bytes
                             + fragment.dst_byte_offset
                         )
-                        for row in range(fragment.rows_per_page):
+                        width = fragment.bytes_per_row
+                        rows = fragment.rows_per_page
+                        src_pitch = fragment.src_row_stride_bytes
+                        dst_pitch = fragment.dst_row_stride_bytes
+                        if rows > 1 and dst_pitch == width:
+                            if src_pitch == width:
+                                yield (src_page_addr, dst_page_addr, width * rows)
+                                continue
+                            yield PackedCopy(
+                                src=src_page_addr,
+                                dst=dst_page_addr,
+                                width=width,
+                                src_pitch=src_pitch,
+                                rows=rows,
+                            )
+                            continue
+                        for row in range(rows):
                             yield (
-                                src_page_addr + row * fragment.src_row_stride_bytes,
-                                dst_page_addr + row * fragment.dst_row_stride_bytes,
-                                fragment.bytes_per_row,
+                                src_page_addr + row * src_pitch,
+                                dst_page_addr + row * dst_pitch,
+                                width,
                             )
                 continue
 
@@ -512,9 +564,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             time.sleep(1e-4)
 
     @staticmethod
-    def _prime_transfer_blocks(
-        transfer_blocks: Iterator[tuple[int, int, int]],
-    ) -> Iterator[tuple[int, int, int]]:
+    def _prime_transfer_blocks(transfer_blocks) -> Iterator:
         """Start a lazy descriptor before any destination begins DMA."""
         iterator = iter(transfer_blocks)
         try:
@@ -527,6 +577,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         self,
         kv_chunk: TransferKVChunk,
         reqs: tuple[TransferInfo, ...],
+        packer=None,
     ) -> bool:
         """Wait one producer interval, then fan it out to every Decode peer."""
         block_selection = kv_chunk.cache_block_selection
@@ -594,7 +645,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 )
 
             for req, registration, blocks, started_at in prepared:
-                ret = self._transfer_data(req.mooncake_session_id, blocks)
+                ret = self._transfer_data(req.mooncake_session_id, blocks, packer)
                 if self.kv_transfer_metrics:
                     self.kv_transfer_metrics.observe_kv_transfer_latency(
                         time.monotonic() - started_at
@@ -734,6 +785,13 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         queue: FastQueue,
         _executor: concurrent.futures.ThreadPoolExecutor,
     ):
+        packer = None
+        engine = getattr(self, "engine", None)
+        if engine is not None and hasattr(engine, "register"):
+            gpu_id = getattr(getattr(self, "kv_args", None), "gpu_id", None)
+            packer = PrefillPackScratch(
+                engine, gpu_id=None if gpu_id is None else int(gpu_id)
+            )
         while True:
             kv_chunk = queue.get()
             try:
@@ -747,7 +805,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     continue
 
                 if kv_chunk.cache_block_selection is not None:
-                    self._send_cache_layerwise_fanout(kv_chunk, reqs)
+                    self._send_cache_layerwise_fanout(kv_chunk, reqs, packer=packer)
                     if kv_chunk.room not in self.request_status or self.check_status(
                         kv_chunk.room
                     ) in (TransferPoll.Success, TransferPoll.Failed):
@@ -784,7 +842,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                     )
 
                 for req, registration, blocks, started_at in prepared:
-                    ret = self._transfer_data(req.mooncake_session_id, blocks)
+                    ret = self._transfer_data(req.mooncake_session_id, blocks, packer)
                     if ret != 0:
                         with self.session_lock:
                             self.session_failures[req.mooncake_session_id] += 1

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -207,6 +207,7 @@ def _transfer_cache(
     src_block_manifest: CachePDBlockManifest,
     dst_block_manifest: CachePDBlockManifest,
     dst_cache_layout,
+    packer=None,
 ) -> int:
     return manager._transfer_data(
         session,
@@ -217,6 +218,7 @@ def _transfer_cache(
             transfer_fragments=transfer_fragments,
             dst_cache_layout=dst_cache_layout,
         ),
+        packer,
     )
 
 
@@ -708,6 +710,277 @@ def test_shared_manager_executes_strided_cache_tp_fragment() -> None:
     ]
 
 
+class _FakePackScratch:
+    def __init__(self, base: int = 0xB000) -> None:
+        self.base = base
+
+    def materialize(self, blocks):
+        from tokenspeed.runtime.pd.mooncake.pack import PackedCopy
+
+        sges = []
+        offset = 0
+        for block in blocks:
+            if isinstance(block, PackedCopy):
+                sges.append((self.base + offset, block.dst, block.nbytes))
+                offset += block.nbytes
+            else:
+                src, dst, length = block
+                sges.append((int(src), int(dst), int(length)))
+        return sges
+
+
+def test_dest_contiguous_strided_src_packs_into_one_sge() -> None:
+    source_segment = make_segment(
+        "layer.0.k",
+        dtype="bfloat16",
+        shape=(2, 2, 2),
+        stride=32,
+        axis=1,
+        extent=4,
+    )
+    destination_segment = make_segment(
+        "layer.0.k",
+        dtype="bfloat16",
+        shape=(2, 1, 2),
+        stride=16,
+        axis=1,
+        extent=4,
+    )
+
+    def one_field_layout(field):
+        return make_layout(make_group("history", field), capacity=5, page_bytes=64)
+
+    source_layout = one_field_layout(source_segment)
+    destination_layout = one_field_layout(destination_segment)
+    source_manifest = _single_group_block_manifest("history", (1,))
+    destination_manifest = _single_group_block_manifest("history", (2,))
+    fragment = CacheTransferFragment(
+        group_id="history",
+        field_id="layer.0.k",
+        src_byte_offset=0,
+        dst_byte_offset=0,
+        src_row_stride_bytes=16,
+        dst_row_stride_bytes=8,
+        bytes_per_row=8,
+        rows_per_page=2,
+    )
+    manager, calls = _recording_transfer_manager(source_layout, 0x1000)
+
+    assert (
+        _transfer_cache(
+            manager,
+            "session",
+            0x2000,
+            (fragment,),
+            src_block_manifest=source_manifest,
+            dst_block_manifest=destination_manifest,
+            dst_cache_layout=destination_layout,
+            packer=_FakePackScratch(),
+        )
+        == 0
+    )
+    assert len(calls) == 1
+    session, src, dst, lengths = calls[0]
+    assert session == "session"
+    assert lengths == [16]
+    assert src == [0xB000]
+    assert len(dst) == 1
+
+
+def test_flatten_packed_copy_emits_contiguous_dest_rows() -> None:
+    from tokenspeed.runtime.pd.mooncake.pack import PackedCopy, flatten_transfer_blocks
+
+    copy = PackedCopy(src=0x10, dst=0x20, width=8, src_pitch=16, rows=2)
+    flattened = flatten_transfer_blocks([copy, (1, 2, 3)])
+    assert not isinstance(flattened, list)
+    assert list(flattened) == [
+        (0x10, 0x20, 8),
+        (0x20, 0x28, 8),
+        (1, 2, 3),
+    ]
+
+
+def test_pack_scratch_device_uses_explicit_gpu_index() -> None:
+    import torch
+
+    from tokenspeed.runtime.pd.mooncake.pack import PrefillPackScratch, scratch_device
+
+    assert scratch_device(3) == torch.device("cuda", 3)
+    assert scratch_device(None).type == "cuda"
+    engine = SimpleNamespace(
+        register=lambda *_a, **_k: None, deregister=lambda *_a: None
+    )
+    assert PrefillPackScratch(engine, gpu_id=3)._gpu_id == 3
+
+
+def test_pack_scratch_keeps_old_buffer_when_growth_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch
+
+    from tokenspeed.runtime.pd.mooncake.pack import PrefillPackScratch
+
+    events: list[tuple] = []
+
+    def register(ptr, nbytes):
+        events.append(("register", int(ptr), int(nbytes)))
+
+    def deregister(ptr):
+        events.append(("deregister", int(ptr)))
+
+    class _Tensor:
+        def __init__(self, ptr: int) -> None:
+            self._ptr = ptr
+
+        def data_ptr(self) -> int:
+            return self._ptr
+
+    scratch = PrefillPackScratch(
+        SimpleNamespace(register=register, deregister=deregister), gpu_id=0
+    )
+    monkeypatch.setattr(
+        torch.cuda, "Stream", lambda device=None: SimpleNamespace(cuda_stream=1)
+    )
+
+    def fake_empty(nbytes, dtype=None, device=None):
+        if nbytes > 64:
+            raise RuntimeError("OOM")
+        return _Tensor(0x1000)
+
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    scratch._ensure(64)
+    with pytest.raises(RuntimeError, match="OOM"):
+        scratch._ensure(256)
+    assert scratch._ptr == 0x1000
+    assert scratch._nbytes == 64
+    assert events == [("register", 0x1000, 64)]
+
+
+def test_pack_cuda_skips_non_nvidia(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tokenspeed.runtime.pd.mooncake.pack import PackedCopy, PrefillPackScratch
+
+    monkeypatch.setattr(
+        "tokenspeed_kernel.platform.current_platform",
+        lambda: SimpleNamespace(is_nvidia=False),
+    )
+    copy = PackedCopy(src=0x10, dst=0x20, width=8, src_pitch=16, rows=2)
+    engine = SimpleNamespace(
+        register=lambda *_a, **_k: None, deregister=lambda *_a: None
+    )
+    assert list(PrefillPackScratch(engine).materialize([copy])) == [
+        (0x10, 0x20, 8),
+        (0x20, 0x28, 8),
+    ]
+
+
+def test_pack_scratch_keeps_old_buffer_when_register_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch
+
+    from tokenspeed.runtime.pd.mooncake.pack import PrefillPackScratch
+
+    events: list[tuple] = []
+
+    def register(ptr, nbytes):
+        events.append(("register", int(ptr), int(nbytes)))
+        return 0 if nbytes <= 64 else -1
+
+    def deregister(ptr):
+        events.append(("deregister", int(ptr)))
+
+    class _Tensor:
+        def __init__(self, ptr: int) -> None:
+            self._ptr = ptr
+
+        def data_ptr(self) -> int:
+            return self._ptr
+
+    scratch = PrefillPackScratch(
+        SimpleNamespace(register=register, deregister=deregister), gpu_id=0
+    )
+    monkeypatch.setattr(
+        torch.cuda, "Stream", lambda device=None: SimpleNamespace(cuda_stream=1)
+    )
+
+    def fake_empty(nbytes, dtype=None, device=None):
+        return _Tensor(0x1000 if nbytes <= 64 else 0x2000)
+
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    scratch._ensure(64)
+    with pytest.raises(RuntimeError, match="registration failed"):
+        scratch._ensure(256)
+    assert scratch._ptr == 0x1000
+    assert scratch._nbytes == 64
+    assert events == [
+        ("register", 0x1000, 64),
+        ("register", 0x2000, 256),
+    ]
+
+
+def test_materialize_falls_back_when_register_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import torch
+
+    from tokenspeed.runtime.pd.mooncake.pack import PackedCopy, PrefillPackScratch
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        "tokenspeed_kernel.platform.current_platform",
+        lambda: SimpleNamespace(is_nvidia=True),
+    )
+    monkeypatch.setattr(
+        torch,
+        "empty",
+        lambda *a, **k: SimpleNamespace(data_ptr=lambda: 0x1000),
+    )
+    events: list[str] = []
+    copy = PackedCopy(src=0x10, dst=0x20, width=8, src_pitch=16, rows=2)
+    engine = SimpleNamespace(
+        register=lambda *_a, **_k: -1,
+        deregister=lambda *_a: events.append("deregister"),
+    )
+    scratch = PrefillPackScratch(engine, gpu_id=0)
+    assert list(scratch.materialize([copy])) == [
+        (0x10, 0x20, 8),
+        (0x20, 0x28, 8),
+    ]
+    assert scratch._ptr == 0
+    assert events == []
+
+
+def test_fallback_write_batches_expanded_row_sges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tokenspeed.runtime.pd.mooncake.pack import PackedCopy, PrefillPackScratch
+    from tokenspeed.runtime.pd.mooncake.prefill import (
+        _TRANSFER_DESCRIPTOR_BATCH_SIZE,
+        MooncakeKVManagerPrefill,
+    )
+
+    monkeypatch.setattr(
+        "tokenspeed_kernel.platform.current_platform",
+        lambda: SimpleNamespace(is_nvidia=False),
+    )
+    batch_sizes: list[int] = []
+    manager = object.__new__(MooncakeKVManagerPrefill)
+    manager.engine = SimpleNamespace(
+        batch_transfer_sync=lambda _s, src, _d, _l: batch_sizes.append(len(src)) or 0
+    )
+    packer = PrefillPackScratch(
+        SimpleNamespace(register=lambda *_a, **_k: None, deregister=lambda *_a: None)
+    )
+    copies = [
+        PackedCopy(src=index * 16, dst=index * 8, width=8, src_pitch=16, rows=2)
+        for index in range(3000)
+    ]
+    assert manager._transfer_data("session", copies, packer) == 0
+    assert batch_sizes == [4096, 1904]
+    assert sum(batch_sizes) == 6000
+    assert all(size <= _TRANSFER_DESCRIPTOR_BATCH_SIZE for size in batch_sizes)
+
+
 def test_transfer_worker_completes_real_heterogeneous_fanout_before_status() -> None:
     from tokenspeed.runtime.pd.base.status import TransferPoll
 
@@ -728,7 +1001,7 @@ def test_transfer_worker_completes_real_heterogeneous_fanout_before_status() -> 
     manager.transfer_infos = {9: requests}
     manager.session_lock = nullcontext()
     manager._is_session_failed = lambda _session: False
-    manager._transfer_data = lambda session, blocks: (
+    manager._transfer_data = lambda session, blocks, packer=None: (
         sends.append((session, tuple(blocks))) or 0
     )
     manager.update_status = lambda room, status: statuses.__setitem__(room, status)
@@ -764,19 +1037,26 @@ def test_shared_manager_lazily_bounds_application_descriptor_batches() -> None:
     )
 
     batch_sizes = []
+    pulled_at_first_write = []
+    pulled = []
     manager = object.__new__(MooncakeKVManagerPrefill)
-    manager.engine = SimpleNamespace(
-        batch_transfer_sync=lambda _session, src, dst, lengths: (
-            batch_sizes.append((len(src), len(dst), len(lengths))) or 0
-        )
-    )
+
+    def record_write(_session, src, dst, lengths):
+        if not pulled_at_first_write:
+            pulled_at_first_write.append(len(pulled))
+        batch_sizes.append((len(src), len(dst), len(lengths)))
+        return 0
+
+    manager.engine = SimpleNamespace(batch_transfer_sync=record_write)
     block_count = 2 * _TRANSFER_DESCRIPTOR_BATCH_SIZE + 17
 
     def blocks():
         for index in range(block_count):
+            pulled.append(index)
             yield (0x1000 + index * 64, 0x2000 + index * 64, 64)
 
     assert manager._transfer_data("decode-session", blocks()) == 0
+    assert pulled_at_first_write == [_TRANSFER_DESCRIPTOR_BATCH_SIZE]
     assert batch_sizes == [
         (_TRANSFER_DESCRIPTOR_BATCH_SIZE,) * 3,
         (_TRANSFER_DESCRIPTOR_BATCH_SIZE,) * 3,

--- a/test/runtime/distributed/test_cache_pd_layerwise.py
+++ b/test/runtime/distributed/test_cache_pd_layerwise.py
@@ -562,7 +562,7 @@ def test_layerwise_fanout_is_layer_major_and_completes_once() -> None:
 
     manager._cache_transfer_blocks = cache_transfer_blocks
 
-    def transfer_data(session, blocks):
+    def transfer_data(session, blocks, packer=None):
         events.append(("send", session, tuple(blocks)))
         return 0
 
@@ -631,7 +631,7 @@ def test_layerwise_fanout_failure_aborts_before_later_intervals() -> None:
     )
     manager._cache_transfer_blocks = lambda **_kwargs: iter(((1, 2, 3),))
 
-    def transfer(session, _blocks):
+    def transfer(session, _blocks, packer=None):
         events.append(("send", session))
         return -1 if session == "session-1" else 0
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/copy/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/copy/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Device copy helpers."""

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/copy/cuda.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/copy/cuda.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""NVIDIA 2D device-to-device copy."""
+
+from __future__ import annotations
+
+from tokenspeed_kernel.platform import current_platform
+
+
+def memcpy_2d_async(
+    *,
+    dst: int,
+    dst_pitch: int,
+    src: int,
+    src_pitch: int,
+    width: int,
+    height: int,
+    stream_ptr: int,
+) -> None:
+    """Copy a 2D device rectangle asynchronously.
+
+    Args:
+        dst: Destination device pointer.
+        dst_pitch: Destination row pitch in bytes.
+        src: Source device pointer.
+        src_pitch: Source row pitch in bytes.
+        width: Bytes copied per row.
+        height: Number of rows.
+        stream_ptr: CUDA stream handle.
+
+    Returns:
+        None.
+
+    Raises:
+        RuntimeError: If the platform is not NVIDIA or the runtime copy fails.
+    """
+    if not current_platform().is_nvidia:
+        raise RuntimeError("memcpy_2d_async is NVIDIA-only")
+    from tokenspeed_kernel.thirdparty.cuda.memcpy_2d import cuda_memcpy_2d_async
+
+    cuda_memcpy_2d_async(
+        dst=dst,
+        dst_pitch=dst_pitch,
+        src=src,
+        src_pitch=src_pitch,
+        width=width,
+        height=height,
+        stream_ptr=stream_ptr,
+    )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/memcpy_2d.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/memcpy_2d.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""libcudart ``cudaMemcpy2DAsync`` wrapper."""
+
+from __future__ import annotations
+
+import ctypes
+
+_CUDA_MEMCPY_DEVICE_TO_DEVICE = 3
+_cudart = None
+
+
+def _load_cudart():
+    global _cudart
+    if _cudart is not None:
+        return _cudart
+    lib = ctypes.CDLL("libcudart.so")
+    lib.cudaMemcpy2DAsync.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_size_t,
+        ctypes.c_size_t,
+        ctypes.c_int,
+        ctypes.c_void_p,
+    ]
+    lib.cudaMemcpy2DAsync.restype = ctypes.c_int
+    _cudart = lib
+    return _cudart
+
+
+def cuda_memcpy_2d_async(
+    *,
+    dst: int,
+    dst_pitch: int,
+    src: int,
+    src_pitch: int,
+    width: int,
+    height: int,
+    stream_ptr: int,
+) -> None:
+    runtime = _load_cudart()
+    err = runtime.cudaMemcpy2DAsync(
+        dst,
+        dst_pitch,
+        src,
+        src_pitch,
+        width,
+        height,
+        _CUDA_MEMCPY_DEVICE_TO_DEVICE,
+        stream_ptr,
+    )
+    code = getattr(err, "value", err)
+    if int(code) != 0:
+        raise RuntimeError(f"cudaMemcpy2DAsync failed: {err}")

--- a/tokenspeed-kernel/test/ops/test_memcpy_2d.py
+++ b/tokenspeed-kernel/test/ops/test_memcpy_2d.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_memcpy_2d_async_rejects_non_nvidia(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tokenspeed_kernel.ops.copy.cuda import memcpy_2d_async
+
+    monkeypatch.setattr(
+        "tokenspeed_kernel.ops.copy.cuda.current_platform",
+        lambda: SimpleNamespace(is_nvidia=False),
+    )
+    with pytest.raises(RuntimeError, match="NVIDIA-only"):
+        memcpy_2d_async(
+            dst=1,
+            dst_pitch=8,
+            src=2,
+            src_pitch=16,
+            width=8,
+            height=2,
+            stream_ptr=0,
+        )


### PR DESCRIPTION
## What

CachePD already plans KV movement as 2D fragments (`bytes_per_row` ×
`rows_per_page`, independent source/dest pitches). A page is often not
one contiguous byte range on both sides — tensor-parallel head slices,
GQA, pipeline-stage windows, layout pitch vs payload width, mixed
Prefill/Decode TP. Mooncake WRITE has no stride field, so Prefill
expanded every row into its own SGE (often ~1KB).

That is a submit-cost problem, not a bandwidth problem: ibverbs posts
one work request per SGE. Dest-contiguous fragments paid tens/hundreds
of thousands of 1KB posts per peer.

Dest-strided fragments (Prefill wider than Decode) are out of scope
here: packing them would land on the wrong Decode layout without a
remote unpack.

## How

Prefill packs dest-contiguous fragments on the transfer worker, then
WRITEs Decode peers in order on that same worker (one registered
scratch, reused after each WRITE returns):

- Source-contiguous + dest-contiguous: one SGE for the whole page.
- Source-strided + dest-contiguous: `cudaMemcpy2D` into a registered
  scratch on the local CUDA index, then one SGE. Pack failure falls
  back to per-row SGEs. NVIDIA-only; other platforms keep per-row SGEs.
- Dest-strided: still one SGE per row.

The CUDA copy is data-plane work on the transfer worker, not the event
loop. Mooncake still uses `batch_transfer_sync`.

## Result

Same-machine PD, classic Mooncake RDMA, Qwen3-8B, `max_tokens=8`, cold
prompts. Dest-contiguous runs used Prefill TP1 / Decode TP2 (two WRITE
peers). Equal-TP is the already-contiguous control (Prefill TP1 / Decode
TP1, one peer, ~128KB SGEs); that path does not pack, so the control
numbers are unchanged.

**Mooncake WRITE shape**

| Prompt | Dest-contiguous, before | Dest-contiguous, this PR | Equal-TP control |
| ---: | --- | --- | --- |
| ~2k tok | 147k–170k × 1KB, 36–42 batches | 2.2k–2.6k × 64KB, 1 batch | 2.5k–2.7k × 128KB, 1 batch |
| ~4k tok | 309k–318k × 1KB, 76–78 batches | 4.5k × 64KB, 2 batches | 4.8k–4.9k × 128KB, 2 batches |

**Latency (dest-contiguous vs this PR; Equal-TP as the contiguous target)**

| Prompt | Metric | Before | This PR | Speedup | Equal-TP |
| ---: | --- | ---: | ---: | ---: | ---: |
| ~2k tok | WRITE | 276–356 ms | 16–19 ms | 15–22× | 20–22 ms |
| ~2k tok | HTTP TTFT | 553–668 ms | 433–494 ms | 1.1–1.5× | 354–359 ms |
| ~4k tok | WRITE | 562–618 ms | 32–34 ms | 17–19× | 31–32 ms |
| ~4k tok | HTTP TTFT | 1101–1174 ms | 824–838 ms | 1.3–1.4× | 596 ms |

WRITE is the sum of the two Decode peers (serial). Packed dest-contiguous
WRITE is in the equal-TP ballpark (16–34 ms vs 20–32 ms). ~2k HTTP TTFT is
close to equal-TP; ~4k is still above it because Prefill stays TP1 while
Decode is TP2. No 2D-pack fallback. Pack/flatten/fanout executor tests: 43
passed.