### PR TITLE
[DO NOT MERGE] ci(kimi-k3): make the tensor-parallel MoE placement the per-commit gate

### DIFF
--- a/.github/workflows/k8s-dispatch.yml
+++ b/.github/workflows/k8s-dispatch.yml
@@ -32,6 +32,7 @@ on:
           - test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-mmlu.yaml
           - test/ci/eval/kimi-k2.5-nvfp4-eagle3-evalscope-ocr-bench.yaml
           - test/ci/eval/kimi-k2.5-mxfp4-eagle3-evalscope-aime25-amd.yaml
+          - test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
           - test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml

--- a/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
@@ -1,0 +1,120 @@
+api_version: ci.tokenspeed.io/v1
+# Kimi-K3 + EAGLE3 at the tensor-parallel MoE placement. Differs from the tp8ep8
+# twin only in --ep-size, so a disagreement between them is attributable to the
+# placement and nothing else.
+#
+# Speculative decoding is why this placement wants its own eval rather than
+# inheriting the speculator-free tp8ep1 job's coverage: EAGLE3 verifies 4 draft
+# tokens per step, so the MoE input projection runs at 4+ tokens and selects a
+# different kernel than the single-token decode specialist plain decode reaches.
+# That branch has no other per-commit coverage at ep1.
+name: eval-kimi-k3-eagle3-mxfp4-tp8ep1-aime26-amd
+type: eval
+workflow_stage: model-test
+triggers:
+  - per-commit
+  - manual
+runner:
+  labels:
+    - amd-mi35x-8gpu-test
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+# --disable-prefill-graph: prefill graphs want 40 buckets on top of the decode
+# ones and OOM at this memory fraction. Decode graphs, which speculative
+# decoding rides on, capture cleanly at every bucket.
+server:
+  command: >-
+    ts serve
+    --model moonshotai/Kimi-K3
+    --served-model-name kimi-k3
+    --speculative-algorithm EAGLE3
+    --speculative-draft-model-path lightseekorg/kimi-k3-eagle3-mla
+    --speculative-num-steps 3
+    --speculative-num-draft-tokens 4
+    --speculative-eagle-topk 1
+    --speculative-draft-model-quantization unquant
+    --eagle3-layers-to-capture 2,46,90
+    --tp 8
+    --ep-size 1
+    --attention-backend mla
+    --drafter-attention-backend mla
+    --moe-backend auto
+    --kv-cache-dtype fp8
+    --mm-encoder-tp-mode data
+    --max-model-len 65536
+    --max-num-seqs 16
+    --max-cudagraph-capture-size 16
+    --cudagraph-capture-sizes 1 2 4 8 16
+    --disable-prefill-graph
+    --gpu-memory-utilization 0.92
+    --trust-remote-code
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --enable-cache-report
+    --host 127.0.0.1
+    --port 8000
+    --policy round_robin
+    --engine-startup-timeout 3000
+    --gateway-startup-timeout 600
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 3600
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets aime26
+    --dataset-hub huggingface
+    --dataset-args '{"aime26":{"dataset_id":"math-ai/aime26"}}'
+    --eval-batch-size 16
+    --stream
+    --generation-config '{"do_sample":true,"temperature":1.0,"seed":42,"max_tokens":32768,"extra_body":{"reasoning_effort":"high"}}'
+report:
+  github_step_summary: true
+
+# No score_threshold, deliberately and not as a placeholder.
+#
+# What this job guards per commit is that the configuration still *runs*: server
+# startup, HIP graph capture, the gfx950 A8W4 SiTU kernel and the speculator, at
+# the tensor-parallel placement. That is the coverage whose absence let a
+# graph-capture deadlock reach main -- it was found by hand, not by CI. The
+# AIME26 score is reported for humans to watch, not gated on.
+#
+# It is not gated on because a 30-problem AIME26 bar cannot be made both
+# meaningful and stable. Measured on the DSpark tp8ep1 predecessor of this job
+# (26/30 then 27/30, so p ~= 0.883), the false-failure rate by the score values
+# a 30-problem run can actually take:
+#
+#   passes at   score    P(false failure)
+#      27/30    0.9000        47.2%
+#      26/30    0.8667        27.0%
+#      25/30    0.8333        13.1%
+#      24/30    0.8000         5.4%
+#      23/30    0.7667         1.9%
+#      22/30    0.7333         0.6%
+#
+# Stated as exact fractions on purpose. A threshold is compared against a score
+# that can only be k/30, so a rounded decimal silently moves the bar: 0.867 does
+# not admit 26/30, because 26/30 = 0.8667 is below it, and lands on the 47.2%
+# row rather than the 27.0% one. Pick k first, then write k/30 to four places.
+#
+# Inheriting the tp8ep8 twin's 0.90 would fail almost half of all PRs. The same
+# arithmetic applies to that twin, which gates commits today at 0.90 with
+# roughly a 1-in-8 false-failure rate; fixing that means more problems per run
+# and is out of scope here. Those numbers come from the DSpark predecessor, so
+# re-derive them from this job's own history before setting any bar.
+#
+# On whether A8W4 costs accuracy at all: measured on GSM8K (1319 greedy
+# problems) and GPQA-Diamond, tp8ep1 sat 0.5 and 3.0 points below tp8ep8, both
+# under 1 sigma, with the effect bounded under 1.07 pp. Resolving it more finely
+# needs ~12,300 samples per arm, so it is bounded rather than measured, and no
+# AIME26 threshold could ever see it.

--- a/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
@@ -107,11 +107,12 @@ report:
 # not admit 26/30, because 26/30 = 0.8667 is below it, and lands on the 47.2%
 # row rather than the 27.0% one. Pick k first, then write k/30 to four places.
 #
-# Inheriting the tp8ep8 twin's 0.90 would fail almost half of all PRs. The same
-# arithmetic applies to that twin, which gates commits today at 0.90 with
-# roughly a 1-in-8 false-failure rate; fixing that means more problems per run
-# and is out of scope here. Those numbers come from the DSpark predecessor, so
-# re-derive them from this job's own history before setting any bar.
+# Inheriting the tp8ep8 twin's 0.90 would fail almost half of all PRs. That twin
+# keeps its 0.90 and becomes a manual control in this change, so the bar stops
+# gating anything; it was running at roughly a 1-in-8 false-failure rate while
+# it did. Making a 30-problem bar dependable needs more problems per run, which
+# is out of scope here. The numbers above come from the DSpark predecessor of
+# this job, so re-derive them from its own history before setting any bar.
 #
 # On whether A8W4 costs accuracy at all: measured on GSM8K (1319 greedy
 # problems) and GPQA-Diamond, tp8ep1 sat 0.5 and 3.0 points below tp8ep8, both

--- a/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -1,11 +1,12 @@
 api_version: ci.tokenspeed.io/v1
-# Kimi-K3 + EAGLE3 is the per-commit AIME26 gate. The matching speculator-free
-# configuration remains available as a manual control for direct comparison.
+# Kimi-K3 + EAGLE3 at the expert-parallel MoE placement, kept as a manual
+# control. The per-commit AIME26 gate is the tp8ep1 twin, which differs from
+# this file only in --ep-size; run this one by hand to attribute a regression to
+# the placement. The matching speculator-free configuration is also manual.
 name: eval-kimi-k3-eagle3-mxfp4-tp8ep8-aime26-amd
 type: eval
 workflow_stage: model-test
 triggers:
-  - per-commit
   - manual
 runner:
   labels:

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
@@ -7,9 +7,12 @@ api_version: ci.tokenspeed.io/v1
 # output buffer, and the model emitted repetition loops and wrong arithmetic
 # while EP8 stayed clean.
 #
-# Manual, matching the non-DSpark tp8ep8 eval: the per-commit signal for this
-# placement is the cheaper perf job, which catches startup and graph-capture
-# regressions without the full AIME26 budget.
+# Manual, matching the speculator-free tp8ep8 eval. This placement carries two
+# per-commit signals of its own -- the cheaper perf job, which catches startup
+# and graph-capture regressions without the full AIME26 budget, and the EAGLE3
+# tp8ep1 eval, which additionally exercises the speculator. Neither gates on an
+# accuracy score, so this job remains the deliberate by-hand accuracy check for
+# the placement.
 name: eval-kimi-k3-mxfp4-tp8ep1-aime26-amd
 type: eval
 workflow_stage: model-test

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 # Keep the pure target as a manual control; the matching EAGLE3 configuration
-# is the per-commit Kimi-K3 AIME26 gate.
+# is a manual control too. The per-commit Kimi-K3 AIME26 gate is the EAGLE3 job
+# at the tp8ep1 placement, so both arms of tp8ep8 are now run by hand.
 name: eval-kimi-k3-mxfp4-tp8ep8-aime26-amd
 type: eval
 workflow_stage: model-test

--- a/test/ci/perf/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -6,7 +6,6 @@ name: perf-kimi-k3-eagle3-mxfp4-tp8ep8-random-4k-1k-mi35x
 type: perf
 workflow_stage: model-test
 triggers:
-  - per-commit
   - manual
 runner:
   labels:

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
@@ -21,6 +21,10 @@ api_version: ci.tokenspeed.io/v1
 # CPU-only test/runtime/test_kimi_k3_moe_fork_warmup.py, which is narrower --
 # it pins the call site, not the stream behaviour. Run this job by hand when
 # touching the MoE stream fork, the A8W4 SiTU kernel, or graph capture.
+#
+# Being manual is why the tokenizer defect below went unnoticed for so long: a
+# cold-runner failure in a job nobody runs on a schedule looks like bad luck the
+# one time someone does run it.
 name: perf-kimi-k3-mxfp4-tp8ep1-random-4k-1k-mi35x
 type: perf
 workflow_stage: model-test
@@ -74,13 +78,24 @@ perf:
     # Keep the load generator aligned with the version used to establish the
     # perf_reference below; EvalScope 1.10 changed its metric semantics.
     - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]==1.9.1'
+  # EvalScope resolves remote tokenizer paths through ModelScope even when the
+  # dataset source is Hugging Face, so materialize the HF tokenizer locally.
+  # Passing the remote ID instead depends on a warm ModelScope cache. Observed
+  # on a cold runner as "Couldn't instantiate the backend tokenizer", raised
+  # inside modelscope's AutoTokenizer patcher partway through the run with the
+  # server already healthy and serving; a re-run minutes later passed against
+  # the now warm cache, so it reads as flaky while being a real cold-start
+  # dependency. The tp8ep8 sibling has materialized the tokenizer since it was
+  # written; this job was missed.
   command: >-
     REPO_ROOT=$PWD &&
     MODEL=kimi-k3 &&
     URL=http://127.0.0.1:21000/v1/completions &&
     OUTPUTS_DIR=/tmp/tokenspeed-kimi-k3-ep1-mi35x-perf &&
+    TOKENIZER_PATH="$OUTPUTS_DIR/tokenizer" &&
     trap 'rm -rf "$OUTPUTS_DIR"' EXIT &&
     rm -rf "$OUTPUTS_DIR" &&
+    /tmp/evalscope-perf/bin/python -c 'import sys; from transformers import AutoTokenizer; AutoTokenizer.from_pretrained("moonshotai/Kimi-K3", trust_remote_code=True).save_pretrained(sys.argv[1])' "$TOKENIZER_PATH" &&
     set +e &&
     echo "==================================================" &&
     echo ">>> input=4k output=1k conc=1" &&
@@ -90,7 +105,8 @@ perf:
     --url "$URL"
     --api openai
     --dataset random
-    --tokenizer-path moonshotai/Kimi-K3
+    --data-source huggingface
+    --tokenizer-path "$TOKENIZER_PATH"
     --min-prompt-length 4096
     --max-prompt-length 4096
     --prefix-length 0
@@ -116,15 +132,25 @@ report:
 perf_threshold: 0.9
 # Values are [Latency (tps/user), Throughput (tps/gpu)]; gate fails any conc whose actual falls below ref * perf_threshold.
 #
-# PROVISIONAL -- these have not been established on this runner. They are set
-# deliberately loose so the job reports rather than gates while it settles, and
-# should be replaced by the documented convention (rounded down from the median
-# of the three most recent passing runs) once there are three.
+# PROVISIONAL. Set from a single run on the CI runner -- 75.64 tps/user and
+# 9.16 tps/gpu -- so replace it with the documented convention (median of the
+# three most recent passing runs, rounded down) once there are three.
 #
-# The starting point is a hand measurement on an 8x MI355X box: EP1 sustained
-# 53.98 tok/s at concurrency 1 against EP8's 73.84 on the same commit. EP1 is
-# expected to be SLOWER here -- its advantage is at batch (it overtook EP8 by
-# ~28% at concurrency 16) and concurrency 1 is its worst case. Do not copy the
-# tp8ep8 reference into this file.
+# 65/7.8 is deliberately well under that measurement. With perf_threshold 0.9
+# the gate trips below 58.5, some 23% under the observed value, against the
+# 3.5% spread across the tp8ep8 job's own three reference runs. The previous
+# 45/5.4 predated the symmetric MoE tail reduction (#1353, via #1358) and the
+# fused input projection (#1358) and would now pass a 40% regression.
+#
+# The note this replaces said tp8ep1 is expected to be slower than tp8ep8 at
+# concurrency 1, citing a pre-fusion hand measurement of 53.98 against 73.84.
+# That is no longer true and should not be carried forward: tp8ep1 now leads at
+# every concurrency measured -- 77.59 against 73.89 at concurrency 1 on an 8x
+# MI355X box, and 75.64 tps/user here against the tp8ep8 job's own reference of
+# 65.
+#
+# Still do not copy the tp8ep8 reference wholesale in future. The two jobs run
+# different server configurations, not just a different MoE placement; the match
+# at 65/7.8 is a coincidence of the current numbers rather than an invariant.
 perf_reference:
-  1: [45, 5.4]
+  1: [65, 7.8]

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
@@ -15,20 +15,24 @@ api_version: ci.tokenspeed.io/v1
 # would skip capture entirely and silence exactly the class of bug it exists
 # to catch.
 #
-# Manual trigger only, so this does not gate commits and does not consume the
-# 8-GPU bench runner on every push. That leaves no automated signal for the
-# EP1 placement: the per-commit guard for the graph-capture contract is the
-# CPU-only test/runtime/test_kimi_k3_moe_fork_warmup.py, which is narrower --
-# it pins the call site, not the stream behaviour. Run this job by hand when
-# touching the MoE stream fork, the A8W4 SiTU kernel, or graph capture.
+# Per-commit, so this consumes the 8-GPU bench runner on every push. The EP1
+# placement carries two per-commit signals and they cover different things:
 #
-# Being manual is why the tokenizer defect below went unnoticed for so long: a
-# cold-runner failure in a job nobody runs on a schedule looks like bad luck the
-# one time someone does run it.
+#   this job                  plain decode, and the only throughput number
+#   eval-kimi-k3-eagle3-...   speculative decode, which drives the MoE input
+#     ...-tp8ep1-aime26-amd   projection at 4+ tokens and so selects a different
+#                             kernel than single-token decode
+#
+# Neither subsumes the other, and only this one would catch a throughput
+# regression, so weigh them separately before demoting either. The remaining
+# guard for the graph-capture contract if both went is the CPU-only
+# test/runtime/test_kimi_k3_moe_fork_warmup.py, which is narrower -- it pins the
+# call site, not the stream behaviour.
 name: perf-kimi-k3-mxfp4-tp8ep1-random-4k-1k-mi35x
 type: perf
 workflow_stage: model-test
 triggers:
+  - per-commit
   - manual
 runner:
   labels:

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -1,6 +1,7 @@
 api_version: ci.tokenspeed.io/v1
 # Keep the pure target as a manual control; the matching EAGLE3 configuration
-# is the per-commit Kimi-K3 performance gate.
+# is a manual control too. The per-commit Kimi-K3 performance gate is the
+# tp8ep1 job, so both arms of tp8ep8 are now run by hand.
 name: perf-kimi-k3-mxfp4-tp8ep8-random-4k-1k-mi35x
 type: perf
 workflow_stage: model-test

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -230,3 +230,37 @@ def test_kvv_configs_use_pinned_upstream_and_local_api():
         assert flag_value(command, "--max-tokens") == max_tokens
         assert "--thinking" in command
         assert flag_value(command, "--thinking-effort") == "max"
+
+
+def test_kimi_k3_perf_configs_materialize_the_tokenizer_locally():
+    """EvalScope perf jobs must not pass a remote tokenizer ID.
+
+    EvalScope resolves remote tokenizer paths through ModelScope even when the
+    dataset source is Hugging Face, so passing the model ID makes the benchmark
+    depend on a warm ModelScope cache. On a cold runner it fails partway through
+    with "Couldn't instantiate the backend tokenizer" while the server is
+    already healthy, and a re-run against the now-warm cache passes -- so the
+    failure reads as flaky and the cause is easy to miss.
+
+    Every Kimi-K3 perf job therefore saves the Hugging Face tokenizer locally
+    first and points EvalScope at the directory. Pinning it here because
+    reverting to the model ID reintroduces a failure that only appears on a cold
+    runner, which is exactly the kind nobody reproduces on demand.
+    """
+    filenames = (
+        "kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml",
+        "kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml",
+        "kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml",
+    )
+    for filename in filenames:
+        task = yaml.safe_load((PERF_CONFIG_DIR / filename).read_text(encoding="utf-8"))
+        command = task["perf"]["command"]
+        tokens = shlex.split(command)
+
+        assert "save_pretrained" in command, filename
+        assert flag_value(tokens, "--data-source") == "huggingface", filename
+
+        tokenizer_path = flag_value(tokens, "--tokenizer-path")
+        # A local directory built by the materialization step, not a hub id.
+        assert tokenizer_path == "$TOKENIZER_PATH", filename
+        assert "/" not in tokenizer_path.lstrip("$"), filename

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -35,7 +35,8 @@ DATASETS = {
         "dataset_args": {"dataset_id": "math-ai/aime25"},
     },
     "aime26": {
-        "count": 11,
+        # +1 for the EAGLE3 tp8ep1 gate, whose tp8ep8 twin is the manual control.
+        "count": 12,
         "dataset_args": {"dataset_id": "math-ai/aime26"},
     },
     "gpqa_diamond": {
@@ -171,7 +172,48 @@ def test_qwen38_flash_next_runs_gsm8k_with_kvstore_enabled():
     assert task["score_threshold"] == 0.90
 
 
-def test_kimi_k3_amd_gates_use_eagle3_tp8ep8():
+def test_kimi_k3_amd_gates_use_tp8ep1():
+    """The AMD per-commit gates run the tensor-parallel MoE placement.
+
+    tp8ep1 leads tp8ep8 at every concurrency measured -- 77.59 against 73.89 at
+    concurrency 1 on an 8x MI355X box, and 75.64 tps/user on the CI runner
+    against tp8ep8's own reference of 65 -- and it is where the gfx950 A8W4 SiTU
+    kernel and the tensor-parallel MoE tail live, both of which reached main
+    unguarded before.
+
+    Two gates covering different things: the perf job is plain decode and the
+    only throughput number, the eval drives the MoE input projection at 4+
+    tokens through EAGLE3 and so selects a different kernel. Neither subsumes
+    the other.
+    """
+    gates = (
+        (EVAL_CONFIG_DIR, "kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml"),
+        (PERF_CONFIG_DIR, "kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml"),
+    )
+    for config_dir, filename in gates:
+        task = yaml.safe_load((config_dir / filename).read_text(encoding="utf-8"))
+        assert task["triggers"] == ["per-commit", "manual"], filename
+        server_tokens = shlex.split(task["server"]["command"])
+        assert flag_value(server_tokens, "--tp") == "8", filename
+        assert flag_value(server_tokens, "--ep-size") == "1", filename
+
+    # The eval gate reports its AIME26 score rather than gating on it: a
+    # 30-problem bar cannot be both meaningful and stable, and inheriting the
+    # tp8ep8 twin's 0.90 would fail roughly half of all runs at the accuracy
+    # this placement measures. See that file for the arithmetic.
+    eval_task = yaml.safe_load(
+        (EVAL_CONFIG_DIR / gates[0][1]).read_text(encoding="utf-8")
+    )
+    assert "score_threshold" not in eval_task
+
+
+def test_kimi_k3_amd_eagle3_tp8ep8_controls():
+    """The EAGLE3 tp8ep8 pair, kept as manual controls for the tp8ep1 gates.
+
+    Everything here except the trigger is the speculator contract and is
+    unchanged; the pair differs from the tp8ep1 gates only in --ep-size, which
+    is what makes it useful for attributing a regression to the placement.
+    """
     filenames = (
         "kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml",
         "kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml",
@@ -183,7 +225,7 @@ def test_kimi_k3_amd_gates_use_eagle3_tp8ep8():
         task = yaml.safe_load((config_dir / filename).read_text(encoding="utf-8"))
         server_tokens = shlex.split(task["server"]["command"])
 
-        assert task["triggers"] == ["per-commit", "manual"]
+        assert task["triggers"] == ["manual"]
         assert flag_value(server_tokens, "--speculative-algorithm") == "EAGLE3"
         assert (
             flag_value(server_tokens, "--speculative-draft-model-path")


### PR DESCRIPTION
> **DO NOT MERGE — this is a call for the code owners.** Nothing here is
> unverified or pending on my side. What it needs is a decision about which MoE
> placement Kimi-K3 should gate on.
>
> **That decision is now live rather than theoretical.** #1379 consolidated the
> AMD gates onto EAGLE3 + tp8ep8 and pinned it with a test. This PR proposes the
> opposite placement and therefore has to change that test. #1379 was about
> swapping the *speculator*, not choosing the placement, so it may simply not
> have had the numbers below — but that is for its author to say, not me to
> assume.

> **Stacked on #1393**, which fixes the tp8ep1 perf job's cold-runner tokenizer
> failure and its stale reference. Those are prerequisites for promoting that
> job and are worth landing whatever happens here.

## What this changes

| job | before | after |
|---|---|---|
| `eval-kimi-k3-eagle3-...-tp8ep1-aime26-amd` | *did not exist* | **per-commit** |
| `eval-kimi-k3-eagle3-...-tp8ep8-aime26-amd` | per-commit | manual |
| `perf-kimi-k3-mxfp4-tp8ep1-random-4k-1k-mi35x` | manual | **per-commit** |
| `perf-kimi-k3-eagle3-...-tp8ep8-random-4k-1k-mi35x` | per-commit | manual |

## Why

| concurrency | tp8ep1 | tp8ep8 |
|---|---|---|
| 1 | **77.59** | 73.89 |
| 8 | **358.13** | 266.45 |
| 16 | **533.28** | 429.59 |

8×MI355X decode. On the CI runner tp8ep1 reads 75.64 tps/user against the
tp8ep8 job's own reference of 65.

Gating on the slower placement also leaves the faster one to manual runs, which
is backwards. tp8ep1 is where the gfx950 A8W4 SiTU kernel and the
tensor-parallel MoE tail live, and both reached main unguarded before — the
graph-capture deadlock that motivated the tp8ep1 perf job was found by hand, not
by CI.

## The two gates cover different things

* **perf** — plain decode, and the only throughput number.
* **eval** — speculative decode. EAGLE3 verifies 4 draft tokens per step, so the
  MoE input projection runs at 4+ tokens and selects a different kernel than the
  single-token decode specialist plain decode reaches.

Neither subsumes the other, so demoting either leaves a real gap.

## Both gates are non-flaky by construction

**Perf** — reference 65/7.8 (from #1393). The gate trips below 58.5, some 23%
under the measured 75.64, against the 3.5% spread across tp8ep8's own three
reference runs.

**Eval** — no `score_threshold`, deliberately. A 30-problem bar cannot be both
meaningful and stable:

| passes at | score | P(false failure) |
|---|---|---|
| 27/30 | 0.9000 | **47.2%** |
| 25/30 | 0.8333 | 13.1% |
| 23/30 | 0.7667 | 1.9% |

Inheriting 0.90 would fail nearly half of all runs. The lowest bar with a sub-2%
false-failure rate admits almost any regression short of a broken kernel. Note
the same arithmetic applies to the tp8ep8 twin **gating commits today** at 0.90
— roughly 1-in-8. Fixing that means more problems per run and is out of scope.

## The accuracy question, resolved

Does A8W4 (fp8 activations, tp8ep1) cost accuracy against A16W4 (bf16, tp8ep8)?

| test | n | tp8ep8 | tp8ep1 | gap | sigma |
|---|---|---|---|---|---|
| AIME26 | 30 | 0.922 | 0.883 | 3.9 pp | 0.78 |
| GSM8K | 1319 | 0.980 | 0.975 | 0.5 pp | 0.87 |
| GPQA-Diamond | 198 | 0.778 | 0.748 | 3.0 pp | 0.70 |

Every comparison leans the same way, so a small real deficit is more likely than
not (Stouffer p = 0.087) — but GSM8K **bounds it under 1.07 pp**, and resolving
it more finely needs ~12,300 samples per arm. It is bounded, not measured.

It also cannot be fixed today: A8W4 is not a speed choice, it is the only expert
kernel that works at tp8's 384-wide intermediate shard. The A16W4 kernel returns
rel-L2 0.42 there and its sibling path fails to compile, so
`intermediate % 256 == 0` is load bearing. And fp8 is not buying anything to
trade against — activations are 0.02–0.09% of memory traffic at every decode
batch size.

## On the test change

`test_kimi_k3_amd_gates_use_eagle3_tp8ep8` becomes
`test_kimi_k3_amd_eagle3_tp8ep8_controls`. Only its trigger assertion is
invalidated — the speculator flags, seed, threshold and perf reference all still
describe that pair correctly, now as manual controls. A separate
`test_kimi_k3_amd_gates_use_tp8ep1` states the placement policy on its own, so
the choice is visible as a choice rather than folded into a speculator test.

If the answer is that tp8ep8 should keep the gates, close this and the only loss
is the note; #1393 stands on its own.

## Verification

* `test/ci_system` — 202 passed.
* `pre-commit run --all-files` — clean.
* Both promoted jobs previously dispatched and passing at this placement: perf
  75.64 tps/user; the eval's DSpark predecessor scored 0.900 and 0.867.