### PR TITLE
perf(k3): optimize prefill MoE blocks on gfx950

### DIFF
--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -1471,7 +1471,8 @@ class KimiLinearMoE(nn.Module):
                 "activation_situ_linear_beta": situ_linear_beta,
             },
             routing_mode=None,
-            # Native gfx950 and Hopper Marlin both run A16W4 (bf16 activations).
+            # Native gfx950 accepts bf16 model activations; the selected kernel
+            # may quantize them internally. Hopper Marlin runs A16W4.
             # FlashInfer TRT-LLM SiTU depends on the expert weight dtype:
             # MXFP4 cubins are w4a8 (MXFP8 activations -> "fp8"), NVFP4 SiTU
             # runs w4a4 with the kernel wrapper quantizing the bf16 input
@@ -1606,6 +1607,7 @@ class KimiLinearMoE(nn.Module):
                 self.experts.w2_weight_scale,
                 self.experts.plan,
                 topk=self.top_k,
+                linear_clamp=self.experts.activation_situ_linear_beta,
             )
         )
 

--- a/test/runtime/test_kimi_k3_config.py
+++ b/test/runtime/test_kimi_k3_config.py
@@ -440,6 +440,7 @@ class KimiK3RegistrationTests(unittest.TestCase):
                 self.w2_weight = torch.empty(0)
                 self.w2_weight_scale = torch.empty(0)
                 self.plan = {}
+                self.activation_situ_linear_beta = kwargs["activation_situ_linear_beta"]
                 # Consumed by K3MoeTailComm arming (real MoELayer exposes it
                 # from the selected kernel's plan trait).
                 self.supports_deferred_finalize = False

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
@@ -23,14 +23,14 @@ The fused dispatch policy (`fused/moe.py`) is the top of the funnel: it calls
 | File | Role |
 | --- | --- |
 | `__init__.py` | Package exports: the stage invokers, the top-k route entries, the prefill weight aliases, and the scale gather. |
-| `prefill_stage1.py` / `prefill_stage2.py` | A4W4 block-ragged prefill GEMMs (gdot128-preshuffled weights). |
+| `prefill_stage1.py` / `prefill_stage2.py` | Block-ragged MXFP4/MXFP8-activation, MXFP4-weight prefill GEMMs (gdot128-preshuffled weights). |
 | `decode_stage1.py` / `decode_stage2.py` | A4W4 direct-MFMA decode kernels plus their invokers: stage 1 fuses SwiGLU, stage 2 fuses the routed-weight top-k combine. |
 | `decode_common.py` | Direct CDNA4 MFMA primitives shared by both decode stages: tile addressing, MXFP4 operand loads, `mfma_scaled`. |
 | `routing.py` | Fused dense top-k route kernels (softmax, sigmoid-bias, and a prefill variant); output is top-k only, **not** ragged metadata (contrast `fused/routing.py`). |
 | `moe_sorting.py` | Block-aligned expert sort feeding the package prefill stages. |
 | `situ_decode.py` / `situ_grouped.py` | A16W4 in-situ expert-parallel paths that read the unshuffled MXFP4 weights directly: route-direct warp decode and a contiguous-EP grouped GEMM. |
 | `latent_shared_decode.py` | Latent shared-expert decode entry. |
-| `quantize_gluon.py` | Leaf Gluon helpers for MXFP4 tile quantization and CDNA4 scale stores shared by staged and fused kernels. |
+| `quantize_gluon.py` | Leaf Gluon helpers for MXFP4/MXFP8 tile quantization and CDNA4 scale stores shared by staged and fused kernels. |
 | `scale_layout.py` | Single source of truth for the CDNA4 MXFP4 scale swizzle (constants, swizzle/predicate/allocator helpers). Leaf module: torch only. |
 | `scale.py` | Activation-scale gather into sorted-route order for the package stages. |
 | `preprocess.py` / `weight_preprocess.py` | Offline weight interleave, scale swizzle, gdot128 preshuffle, package-prefill aliases. |

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/moe.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/moe.py
@@ -173,8 +173,14 @@ def gluon_mxfp4_fp8_precomputed_situ(
     shared_input: torch.Tensor | None = None,
     shared_weight: torch.Tensor | None = None,
     shared_out: torch.Tensor | None = None,
+    expert_start: int = 0,
+    global_num_experts: int | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | None:
-    """Run route-direct SiTU decode or the block-ragged SiTU prefill path."""
+    """Run route-direct SiTU decode or block-ragged SiTU prefill.
+
+    ``expert_start`` and ``global_num_experts`` describe a contiguous local EP
+    shard. Global top-k IDs outside that shard contribute zero to this rank.
+    """
     if (
         hidden_states.ndim != 2
         or hidden_states.shape[0] <= 0
@@ -209,6 +215,8 @@ def gluon_mxfp4_fp8_precomputed_situ(
                 "shared down fusion requires contiguous colocated BF16 "
                 "[M, 768] input and [7168, 768] weight"
             )
+    if expert_start < 0:
+        raise ValueError("expert_start must be non-negative")
     if M > 16:
         if fuse_shared_down:
             return None
@@ -233,11 +241,12 @@ def gluon_mxfp4_fp8_precomputed_situ(
             swiglu_limit=0.0,
             swiglu_beta=0.0,
             situ_linear_beta=float(situ_linear_beta),
+            expert_start=expert_start,
+            global_num_experts=global_num_experts,
+            out=out,
+            activation_format="e4m3",
         )
-        if result is None or out is None:
-            return result
-        out.copy_(result)
-        return out
+        return result
 
     w13_raw = _extract_gluon_raw_w(w13_weight)
     w2_raw = _extract_gluon_raw_w(w2_weight)
@@ -257,6 +266,15 @@ def gluon_mxfp4_fp8_precomputed_situ(
     ):
         return None
 
+    num_local_experts = int(w13_raw.shape[0])
+    if global_num_experts is None:
+        global_num_experts = num_local_experts
+    if (
+        global_num_experts < num_local_experts
+        or expert_start + num_local_experts > global_num_experts
+    ):
+        raise ValueError("local expert range exceeds global expert count")
+
     two_i = int(w13_raw.shape[2])
     if two_i % 2 or int(getattr(w13_raw, "original_k_pk", 0)) * 2 != D:
         return None
@@ -265,8 +283,10 @@ def gluon_mxfp4_fp8_precomputed_situ(
     if int(getattr(w2_raw, "original_k_pk", 0)) * 2 != i_dim or N != D:
         return None
 
-    topk_ids = topk_ids.to(torch.int32)
-    topk_weights = topk_weights.to(torch.float32)
+    # Tiny-M kernels index routing tensors as flat [M * TOPK] arrays. Preserve
+    # that contract when the caller supplies an otherwise valid strided view.
+    topk_ids = topk_ids.to(torch.int32).contiguous()
+    topk_weights = topk_weights.to(torch.float32).contiguous()
     x_fp8, x_scale = _dynamic_fp8_quantize(hidden_states)
     inter_scale = _situ_intermediate_scale(
         hidden_states.device, float(situ_beta * situ_linear_beta)
@@ -281,9 +301,10 @@ def gluon_mxfp4_fp8_precomputed_situ(
         tuple(out.shape) != (M, N)
         or out.dtype != out_dtype
         or out.device != hidden_states.device
-        or not out.is_contiguous()
+        or out.stride(1) != 1
+        or out.stride(0) < N
     ):
-        raise ValueError("SiTU output must be a contiguous colocated [M, N] tensor")
+        raise ValueError("SiTU output must be a row-major colocated [M, N] tensor")
     if fuse_shared_down:
         if shared_out is None:
             shared_out = torch.empty(
@@ -344,6 +365,8 @@ def gluon_mxfp4_fp8_precomputed_situ(
         HAS_BIAS=False,
         SITU_BETA=float(situ_beta),
         SITU_LINEAR_BETA=float(situ_linear_beta),
+        EXPERT_START=expert_start,
+        NUM_LOCAL_EXPERTS=num_local_experts,
         num_warps=num_warps,
     )
 
@@ -385,6 +408,8 @@ def gluon_mxfp4_fp8_precomputed_situ(
         HAS_BIAS=False,
         SPLIT_K=1,
         SPLIT_TOPK=True,
+        EXPERT_START=expert_start,
+        NUM_LOCAL_EXPERTS=num_local_experts,
         num_warps=stage2_num_warps,
     )
     reduce_block_n = 256
@@ -1044,12 +1069,18 @@ def _maybe_gluon_package_mxfp4_prefill(
     swiglu_limit: float,
     swiglu_beta: float,
     situ_linear_beta: float | None = None,
+    expert_start: int = 0,
+    global_num_experts: int | None = None,
+    out: torch.Tensor | None = None,
+    force_reduce: bool | None = None,
+    activation_format: str = "e2m1",
 ) -> torch.Tensor | None:
-    """Dispatch into the dedicated gfx950 A4W4 block-ragged prefill package.
+    """Dispatch into the dedicated gfx950 block-ragged prefill package.
 
-    Routing top-k and activation quantization reuse the shared MXFP4
-    implementation; the block-aligned sort and both stage GEMMs are the
-    dedicated package kernels, launched directly.
+    The package supports E2M1 or E4M3 block-scaled activations with MXFP4
+    weights. The block-aligned sort and both stage GEMMs are launched directly.
+    ``expert_start`` lets an EP rank consume global route IDs while sorting only
+    its contiguous local expert range.
 
     Selection is automatic: this returns ``None`` (so the caller falls back to
     the reference path) unless the batch is large enough
@@ -1060,6 +1091,11 @@ def _maybe_gluon_package_mxfp4_prefill(
         return None
     if out_dtype != torch.bfloat16:
         return None
+    if activation_format not in ("e2m1", "e4m3"):
+        raise ValueError(
+            "package prefill activation_format must be e2m1 or e4m3, "
+            f"got {activation_format}"
+        )
     package_w13 = getattr(w13_weight, "gluon_package_prefill_weight", None)
     package_w13_scale = getattr(w13_weight, "gluon_package_prefill_scale", None)
     package_w2 = getattr(w2_weight, "gluon_package_prefill_weight", None)
@@ -1146,6 +1182,18 @@ def _maybe_gluon_package_mxfp4_prefill(
     topk_weights = topk_weights.to(torch.float32).contiguous()
     n_tokens = int(hidden_states.shape[0])
     n_experts = int(package_w13.shape[0])
+    if global_num_experts is None:
+        global_num_experts = n_experts
+    if (
+        global_num_experts < n_experts
+        or expert_start < 0
+        or expert_start + n_experts > global_num_experts
+    ):
+        raise ValueError("local expert range exceeds global expert count")
+    if force_reduce is None:
+        # EP ranks own only a fraction of each token's routes. Combining those
+        # sparse local contributions atomically avoids the full top-k scratch.
+        force_reduce = global_num_experts == n_experts and expert_start == 0
     hidden_dim = int(hidden_states.shape[1])
     inter_dim = int(package_w13.shape[1]) // 2
     if (
@@ -1165,15 +1213,24 @@ def _maybe_gluon_package_mxfp4_prefill(
     from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.prefill_stage2 import (
         invoke_gluon_mxfp4_moe_stage2_1x2,
     )
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (
+        quantize_mxfp8_sorted_routes,
+    )
     from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.scale import (
         gather_package_cdna4_scale,
     )
 
-    sort_block_m = _select_package_prefill_block_m(
-        n_tokens,
-        top_k,
-        n_experts,
-    )
+    if activation_format == "e4m3":
+        # With EP8, each rank sees only about two of Kimi-K3's sixteen routes
+        # per token. A 32-row expert tile avoids doubling the sorted padding at
+        # sparse prefill sizes; denser prefills amortize the 64-row tile.
+        sort_block_m = 32 if n_tokens <= 2048 else 64
+    else:
+        sort_block_m = _select_package_prefill_block_m(
+            n_tokens,
+            top_k,
+            global_num_experts,
+        )
     # The stable, chunked sort preserves source-token locality for the stage-1
     # activation gather while keeping all metadata on the current stream.
     sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, out = (
@@ -1184,28 +1241,42 @@ def _maybe_gluon_package_mxfp4_prefill(
             hidden_dim,
             out_dtype,
             sort_block_m,
+            expert_start=expert_start,
+            out=out,
         )
     )
 
-    # Stage 1: quantize the hidden state, gather its scale into sorted-route
-    # order, and run the package gate/up MFMA with fused SwiGLU.
-    q_hidden, q_hidden_scale = _quantize_mxfp4_activation(hidden_states)
-    stage1_scale = gather_package_cdna4_scale(
-        q_hidden_scale,
-        sorted_ids,
-        source_rows=n_tokens,
-        cols=hidden_dim,
-        top_k=top_k,
-        flatten_topk=False,
-    )
+    # Stage 1 consumes route-sorted activations. E4M3 quantization gathers and
+    # quantizes directly into that order; the existing E2M1 path preserves its
+    # token-order quantize plus scale-gather contract.
+    input_sorted = activation_format == "e4m3"
+    if input_sorted:
+        q_hidden, stage1_scale = quantize_mxfp8_sorted_routes(
+            hidden_states,
+            sorted_ids,
+            num_valid_ids,
+        )
+    else:
+        q_hidden, q_hidden_scale = _quantize_mxfp4_activation(hidden_states)
+        stage1_scale = gather_package_cdna4_scale(
+            q_hidden_scale,
+            sorted_ids,
+            source_rows=n_tokens,
+            cols=hidden_dim,
+            top_k=top_k,
+            flatten_topk=False,
+        )
     stage2_k = int(package_w2.shape[2]) * 2
     stage2_k_scale = stage2_k // MXFP4_BLOCK
     stage2_scale_rows = triton.cdiv(int(sorted_ids.shape[0]), 32) * 32
-    # Stage 1 writes the activated intermediate directly as sorted MXFP4,
-    # including the zero K-padding required by the physical W2 shard.
+    # Stage 1 writes the activated intermediate directly in the selected
+    # sorted block-scaled format, including the zero K-padding required by W2.
+    intermediate_format = activation_format
+    inter_div = 1 if intermediate_format == "e4m3" else 2
+    inter_dtype = torch.float8_e4m3fn if intermediate_format == "e4m3" else torch.uint8
     q_inter = torch.empty(
-        (sorted_ids.shape[0], stage2_k // 2),
-        dtype=torch.uint8,
+        (sorted_ids.shape[0], stage2_k // inter_div),
+        dtype=inter_dtype,
         device=hidden_states.device,
     )
     stage2_scale = torch.empty(
@@ -1235,6 +1306,10 @@ def _maybe_gluon_package_mxfp4_prefill(
         output_quantized=True,
         out_scale=stage2_scale,
         output_k=stage2_k,
+        a_format=activation_format,
+        output_format=intermediate_format,
+        input_sorted=input_sorted,
+        source_tokens=n_tokens,
     )
 
     # Both stages consume the same route blocking so the lower-padding choice
@@ -1261,8 +1336,9 @@ def _maybe_gluon_package_mxfp4_prefill(
         b_gdot128=True,
         block_m=stage2_block_m,
         sort_block_m=stage2_block_m,
-        force_reduce=True,
+        force_reduce=force_reduce,
         input_sorted=True,
+        a_format=intermediate_format,
     )
     return out
 

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/warp_decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/warp_decode.py
@@ -245,6 +245,7 @@ def _gluon_mxfp4_fp8_warp_decode_moe(
         BLOCK_K=BLOCK_K, BLOCK_N=S2_BLOCK_N, M_DUP=S2_M_DUP,
         W_PRESHUFFLED=w2_preshuffled,
         HAS_BIAS=w2_bias is not None, SPLIT_K=s2_split_k,
+        EXPERT_START=0, NUM_LOCAL_EXPERTS=n_experts,
         num_warps=1,
     )
     # fmt: on
@@ -345,10 +346,14 @@ def _warp_decode_stage1_coop_compute(
     """
     N = 2 * i_dim
     off_n = pid_n * BLOCK_N
+    valid = (token < M) & (expert >= 0)
+    # Inactive EP routes still instantiate the asynchronous descriptors. Use a
+    # valid local base address while their X/store masks suppress all results.
+    safe_expert = gl.where(valid, expert, 0)
     # Keep base offsets int32 (buffer_load_to_shared requires int32/uint32
     # offsets); expert * stride fits int32 for GPT-OSS shapes.
-    w_base_offset = expert * stride_we
-    ws_base_offset = expert * stride_wse
+    w_base_offset = safe_expert * stride_we
+    ws_base_offset = safe_expert * stride_wse
 
     cfg = MoEConfig(
         BLOCK_M,
@@ -385,7 +390,6 @@ def _warp_decode_stage1_coop_compute(
     offs_xm = gl.arange(0, BLOCK_M, layout=gl.SliceLayout(1, LOAD_X_LAYOUT))
     offs_xk = gl.arange(0, BLOCK_K_X, layout=gl.SliceLayout(0, LOAD_X_LAYOUT))
 
-    valid = (token < M) & (expert >= 0)
     # One decode token per CTA: row 0 of the BLOCK_M tile carries the token,
     # the remaining rows are clamped/masked (buffer OOB -> 0 in LDS).
     rows_m = gl.where(offs_xm == 0, token, gl.zeros_like(offs_xm))
@@ -503,7 +507,7 @@ def _warp_decode_stage1_coop_compute(
         bias_offs = off_n + gl.arange(0, BLOCK_N, gl.SliceLayout(0, cfg.acc_layout))
         bias_mask = bias_offs < N
         bias = gl.load(
-            w13_bias + expert.to(gl.int64) * N + bias_offs,
+            w13_bias + safe_expert.to(gl.int64) * N + bias_offs,
             mask=bias_mask,
             other=0.0,
         )
@@ -704,6 +708,8 @@ def _warp_decode_precomputed_situ_stage1_kernel(
     HAS_BIAS: gl.constexpr,
     SITU_BETA: gl.constexpr,
     SITU_LINEAR_BETA: gl.constexpr,
+    EXPERT_START: gl.constexpr,
+    NUM_LOCAL_EXPERTS: gl.constexpr,
 ):
     """Route-direct FP8xMXFP4 W13 with fused SiTU and FP8 store."""
     pid = gl.program_id(axis=0)
@@ -717,6 +723,12 @@ def _warp_decode_precomputed_situ_stage1_kernel(
         mask=token < M,
         other=-1,
     ).to(gl.int32)
+    expert -= EXPERT_START
+    expert = gl.where(
+        (expert >= 0) & (expert < NUM_LOCAL_EXPERTS),
+        expert,
+        -1,
+    )
     _warp_decode_stage1_coop_compute(
         token,
         slot,
@@ -945,6 +957,8 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
     W_PRESHUFFLED: gl.constexpr,
     HAS_BIAS: gl.constexpr,
     SPLIT_K: gl.constexpr,
+    EXPERT_START: gl.constexpr,
+    NUM_LOCAL_EXPERTS: gl.constexpr,
     SPLIT_TOPK: gl.constexpr = False,
 ):
     """Direct top-k stage2: FP8 intermediate x MXFP4 W2 -> BF16 output.
@@ -1019,12 +1033,13 @@ def _warp_decode_stage2_fp8_mxfp4_kernel(
             expert = gl.load(
                 TopkIds + pid_token * TOPK + slot, mask=pid_token < M, other=-1
             )
+            expert -= EXPERT_START
             gate = gl.load(
                 TopkWeights + pid_token * TOPK + slot,
                 mask=pid_token < M,
                 other=0.0,
             ).to(gl.float32)
-            if expert >= 0:
+            if (expert >= 0) & (expert < NUM_LOCAL_EXPERTS):
                 row = pid_token * TOPK + slot
                 x_row_off = row.to(gl.int64) * stride_xm
                 w_expert_off = expert.to(gl.int64) * stride_we

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/moe_sorting.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/moe_sorting.py
@@ -95,6 +95,7 @@ def _moe_sorting_stage1_kernel(
     num_experts: gl.constexpr,
     numel: gl.constexpr,
     tokens_per_program: gl.constexpr,
+    EXPERT_START: gl.constexpr,
     ROUTE_BLOCK: gl.constexpr,
     EXPERT_PAD: gl.constexpr,
     NUM_WARPS: gl.constexpr,
@@ -112,7 +113,12 @@ def _moe_sorting_stage1_kernel(
     route = gl.arange(0, ROUTE_BLOCK, layout=route_layout)
     idx = pid * tokens_per_program + route
     valid = (route < tokens_per_program) & (idx < numel)
-    expert_id = gl.load(topk_ids_ptr + idx, mask=valid, other=num_experts)
+    expert_id = gl.load(
+        topk_ids_ptr + idx,
+        mask=valid,
+        other=EXPERT_START + num_experts,
+    )
+    expert_id -= EXPERT_START
     valid &= (expert_id >= 0) & (expert_id < num_experts)
     safe_expert = gl.where(valid, expert_id, num_experts)
     histogram = gl.histogram(
@@ -207,6 +213,7 @@ def _moe_sorting_stage4_kernel(
     numel: gl.constexpr,
     tokens_per_program: gl.constexpr,
     TOPK: gl.constexpr,
+    EXPERT_START: gl.constexpr,
     ROUTE_BLOCK: gl.constexpr,
     NUM_WARPS: gl.constexpr,
 ):
@@ -242,7 +249,8 @@ def _moe_sorting_stage4_kernel(
         route = gl.arange(0, ROUTE_BLOCK, layout=route_layout)
         idx = pid * tokens_per_program + route
         valid = (route < tokens_per_program) & (idx < numel)
-        expert_id = gl.load(topk_ids_ptr + idx, mask=valid, other=0)
+        expert_id = gl.load(topk_ids_ptr + idx, mask=valid, other=EXPERT_START)
+        expert_id -= EXPERT_START
         valid &= (expert_id >= 0) & (expert_id < num_experts)
         safe_expert = gl.where(valid, expert_id, 0)
         one = gl.full([ROUTE_BLOCK], 1, gl.int32, layout=route_layout)
@@ -269,6 +277,9 @@ def gluon_moe_sorting(
     model_dim: int,
     out_dtype: torch.dtype,
     block_size: int,
+    *,
+    expert_start: int = 0,
+    out: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Block-aligned expert sort producing sorted routing metadata.
 
@@ -277,13 +288,15 @@ def gluon_moe_sorting(
     contract).
 
     Args:
-        topk_ids: ``(M, TOPK)`` int32 expert assignments. ``-1`` entries are
-            treated as unrouted and skipped.
+        topk_ids: ``(M, TOPK)`` int32 expert assignments. IDs outside the
+            contiguous local expert range are treated as unrouted and skipped.
         topk_weights: ``(M, TOPK)`` float32 routing weights, same layout.
-        num_experts: total number of experts ``E``.
+        num_experts: number of local experts ``E`` represented by this sort.
         model_dim: hidden dim of the ``out`` buffer.
         out_dtype: dtype of the ``out`` buffer (bf16 in production).
         block_size: per-expert padding granularity ``B`` (the stage BLOCK_M).
+        expert_start: global ID of local expert zero.
+        out: optional preallocated ``(M, model_dim)`` output buffer.
 
     Returns:
         ``(sorted_ids, sorted_weights, sorted_expert_ids, num_valid_ids, out)``
@@ -297,6 +310,8 @@ def gluon_moe_sorting(
     numel = M * topk
     E = int(num_experts)
     B = int(block_size)
+    if expert_start < 0:
+        raise ValueError("expert_start must be non-negative")
 
     # Only experts receiving at least one route contribute a padding block.
     # Bounding that count by min(E, routes) avoids scaling activation-sized
@@ -320,7 +335,18 @@ def gluon_moe_sorting(
     # ``out`` does not need zeroing: stage2's reduce epilogue overwrites every
     # token row, and its small-M atomic epilogue zeroes ``out`` itself. Zeroing
     # here would redundantly clear up to tens of MB at large M.
-    out = torch.empty((M, model_dim), dtype=out_dtype, device=device)
+    if out is None:
+        out = torch.empty((M, model_dim), dtype=out_dtype, device=device)
+    elif (
+        tuple(out.shape) != (M, model_dim)
+        or out.dtype != out_dtype
+        or out.device != device
+        or out.stride(1) != 1
+        or out.stride(0) < model_dim
+    ):
+        raise ValueError(
+            "MoE output must be a row-major, colocated (M, model_dim) tensor"
+        )
 
     # Keep route chunks at a practical vector width. The chunk prefix scan
     # preserves their source order even when there are fewer experts than
@@ -343,6 +369,7 @@ def gluon_moe_sorting(
         E,
         numel,
         tokens_per_program,
+        EXPERT_START=int(expert_start),
         ROUTE_BLOCK=route_block,
         EXPERT_PAD=expert_pad,
         NUM_WARPS=_SCAN_NUM_WARPS,
@@ -381,6 +408,7 @@ def gluon_moe_sorting(
         numel,
         tokens_per_program,
         int(topk),
+        EXPERT_START=int(expert_start),
         ROUTE_BLOCK=route_block,
         NUM_WARPS=_SCAN_NUM_WARPS,
         num_warps=_SCAN_NUM_WARPS,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage1.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage1.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 
-"""Gluon MXFP4 MoE stage 1: gate + up GEMM with fused SwiGLU.
+"""Gluon MXFP4-weight MoE stage 1 with a fused gated activation.
 
 For each MoE expert ``e``::
 
@@ -32,12 +32,14 @@ by walking the ``sorted_token_ids`` / ``sorted_expert_ids`` arrays
 produced by the upstream routing kernel.
 
 Kernel shape:
-  BLOCK_M in {64, 128}, BLOCK_N = 128, BLOCK_K = 256, with one wave
-  per 32-row quarter. Each K-tile fires one gate/up MFMA pair for every
-  quarter.
-  K-loop pipelining: 2-slot LDS ping-pong for A data and A scale, and
-  2-slot VGPR ping-pong for B data and B scale; B[k+1] is issued at
-  the top of tile k so its VMEM latency hides behind tile k's MFMAs.
+  BLOCK_M in {32, 64, 128}, BLOCK_N = 128, BLOCK_K = 256, with one
+  accumulator group per 32-row quarter. The 32-row variant is limited to
+  E4M3 activations. Interleaved W13 weights are consumed as one contiguous
+  128-column MFMA tile and split into 64 gate/up outputs in the epilogue.
+  K-loop pipelining: 2-slot LDS ping-pong for A data, direct VGPR loads
+  for A scales, and 2-slot VGPR ping-pong for B data and B scales;
+  B[k+1] is issued at the top of tile k so its VMEM latency hides behind
+  tile k's MFMAs.
 
 B-data is consumed in a (16, 16)-tile layout so each MFMA fetches its
 tile with a single 128-bit ``buffer_load``. The byte at logical
@@ -56,18 +58,18 @@ applies this permutation via ``_b_preshuffle_3d`` when callers pass
 plain B, or skips it when ``b_preshuffled=True``.
 
 Layout contract:
-  hidden_states  (M_padded, K_packed)        uint8, fp4x2 packed
+  hidden_states  (M_padded, K_packed)        packed MXFP4 or MXFP8
   w1             (E, 2 * I_r, K_packed)      uint8, (16, 16) shuffled
   a1_scale       (M_padded_aligned, K // 32) uint8, e8m0
   w1_scale       (E, 2 * I_r, K // 32)       uint8, e8m0 (shuffled)
-  out            unsorted BF16 or sorted packed MXFP4 activation rows
+  out            unsorted BF16 or sorted MXFP4/MXFP8 activation rows
   out_scale      sorted CDNA4-swizzled e8m0 scales for quantized output
   sorted_token_ids    (EM,)             int32; low 24 bits = token_id
   sorted_expert_ids   (EM // BLOCK_M,)  int32; valid blocks only
 
-Stage 1 output is post-SwiGLU at ``I_r`` columns (half of the un-fused
-gate||up width). ``N = 2 * I_r`` is the B-operand column count and is
-passed in for indexing only; the C-side is ``I_r``.
+Stage 1 output is post-activation at ``I_r`` columns (half of the unfused
+gate||up width). ``N = 2 * I_r`` is the B-operand column count and is passed
+in for indexing only; the C-side is ``I_r``.
 """
 
 from __future__ import annotations
@@ -79,6 +81,7 @@ from tokenspeed_kernel_amd._triton import cdna4_async_copy, gl, gluon, triton
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (
     _mxfp4_quantize_tile,
     _mxfp4_store_cdna4_scale,
+    _mxfp8_quantize_tile,
 )
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.scale_layout import (
     CDNA4_SCALE_K_BLOCK,
@@ -145,16 +148,26 @@ def _prefetch_a_data_lds(
     offs_a,
     a_data_k_off,
     mask=None,
+    USE_ASYNC: gl.constexpr = True,
 ):
     # A_scale path is sorted-padded so the wave-uniform K-step
     # is enough; the A data path is per-token-gathered, so callers plumb
     # ``mask=token_mask[:, None]`` here to zero-fill padded sorted slots.
-    cdna4_async_copy.buffer_load_to_shared(
-        smem_a_tile,
-        a_base_ptr,
-        offs_a + a_data_k_off,
-        mask=mask,
-    )
+    offsets = offs_a + a_data_k_off
+    if USE_ASYNC:
+        cdna4_async_copy.buffer_load_to_shared(
+            smem_a_tile,
+            a_base_ptr,
+            offsets,
+            mask=mask,
+        )
+    else:
+        values = gl.load(a_base_ptr + offsets, mask=mask, other=0)
+        # E4M3 MFMAs share each A row across N-partitioned waves. Finish
+        # reading the old tile before any wave reuses this LDS slot.
+        gl.barrier()
+        smem_a_tile.store(values)
+        gl.barrier()
 
 
 @gluon.jit
@@ -198,6 +211,44 @@ def _load_b_scale_vgpr(
 
 
 @gluon.jit
+def _load_b_pair_vgpr(
+    b_base_ptr,
+    b_scales_ptr,
+    offs_b_primary,
+    offs_b_secondary,
+    b_scale_offs_primary,
+    b_scale_offs_secondary,
+    b_data_k_off,
+    tile_k,
+    b_scale_k_step: gl.constexpr,
+    INTERLEAVED: gl.constexpr,
+):
+    primary = _load_b_data_vgpr(b_base_ptr, offs_b_primary, b_data_k_off)
+    if INTERLEAVED:
+        primary_scale = _load_b_scale_vgpr(
+            b_scales_ptr,
+            b_scale_offs_primary,
+            tile_k,
+            b_scale_k_step,
+        )
+        return primary, primary, primary_scale, primary_scale
+    secondary = _load_b_data_vgpr(b_base_ptr, offs_b_secondary, b_data_k_off)
+    primary_scale = _load_b_scale_vgpr(
+        b_scales_ptr,
+        b_scale_offs_primary,
+        tile_k,
+        b_scale_k_step,
+    )
+    secondary_scale = _load_b_scale_vgpr(
+        b_scales_ptr,
+        b_scale_offs_secondary,
+        tile_k,
+        b_scale_k_step,
+    )
+    return primary, secondary, primary_scale, secondary_scale
+
+
+@gluon.jit
 def _read_a_lds_group(
     smem_a_tile,
     GROUP_IDX: gl.constexpr,
@@ -212,16 +263,56 @@ def _read_a_lds_group(
 
 
 @gluon.jit
-def _compute_mxfp4_group(cur_a, a_scale, cur_b, b_scale, acc):
+def _compute_mx_group(
+    cur_a,
+    a_scale,
+    cur_b,
+    b_scale,
+    acc,
+    A_FORMAT: gl.constexpr,
+):
     return gl.amd.cdna4.mfma_scaled(
         a=cur_a,
         a_scale=a_scale,
-        a_format="e2m1",
+        a_format=A_FORMAT,
         b=cur_b,
         b_scale=b_scale,
         b_format="e2m1",
         acc=acc,
     )
+
+
+@gluon.jit
+def _compute_gate_up_group(
+    cur_a,
+    a_scale,
+    cur_b_gate,
+    b_scale_gate,
+    cur_b_up,
+    b_scale_up,
+    gate_acc,
+    up_acc,
+    A_FORMAT: gl.constexpr,
+    INTERLEAVED: gl.constexpr,
+):
+    gate_acc = _compute_mx_group(
+        cur_a,
+        a_scale,
+        cur_b_gate,
+        b_scale_gate,
+        gate_acc,
+        A_FORMAT,
+    )
+    if not INTERLEAVED:
+        up_acc = _compute_mx_group(
+            cur_a,
+            a_scale,
+            cur_b_up,
+            b_scale_up,
+            up_acc,
+            A_FORMAT,
+        )
+    return gate_acc, up_acc
 
 
 @gluon.jit
@@ -248,6 +339,36 @@ def _apply_gate_activation(
 
 
 @gluon.jit
+def _apply_interleaved_gate_activation(
+    acc,
+    DO_SITU: gl.constexpr,
+    ALPHA: gl.constexpr,
+    LIMIT: gl.constexpr,
+    BETA: gl.constexpr,
+    LINEAR_BETA: gl.constexpr,
+    OUT_BLOCK_N: gl.constexpr,
+):
+    block_m: gl.constexpr = acc.shape[0]
+    split_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[1, 8],
+        threads_per_warp=[4, 16],
+        warps_per_cta=[gl.num_warps(), 1],
+        order=[1, 0],
+    )
+    acc = gl.convert_layout(acc, split_layout)
+    gate, up = gl.split(acc.reshape((block_m, OUT_BLOCK_N, 2)))
+    return _apply_gate_activation(
+        gate,
+        up,
+        DO_SITU,
+        ALPHA,
+        LIMIT,
+        BETA,
+        LINEAR_BETA,
+    )
+
+
+@gluon.jit
 def _store_swiglu_tile_group(
     acc_swiglu,
     c_ptr,
@@ -260,7 +381,6 @@ def _store_swiglu_tile_group(
     top_k,
     stride_cm,
     stride_cn,
-    mfma_layout: gl.constexpr,
     GROUP_IDX: gl.constexpr,
     GROUP_M: gl.constexpr,
     BLOCK_M: gl.constexpr,
@@ -269,9 +389,11 @@ def _store_swiglu_tile_group(
     OUTPUT_K: gl.constexpr,
     OUTPUT_SORTED: gl.constexpr,
     OUTPUT_QUANTIZED: gl.constexpr,
+    OUTPUT_FP8: gl.constexpr,
 ):
-    cm_layout: gl.constexpr = gl.SliceLayout(1, mfma_layout)
-    cn_layout: gl.constexpr = gl.SliceLayout(0, mfma_layout)
+    output_layout: gl.constexpr = acc_swiglu.type.layout
+    cm_layout: gl.constexpr = gl.SliceLayout(1, output_layout)
+    cn_layout: gl.constexpr = gl.SliceLayout(0, output_layout)
     offs_cm = (
         pid_m * BLOCK_M + GROUP_IDX * GROUP_M + gl.arange(0, GROUP_M, layout=cm_layout)
     )
@@ -289,20 +411,34 @@ def _store_swiglu_tile_group(
         dst_row_cm = token_id_cm * top_k + topk_id_cm
     token_mask_cm = (offs_cm < EM) if OUTPUT_SORTED else (token_id_cm < num_tokens)
     if OUTPUT_QUANTIZED:
-        packed, scale_byte = _mxfp4_quantize_tile(acc_swiglu)
-        packed = packed.reshape((GROUP_M, BLOCK_N // 2))
-        packed_layout: gl.constexpr = packed.type.layout
-        packed_m = gl.arange(0, GROUP_M, gl.SliceLayout(1, packed_layout))
-        packed_n = gl.arange(0, BLOCK_N // 2, gl.SliceLayout(0, packed_layout))
-        packed_rows = pid_m * BLOCK_M + GROUP_IDX * GROUP_M + packed_m
-        packed_cols = pid_n * (BLOCK_N // 2) + packed_n
-        packed_ptrs = (
-            c_ptr
-            + packed_rows[:, None].to(gl.int64) * stride_cm
-            + packed_cols[None, :].to(gl.int64) * stride_cn
+        if OUTPUT_FP8:
+            quantized, scale_byte = _mxfp8_quantize_tile(acc_swiglu)
+            quantized = quantized.reshape((GROUP_M, BLOCK_N))
+            quantized_cols_per_tile: gl.constexpr = BLOCK_N
+            output_cols: gl.constexpr = I_r
+        else:
+            quantized, scale_byte = _mxfp4_quantize_tile(acc_swiglu)
+            quantized = quantized.reshape((GROUP_M, BLOCK_N // 2))
+            quantized_cols_per_tile: gl.constexpr = BLOCK_N // 2
+            output_cols: gl.constexpr = I_r // 2
+        quantized_layout: gl.constexpr = quantized.type.layout
+        quantized_m = gl.arange(0, GROUP_M, gl.SliceLayout(1, quantized_layout))
+        quantized_n = gl.arange(
+            0,
+            quantized_cols_per_tile,
+            gl.SliceLayout(0, quantized_layout),
         )
-        packed_mask = (packed_rows[:, None] < EM) & (packed_cols[None, :] < I_r // 2)
-        gl.store(packed_ptrs, packed, mask=packed_mask)
+        quantized_rows = pid_m * BLOCK_M + GROUP_IDX * GROUP_M + quantized_m
+        quantized_cols = pid_n * quantized_cols_per_tile + quantized_n
+        quantized_ptrs = (
+            c_ptr
+            + quantized_rows[:, None].to(gl.int64) * stride_cm
+            + quantized_cols[None, :].to(gl.int64) * stride_cn
+        )
+        quantized_mask = (quantized_rows[:, None] < EM) & (
+            quantized_cols[None, :] < output_cols
+        )
+        gl.store(quantized_ptrs, quantized, mask=quantized_mask)
 
         scale_layout: gl.constexpr = scale_byte.type.layout
         scale_m = (
@@ -325,37 +461,58 @@ def _store_swiglu_tile_group(
             K_SWIZZLE=8,
         )
         if OUTPUT_K > I_r and pid_n == gl.cdiv(I_r, BLOCK_N) - 1:
-            gl.static_assert(OUTPUT_K - I_r <= BLOCK_N)
-            tail_packed_cols = I_r // 2 + packed_n
-            tail_packed_ptrs = (
-                c_ptr
-                + packed_rows[:, None].to(gl.int64) * stride_cm
-                + tail_packed_cols[None, :].to(gl.int64) * stride_cn
-            )
-            tail_packed_mask = (packed_rows[:, None] < EM) & (
-                tail_packed_cols[None, :] < OUTPUT_K // 2
-            )
-            gl.store(tail_packed_ptrs, gl.zeros_like(packed), mask=tail_packed_mask)
+            # W2 alignment can require more than one logical output tile of
+            # padding (for example, I=384 padded to K=512 with a 64-wide W13
+            # tile). The final active CTA initializes every padded tile.
+            num_tail_tiles: gl.constexpr = gl.cdiv(OUTPUT_K - I_r, BLOCK_N)
+            for tail_tile in range(0, num_tail_tiles):
+                if OUTPUT_FP8:
+                    tail_quantized_cols = I_r + tail_tile * BLOCK_N + quantized_n
+                    tail_output_cols: gl.constexpr = OUTPUT_K
+                else:
+                    tail_quantized_cols = (
+                        I_r // 2 + tail_tile * (BLOCK_N // 2) + quantized_n
+                    )
+                    tail_output_cols: gl.constexpr = OUTPUT_K // 2
+                tail_quantized_ptrs = (
+                    c_ptr
+                    + quantized_rows[:, None].to(gl.int64) * stride_cm
+                    + tail_quantized_cols[None, :].to(gl.int64) * stride_cn
+                )
+                tail_quantized_mask = (quantized_rows[:, None] < EM) & (
+                    tail_quantized_cols[None, :] < tail_output_cols
+                )
+                gl.store(
+                    tail_quantized_ptrs,
+                    gl.zeros_like(quantized),
+                    mask=tail_quantized_mask,
+                )
 
-            tail_scale_k = I_r // 32 + gl.arange(
-                0, BLOCK_N // 32, gl.SliceLayout(0, scale_layout)
-            )
-            _mxfp4_store_cdna4_scale(
-                c_scale_ptr,
-                gl.full(
-                    scale_byte.shape,
-                    127,
-                    gl.uint8,
-                    layout=scale_byte.type.layout,
-                ),
-                scale_m[:, None],
-                tail_scale_k[None, :],
-                1,
-                (OUTPUT_K // 32) * 32,
-                (scale_m[:, None] < EM) & (tail_scale_k[None, :] < OUTPUT_K // 32),
-                M_SWIZZLE=32,
-                K_SWIZZLE=8,
-            )
+                tail_scale_k = (
+                    I_r // 32
+                    + tail_tile * (BLOCK_N // 32)
+                    + gl.arange(
+                        0,
+                        BLOCK_N // 32,
+                        gl.SliceLayout(0, scale_layout),
+                    )
+                )
+                _mxfp4_store_cdna4_scale(
+                    c_scale_ptr,
+                    gl.full(
+                        scale_byte.shape,
+                        127,
+                        gl.uint8,
+                        layout=scale_byte.type.layout,
+                    ),
+                    scale_m[:, None],
+                    tail_scale_k[None, :],
+                    1,
+                    (OUTPUT_K // 32) * 32,
+                    (scale_m[:, None] < EM) & (tail_scale_k[None, :] < OUTPUT_K // 32),
+                    M_SWIZZLE=32,
+                    K_SWIZZLE=8,
+                )
     else:
         c_val = acc_swiglu.to(c_ptr.type.element_ty)
         c_ptrs = (
@@ -365,6 +522,360 @@ def _store_swiglu_tile_group(
         )
         c_mask = token_mask_cm[:, None] & (offs_cn[None, :] < I_r)
         gl.store(c_ptrs, c_val, mask=c_mask)
+
+
+@gluon.jit
+def gluon_mxfp4_moe_stage1_e4m3_async_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    c_scale_ptr,
+    a_scales_ptr,
+    b_scales_ptr,
+    sorted_token_ids_ptr,
+    sorted_expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    EM,
+    num_tokens,
+    top_k,
+    stride_be,
+    stride_cm,
+    stride_cn,
+    stride_bse_e,
+    stride_se_n_pad,
+    STRIDE_AM: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    K_PACKED_TOTAL: gl.constexpr,
+    I_r: gl.constexpr,
+    OUTPUT_K: gl.constexpr,
+    SWIGLU_ALPHA: gl.constexpr,
+    SWIGLU_LIMIT: gl.constexpr,
+    SWIGLU_BETA: gl.constexpr,
+    SITU_LINEAR_BETA: gl.constexpr,
+):
+    """Stage 1 with four-wave async FP8 activation staging.
+
+    Each logical K=256 tile is split into two K=128 MFMA steps. Each 32-row
+    slice then moves aligned 16-byte lane transactions, the native CDNA4
+    async-copy width, while preserving the GDOT128 interleaved weight and
+    sorted MXFP8 output contracts.
+    """
+
+    BLOCK_N: gl.constexpr = 128
+    OUTPUT_BLOCK_N: gl.constexpr = 64
+    BLOCK_K_HALF: gl.constexpr = 128
+    BLOCK_K_PACKED_HALF: gl.constexpr = 64
+    BLOCK_K_SCALE_HALF: gl.constexpr = 4
+    NUM_WARPS: gl.constexpr = 4
+    NUM_BUFFERS: gl.constexpr = 2
+    NUM_K_TILES: gl.constexpr = K_PACKED_TOTAL // 128
+
+    gl.static_assert(
+        BLOCK_M == 32 or BLOCK_M == 64 or BLOCK_M == 128,
+        "async stage1 requires BLOCK_M in {32, 64, 128}",
+    )
+    gl.static_assert(K_PACKED_TOTAL % 128 == 0)
+    gl.static_assert(I_r % OUTPUT_BLOCK_N == 0)
+
+    pid = gl.program_id(axis=0)
+    num_pid_m = gl.cdiv(EM, BLOCK_M)
+    num_pid_n: gl.constexpr = I_r // OUTPUT_BLOCK_N
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+
+    num_tokens_post_padded = gl.load(num_tokens_post_padded_ptr)
+    if pid_n >= num_pid_n or pid_m * BLOCK_M >= num_tokens_post_padded:
+        return
+
+    expert = gl.load(sorted_expert_ids_ptr + pid_m)
+
+    mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
+        version=4,
+        instr_shape=[16, 16, 128],
+        transposed=True,
+        warps_per_cta=[1, 4],
+    )
+    dot_a_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=mfma_layout, k_width=16
+    )
+    dot_b_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=mfma_layout, k_width=16
+    )
+    a_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_a_layout, [BLOCK_M, BLOCK_K_SCALE_HALF]
+    )
+    b_scale_layout: gl.constexpr = gl.amd.cdna4.get_mfma_scale_layout(
+        dot_b_layout, [BLOCK_N, BLOCK_K_SCALE_HALF]
+    )
+
+    # This distribution gives every lane one aligned 128-bit copy per 32-row
+    # slice. Two independent half-tile buffers avoid slicing the shared
+    # descriptor, which the CDNA4 direct-copy lowering cannot legalize.
+    gload_a_layout: gl.constexpr = gl.BlockedLayout(
+        [1, 16],
+        [8, 8],
+        [4, 1],
+        [1, 0],
+    )
+    shared_a_layout: gl.constexpr = gl.SwizzledSharedLayout(16, 1, 16, order=[1, 0])
+    smem_a_lo = gl.allocate_shared_memory(
+        a_ptr.type.element_ty,
+        [NUM_BUFFERS, BLOCK_M, BLOCK_K_HALF],
+        shared_a_layout,
+    )
+    smem_a_hi = gl.allocate_shared_memory(
+        a_ptr.type.element_ty,
+        [NUM_BUFFERS, BLOCK_M, BLOCK_K_HALF],
+        shared_a_layout,
+    )
+
+    m_load_layout: gl.constexpr = gl.SliceLayout(1, gload_a_layout)
+    k_load_layout: gl.constexpr = gl.SliceLayout(0, gload_a_layout)
+    tile_row = gl.arange(0, BLOCK_M, layout=m_load_layout)
+    sorted_row = pid_m * BLOCK_M + tile_row
+    packed_route = gl.load(
+        sorted_token_ids_ptr + sorted_row,
+        mask=sorted_row < EM,
+        other=num_tokens,
+    )
+    token_id = packed_route & 0xFFFFFF
+    token_mask = token_id < num_tokens
+    a_k = gl.arange(0, BLOCK_K_HALF, layout=k_load_layout)
+    # Keep the direct-copy offset within one M tile. The scalar base retains
+    # the full 64-bit routed-row address while the buffer instruction gets the
+    # compact 32-bit offset it requires.
+    a_base = a_ptr + (pid_m * BLOCK_M).to(gl.int64) * STRIDE_AM
+    a_offsets_lo = tile_row[:, None] * STRIDE_AM + a_k[None, :]
+    a_offsets_hi = a_offsets_lo + BLOCK_K_HALF
+
+    m_scale_layout: gl.constexpr = gl.SliceLayout(1, a_scale_layout)
+    k_scale_layout: gl.constexpr = gl.SliceLayout(0, a_scale_layout)
+    a_scale_rows = (pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=m_scale_layout)).to(
+        gl.uint32
+    )
+    a_scale_m_part = (
+        (a_scale_rows // 32) * (stride_se_n_pad * 32)
+        + (a_scale_rows % 16) * 4
+        + ((a_scale_rows % 32) // 16)
+    )[:, None]
+    a_scale_k = gl.arange(0, BLOCK_K_SCALE_HALF, layout=k_scale_layout).to(gl.uint32)
+    a_scale_lo_offsets = a_scale_m_part + (a_scale_k % 4)[None, :] * 64
+    a_scale_hi_offsets = a_scale_lo_offsets + 2
+
+    b_k_layout: gl.constexpr = gl.SliceLayout(1, dot_b_layout)
+    b_n_layout: gl.constexpr = gl.SliceLayout(0, dot_b_layout)
+    b_k = gl.arange(0, BLOCK_K_PACKED_HALF, layout=b_k_layout).to(gl.uint32)
+    b_n = (pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_n_layout)).to(gl.uint32)
+    b_n_in = b_n % 128
+    b_n_tiles: gl.constexpr = (2 * I_r) // 128
+    b_in_lo = (
+        (b_n_in // 16)[None, :] * 2048
+        + (b_n_in % 16)[None, :] * 16
+        + (b_k % 16)[:, None]
+        + ((b_k // 16) % 4)[:, None] * 256
+    )
+    b_in_hi = b_in_lo + 1024
+    b_tile_base = (b_n // 128)[None, :] * (128 * 128)
+    b_offsets_lo = b_tile_base + b_in_lo
+    b_offsets_hi = b_tile_base + b_in_hi
+    B_DATA_K_STEP: gl.constexpr = b_n_tiles * (128 * 128)
+
+    b_scale_n_layout: gl.constexpr = gl.SliceLayout(1, b_scale_layout)
+    b_scale_k_layout: gl.constexpr = gl.SliceLayout(0, b_scale_layout)
+    b_scale_rows = (
+        pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_scale_n_layout)
+    ).to(gl.uint32)
+    b_scale_n_part = (
+        (b_scale_rows // 32) * (K_PACKED_TOTAL * 2)
+        + (b_scale_rows % 16) * 4
+        + ((b_scale_rows % 32) // 16)
+    )[:, None]
+    b_scale_k = gl.arange(0, BLOCK_K_SCALE_HALF, layout=b_scale_k_layout).to(gl.uint32)
+    b_scale_lo_offsets = b_scale_n_part + (b_scale_k % 4)[None, :] * 64
+    b_scale_hi_offsets = b_scale_lo_offsets + 2
+
+    b_base = b_ptr + expert.to(gl.int64) * stride_be
+    b_scale_base = b_scales_ptr + expert.to(gl.int64) * stride_bse_e
+    acc = gl.zeros((BLOCK_M, BLOCK_N), gl.float32, mfma_layout)
+
+    cdna4_async_copy.buffer_load_to_shared(
+        smem_a_lo.index(0),
+        a_base,
+        a_offsets_lo,
+        mask=token_mask[:, None],
+    )
+    cdna4_async_copy.buffer_load_to_shared(
+        smem_a_hi.index(0),
+        a_base,
+        a_offsets_hi,
+        mask=token_mask[:, None],
+    )
+    cdna4_async_copy.commit_group()
+
+    for tile_k in gl.static_range(0, NUM_K_TILES - 1):
+        load_slot = tile_k % NUM_BUFFERS
+        next_slot = (tile_k + 1) % NUM_BUFFERS
+        next_a_offset = (tile_k + 1) * 256
+        cdna4_async_copy.buffer_load_to_shared(
+            smem_a_lo.index(next_slot),
+            a_base,
+            a_offsets_lo + next_a_offset,
+            mask=token_mask[:, None],
+        )
+        cdna4_async_copy.buffer_load_to_shared(
+            smem_a_hi.index(next_slot),
+            a_base,
+            a_offsets_hi + next_a_offset,
+            mask=token_mask[:, None],
+        )
+        cdna4_async_copy.commit_group()
+
+        b_tile_offset = tile_k * B_DATA_K_STEP
+        scale_tile_offset = tile_k * 256
+        b_lo = gl.amd.cdna4.buffer_load(
+            ptr=b_base,
+            offsets=b_offsets_lo + b_tile_offset,
+        )
+        a_scale_lo = gl.amd.cdna4.buffer_load(
+            ptr=a_scales_ptr,
+            offsets=a_scale_lo_offsets + scale_tile_offset,
+        )
+        b_scale_lo = gl.amd.cdna4.buffer_load(
+            ptr=b_scale_base,
+            offsets=b_scale_lo_offsets + scale_tile_offset,
+        )
+        cdna4_async_copy.wait_group(1)
+        # The copy wait is wave-local. A is loaded across four waves but each
+        # N-partitioned MFMA wave consumes every row, so make all LDS writes
+        # visible before the cross-wave reads.
+        gl.barrier()
+        a_lo = cdna4_async_copy.load_shared_relaxed(
+            smem_a_lo.index(load_slot), dot_a_layout
+        )
+        acc = gl.amd.cdna4.mfma_scaled(
+            a=a_lo,
+            a_scale=a_scale_lo,
+            a_format="e4m3",
+            b=b_lo,
+            b_scale=b_scale_lo,
+            b_format="e2m1",
+            acc=acc,
+        )
+
+        b_hi = gl.amd.cdna4.buffer_load(
+            ptr=b_base,
+            offsets=b_offsets_hi + b_tile_offset,
+        )
+        a_scale_hi = gl.amd.cdna4.buffer_load(
+            ptr=a_scales_ptr,
+            offsets=a_scale_hi_offsets + scale_tile_offset,
+        )
+        b_scale_hi = gl.amd.cdna4.buffer_load(
+            ptr=b_scale_base,
+            offsets=b_scale_hi_offsets + scale_tile_offset,
+        )
+        a_hi = cdna4_async_copy.load_shared_relaxed(
+            smem_a_hi.index(load_slot), dot_a_layout
+        )
+        acc = gl.amd.cdna4.mfma_scaled(
+            a=a_hi,
+            a_scale=a_scale_hi,
+            a_format="e4m3",
+            b=b_hi,
+            b_scale=b_scale_hi,
+            b_format="e2m1",
+            acc=acc,
+        )
+        # All N-partitioned waves must finish reading the current A slot
+        # before the next iteration reuses it as the async-copy destination.
+        gl.barrier()
+
+    last_tile: gl.constexpr = NUM_K_TILES - 1
+    last_slot: gl.constexpr = last_tile % NUM_BUFFERS
+    last_b_offset: gl.constexpr = last_tile * B_DATA_K_STEP
+    last_scale_offset: gl.constexpr = last_tile * 256
+    b_lo = gl.amd.cdna4.buffer_load(
+        ptr=b_base,
+        offsets=b_offsets_lo + last_b_offset,
+    )
+    a_scale_lo = gl.amd.cdna4.buffer_load(
+        ptr=a_scales_ptr,
+        offsets=a_scale_lo_offsets + last_scale_offset,
+    )
+    b_scale_lo = gl.amd.cdna4.buffer_load(
+        ptr=b_scale_base,
+        offsets=b_scale_lo_offsets + last_scale_offset,
+    )
+    cdna4_async_copy.wait_group(0)
+    gl.barrier()
+    a_lo = cdna4_async_copy.load_shared_relaxed(
+        smem_a_lo.index(last_slot), dot_a_layout
+    )
+    acc = gl.amd.cdna4.mfma_scaled(
+        a=a_lo,
+        a_scale=a_scale_lo,
+        a_format="e4m3",
+        b=b_lo,
+        b_scale=b_scale_lo,
+        b_format="e2m1",
+        acc=acc,
+    )
+    b_hi = gl.amd.cdna4.buffer_load(
+        ptr=b_base,
+        offsets=b_offsets_hi + last_b_offset,
+    )
+    a_scale_hi = gl.amd.cdna4.buffer_load(
+        ptr=a_scales_ptr,
+        offsets=a_scale_hi_offsets + last_scale_offset,
+    )
+    b_scale_hi = gl.amd.cdna4.buffer_load(
+        ptr=b_scale_base,
+        offsets=b_scale_hi_offsets + last_scale_offset,
+    )
+    a_hi = cdna4_async_copy.load_shared_relaxed(
+        smem_a_hi.index(last_slot), dot_a_layout
+    )
+    acc = gl.amd.cdna4.mfma_scaled(
+        a=a_hi,
+        a_scale=a_scale_hi,
+        a_format="e4m3",
+        b=b_hi,
+        b_scale=b_scale_hi,
+        b_format="e2m1",
+        acc=acc,
+    )
+
+    activated = _apply_interleaved_gate_activation(
+        acc,
+        True,
+        SWIGLU_ALPHA,
+        SWIGLU_LIMIT,
+        SWIGLU_BETA,
+        SITU_LINEAR_BETA,
+        OUTPUT_BLOCK_N,
+    )
+    _store_swiglu_tile_group(
+        activated,
+        c_ptr,
+        c_scale_ptr,
+        sorted_token_ids_ptr,
+        pid_m,
+        pid_n,
+        EM,
+        num_tokens,
+        top_k,
+        stride_cm,
+        stride_cn,
+        0,
+        BLOCK_M,
+        BLOCK_M,
+        OUTPUT_BLOCK_N,
+        I_r,
+        OUTPUT_K,
+        True,
+        True,
+        True,
+    )
 
 
 @gluon.jit
@@ -406,55 +917,54 @@ def gluon_mxfp4_moe_stage1_kernel(
     SITU_LINEAR_BETA: gl.constexpr,
     OUTPUT_SORTED: gl.constexpr,
     OUTPUT_QUANTIZED: gl.constexpr,
+    A_FORMAT: gl.constexpr,
+    OUTPUT_FP8: gl.constexpr,
+    INPUT_SORTED: gl.constexpr,
 ):
     """Stage 1 kernel with per-token A gather and fused SwiGLU.
 
     Tile config: ``BLOCK_M x 128 x 256`` (M x N x K), with ``BLOCK_M``
-    in ``{64, 128}`` and one wave per 32 output rows. MFMA target:
+    in ``{32, 64, 128}``; the 32-row variant is E4M3-only. MFMA target:
     ``v_mfma_scale_f32_16x16x128_f8f6f4`` (gfx950, AMDMFMALayout
-    version=4). The launch grid covers ``num_pid_m * (I_r / BLOCK_N)``
-    programs (i.e. ``num_pid_n = I_r / BLOCK_N``, NOT ``N / BLOCK_N``);
-    each CTA owns one ``BLOCK_N`` slab of the ``[EM, I_r]`` SwiGLU
-    output and computes the corresponding gate and up contributions
-    itself.
+    version=4). Each CTA owns ``BLOCK_N / 2`` output columns for interleaved
+    GDOT128 W13 or ``BLOCK_N`` columns for separate gate/up layouts.
 
-    Each K tile fires two ``mfma_scaled`` calls per 32-row quarter. The
-    K loop alternates two A-data LDS slots while loading A scales and B
-    operands directly into VGPRs.
+    For GDOT128 W13, each K tile consumes the physical interleaved gate/up
+    rows in one ``BLOCK_N`` MFMA accumulator per 32-row quarter. Other
+    layouts retain separate gate and up accumulators. The K loop alternates
+    two A-data LDS slots while loading A scales and B operands into VGPRs.
 
-    Epilogue: ``silu(gate_acc_groupX) * up_acc_groupX`` for each quarter,
-    cast to bf16, stored at sorted-row positions over ``BLOCK_N`` cols
-    starting at ``pid_n * BLOCK_N`` of the ``[EM, I_r]`` output buffer.
+    The epilogue splits interleaved accumulators into gate/up pairs, applies
+    the activation, and stores the resulting output tile in ``[EM, I_r]``.
     """
 
     gl.static_assert(
-        BLOCK_M == 64 or BLOCK_M == 128,
-        "stage1 kernel requires BLOCK_M in {64, 128}",
+        BLOCK_M == 64 or BLOCK_M == 128 or (BLOCK_M == 32 and A_FORMAT == "e4m3"),
+        "stage1 kernel requires BLOCK_M in {64, 128}, or 32 for E4M3",
     )
     gl.static_assert(BLOCK_N == 128, "stage1 kernel requires BLOCK_N=128")
     gl.static_assert(BLOCK_K == 256, "stage1 kernel requires BLOCK_K=256")
     gl.static_assert(
-        NUM_WARPS == BLOCK_M // 32,
-        "stage1 kernel requires one wave per 32 output rows",
+        NUM_WARPS == BLOCK_M // 32 or (A_FORMAT == "e4m3" and NUM_WARPS == 8),
+        "stage1 kernel requires the native E2M1 wave count or eight E4M3 waves",
     )
     gl.static_assert(not OUTPUT_QUANTIZED or OUTPUT_SORTED)
 
     SCALE_GROUP: gl.constexpr = 32
-    DIV: gl.constexpr = 2
-    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // DIV
+    A_DIV: gl.constexpr = 1 if A_FORMAT == "e4m3" else 2
+    BLOCK_K_A: gl.constexpr = BLOCK_K // A_DIV
+    BLOCK_K_B: gl.constexpr = BLOCK_K // 2
     BLOCK_K_SCALE: gl.constexpr = BLOCK_K // SCALE_GROUP
     NUM_BUFFERS: gl.constexpr = 2
     GROUP_MFMA_M: gl.constexpr = 32
 
     pid = gl.program_id(axis=0)
     num_pid_m = gl.cdiv(EM, BLOCK_M)
-    # Grid covers the SwiGLU output columns ``I_r``, not the un-fused
-    # gate||up GEMM columns ``N = 2 * I_r``. Each CTA owns one
-    # ``BLOCK_N`` slab of the ``I_r``-wide output and internally issues
-    # both the gate MFMAs (B columns ``pid_n * BLOCK_N``) and the up
-    # MFMAs (B columns ``(pid_n + num_pid_n) * BLOCK_N``) against the
-    # same A operand.
-    num_pid_n = gl.cdiv(I_r, BLOCK_N)
+    OUTPUT_BLOCK_N: gl.constexpr = BLOCK_N // 2 if B_GDOT128 else BLOCK_N
+    # Grid over the activated ``I_r`` columns. Interleaved W13 consumes a
+    # physical BLOCK_N tile for each OUTPUT_BLOCK_N result tile; separate
+    # layouts issue gate and up MFMAs for the same output tile.
+    num_pid_n = gl.cdiv(I_r, OUTPUT_BLOCK_N)
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     group_id = pid // num_pid_in_group
     first_pid_m = group_id * GROUP_SIZE_M
@@ -466,11 +976,14 @@ def gluon_mxfp4_moe_stage1_kernel(
     if pid_m * BLOCK_M >= num_tokens_post_padded:
         return
 
+    mfma_warps: gl.constexpr = (
+        [2, NUM_WARPS // 2] if A_FORMAT == "e4m3" else [1, NUM_WARPS]
+    )
     mfma_layout: gl.constexpr = gl.amd.AMDMFMALayout(
         version=4,
         instr_shape=[16, 16, 128],
         transposed=True,
-        warps_per_cta=[1, NUM_WARPS],
+        warps_per_cta=mfma_warps,
     )
     dot_a_layout: gl.constexpr = gl.DotOperandLayout(
         operand_index=0, parent=mfma_layout, k_width=16
@@ -496,10 +1009,45 @@ def gluon_mxfp4_moe_stage1_kernel(
         [NUM_WARPS, 1],
         [1, 0],
     )
-    if BLOCK_M == 64:
-        shared_a: gl.constexpr = gl.PaddedSharedLayout(
-            [[4096, 128]],
-            [
+    if BLOCK_M == 32:
+        if A_FORMAT == "e4m3":
+            shared_a_bases: gl.constexpr = [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [0, 128],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+                [16, 0],
+            ]
+        else:
+            shared_a_bases: gl.constexpr = []
+    elif BLOCK_M == 64:
+        if A_FORMAT == "e4m3":
+            shared_a_bases: gl.constexpr = [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [0, 128],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+                [16, 0],
+                [32, 0],
+            ]
+        else:
+            shared_a_bases: gl.constexpr = [
                 [0, 1],
                 [0, 2],
                 [0, 4],
@@ -513,14 +1061,28 @@ def gluon_mxfp4_moe_stage1_kernel(
                 [8, 0],
                 [16, 0],
                 [32, 0],
-            ],
-            [],
-            [BLOCK_M, BLOCK_K_PACKED],
-        )
+            ]
     else:
-        shared_a: gl.constexpr = gl.PaddedSharedLayout(
-            [[4096, 128]],
-            [
+        if A_FORMAT == "e4m3":
+            shared_a_bases: gl.constexpr = [
+                [0, 1],
+                [0, 2],
+                [0, 4],
+                [0, 8],
+                [0, 16],
+                [0, 32],
+                [0, 64],
+                [0, 128],
+                [1, 0],
+                [2, 0],
+                [4, 0],
+                [8, 0],
+                [16, 0],
+                [32, 0],
+                [64, 0],
+            ]
+        else:
+            shared_a_bases: gl.constexpr = [
                 [0, 1],
                 [0, 2],
                 [0, 4],
@@ -535,10 +1097,16 @@ def gluon_mxfp4_moe_stage1_kernel(
                 [16, 0],
                 [32, 0],
                 [64, 0],
-            ],
-            [],
-            [BLOCK_M, BLOCK_K_PACKED],
-        )
+            ]
+    shared_a_padding: gl.constexpr = (
+        [[1024, 32]] if A_FORMAT == "e4m3" else [[4096, 128]]
+    )
+    shared_a: gl.constexpr = gl.PaddedSharedLayout(
+        shared_a_padding,
+        shared_a_bases,
+        [],
+        [BLOCK_M, BLOCK_K_A],
+    )
 
     # ---- per-token A row gather -----------------------------------------
     # ``sorted_token_ids`` packs ``(topk_id << 24) | token_id`` per
@@ -559,14 +1127,17 @@ def gluon_mxfp4_moe_stage1_kernel(
         other=num_tokens,
     )
     token_mask = (offs_token & 0xFFFFFF) < num_tokens
-    a_row = offs_token & 0xFFFFFF
+    if INPUT_SORTED:
+        a_row = offs_token_id
+    else:
+        a_row = offs_token & 0xFFFFFF
 
     # The valid-count guard above excludes every unwritten tail block, so the
     # sort contract guarantees a valid expert for each program reaching here.
     off_experts = gl.load(sorted_expert_ids_ptr + pid_m)
 
     # ---- A data-load offsets (consumed by per-tile prefetch) ----------
-    offs_ak = gl.arange(0, BLOCK_K_PACKED, layout=k_layout)
+    offs_ak = gl.arange(0, BLOCK_K_A, layout=k_layout)
     offs_a = a_row[:, None].to(gl.int64) * stride_am + offs_ak[None, :] * stride_ak
 
     # ---- A_scale gather offsets ----------------------------------------
@@ -605,57 +1176,50 @@ def gluon_mxfp4_moe_stage1_kernel(
     a_scale_base_offsets = a_m_part + a_k_lane
     a_scale_group_stride = stride_se_n_pad * 32
 
-    # ---- B data offsets (gate + up halves; preshuffle-B closed form) ---
+    # ---- B data offsets (preshuffle-B closed form) --------------------
     # B is in the (16, 16) MFMA-tile layout described in the module
-    # docstring, so the byte for logical ``(n, k_pk)`` is the closed
-    # form computed below (the per-expert term is folded into
-    # ``b_base_ptr``). GU-fusion builds two N-offset tensors -- one
-    # for the gate half starting at column ``pid_n * BLOCK_N``, one
-    # for the up half starting at ``(pid_n + num_pid_n) * BLOCK_N`` --
-    # against the same K offsets. The ``% N`` wrap defends a
-    # degenerate ``I_r < BLOCK_N`` test path where the up rows would
-    # otherwise exceed ``N``.
-    offs_bk = gl.arange(0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout))
-    offs_bn_gate = (
-        pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))
-    ) % N
-    offs_bn_up = (
-        (pid_n + num_pid_n) * BLOCK_N
-        + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))
-    ) % N
+    # docstring, so the byte for logical ``(n, k_pk)`` is the closed form
+    # computed below (the per-expert term is folded into ``b_base_ptr``).
+    # The GDOT128 layout physically interleaves gate/up rows and is consumed
+    # as one contiguous ``BLOCK_N`` stream. Other layouts retain separate
+    # gate and up streams. The ``% N`` wraps below defend the degenerate
+    # ``I_r < BLOCK_N`` test path.
+    offs_bk = gl.arange(0, BLOCK_K_B, layout=gl.SliceLayout(1, dot_b_layout))
     if B_GDOT128:
         n_tiles: gl.constexpr = (2 * I_r) // 128
-        # Tokenspeed stores gate/up rows interleaved (g0,u0,g1,u1,...),
-        # while this kernel's logical N axis is concatenated gate||up.
-        n_gate_phys = offs_bn_gate * 2
-        n_up_phys = (offs_bn_up - I_r) * 2 + 1
+        offs_bn_primary = (
+            pid_n * BLOCK_N
+            + gl.arange(
+                0,
+                BLOCK_N,
+                layout=gl.SliceLayout(0, dot_b_layout),
+            )
+        ) % N
         k_in = offs_bk % 128
         k_within = k_in % 16
         k_quad = (k_in // 16) % 4
         k_block = k_in // 64
-        n_gate_in = n_gate_phys % 128
-        n_up_in = n_up_phys % 128
-        in_gate = (
-            (n_gate_in // 16)[None, :] * 2048
+        n_primary_in = offs_bn_primary % 128
+        in_primary = (
+            (n_primary_in // 16)[None, :] * 2048
             + k_block[:, None] * 1024
             + k_quad[:, None] * 256
-            + (n_gate_in % 16)[None, :] * 16
-            + k_within[:, None]
-        )
-        in_up = (
-            (n_up_in // 16)[None, :] * 2048
-            + k_block[:, None] * 1024
-            + k_quad[:, None] * 256
-            + (n_up_in % 16)[None, :] * 16
+            + (n_primary_in % 16)[None, :] * 16
             + k_within[:, None]
         )
         offs_b_gate = (
-            (offs_bk // 128)[:, None] * n_tiles + (n_gate_phys // 128)[None, :]
-        ) * (128 * 128) + in_gate
-        offs_b_up = (
-            (offs_bk // 128)[:, None] * n_tiles + (n_up_phys // 128)[None, :]
-        ) * (128 * 128) + in_up
+            (offs_bk // 128)[:, None] * n_tiles + (offs_bn_primary // 128)[None, :]
+        ) * (128 * 128) + in_primary
+        offs_b_up = offs_b_gate
     else:
+        offs_bn_gate = (
+            pid_n * BLOCK_N
+            + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))
+        ) % N
+        offs_bn_up = (
+            (pid_n + num_pid_n) * BLOCK_N
+            + gl.arange(0, BLOCK_N, layout=gl.SliceLayout(0, dot_b_layout))
+        ) % N
         b_k_part = (
             (offs_bk // 32) * 512 + ((offs_bk // 16) % 2) * 256 + (offs_bk % 16)
         )[:, None]
@@ -668,7 +1232,7 @@ def gluon_mxfp4_moe_stage1_kernel(
         offs_b_gate = b_k_part + b_n_part_gate
         offs_b_up = b_k_part + b_n_part_up
 
-    # ---- B_scale offsets (gate + up halves; e8m0_shuffle_opsel_b) -----
+    # ---- B_scale offsets (e8m0_shuffle_opsel_b) -----------------------
     # Same row-part decomposition as the prior preshuffle-B port; the
     # cross-tile step is the constexpr ``B_SCALE_K_STEP = 1024`` because
     # ``BLOCK_K_SCALE = 8`` covers a full ``y/8`` block per K iter. The
@@ -676,26 +1240,23 @@ def gluon_mxfp4_moe_stage1_kernel(
     # K-loop only carries the K-step.
     b_n_layout_scale: gl.constexpr = gl.SliceLayout(1, b_scale_layout)
     b_k_layout_scale: gl.constexpr = gl.SliceLayout(0, b_scale_layout)
-    b_rows_gate = (pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_n_layout_scale)).to(
-        gl.uint32
-    )
-    b_rows_up = (
-        (pid_n + num_pid_n) * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_n_layout_scale)
-    ).to(gl.uint32)
     if B_GDOT128:
-        b_rows_gate_phys = b_rows_gate * 2
-        b_rows_up_phys = (b_rows_up - I_r) * 2 + 1
+        b_rows_primary = (
+            pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_n_layout_scale)
+        ).to(gl.uint32)
         b_n_part_gate_scale = (
-            (b_rows_gate_phys // 32) * (K_PACKED_TOTAL * 2)
-            + (b_rows_gate_phys % 16) * 4
-            + ((b_rows_gate_phys % 32) // 16)
-        )[:, None]
-        b_n_part_up_scale = (
-            (b_rows_up_phys // 32) * (K_PACKED_TOTAL * 2)
-            + (b_rows_up_phys % 16) * 4
-            + ((b_rows_up_phys % 32) // 16)
+            (b_rows_primary // 32) * (K_PACKED_TOTAL * 2)
+            + (b_rows_primary % 16) * 4
+            + ((b_rows_primary % 32) // 16)
         )[:, None]
     else:
+        b_rows_gate = (
+            pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=b_n_layout_scale)
+        ).to(gl.uint32)
+        b_rows_up = (
+            (pid_n + num_pid_n) * BLOCK_N
+            + gl.arange(0, BLOCK_N, layout=b_n_layout_scale)
+        ).to(gl.uint32)
         b_n_part_gate_scale = (
             (b_rows_gate // 128) * (stride_se_n_pad * 128)
             + ((b_rows_gate % 64) // 16) * 64
@@ -721,10 +1282,12 @@ def gluon_mxfp4_moe_stage1_kernel(
         b_k_lane_offsets = ((b_k_lanes % 4) * 256 + (b_k_lanes // 4))[None, :]
         B_SCALE_K_STEP: gl.constexpr = 1024
     b_scale_static_offs_gate = b_n_part_gate_scale + b_k_lane_offsets
-    b_scale_static_offs_up = b_n_part_up_scale + b_k_lane_offsets
-
     b_off_gate = b_scale_static_offs_gate
-    b_off_up = b_scale_static_offs_up
+    if B_GDOT128:
+        b_off_up = b_off_gate
+    else:
+        b_scale_static_offs_up = b_n_part_up_scale + b_k_lane_offsets
+        b_off_up = b_scale_static_offs_up
 
     b_scales_ptr_e = b_scales_ptr + off_experts.to(gl.int64) * stride_bse_e
 
@@ -734,7 +1297,7 @@ def gluon_mxfp4_moe_stage1_kernel(
     # async-copy path that Gluon fails to lower for prefill.
     smem_a = gl.allocate_shared_memory(
         a_ptr.type.element_ty,
-        [NUM_BUFFERS, BLOCK_M, BLOCK_K_PACKED],
+        [NUM_BUFFERS, BLOCK_M, BLOCK_K_A],
         shared_a,
     )
 
@@ -743,11 +1306,11 @@ def gluon_mxfp4_moe_stage1_kernel(
 
     offs_a_i32 = offs_a.to(gl.int32)
 
-    A_DATA_K_STEP: gl.constexpr = BLOCK_K_PACKED
+    a_data_k_step = BLOCK_K_A * stride_ak
     if B_GDOT128:
         B_DATA_K_STEP: gl.constexpr = ((2 * I_r) // 128) * (128 * 128)
     else:
-        B_DATA_K_STEP: gl.constexpr = (BLOCK_K_PACKED // 32) * 512
+        B_DATA_K_STEP: gl.constexpr = (BLOCK_K_B // 32) * 512
     A_SCALE_K_STEP: gl.constexpr = 256
 
     GROUP0_IDX: gl.constexpr = 0
@@ -767,21 +1330,22 @@ def gluon_mxfp4_moe_stage1_kernel(
         offs_a_i32,
         0,
         mask=token_mask[:, None],
+        USE_ASYNC=A_FORMAT != "e4m3",
     )
     cdna4_async_copy.commit_group()
 
-    cur_b_gate = _load_b_data_vgpr(
+    cur_b_gate, cur_b_up, b_scale_gate, b_scale_up = _load_b_pair_vgpr(
         b_base_ptr,
+        b_scales_ptr_e,
         offs_b_gate,
-        0,
-    )
-    cur_b_up = _load_b_data_vgpr(
-        b_base_ptr,
         offs_b_up,
+        b_off_gate,
+        b_off_up,
         0,
+        0,
+        B_SCALE_K_STEP,
+        B_GDOT128,
     )
-    b_scale_gate = _load_b_scale_vgpr(b_scales_ptr_e, b_off_gate, 0, B_SCALE_K_STEP)
-    b_scale_up = _load_b_scale_vgpr(b_scales_ptr_e, b_off_up, 0, B_SCALE_K_STEP)
 
     cdna4_async_copy.wait_group(0)
     cur_a_group0 = _read_a_lds_group(
@@ -798,34 +1362,36 @@ def gluon_mxfp4_moe_stage1_kernel(
         a_scale_group_stride,
         A_SCALE_K_STEP,
     )
-    cur_a_group1 = _read_a_lds_group(
-        smem_a_slot0,
-        GROUP1_IDX,
-        dot_a_layout,
-        GROUP_MFMA_M,
-    )
-    a_scale_group1 = _load_a_scale_vgpr(
-        a_scales_ptr,
-        a_scale_base_offsets,
-        GROUP1_IDX,
-        0,
-        a_scale_group_stride,
-        A_SCALE_K_STEP,
-    )
+    if BLOCK_M >= 64:
+        cur_a_group1 = _read_a_lds_group(
+            smem_a_slot0,
+            GROUP1_IDX,
+            dot_a_layout,
+            GROUP_MFMA_M,
+        )
+        a_scale_group1 = _load_a_scale_vgpr(
+            a_scales_ptr,
+            a_scale_base_offsets,
+            GROUP1_IDX,
+            0,
+            a_scale_group_stride,
+            A_SCALE_K_STEP,
+        )
 
     # ---- Per-quarter accumulators (gate + up) -------------------------
     gate_acc_group0 = gl.zeros(
         (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
     )
-    gate_acc_group1 = gl.zeros(
-        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
-    )
     up_acc_group0 = gl.zeros(
         (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
     )
-    up_acc_group1 = gl.zeros(
-        (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
-    )
+    if BLOCK_M >= 64:
+        gate_acc_group1 = gl.zeros(
+            (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+        )
+        up_acc_group1 = gl.zeros(
+            (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
+        )
     if BLOCK_M == 128:
         gate_acc_group2 = gl.zeros(
             (GROUP_MFMA_M, BLOCK_N), dtype=gl.float32, layout=mfma_layout
@@ -860,65 +1426,58 @@ def gluon_mxfp4_moe_stage1_kernel(
         nxt_b_scale_k = tile0_k + 1
 
         # Issue B[k+1] loads early for overlap with MFMA below.
-        next_b_gate = _load_b_data_vgpr(
+        next_b_gate, next_b_up, next_bsc_gate, next_bsc_up = _load_b_pair_vgpr(
             b_base_ptr,
+            b_scales_ptr_e,
             offs_b_gate,
-            nxt_b_data_off,
-        )
-        next_b_up = _load_b_data_vgpr(
-            b_base_ptr,
             offs_b_up,
+            b_off_gate,
+            b_off_up,
             nxt_b_data_off,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+            B_GDOT128,
         )
-        next_bsc_gate = _load_b_scale_vgpr(
-            b_scales_ptr_e, b_off_gate, nxt_b_scale_k, B_SCALE_K_STEP
-        )
-        next_bsc_up = _load_b_scale_vgpr(
-            b_scales_ptr_e, b_off_up, nxt_b_scale_k, B_SCALE_K_STEP
-        )
-
         # MFMA groups 0,1 with current A[k] + current B[k].
-        gate_acc_group0 = _compute_mxfp4_group(
+        gate_acc_group0, up_acc_group0 = _compute_gate_up_group(
             cur_a_group0,
             a_scale_group0,
             cur_b_gate,
             b_scale_gate,
+            cur_b_up,
+            b_scale_up,
             gate_acc_group0,
-        )
-        up_acc_group0 = _compute_mxfp4_group(
-            cur_a_group0,
-            a_scale_group0,
-            cur_b_up,
-            b_scale_up,
             up_acc_group0,
+            A_FORMAT,
+            B_GDOT128,
         )
-        gate_acc_group1 = _compute_mxfp4_group(
-            cur_a_group1,
-            a_scale_group1,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group1,
-        )
-        up_acc_group1 = _compute_mxfp4_group(
-            cur_a_group1,
-            a_scale_group1,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group1,
-        )
+        if BLOCK_M >= 64:
+            gate_acc_group1, up_acc_group1 = _compute_gate_up_group(
+                cur_a_group1,
+                a_scale_group1,
+                cur_b_gate,
+                b_scale_gate,
+                cur_b_up,
+                b_scale_up,
+                gate_acc_group1,
+                up_acc_group1,
+                A_FORMAT,
+                B_GDOT128,
+            )
 
         # Prefetch A[k+1] data into LDS slot1. A-scale stays direct-to-VGPR.
         _prefetch_a_data_lds(
             smem_a_slot1,
             a_base_ptr,
             offs_a_i32,
-            (tile0_k + 1) * A_DATA_K_STEP,
+            (tile0_k + 1) * a_data_k_step,
             mask=token_mask[:, None],
+            USE_ASYNC=A_FORMAT != "e4m3",
         )
 
         # The 128-row variant consumes the remaining two A[k] quarters while
-        # the next A tile is in flight. The 64-row variant has already consumed
-        # its complete tile above.
+        # the next A tile is in flight. Smaller variants have consumed their
+        # complete tile above.
         if BLOCK_M == 128:
             cur_a_group2 = _read_a_lds_group(
                 smem_a_slot0,
@@ -952,39 +1511,33 @@ def gluon_mxfp4_moe_stage1_kernel(
         cdna4_async_copy.commit_group()
 
         if BLOCK_M == 128:
-            gate_acc_group2 = _compute_mxfp4_group(
+            gate_acc_group2, up_acc_group2 = _compute_gate_up_group(
                 cur_a_group2,
                 a_scale_group2,
                 cur_b_gate,
                 b_scale_gate,
+                cur_b_up,
+                b_scale_up,
                 gate_acc_group2,
-            )
-            up_acc_group2 = _compute_mxfp4_group(
-                cur_a_group2,
-                a_scale_group2,
-                cur_b_up,
-                b_scale_up,
                 up_acc_group2,
+                A_FORMAT,
+                B_GDOT128,
             )
-            gate_acc_group3 = _compute_mxfp4_group(
+            gate_acc_group3, up_acc_group3 = _compute_gate_up_group(
                 cur_a_group3,
                 a_scale_group3,
                 cur_b_gate,
                 b_scale_gate,
-                gate_acc_group3,
-            )
-            up_acc_group3 = _compute_mxfp4_group(
-                cur_a_group3,
-                a_scale_group3,
                 cur_b_up,
                 b_scale_up,
+                gate_acc_group3,
                 up_acc_group3,
+                A_FORMAT,
+                B_GDOT128,
             )
 
         # Drain A[k+1] prefetch; B[k+1] should also be done by now.
         cdna4_async_copy.wait_group(0)
-
-        # Read A[k+1] groups 0,1 from LDS slot1.
         cur_a_group0 = _read_a_lds_group(
             smem_a_slot1,
             GROUP0_IDX,
@@ -999,25 +1552,26 @@ def gluon_mxfp4_moe_stage1_kernel(
             a_scale_group_stride,
             A_SCALE_K_STEP,
         )
-        cur_a_group1 = _read_a_lds_group(
-            smem_a_slot1,
-            GROUP1_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group1 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP1_IDX,
-            tile0_k + 1,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
+        if BLOCK_M >= 64:
+            cur_a_group1 = _read_a_lds_group(
+                smem_a_slot1,
+                GROUP1_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group1 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP1_IDX,
+                tile0_k + 1,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
 
         # Swap B: next -> current.
         cur_b_gate = next_b_gate
-        cur_b_up = next_b_up
         b_scale_gate = next_bsc_gate
+        cur_b_up = next_b_up
         b_scale_up = next_bsc_up
 
         # Swap A LDS slots.
@@ -1029,58 +1583,51 @@ def gluon_mxfp4_moe_stage1_kernel(
         nxt_b_data_off = (tile1_k + 1) * B_DATA_K_STEP
         nxt_b_scale_k = tile1_k + 1
 
-        next_b_gate = _load_b_data_vgpr(
+        next_b_gate, next_b_up, next_bsc_gate, next_bsc_up = _load_b_pair_vgpr(
             b_base_ptr,
+            b_scales_ptr_e,
             offs_b_gate,
-            nxt_b_data_off,
-        )
-        next_b_up = _load_b_data_vgpr(
-            b_base_ptr,
             offs_b_up,
+            b_off_gate,
+            b_off_up,
             nxt_b_data_off,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+            B_GDOT128,
         )
-        next_bsc_gate = _load_b_scale_vgpr(
-            b_scales_ptr_e, b_off_gate, nxt_b_scale_k, B_SCALE_K_STEP
-        )
-        next_bsc_up = _load_b_scale_vgpr(
-            b_scales_ptr_e, b_off_up, nxt_b_scale_k, B_SCALE_K_STEP
-        )
-
-        gate_acc_group0 = _compute_mxfp4_group(
+        gate_acc_group0, up_acc_group0 = _compute_gate_up_group(
             cur_a_group0,
             a_scale_group0,
             cur_b_gate,
             b_scale_gate,
+            cur_b_up,
+            b_scale_up,
             gate_acc_group0,
-        )
-        up_acc_group0 = _compute_mxfp4_group(
-            cur_a_group0,
-            a_scale_group0,
-            cur_b_up,
-            b_scale_up,
             up_acc_group0,
+            A_FORMAT,
+            B_GDOT128,
         )
-        gate_acc_group1 = _compute_mxfp4_group(
-            cur_a_group1,
-            a_scale_group1,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group1,
-        )
-        up_acc_group1 = _compute_mxfp4_group(
-            cur_a_group1,
-            a_scale_group1,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group1,
-        )
+        if BLOCK_M >= 64:
+            gate_acc_group1, up_acc_group1 = _compute_gate_up_group(
+                cur_a_group1,
+                a_scale_group1,
+                cur_b_gate,
+                b_scale_gate,
+                cur_b_up,
+                b_scale_up,
+                gate_acc_group1,
+                up_acc_group1,
+                A_FORMAT,
+                B_GDOT128,
+            )
 
         _prefetch_a_data_lds(
             smem_a_slot1,
             a_base_ptr,
             offs_a_i32,
-            (tile1_k + 1) * A_DATA_K_STEP,
+            (tile1_k + 1) * a_data_k_step,
             mask=token_mask[:, None],
+            USE_ASYNC=A_FORMAT != "e4m3",
         )
 
         if BLOCK_M == 128:
@@ -1116,37 +1663,32 @@ def gluon_mxfp4_moe_stage1_kernel(
         cdna4_async_copy.commit_group()
 
         if BLOCK_M == 128:
-            gate_acc_group2 = _compute_mxfp4_group(
+            gate_acc_group2, up_acc_group2 = _compute_gate_up_group(
                 cur_a_group2,
                 a_scale_group2,
                 cur_b_gate,
                 b_scale_gate,
+                cur_b_up,
+                b_scale_up,
                 gate_acc_group2,
-            )
-            up_acc_group2 = _compute_mxfp4_group(
-                cur_a_group2,
-                a_scale_group2,
-                cur_b_up,
-                b_scale_up,
                 up_acc_group2,
+                A_FORMAT,
+                B_GDOT128,
             )
-            gate_acc_group3 = _compute_mxfp4_group(
+            gate_acc_group3, up_acc_group3 = _compute_gate_up_group(
                 cur_a_group3,
                 a_scale_group3,
                 cur_b_gate,
                 b_scale_gate,
-                gate_acc_group3,
-            )
-            up_acc_group3 = _compute_mxfp4_group(
-                cur_a_group3,
-                a_scale_group3,
                 cur_b_up,
                 b_scale_up,
+                gate_acc_group3,
                 up_acc_group3,
+                A_FORMAT,
+                B_GDOT128,
             )
 
         cdna4_async_copy.wait_group(0)
-
         cur_a_group0 = _read_a_lds_group(
             smem_a_slot1,
             GROUP0_IDX,
@@ -1161,24 +1703,25 @@ def gluon_mxfp4_moe_stage1_kernel(
             a_scale_group_stride,
             A_SCALE_K_STEP,
         )
-        cur_a_group1 = _read_a_lds_group(
-            smem_a_slot1,
-            GROUP1_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group1 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP1_IDX,
-            tile1_k + 1,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
+        if BLOCK_M >= 64:
+            cur_a_group1 = _read_a_lds_group(
+                smem_a_slot1,
+                GROUP1_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group1 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP1_IDX,
+                tile1_k + 1,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
 
         cur_b_gate = next_b_gate
-        cur_b_up = next_b_up
         b_scale_gate = next_bsc_gate
+        cur_b_up = next_b_up
         b_scale_up = next_bsc_up
 
         smem_a_slot0, smem_a_slot1 = smem_a_slot1, smem_a_slot0
@@ -1190,58 +1733,51 @@ def gluon_mxfp4_moe_stage1_kernel(
         nxt_b_data_off = (pk + 1) * B_DATA_K_STEP
         nxt_b_scale_k = pk + 1
 
-        next_b_gate = _load_b_data_vgpr(
+        next_b_gate, next_b_up, next_bsc_gate, next_bsc_up = _load_b_pair_vgpr(
             b_base_ptr,
+            b_scales_ptr_e,
             offs_b_gate,
-            nxt_b_data_off,
-        )
-        next_b_up = _load_b_data_vgpr(
-            b_base_ptr,
             offs_b_up,
+            b_off_gate,
+            b_off_up,
             nxt_b_data_off,
+            nxt_b_scale_k,
+            B_SCALE_K_STEP,
+            B_GDOT128,
         )
-        next_bsc_gate = _load_b_scale_vgpr(
-            b_scales_ptr_e, b_off_gate, nxt_b_scale_k, B_SCALE_K_STEP
-        )
-        next_bsc_up = _load_b_scale_vgpr(
-            b_scales_ptr_e, b_off_up, nxt_b_scale_k, B_SCALE_K_STEP
-        )
-
-        gate_acc_group0 = _compute_mxfp4_group(
+        gate_acc_group0, up_acc_group0 = _compute_gate_up_group(
             cur_a_group0,
             a_scale_group0,
             cur_b_gate,
             b_scale_gate,
+            cur_b_up,
+            b_scale_up,
             gate_acc_group0,
-        )
-        up_acc_group0 = _compute_mxfp4_group(
-            cur_a_group0,
-            a_scale_group0,
-            cur_b_up,
-            b_scale_up,
             up_acc_group0,
+            A_FORMAT,
+            B_GDOT128,
         )
-        gate_acc_group1 = _compute_mxfp4_group(
-            cur_a_group1,
-            a_scale_group1,
-            cur_b_gate,
-            b_scale_gate,
-            gate_acc_group1,
-        )
-        up_acc_group1 = _compute_mxfp4_group(
-            cur_a_group1,
-            a_scale_group1,
-            cur_b_up,
-            b_scale_up,
-            up_acc_group1,
-        )
+        if BLOCK_M >= 64:
+            gate_acc_group1, up_acc_group1 = _compute_gate_up_group(
+                cur_a_group1,
+                a_scale_group1,
+                cur_b_gate,
+                b_scale_gate,
+                cur_b_up,
+                b_scale_up,
+                gate_acc_group1,
+                up_acc_group1,
+                A_FORMAT,
+                B_GDOT128,
+            )
 
         _prefetch_a_data_lds(
             smem_a_slot1,
             a_base_ptr,
             offs_a_i32,
-            (pk + 1) * A_DATA_K_STEP,
+            (pk + 1) * a_data_k_step,
             mask=token_mask[:, None],
+            USE_ASYNC=A_FORMAT != "e4m3",
         )
 
         if BLOCK_M == 128:
@@ -1277,37 +1813,32 @@ def gluon_mxfp4_moe_stage1_kernel(
         cdna4_async_copy.commit_group()
 
         if BLOCK_M == 128:
-            gate_acc_group2 = _compute_mxfp4_group(
+            gate_acc_group2, up_acc_group2 = _compute_gate_up_group(
                 cur_a_group2,
                 a_scale_group2,
                 cur_b_gate,
                 b_scale_gate,
+                cur_b_up,
+                b_scale_up,
                 gate_acc_group2,
-            )
-            up_acc_group2 = _compute_mxfp4_group(
-                cur_a_group2,
-                a_scale_group2,
-                cur_b_up,
-                b_scale_up,
                 up_acc_group2,
+                A_FORMAT,
+                B_GDOT128,
             )
-            gate_acc_group3 = _compute_mxfp4_group(
+            gate_acc_group3, up_acc_group3 = _compute_gate_up_group(
                 cur_a_group3,
                 a_scale_group3,
                 cur_b_gate,
                 b_scale_gate,
-                gate_acc_group3,
-            )
-            up_acc_group3 = _compute_mxfp4_group(
-                cur_a_group3,
-                a_scale_group3,
                 cur_b_up,
                 b_scale_up,
+                gate_acc_group3,
                 up_acc_group3,
+                A_FORMAT,
+                B_GDOT128,
             )
 
         cdna4_async_copy.wait_group(0)
-
         cur_a_group0 = _read_a_lds_group(
             smem_a_slot1,
             GROUP0_IDX,
@@ -1322,30 +1853,31 @@ def gluon_mxfp4_moe_stage1_kernel(
             a_scale_group_stride,
             A_SCALE_K_STEP,
         )
-        cur_a_group1 = _read_a_lds_group(
-            smem_a_slot1,
-            GROUP1_IDX,
-            dot_a_layout,
-            GROUP_MFMA_M,
-        )
-        a_scale_group1 = _load_a_scale_vgpr(
-            a_scales_ptr,
-            a_scale_base_offsets,
-            GROUP1_IDX,
-            pk + 1,
-            a_scale_group_stride,
-            A_SCALE_K_STEP,
-        )
+        if BLOCK_M >= 64:
+            cur_a_group1 = _read_a_lds_group(
+                smem_a_slot1,
+                GROUP1_IDX,
+                dot_a_layout,
+                GROUP_MFMA_M,
+            )
+            a_scale_group1 = _load_a_scale_vgpr(
+                a_scales_ptr,
+                a_scale_base_offsets,
+                GROUP1_IDX,
+                pk + 1,
+                a_scale_group_stride,
+                A_SCALE_K_STEP,
+            )
 
         cur_b_gate = next_b_gate
-        cur_b_up = next_b_up
         b_scale_gate = next_bsc_gate
+        cur_b_up = next_b_up
         b_scale_up = next_bsc_up
 
         smem_a_slot0, smem_a_slot1 = smem_a_slot1, smem_a_slot0
 
     # ---- 1-tile drain (last K tile, no prefetch) ---------------------
-    # cur_a_group0/1 and cur_b_* hold the last tile's data.
+    # The active cur_a_group* values and cur_b_* hold the last tile's data.
     if BLOCK_M == 128:
         cur_a_group2 = _read_a_lds_group(
             smem_a_slot0,
@@ -1376,101 +1908,137 @@ def gluon_mxfp4_moe_stage1_kernel(
             A_SCALE_K_STEP,
         )
 
-    gate_acc_group0 = _compute_mxfp4_group(
+    gate_acc_group0, up_acc_group0 = _compute_gate_up_group(
         cur_a_group0,
         a_scale_group0,
         cur_b_gate,
         b_scale_gate,
+        cur_b_up,
+        b_scale_up,
         gate_acc_group0,
-    )
-    up_acc_group0 = _compute_mxfp4_group(
-        cur_a_group0,
-        a_scale_group0,
-        cur_b_up,
-        b_scale_up,
         up_acc_group0,
+        A_FORMAT,
+        B_GDOT128,
     )
-    gate_acc_group1 = _compute_mxfp4_group(
-        cur_a_group1,
-        a_scale_group1,
-        cur_b_gate,
-        b_scale_gate,
-        gate_acc_group1,
-    )
-    up_acc_group1 = _compute_mxfp4_group(
-        cur_a_group1,
-        a_scale_group1,
-        cur_b_up,
-        b_scale_up,
-        up_acc_group1,
-    )
+    if BLOCK_M >= 64:
+        gate_acc_group1, up_acc_group1 = _compute_gate_up_group(
+            cur_a_group1,
+            a_scale_group1,
+            cur_b_gate,
+            b_scale_gate,
+            cur_b_up,
+            b_scale_up,
+            gate_acc_group1,
+            up_acc_group1,
+            A_FORMAT,
+            B_GDOT128,
+        )
     if BLOCK_M == 128:
-        gate_acc_group2 = _compute_mxfp4_group(
+        gate_acc_group2, up_acc_group2 = _compute_gate_up_group(
             cur_a_group2,
             a_scale_group2,
             cur_b_gate,
             b_scale_gate,
+            cur_b_up,
+            b_scale_up,
             gate_acc_group2,
-        )
-        up_acc_group2 = _compute_mxfp4_group(
-            cur_a_group2,
-            a_scale_group2,
-            cur_b_up,
-            b_scale_up,
             up_acc_group2,
+            A_FORMAT,
+            B_GDOT128,
         )
-        gate_acc_group3 = _compute_mxfp4_group(
+        gate_acc_group3, up_acc_group3 = _compute_gate_up_group(
             cur_a_group3,
             a_scale_group3,
             cur_b_gate,
             b_scale_gate,
-            gate_acc_group3,
-        )
-        up_acc_group3 = _compute_mxfp4_group(
-            cur_a_group3,
-            a_scale_group3,
             cur_b_up,
             b_scale_up,
+            gate_acc_group3,
             up_acc_group3,
+            A_FORMAT,
+            B_GDOT128,
         )
 
-    acc_swiglu_group0 = _apply_gate_activation(
-        gate_acc_group0,
-        up_acc_group0,
-        DO_SITU,
-        SWIGLU_ALPHA,
-        SWIGLU_LIMIT,
-        SWIGLU_BETA,
-        SITU_LINEAR_BETA,
-    )
-    acc_swiglu_group1 = _apply_gate_activation(
-        gate_acc_group1,
-        up_acc_group1,
-        DO_SITU,
-        SWIGLU_ALPHA,
-        SWIGLU_LIMIT,
-        SWIGLU_BETA,
-        SITU_LINEAR_BETA,
-    )
+    if B_GDOT128:
+        acc_swiglu_group0 = _apply_interleaved_gate_activation(
+            gate_acc_group0,
+            DO_SITU,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+            SWIGLU_BETA,
+            SITU_LINEAR_BETA,
+            OUTPUT_BLOCK_N,
+        )
+    else:
+        acc_swiglu_group0 = _apply_gate_activation(
+            gate_acc_group0,
+            up_acc_group0,
+            DO_SITU,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+            SWIGLU_BETA,
+            SITU_LINEAR_BETA,
+        )
+    if BLOCK_M >= 64:
+        if B_GDOT128:
+            acc_swiglu_group1 = _apply_interleaved_gate_activation(
+                gate_acc_group1,
+                DO_SITU,
+                SWIGLU_ALPHA,
+                SWIGLU_LIMIT,
+                SWIGLU_BETA,
+                SITU_LINEAR_BETA,
+                OUTPUT_BLOCK_N,
+            )
+        else:
+            acc_swiglu_group1 = _apply_gate_activation(
+                gate_acc_group1,
+                up_acc_group1,
+                DO_SITU,
+                SWIGLU_ALPHA,
+                SWIGLU_LIMIT,
+                SWIGLU_BETA,
+                SITU_LINEAR_BETA,
+            )
     if BLOCK_M == 128:
-        acc_swiglu_group2 = _apply_gate_activation(
-            gate_acc_group2,
-            up_acc_group2,
-            DO_SITU,
-            SWIGLU_ALPHA,
-            SWIGLU_LIMIT,
-            SWIGLU_BETA,
-            SITU_LINEAR_BETA,
-        )
-        acc_swiglu_group3 = _apply_gate_activation(
-            gate_acc_group3,
-            up_acc_group3,
-            DO_SITU,
-            SWIGLU_ALPHA,
-            SWIGLU_LIMIT,
-            SWIGLU_BETA,
-            SITU_LINEAR_BETA,
-        )
+        if B_GDOT128:
+            acc_swiglu_group2 = _apply_interleaved_gate_activation(
+                gate_acc_group2,
+                DO_SITU,
+                SWIGLU_ALPHA,
+                SWIGLU_LIMIT,
+                SWIGLU_BETA,
+                SITU_LINEAR_BETA,
+                OUTPUT_BLOCK_N,
+            )
+            acc_swiglu_group3 = _apply_interleaved_gate_activation(
+                gate_acc_group3,
+                DO_SITU,
+                SWIGLU_ALPHA,
+                SWIGLU_LIMIT,
+                SWIGLU_BETA,
+                SITU_LINEAR_BETA,
+                OUTPUT_BLOCK_N,
+            )
+        else:
+            acc_swiglu_group2 = _apply_gate_activation(
+                gate_acc_group2,
+                up_acc_group2,
+                DO_SITU,
+                SWIGLU_ALPHA,
+                SWIGLU_LIMIT,
+                SWIGLU_BETA,
+                SITU_LINEAR_BETA,
+            )
+            acc_swiglu_group3 = _apply_gate_activation(
+                gate_acc_group3,
+                up_acc_group3,
+                DO_SITU,
+                SWIGLU_ALPHA,
+                SWIGLU_LIMIT,
+                SWIGLU_BETA,
+                SITU_LINEAR_BETA,
+            )
 
     _store_swiglu_tile_group(
         acc_swiglu_group0,
@@ -1484,38 +2052,39 @@ def gluon_mxfp4_moe_stage1_kernel(
         top_k,
         stride_cm,
         stride_cn,
-        mfma_layout,
         GROUP0_IDX,
         GROUP_MFMA_M,
         BLOCK_M,
-        BLOCK_N,
+        OUTPUT_BLOCK_N,
         I_r,
         OUTPUT_K,
         OUTPUT_SORTED,
         OUTPUT_QUANTIZED,
+        OUTPUT_FP8,
     )
-    _store_swiglu_tile_group(
-        acc_swiglu_group1,
-        c_ptr,
-        c_scale_ptr,
-        sorted_token_ids_ptr,
-        pid_m,
-        pid_n,
-        EM,
-        num_tokens,
-        top_k,
-        stride_cm,
-        stride_cn,
-        mfma_layout,
-        GROUP1_IDX,
-        GROUP_MFMA_M,
-        BLOCK_M,
-        BLOCK_N,
-        I_r,
-        OUTPUT_K,
-        OUTPUT_SORTED,
-        OUTPUT_QUANTIZED,
-    )
+    if BLOCK_M >= 64:
+        _store_swiglu_tile_group(
+            acc_swiglu_group1,
+            c_ptr,
+            c_scale_ptr,
+            sorted_token_ids_ptr,
+            pid_m,
+            pid_n,
+            EM,
+            num_tokens,
+            top_k,
+            stride_cm,
+            stride_cn,
+            GROUP1_IDX,
+            GROUP_MFMA_M,
+            BLOCK_M,
+            OUTPUT_BLOCK_N,
+            I_r,
+            OUTPUT_K,
+            OUTPUT_SORTED,
+            OUTPUT_QUANTIZED,
+            OUTPUT_FP8,
+        )
     if BLOCK_M == 128:
         _store_swiglu_tile_group(
             acc_swiglu_group2,
@@ -1529,15 +2098,15 @@ def gluon_mxfp4_moe_stage1_kernel(
             top_k,
             stride_cm,
             stride_cn,
-            mfma_layout,
             GROUP2_IDX,
             GROUP_MFMA_M,
             BLOCK_M,
-            BLOCK_N,
+            OUTPUT_BLOCK_N,
             I_r,
             OUTPUT_K,
             OUTPUT_SORTED,
             OUTPUT_QUANTIZED,
+            OUTPUT_FP8,
         )
         _store_swiglu_tile_group(
             acc_swiglu_group3,
@@ -1551,15 +2120,15 @@ def gluon_mxfp4_moe_stage1_kernel(
             top_k,
             stride_cm,
             stride_cn,
-            mfma_layout,
             GROUP3_IDX,
             GROUP_MFMA_M,
             BLOCK_M,
-            BLOCK_N,
+            OUTPUT_BLOCK_N,
             I_r,
             OUTPUT_K,
             OUTPUT_SORTED,
             OUTPUT_QUANTIZED,
+            OUTPUT_FP8,
         )
 
 
@@ -1592,6 +2161,10 @@ def invoke_gluon_mxfp4_moe_stage1(
     output_quantized: bool = False,
     out_scale: torch.Tensor | None = None,
     output_k: int | None = None,
+    a_format: str = "e2m1",
+    output_format: str = "e2m1",
+    input_sorted: bool = False,
+    source_tokens: int | None = None,
 ):
     """Host-side launcher for Gluon MXFP4 MoE stage 1.
 
@@ -1602,15 +2175,19 @@ def invoke_gluon_mxfp4_moe_stage1(
 
     When ``situ_linear_beta`` is provided, the same GEMM body instead uses the
     SiTU-v2 epilogue. Both modes run in one kernel launch over all experts.
-    The grid is one CTA per
-    (M-tile, N-tile); each CTA owns one ``BLOCK_M`` x ``BLOCK_N``
-    output region for the expert ``sorted_expert_ids[pid_m]``.
+    The grid is one CTA per (M-tile, N-tile). Separate gate/up layouts
+    produce a ``BLOCK_M`` x ``BLOCK_N`` output region per CTA; interleaved
+    W13 produces ``BLOCK_M`` x ``(BLOCK_N / 2)`` after its gate/up epilogue.
 
+    ``a_format`` selects E2M1 or E4M3 block-scaled activations.
     ``output_sorted`` writes rows in routing order rather than restoring
-    token/slot order. ``output_quantized`` additionally writes packed MXFP4
+    token/slot order. ``output_quantized`` additionally writes E2M1 or E4M3
     values to ``out`` and CDNA4-swizzled e8m0 scales to ``out_scale``;
-    ``output_k`` is the physical, padding-inclusive output width. The function
-    returns the same ``out`` tensor supplied by the caller.
+    ``output_k`` is the physical, padding-inclusive output width.
+    ``input_sorted`` consumes activation rows already ordered like
+    ``sorted_token_ids``; ``source_tokens`` retains the original token bound
+    used to identify padding routes. The function returns the same ``out``
+    tensor supplied by the caller.
 
     Steps below correspond to the ``# Step N:`` comments in the body:
       1. Validate dtypes / shapes; reject unsupported options.
@@ -1649,9 +2226,18 @@ def invoke_gluon_mxfp4_moe_stage1(
         )
     del kernelName, use_non_temporal_load, w2
 
-    assert (
-        hidden_states.dtype == torch.uint8
-    ), f"hidden_states must be packed fp4x2 (uint8), got {hidden_states.dtype}"
+    if a_format not in ("e2m1", "e4m3"):
+        raise ValueError(f"stage1 a_format must be e2m1 or e4m3, got {a_format}")
+    if output_format not in ("e2m1", "e4m3"):
+        raise ValueError(
+            f"stage1 output_format must be e2m1 or e4m3, got {output_format}"
+        )
+    expected_a_dtype = torch.float8_e4m3fn if a_format == "e4m3" else torch.uint8
+    if hidden_states.dtype != expected_a_dtype:
+        raise TypeError(
+            f"{a_format} stage1 input must use {expected_a_dtype}, "
+            f"got {hidden_states.dtype}"
+        )
     assert w1.dtype == torch.uint8, f"w1 must be packed fp4x2 (uint8), got {w1.dtype}"
     # Step 2: shuffle w1 to the MFMA-tile layout the kernel expects.
     if not b_preshuffled:
@@ -1669,8 +2255,14 @@ def invoke_gluon_mxfp4_moe_stage1(
     if output_quantized:
         if not output_sorted:
             raise ValueError("quantized stage1 output requires sorted row order")
-        if out.dtype != torch.uint8:
-            raise TypeError(f"quantized stage1 out must be uint8, got {out.dtype}")
+        expected_out_dtype = (
+            torch.float8_e4m3fn if output_format == "e4m3" else torch.uint8
+        )
+        if out.dtype != expected_out_dtype:
+            raise TypeError(
+                f"{output_format} stage1 output must use {expected_out_dtype}, "
+                f"got {out.dtype}"
+            )
         if out_scale is None or out_scale.dtype != torch.uint8:
             raise TypeError("quantized stage1 out_scale must be a uint8 tensor")
     elif out.dtype != torch.bfloat16:
@@ -1686,27 +2278,30 @@ def invoke_gluon_mxfp4_moe_stage1(
         f"hidden_states must be 2-D (M_padded, K_packed), got "
         f"shape {tuple(hidden_states.shape)}"
     )
-    M_padded, D_packed = hidden_states.shape
-    K = D_packed * 2
+    M_padded, D_stored = hidden_states.shape
+    a_div = 1 if a_format == "e4m3" else 2
+    K = D_stored * a_div
     assert (
         w1.dim() == 3
     ), f"w1 must be 3-D (E, 2*I_r, K_packed), got shape {tuple(w1.shape)}"
     E_w, two_Ir, D_packed_w = w1.shape
-    assert D_packed_w == D_packed, (
-        f"w1 K-packed dim ({D_packed_w}) must match hidden_states K-packed "
-        f"dim ({D_packed})"
-    )
+    assert (
+        D_packed_w * 2 == K
+    ), f"w1 packed K ({D_packed_w * 2}) must match activation K ({K})"
     assert two_Ir % 2 == 0, f"w1.shape[1] (= 2*I_r) must be even, got {two_Ir}"
     I_r = two_Ir // 2
     N = 2 * I_r
     EM = sorted_token_ids.shape[0]
     output_k = I_r if output_k is None else int(output_k)
-    if output_k < I_r or output_k - I_r > 128 or output_k % 32:
+    # A gdot128 K tile is 128 packed FP4 bytes, so its logical activation
+    # width rounds up in 256-column increments and can add at most 224 columns.
+    if output_k < I_r or output_k - I_r >= 256 or output_k % 32:
         raise ValueError(
             "stage1 output_k must be a multiple of 32 in "
-            f"[{I_r}, {I_r + 128}], got {output_k}"
+            f"[{I_r}, {I_r + 256}), got {output_k}"
         )
     if output_quantized:
+        output_div = 1 if output_format == "e4m3" else 2
         output_scale_cols = output_k // 32
         if output_scale_cols % CDNA4_SCALE_K_BLOCK:
             raise ValueError(
@@ -1714,10 +2309,14 @@ def invoke_gluon_mxfp4_moe_stage1(
                 f"{32 * CDNA4_SCALE_K_BLOCK} for complete CDNA4 scale panels; "
                 f"got {output_k}"
             )
-        if out.dim() != 2 or out.shape[0] < EM or out.shape[1] != output_k // 2:
+        if (
+            out.dim() != 2
+            or out.shape[0] < EM
+            or out.shape[1] != output_k // output_div
+        ):
             raise ValueError(
                 "quantized stage1 out must have shape "
-                f"(>= {EM}, {output_k // 2}), got {tuple(out.shape)}"
+                f"(>= {EM}, {output_k // output_div}), got {tuple(out.shape)}"
             )
         assert out_scale is not None
         if (
@@ -1760,7 +2359,15 @@ def invoke_gluon_mxfp4_moe_stage1(
         f"w1_scale.shape {tuple(w1_scale.shape)} must be (E, N, K//32) = "
         f"({E_w}, {N}, {K_scale})"
     )
-    num_tokens = M_padded
+    num_tokens = M_padded if source_tokens is None else int(source_tokens)
+    if num_tokens <= 0 or num_tokens > M_padded:
+        raise ValueError(
+            f"stage1 source_tokens must be in [1, {M_padded}], got {num_tokens}"
+        )
+    if input_sorted and M_padded < EM:
+        raise ValueError(
+            f"sorted stage1 input has {M_padded} rows but routing requires {EM}"
+        )
     del M_padded
 
     # Step 3: materialise scalar / None args as device tensors so the
@@ -1772,18 +2379,28 @@ def invoke_gluon_mxfp4_moe_stage1(
             [int(num_valid_ids)], dtype=torch.int32, device=hidden_states.device
         )
     BLOCK_M = int(block_m)
-    if BLOCK_M not in (64, 128):
-        raise ValueError(f"stage1 block_m must be 64 or 128; got {BLOCK_M}")
+    if BLOCK_M not in (32, 64, 128) or (BLOCK_M == 32 and a_format != "e4m3"):
+        raise ValueError(
+            "stage1 block_m must be 64 or 128, or 32 for E4M3; "
+            f"got block_m={BLOCK_M}, a_format={a_format}"
+        )
     BLOCK_N = 128
     BLOCK_K = 256
     GROUP_SIZE_M = 1
-    NUM_WARPS = BLOCK_M // 32
+    NUM_WARPS = 8 if a_format == "e4m3" else BLOCK_M // 32
     num_pid_m = triton.cdiv(EM, BLOCK_M)
-    num_pid_n = triton.cdiv(I_r, BLOCK_N)
+    output_block_n = BLOCK_N // 2 if b_gdot128 else BLOCK_N
+    num_pid_n = triton.cdiv(I_r, output_block_n)
     grid = (num_pid_m * num_pid_n,)
 
-    stride_am = hidden_states.stride(0)
-    stride_ak = hidden_states.stride(1)
+    # Keep the public tensor typed as FP8, but pass its bit-identical uint8 view
+    # to the kernel; ``mfma_scaled(..., a_format="e4m3")`` interprets the raw
+    # bytes after the synchronous HBM-to-LDS load.
+    kernel_hidden_states = (
+        hidden_states.view(torch.uint8) if a_format == "e4m3" else hidden_states
+    )
+    stride_am = kernel_hidden_states.stride(0)
+    stride_ak = kernel_hidden_states.stride(1)
     stride_be = w1.stride(0)
     stride_cm = out_2d.stride(0)
     stride_cn = out_2d.stride(1)
@@ -1791,11 +2408,55 @@ def invoke_gluon_mxfp4_moe_stage1(
     stride_se_n_pad = a1_scale.shape[1]
     K_packed_total = K // 2
 
+    use_e4m3_async = (
+        a_format == "e4m3"
+        and b_gdot128
+        and K % 256 == 0
+        and I_r % 64 == 0
+        and input_sorted
+        and output_sorted
+        and output_quantized
+        and output_format == "e4m3"
+        and situ_linear_beta is not None
+        and stride_ak == 1
+    )
+    if use_e4m3_async:
+        gluon_mxfp4_moe_stage1_e4m3_async_kernel[grid](
+            kernel_hidden_states,
+            w1,
+            out_2d,
+            out_scale_ptr,
+            a1_scale,
+            w1_scale,
+            sorted_token_ids,
+            sorted_expert_ids,
+            num_valid_ids_ptr,
+            EM,
+            num_tokens,
+            topk,
+            stride_be,
+            stride_cm,
+            stride_cn,
+            stride_bse_e,
+            stride_se_n_pad,
+            STRIDE_AM=stride_am,
+            BLOCK_M=BLOCK_M,
+            K_PACKED_TOTAL=K_packed_total,
+            I_r=I_r,
+            OUTPUT_K=output_k,
+            SWIGLU_ALPHA=float(swiglu_alpha),
+            SWIGLU_LIMIT=float(swiglu_limit),
+            SWIGLU_BETA=float(swiglu_beta),
+            SITU_LINEAR_BETA=float(situ_linear_beta),
+            num_warps=4,
+        )
+        return out
+
     # Step 4: launch the GEMM. One CTA per (M-tile, N-tile); the per-CTA
-    # expert id is ``sorted_expert_ids[pid_m]``. Each CTA produces
-    # BLOCK_M rows x BLOCK_N cols of the gate-up fused intermediate.
+    # expert id is ``sorted_expert_ids[pid_m]``. Interleaved W13 tiles produce
+    # BLOCK_N / 2 outputs; separate gate/up layouts produce BLOCK_N outputs.
     gluon_mxfp4_moe_stage1_kernel[grid](
-        hidden_states,
+        kernel_hidden_states,
         w1,
         out_2d,
         out_scale_ptr,
@@ -1832,6 +2493,9 @@ def invoke_gluon_mxfp4_moe_stage1(
         SITU_LINEAR_BETA=(1.0 if situ_linear_beta is None else float(situ_linear_beta)),
         OUTPUT_SORTED=bool(output_sorted),
         OUTPUT_QUANTIZED=bool(output_quantized),
+        A_FORMAT=a_format,
+        OUTPUT_FP8=output_format == "e4m3",
+        INPUT_SORTED=bool(input_sorted),
         num_warps=NUM_WARPS,
     )
     return out

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage2.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/prefill_stage2.py
@@ -111,6 +111,30 @@ def _gdot128_weight_offset(k_pack, n_col, n_phys: gl.constexpr):
     return tile * (128 * 128) + in_tile
 
 
+@gluon.jit
+def _load_a_to_shared(
+    destination,
+    base,
+    offsets,
+    mask,
+    USE_ASYNC: gl.constexpr,
+):
+    if USE_ASYNC:
+        cdna4_async_copy.buffer_load_to_shared(
+            destination,
+            base,
+            offsets,
+            mask=mask,
+        )
+    else:
+        values = gl.load(base + offsets, mask=mask, other=0)
+        # E4M3 MFMAs share each A row across N-partitioned waves. Finish
+        # reading the old tile before any wave reuses this LDS slot.
+        gl.barrier()
+        destination.store(values)
+        gl.barrier()
+
+
 # ---------------------------------------------------------------------------
 # Kernel
 # ---------------------------------------------------------------------------
@@ -163,6 +187,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
     DIRECT_SCALE_LAYOUT: gl.constexpr = False,
     DEFER_EPILOGUE: gl.constexpr = True,
     INPUT_SORTED: gl.constexpr = False,
+    A_FORMAT: gl.constexpr = "e2m1",
 ):
     """Stage 2 1x2 kernel: 2 waves/CTA, BLOCK_N=256, 2-stage v3 pipeline.
 
@@ -198,8 +223,14 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
     gl.static_assert(BLOCK_K == 128, "1x2 kernel requires BLOCK_K=128")
     gl.static_assert(NUM_WARPS == 4, "1x2 kernel requires NUM_WARPS=4")
 
-    BLOCK_K_PACKED: gl.constexpr = BLOCK_K // 2  # 64
+    A_DIV: gl.constexpr = 1 if A_FORMAT == "e4m3" else 2
+    USE_ASYNC_A: gl.constexpr = A_FORMAT != "e4m3" or INPUT_SORTED
+    USE_ASYNC_E4M3: gl.constexpr = A_FORMAT == "e4m3" and INPUT_SORTED
+    BLOCK_K_A: gl.constexpr = BLOCK_K // A_DIV
+    BLOCK_K_B: gl.constexpr = BLOCK_K // 2
     BLOCK_K_SCALE: gl.constexpr = BLOCK_K // 32  # 4
+    NUM_K_ITERS: gl.constexpr = K_PACKED_TOTAL // BLOCK_K_B
+    gl.static_assert(NUM_K_ITERS >= 2 and NUM_K_ITERS % 2 == 0)
     NUM_BUFFERS: gl.constexpr = 2
     # 4 N-chunks of 64 cols each at BLOCK_N = 256. With warps_per_cta=[1, 4]
     # each wave owns 1/4 of a chunk = 16 cols, so per wave [128, 16] per chunk.
@@ -254,20 +285,24 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
     # identical numerics against BM128 for the package stage2 contract.
     # The LDS layout below remains the original padded swizzle consumed by
     # the MFMA dot operand.
-    if BLOCK_M == 32:
+    if USE_ASYNC_E4M3:
+        # Match the direct-copy distribution used by stage 1: every lane
+        # contributes one aligned 128-bit segment to each 32-row slice.
+        gload_a_layout: gl.constexpr = gl.BlockedLayout(
+            [1, 16],
+            [8, 8],
+            [4, 1],
+            [1, 0],
+        )
+        shared_a_m_bases: gl.constexpr = []
+    elif BLOCK_M == 32:
         gload_a_layout: gl.constexpr = gl.BlockedLayout(
             [1, 16],
             [16, 4],
             [2, 2],
             [1, 0],
         )
-        shared_a_bases: gl.constexpr = [
-            [0, 1],
-            [0, 2],
-            [0, 4],
-            [0, 8],
-            [0, 16],
-            [0, 32],
+        shared_a_m_bases: gl.constexpr = [
             [1, 0],
             [2, 0],
             [4, 0],
@@ -281,13 +316,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
             [2, 2],
             [1, 0],
         )
-        shared_a_bases: gl.constexpr = [
-            [0, 1],
-            [0, 2],
-            [0, 4],
-            [0, 8],
-            [0, 16],
-            [0, 32],
+        shared_a_m_bases: gl.constexpr = [
             [1, 0],
             [2, 0],
             [4, 0],
@@ -302,13 +331,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
             [4, 1],
             [1, 0],
         )
-        shared_a_bases: gl.constexpr = [
-            [0, 1],
-            [0, 2],
-            [0, 4],
-            [0, 8],
-            [0, 16],
-            [0, 32],
+        shared_a_m_bases: gl.constexpr = [
             [1, 0],
             [2, 0],
             [4, 0],
@@ -318,13 +341,38 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
             [64, 0],
         ]
 
-    # Padded shared layout for A data. Scales bypass LDS (direct-to-VGPR).
-    shared_a: gl.constexpr = gl.PaddedSharedLayout(
-        [[1024, 16]],
-        shared_a_bases,
-        [],
-        [BLOCK_M, BLOCK_K_PACKED],
-    )
+    if A_FORMAT == "e4m3":
+        shared_a_k_bases: gl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+            [0, 64],
+        ]
+    else:
+        shared_a_k_bases: gl.constexpr = [
+            [0, 1],
+            [0, 2],
+            [0, 4],
+            [0, 8],
+            [0, 16],
+            [0, 32],
+        ]
+    shared_a_bases: gl.constexpr = shared_a_k_bases + shared_a_m_bases
+
+    # Padded shared layout for packed FP4 and unsorted E4M3 data. Sorted E4M3
+    # uses the verifier-safe CDNA4 direct-copy swizzle.
+    if USE_ASYNC_E4M3:
+        shared_a: gl.constexpr = gl.SwizzledSharedLayout(16, 1, 16, order=[1, 0])
+    else:
+        shared_a: gl.constexpr = gl.PaddedSharedLayout(
+            [[1024, 16]],
+            shared_a_bases,
+            [],
+            [BLOCK_M, BLOCK_K_A],
+        )
 
     cta_id = gl.program_id(axis=0)
     num_pid_m = gl.cdiv(EM, BLOCK_M)
@@ -381,14 +429,20 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
             topk_id = offs_token >> 24
             if INPUT_SORTED:
                 inter_row = offs_sorted_slot
+                # Stage 1 emits E4M3 rows in sorted order. Rebase the scalar
+                # pointer per M tile so the buffer-copy offset stays 32-bit
+                # even when the full intermediate exceeds 2 GiB.
+                a_base_ptr = a_ptr + (pid_m * BLOCK_M).to(gl.int64) * stride_am
+                a_row = inter_row - pid_m * BLOCK_M
             else:
                 inter_row = token_id * top_k + topk_id
+                a_base_ptr = a_ptr
+                a_row = inter_row
             token_mask = token_id < token_num
 
-            offs_ak = gl.arange(0, BLOCK_K_PACKED, layout=k_layout)
+            offs_ak = gl.arange(0, BLOCK_K_A, layout=k_layout)
             offs_a = (
-                inter_row[:, None].to(gl.int64) * stride_am
-                + offs_ak[None, :] * stride_ak
+                a_row[:, None].to(gl.int64) * stride_am + offs_ak[None, :] * stride_ak
             )
 
             # Expert id is indexed at the sort-block granularity.  FlyDSL
@@ -543,7 +597,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 # per-chunk tile. SliceLayout(0,dot_b_layout) over arange(0,32) yields the
                 # natural N-axis sublayout for each 32-col chunk.
                 offs_bk = gl.arange(
-                    0, BLOCK_K_PACKED, layout=gl.SliceLayout(1, dot_b_layout)
+                    0, BLOCK_K_B, layout=gl.SliceLayout(1, dot_b_layout)
                 )
                 b_k_part = (
                     (offs_bk // 32) * 512 + ((offs_bk // 16) % 2) * 256 + (offs_bk % 16)
@@ -666,24 +720,22 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 # LDS holds A data only; 2 ping-pong buffers
                 smem_a = gl.allocate_shared_memory(
                     a_ptr.type.element_ty,
-                    [NUM_BUFFERS, BLOCK_M, BLOCK_K_PACKED],
+                    [NUM_BUFFERS, BLOCK_M, BLOCK_K_A],
                     shared_a,
                 )
 
-                a_base_ptr = a_ptr
                 b_base_ptr = b_ptr + off_experts.to(gl.int64) * stride_be
                 b_scale_base = b_scales_ptr + off_experts.to(gl.uint32) * stride_bse_e
-                offs_a_i32 = offs_a.to(gl.int32)
+                if USE_ASYNC_A:
+                    a_copy_offsets = offs_a.to(gl.int32)
+                else:
+                    a_copy_offsets = offs_a
 
-                A_DATA_K_STEP: gl.constexpr = BLOCK_K_PACKED  # 64
+                A_DATA_K_STEP: gl.constexpr = BLOCK_K_A
                 if B_GDOT128:
                     B_DATA_K_STEP1: gl.constexpr = 1024
-                    B_DATA_K_STEP2: gl.constexpr = (N_PHYS // 128) * (128 * 128)
-                    B_DATA_K_STEP3: gl.constexpr = B_DATA_K_STEP2 + 1024
                 else:
-                    B_DATA_K_STEP1: gl.constexpr = (BLOCK_K_PACKED // 32) * 512
-                    B_DATA_K_STEP2: gl.constexpr = 2 * B_DATA_K_STEP1
-                    B_DATA_K_STEP3: gl.constexpr = 3 * B_DATA_K_STEP1
+                    B_DATA_K_STEP1: gl.constexpr = (BLOCK_K_B // 32) * 512
 
                 # 4 independent accumulators of shape [BLOCK_M, BLOCK_N_CHUNK=32].
                 # mfma_layout is shape-agnostic; each acc covers 8 (M) x 2 (N) x 2 (K) =
@@ -704,18 +756,20 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 # ---- paired K=128 subtiles (production K=256) -------------------
                 # Issue both K-subtiles' B/B_scale/A_scale loads before the first
                 # MFMA block so tile-1 global-load latency overlaps tile-0 compute.
-                cdna4_async_copy.buffer_load_to_shared(
+                _load_a_to_shared(
                     smem_a.index(0),
                     a_base_ptr,
-                    offs_a_i32,
-                    mask=token_mask[:, None],
+                    a_copy_offsets,
+                    token_mask[:, None],
+                    USE_ASYNC=USE_ASYNC_A,
                 )
                 cdna4_async_copy.commit_group()
-                cdna4_async_copy.buffer_load_to_shared(
+                _load_a_to_shared(
                     smem_a.index(1),
                     a_base_ptr,
-                    offs_a_i32 + A_DATA_K_STEP,
-                    mask=token_mask[:, None],
+                    a_copy_offsets + A_DATA_K_STEP,
+                    token_mask[:, None],
+                    USE_ASYNC=USE_ASYNC_A,
                 )
                 cdna4_async_copy.commit_group()
 
@@ -870,11 +924,16 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     b_scale1_c3 = gl.convert_layout(b_scale1_c3, b_scale_layout_chunk)
 
                 cdna4_async_copy.wait_group(1)
+                if USE_ASYNC_E4M3:
+                    # The copy distributes M across waves while every MFMA
+                    # wave consumes all rows, so publish the completed LDS
+                    # writes before cross-wave reads.
+                    gl.barrier()
                 a0 = cdna4_async_copy.load_shared_relaxed(smem_a.index(0), dot_a_layout)
                 acc0 = gl.amd.cdna4.mfma_scaled(
                     a=a0,
                     a_scale=a_scale0,
-                    a_format="e2m1",
+                    a_format=A_FORMAT,
                     b=b0_c0,
                     b_scale=b_scale0_c0,
                     b_format="e2m1",
@@ -883,7 +942,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 acc1 = gl.amd.cdna4.mfma_scaled(
                     a=a0,
                     a_scale=a_scale0,
-                    a_format="e2m1",
+                    a_format=A_FORMAT,
                     b=b0_c1,
                     b_scale=b_scale0_c1,
                     b_format="e2m1",
@@ -892,7 +951,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 acc2 = gl.amd.cdna4.mfma_scaled(
                     a=a0,
                     a_scale=a_scale0,
-                    a_format="e2m1",
+                    a_format=A_FORMAT,
                     b=b0_c2,
                     b_scale=b_scale0_c2,
                     b_format="e2m1",
@@ -901,7 +960,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 acc3 = gl.amd.cdna4.mfma_scaled(
                     a=a0,
                     a_scale=a_scale0,
-                    a_format="e2m1",
+                    a_format=A_FORMAT,
                     b=b0_c3,
                     b_scale=b_scale0_c3,
                     b_format="e2m1",
@@ -1008,6 +1067,8 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                 m3 = tok_ok
 
                 cdna4_async_copy.wait_group(0)
+                if USE_ASYNC_E4M3:
+                    gl.barrier()
                 a1 = cdna4_async_copy.load_shared_relaxed(smem_a.index(1), dot_a_layout)
 
                 if DEFER_EPILOGUE:
@@ -1018,7 +1079,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc0 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c0,
                         b_scale=b_scale1_c0,
                         b_format="e2m1",
@@ -1027,7 +1088,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc1 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c1,
                         b_scale=b_scale1_c1,
                         b_format="e2m1",
@@ -1036,7 +1097,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc2 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c2,
                         b_scale=b_scale1_c2,
                         b_format="e2m1",
@@ -1045,192 +1106,246 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc3 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c3,
                         b_scale=b_scale1_c3,
                         b_format="e2m1",
                         acc=acc3,
                     )
-                    if K_PACKED_TOTAL > 2 * BLOCK_K_PACKED:
-                        # Kimi TP4 stage2 has logical K=512.  The original
-                        # production body above covers the first K=256
-                        # (two K=128 scaled-MFMA subtiles); accumulate the
-                        # second K=256 pair before the epilogue.  The host
-                        # wrapper gates this path to direct-scale loads for
-                        # now; the coalesced full-K scale loader is currently
-                        # specialized to one K=256 pair.
-                        cdna4_async_copy.buffer_load_to_shared(
+                    # The prologue above covers the first K=256. Accumulate
+                    # every remaining pair so EP can consume the full expert
+                    # intermediate (K=3072 for Kimi-K3), while retaining the
+                    # same two-buffer schedule used by the short TP shard.
+                    for pair_k in range(2, NUM_K_ITERS, 2):
+                        if USE_ASYNC_E4M3:
+                            # Every MFMA wave reads all M rows. Finish those
+                            # cross-wave reads before any wave reuses either
+                            # shared slot as the next async-copy destination.
+                            gl.barrier()
+                        _load_a_to_shared(
                             smem_a.index(0),
                             a_base_ptr,
-                            offs_a_i32 + 2 * A_DATA_K_STEP,
-                            mask=token_mask[:, None],
+                            a_copy_offsets + pair_k * A_DATA_K_STEP,
+                            token_mask[:, None],
+                            USE_ASYNC=USE_ASYNC_A,
                         )
                         cdna4_async_copy.commit_group()
-                        cdna4_async_copy.buffer_load_to_shared(
+                        _load_a_to_shared(
                             smem_a.index(1),
                             a_base_ptr,
-                            offs_a_i32 + 3 * A_DATA_K_STEP,
-                            mask=token_mask[:, None],
+                            a_copy_offsets + (pair_k + 1) * A_DATA_K_STEP,
+                            token_mask[:, None],
+                            USE_ASYNC=USE_ASYNC_A,
                         )
                         cdna4_async_copy.commit_group()
 
-                        a_k_iter2 = 2 * BLOCK_K_SCALE + a_k_lanes
-                        a_k_part2 = (
-                            (a_k_iter2 // 8) * 256
-                            + (a_k_iter2 % 4) * 64
-                            + ((a_k_iter2 % 8) // 4) * 2
+                        a_k_even = pair_k * BLOCK_K_SCALE + a_k_lanes
+                        a_k_part_even = (
+                            (a_k_even // 8) * 256
+                            + (a_k_even % 4) * 64
+                            + ((a_k_even % 8) // 4) * 2
                         )[None, :]
-                        a_scale2 = gl.amd.cdna4.buffer_load(
-                            ptr=a_scales_ptr, offsets=a_m_part + a_k_part2
+                        a_scale_even = gl.amd.cdna4.buffer_load(
+                            ptr=a_scales_ptr, offsets=a_m_part + a_k_part_even
                         )
-                        b2_c0 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c0 + B_DATA_K_STEP2
-                        )
-                        b2_c1 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c1 + B_DATA_K_STEP2
-                        )
-                        b2_c2 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c2 + B_DATA_K_STEP2
-                        )
-                        b2_c3 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c3 + B_DATA_K_STEP2
-                        )
-                        bsc_k_iter2 = 2 * BLOCK_K_SCALE + b_k_lanes
-                        bsc_k_off2 = (
-                            (bsc_k_iter2 // 8) * 256
-                            + (bsc_k_iter2 % 4) * 64
-                            + ((bsc_k_iter2 % 8) // 4) * 2
+                        a_k_odd = (pair_k + 1) * BLOCK_K_SCALE + a_k_lanes
+                        a_k_part_odd = (
+                            (a_k_odd // 8) * 256
+                            + (a_k_odd % 4) * 64
+                            + ((a_k_odd % 8) // 4) * 2
                         )[None, :]
-                        b_scale2_c0 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c0 + bsc_k_off2
-                        )
-                        b_scale2_c1 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c1 + bsc_k_off2
-                        )
-                        b_scale2_c2 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c2 + bsc_k_off2
-                        )
-                        b_scale2_c3 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c3 + bsc_k_off2
+                        a_scale_odd = gl.amd.cdna4.buffer_load(
+                            ptr=a_scales_ptr, offsets=a_m_part + a_k_part_odd
                         )
 
-                        a_k_iter3 = 3 * BLOCK_K_SCALE + a_k_lanes
-                        a_k_part3 = (
-                            (a_k_iter3 // 8) * 256
-                            + (a_k_iter3 % 4) * 64
-                            + ((a_k_iter3 % 8) // 4) * 2
+                        if B_GDOT128:
+                            b_even_k = pair_k * BLOCK_K_B + offs_bk
+                            b_odd_k = (pair_k + 1) * BLOCK_K_B + offs_bk
+                            b_even_c0_off = _gdot128_weight_offset(
+                                b_even_k[:, None], offs_bn_c0[None, :], N_PHYS
+                            )
+                            b_even_c1_off = _gdot128_weight_offset(
+                                b_even_k[:, None], offs_bn_c1[None, :], N_PHYS
+                            )
+                            b_even_c2_off = _gdot128_weight_offset(
+                                b_even_k[:, None], offs_bn_c2[None, :], N_PHYS
+                            )
+                            b_even_c3_off = _gdot128_weight_offset(
+                                b_even_k[:, None], offs_bn_c3[None, :], N_PHYS
+                            )
+                            b_odd_c0_off = _gdot128_weight_offset(
+                                b_odd_k[:, None], offs_bn_c0[None, :], N_PHYS
+                            )
+                            b_odd_c1_off = _gdot128_weight_offset(
+                                b_odd_k[:, None], offs_bn_c1[None, :], N_PHYS
+                            )
+                            b_odd_c2_off = _gdot128_weight_offset(
+                                b_odd_k[:, None], offs_bn_c2[None, :], N_PHYS
+                            )
+                            b_odd_c3_off = _gdot128_weight_offset(
+                                b_odd_k[:, None], offs_bn_c3[None, :], N_PHYS
+                            )
+                        else:
+                            b_even_c0_off = offs_b_c0 + pair_k * B_DATA_K_STEP1
+                            b_even_c1_off = offs_b_c1 + pair_k * B_DATA_K_STEP1
+                            b_even_c2_off = offs_b_c2 + pair_k * B_DATA_K_STEP1
+                            b_even_c3_off = offs_b_c3 + pair_k * B_DATA_K_STEP1
+                            b_odd_c0_off = offs_b_c0 + (pair_k + 1) * B_DATA_K_STEP1
+                            b_odd_c1_off = offs_b_c1 + (pair_k + 1) * B_DATA_K_STEP1
+                            b_odd_c2_off = offs_b_c2 + (pair_k + 1) * B_DATA_K_STEP1
+                            b_odd_c3_off = offs_b_c3 + (pair_k + 1) * B_DATA_K_STEP1
+
+                        b_even_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_even_c0_off
+                        )
+                        b_even_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_even_c1_off
+                        )
+                        b_even_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_even_c2_off
+                        )
+                        b_even_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_even_c3_off
+                        )
+                        b_odd_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_odd_c0_off
+                        )
+                        b_odd_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_odd_c1_off
+                        )
+                        b_odd_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_odd_c2_off
+                        )
+                        b_odd_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_base_ptr, offsets=b_odd_c3_off
+                        )
+
+                        bsc_k_even = pair_k * BLOCK_K_SCALE + b_k_lanes
+                        bsc_k_off_even = (
+                            (bsc_k_even // 8) * 256
+                            + (bsc_k_even % 4) * 64
+                            + ((bsc_k_even % 8) // 4) * 2
                         )[None, :]
-                        a_scale3 = gl.amd.cdna4.buffer_load(
-                            ptr=a_scales_ptr, offsets=a_m_part + a_k_part3
+                        b_scale_even_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c0 + bsc_k_off_even,
                         )
-                        b3_c0 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c0 + B_DATA_K_STEP3
+                        b_scale_even_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c1 + bsc_k_off_even,
                         )
-                        b3_c1 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c1 + B_DATA_K_STEP3
+                        b_scale_even_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c2 + bsc_k_off_even,
                         )
-                        b3_c2 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c2 + B_DATA_K_STEP3
+                        b_scale_even_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c3 + bsc_k_off_even,
                         )
-                        b3_c3 = gl.amd.cdna4.buffer_load(
-                            ptr=b_base_ptr, offsets=offs_b_c3 + B_DATA_K_STEP3
-                        )
-                        bsc_k_iter3 = 3 * BLOCK_K_SCALE + b_k_lanes
-                        bsc_k_off3 = (
-                            (bsc_k_iter3 // 8) * 256
-                            + (bsc_k_iter3 % 4) * 64
-                            + ((bsc_k_iter3 % 8) // 4) * 2
+                        bsc_k_odd = (pair_k + 1) * BLOCK_K_SCALE + b_k_lanes
+                        bsc_k_off_odd = (
+                            (bsc_k_odd // 8) * 256
+                            + (bsc_k_odd % 4) * 64
+                            + ((bsc_k_odd % 8) // 4) * 2
                         )[None, :]
-                        b_scale3_c0 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c0 + bsc_k_off3
+                        b_scale_odd_c0 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c0 + bsc_k_off_odd,
                         )
-                        b_scale3_c1 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c1 + bsc_k_off3
+                        b_scale_odd_c1 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c1 + bsc_k_off_odd,
                         )
-                        b_scale3_c2 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c2 + bsc_k_off3
+                        b_scale_odd_c2 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c2 + bsc_k_off_odd,
                         )
-                        b_scale3_c3 = gl.amd.cdna4.buffer_load(
-                            ptr=b_scale_base, offsets=b_n_scale_part_c3 + bsc_k_off3
+                        b_scale_odd_c3 = gl.amd.cdna4.buffer_load(
+                            ptr=b_scale_base,
+                            offsets=b_n_scale_part_c3 + bsc_k_off_odd,
                         )
 
                         cdna4_async_copy.wait_group(1)
-                        a2 = cdna4_async_copy.load_shared_relaxed(
+                        if USE_ASYNC_E4M3:
+                            gl.barrier()
+                        a_even = cdna4_async_copy.load_shared_relaxed(
                             smem_a.index(0), dot_a_layout
                         )
                         acc0 = gl.amd.cdna4.mfma_scaled(
-                            a=a2,
-                            a_scale=a_scale2,
-                            a_format="e2m1",
-                            b=b2_c0,
-                            b_scale=b_scale2_c0,
+                            a=a_even,
+                            a_scale=a_scale_even,
+                            a_format=A_FORMAT,
+                            b=b_even_c0,
+                            b_scale=b_scale_even_c0,
                             b_format="e2m1",
                             acc=acc0,
                         )
                         acc1 = gl.amd.cdna4.mfma_scaled(
-                            a=a2,
-                            a_scale=a_scale2,
-                            a_format="e2m1",
-                            b=b2_c1,
-                            b_scale=b_scale2_c1,
+                            a=a_even,
+                            a_scale=a_scale_even,
+                            a_format=A_FORMAT,
+                            b=b_even_c1,
+                            b_scale=b_scale_even_c1,
                             b_format="e2m1",
                             acc=acc1,
                         )
                         acc2 = gl.amd.cdna4.mfma_scaled(
-                            a=a2,
-                            a_scale=a_scale2,
-                            a_format="e2m1",
-                            b=b2_c2,
-                            b_scale=b_scale2_c2,
+                            a=a_even,
+                            a_scale=a_scale_even,
+                            a_format=A_FORMAT,
+                            b=b_even_c2,
+                            b_scale=b_scale_even_c2,
                             b_format="e2m1",
                             acc=acc2,
                         )
                         acc3 = gl.amd.cdna4.mfma_scaled(
-                            a=a2,
-                            a_scale=a_scale2,
-                            a_format="e2m1",
-                            b=b2_c3,
-                            b_scale=b_scale2_c3,
+                            a=a_even,
+                            a_scale=a_scale_even,
+                            a_format=A_FORMAT,
+                            b=b_even_c3,
+                            b_scale=b_scale_even_c3,
                             b_format="e2m1",
                             acc=acc3,
                         )
                         cdna4_async_copy.wait_group(0)
-                        a3 = cdna4_async_copy.load_shared_relaxed(
+                        if USE_ASYNC_E4M3:
+                            gl.barrier()
+                        a_odd = cdna4_async_copy.load_shared_relaxed(
                             smem_a.index(1), dot_a_layout
                         )
                         acc0 = gl.amd.cdna4.mfma_scaled(
-                            a=a3,
-                            a_scale=a_scale3,
-                            a_format="e2m1",
-                            b=b3_c0,
-                            b_scale=b_scale3_c0,
+                            a=a_odd,
+                            a_scale=a_scale_odd,
+                            a_format=A_FORMAT,
+                            b=b_odd_c0,
+                            b_scale=b_scale_odd_c0,
                             b_format="e2m1",
                             acc=acc0,
                         )
                         acc1 = gl.amd.cdna4.mfma_scaled(
-                            a=a3,
-                            a_scale=a_scale3,
-                            a_format="e2m1",
-                            b=b3_c1,
-                            b_scale=b_scale3_c1,
+                            a=a_odd,
+                            a_scale=a_scale_odd,
+                            a_format=A_FORMAT,
+                            b=b_odd_c1,
+                            b_scale=b_scale_odd_c1,
                             b_format="e2m1",
                             acc=acc1,
                         )
                         acc2 = gl.amd.cdna4.mfma_scaled(
-                            a=a3,
-                            a_scale=a_scale3,
-                            a_format="e2m1",
-                            b=b3_c2,
-                            b_scale=b_scale3_c2,
+                            a=a_odd,
+                            a_scale=a_scale_odd,
+                            a_format=A_FORMAT,
+                            b=b_odd_c2,
+                            b_scale=b_scale_odd_c2,
                             b_format="e2m1",
                             acc=acc2,
                         )
                         acc3 = gl.amd.cdna4.mfma_scaled(
-                            a=a3,
-                            a_scale=a_scale3,
-                            a_format="e2m1",
-                            b=b3_c3,
-                            b_scale=b_scale3_c3,
+                            a=a_odd,
+                            a_scale=a_scale_odd,
+                            a_format=A_FORMAT,
+                            b=b_odd_c3,
+                            b_scale=b_scale_odd_c3,
                             b_format="e2m1",
                             acc=acc3,
                         )
@@ -1265,7 +1380,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc0 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c0,
                         b_scale=b_scale1_c0,
                         b_format="e2m1",
@@ -1282,7 +1397,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc1 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c1,
                         b_scale=b_scale1_c1,
                         b_format="e2m1",
@@ -1299,7 +1414,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc2 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c2,
                         b_scale=b_scale1_c2,
                         b_format="e2m1",
@@ -1316,7 +1431,7 @@ def gluon_mxfp4_moe_stage2_1x2_kernel(
                     acc3 = gl.amd.cdna4.mfma_scaled(
                         a=a1,
                         a_scale=a_scale1,
-                        a_format="e2m1",
+                        a_format=A_FORMAT,
                         b=b1_c3,
                         b_scale=b_scale1_c3,
                         b_format="e2m1",
@@ -1451,6 +1566,7 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
     b_gdot128: bool = False,
     force_reduce: bool | None = None,
     input_sorted: bool = False,
+    a_format: str = "e2m1",
 ):
     """Host-side launcher for Gluon MXFP4 MoE stage 2.
 
@@ -1480,8 +1596,8 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
          ``out``.
 
     Layout contract:
-        inter_states : (token_num, topk, K_packed) uint8
-                       OR (M_padded, K_packed) uint8 (already flattened)
+        inter_states : E2M1-packed uint8 or E4M3 activation rows, optionally
+                       already flattened and sorted
         w2           : (E, D, I_r_packed) uint8 in MFMA-tile layout
         a2_scale     : (M_padded_aligned, K // 32) uint8 e8m0
         w2_scale     : (E, D, K // 32) uint8 e8m0
@@ -1506,7 +1622,14 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
         raise NotImplementedError(f"only dst_type=bfloat16 supported, got {dst_type!r}")
     del kernelName, use_non_temporal_load, w1
 
-    assert inter_states.dtype == torch.uint8
+    if a_format not in ("e2m1", "e4m3"):
+        raise ValueError(f"stage2 a_format must be e2m1 or e4m3, got {a_format}")
+    expected_a_dtype = torch.float8_e4m3fn if a_format == "e4m3" else torch.uint8
+    if inter_states.dtype != expected_a_dtype:
+        raise TypeError(
+            f"{a_format} stage2 input must use {expected_a_dtype}, "
+            f"got {inter_states.dtype}"
+        )
     assert w2.dtype == torch.uint8
     # Step 2: shuffle w2 to MFMA-tile layout if the caller didn't.
     if not b_preshuffled:
@@ -1536,13 +1659,14 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
     if out.dim() != 2:
         raise NotImplementedError(f"stage 2 out must be 2-D, got {tuple(out.shape)}")
     token_num = out.shape[0]
-    M_padded, I_r_packed = inter_2d.shape
-    K = I_r_packed * 2
+    M_padded, I_r_stored = inter_2d.shape
+    a_div = 1 if a_format == "e4m3" else 2
+    K = I_r_stored * a_div
 
     assert w2.dim() == 3
     E_w, D, I_r_packed_w = w2.shape
     N = D
-    assert I_r_packed_w == I_r_packed
+    assert I_r_packed_w * 2 == K
     EM = sorted_token_ids.shape[0]
     if input_sorted and M_padded < EM:
         raise ValueError(
@@ -1631,8 +1755,11 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
         _use_reduce = token_num >= 512
     _mfma_store_layout = not _use_reduce
 
-    stride_am = inter_2d.stride(0)
-    stride_ak = inter_2d.stride(1)
+    # See stage 1: the async-copy path uses raw bytes in LDS and the scaled
+    # MFMA interprets them as E4M3 according to ``A_FORMAT``.
+    kernel_inter = inter_2d.view(torch.uint8) if a_format == "e4m3" else inter_2d
+    stride_am = kernel_inter.stride(0)
+    stride_ak = kernel_inter.stride(1)
     stride_be = w2.stride(0)
     stride_bn = w2.stride(1)
     stride_bk = w2.stride(2)
@@ -1670,7 +1797,7 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
     # Step 5: GEMM. Writes either to `partials` (reduce mode) or directly
     # to `out` (atomic mode), selected by ``USE_REDUCE``.
     gluon_mxfp4_moe_stage2_1x2_kernel[grid](
-        inter_2d,
+        kernel_inter,
         w2,
         c_ptr,
         a2_scale,
@@ -1714,6 +1841,7 @@ def invoke_gluon_mxfp4_moe_stage2_1x2(
         DIRECT_SCALE_LAYOUT=DIRECT_SCALE_LAYOUT,
         DEFER_EPILOGUE=DEFER_EPILOGUE,
         INPUT_SORTED=bool(input_sorted),
+        A_FORMAT=a_format,
         # ``CU_NUM`` is the divisor for ``tiles_per_block`` in the
         # persistent path. When PERSISTENT=False it is unused inside
         # the kernel (branch is constexpr-pruned), so we keep it at the

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/preprocess.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/preprocess.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 
-"""Model-load helpers for the gfx950 A4W4 MoE package.
+"""Model-load helpers for the gfx950 MXFP4-weight MoE package.
 
 The package-prefill kernels consume the same gdot128-preshuffled weight storage
 that the decode/prefill stages use, but with the ``(E, N, K/2)`` /

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/quantize_gluon.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/quantize_gluon.py
@@ -18,9 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Gluon device helpers shared by staged and fused MXFP4 MoE kernels."""
+"""Gluon MXFP4/MXFP8 quantization helpers for staged MXFP4-weight MoE."""
 
-from tokenspeed_kernel_amd._triton import gl, gluon
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon, triton
 
 
 @gluon.jit
@@ -84,6 +87,28 @@ def _mxfp4_quantize_tile(out):
 
 
 @gluon.jit
+def _mxfp8_quantize_tile(out):
+    """Quantize each contiguous 32-value group to E4M3 + UE8M0."""
+
+    BLOCK_M: gl.constexpr = out.shape[0]
+    OUT_BLOCK_N: gl.constexpr = out.shape[1]
+    Q_GROUPS: gl.constexpr = OUT_BLOCK_N // 32
+    gl.static_assert(OUT_BLOCK_N % 32 == 0)
+
+    vals = out.to(gl.bfloat16).to(gl.float32).reshape((BLOCK_M, Q_GROUPS, 32))
+    amax = gl.max(gl.abs(vals), axis=2, keep_dims=True)
+    safe_amax = gl.where(amax > 0.0, amax, 448.0 * (2.0**-127))
+    scale_exp = gl.ceil(gl.log2(safe_amax / 448.0))
+    scale_exp = gl.minimum(gl.maximum(scale_exp, -127.0), 127.0)
+    scale_exp = gl.where(amax > 0.0, scale_exp, -127.0)
+    quantized = (vals * gl.exp2(-scale_exp)).to(gl.float8e4nv)
+    scale_byte = (scale_exp + 127.0).to(gl.uint8)
+    return quantized.reshape((BLOCK_M, OUT_BLOCK_N)), scale_byte.reshape(
+        (BLOCK_M, Q_GROUPS)
+    )
+
+
+@gluon.jit
 def _mxfp4_store_cdna4_scale(
     scale_ptr,
     scale_byte,
@@ -111,3 +136,140 @@ def _mxfp4_store_cdna4_scale(
         scale_byte,
         mask=mask,
     )
+
+
+@gluon.jit
+def _mxfp8_quantize_sorted_kernel(
+    x_ptr,
+    sorted_ids_ptr,
+    num_valid_ids_ptr,
+    out_ptr,
+    scale_ptr,
+    M,
+    K,
+    EM,
+    stride_xm,
+    stride_xk,
+    stride_om,
+    stride_ok,
+    scale_stride_kswizzled,
+    scale_stride_mblock,
+    BLOCK_M: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+):
+    """Gather routed rows and quantize them directly into sorted order."""
+
+    layout: gl.constexpr = gl.BlockedLayout(
+        [1, 16],
+        [8, 8],
+        [4, 1],
+        [1, 0],
+    )
+    m_layout: gl.constexpr = gl.SliceLayout(1, layout)
+    k_layout: gl.constexpr = gl.SliceLayout(0, layout)
+
+    pid = gl.program_id(axis=0)
+    num_pid_k = gl.cdiv(K, BLOCK_K)
+    pid_m = pid // num_pid_k
+    pid_k = pid % num_pid_k
+    valid_extent = gl.load(num_valid_ids_ptr)
+    if pid_m * BLOCK_M >= valid_extent:
+        return
+
+    rows = pid_m * BLOCK_M + gl.arange(0, BLOCK_M, layout=m_layout)
+    cols = pid_k * BLOCK_K + gl.arange(0, BLOCK_K, layout=k_layout)
+    packed_ids = gl.load(
+        sorted_ids_ptr + rows,
+        mask=rows < valid_extent,
+        other=M,
+    )
+    source_rows = packed_ids & 0xFFFFFF
+    valid_rows = (rows < valid_extent) & (source_rows < M)
+    values = gl.load(
+        x_ptr
+        + source_rows[:, None].to(gl.int64) * stride_xm
+        + cols[None, :].to(gl.int64) * stride_xk,
+        mask=valid_rows[:, None] & (cols[None, :] < K),
+        other=0.0,
+    )
+    quantized, scale_byte = _mxfp8_quantize_tile(values)
+    gl.store(
+        out_ptr
+        + rows[:, None].to(gl.int64) * stride_om
+        + cols[None, :].to(gl.int64) * stride_ok,
+        quantized,
+        mask=(rows[:, None] < valid_extent) & (cols[None, :] < K),
+    )
+
+    scale_layout: gl.constexpr = scale_byte.type.layout
+    scale_rows = pid_m * BLOCK_M + gl.arange(
+        0, BLOCK_M, layout=gl.SliceLayout(1, scale_layout)
+    )
+    scale_cols = pid_k * (BLOCK_K // 32) + gl.arange(
+        0, BLOCK_K // 32, layout=gl.SliceLayout(0, scale_layout)
+    )
+    _mxfp4_store_cdna4_scale(
+        scale_ptr,
+        scale_byte,
+        scale_rows[:, None],
+        scale_cols[None, :],
+        scale_stride_kswizzled,
+        scale_stride_mblock,
+        (scale_rows[:, None] < valid_extent) & (scale_cols[None, :] < K // 32),
+        M_SWIZZLE=32,
+        K_SWIZZLE=8,
+    )
+
+
+def quantize_mxfp8_sorted_routes(
+    hidden_states: torch.Tensor,
+    sorted_ids: torch.Tensor,
+    num_valid_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Gather BF16 routes and emit sorted MXFP8 data and CDNA4 scales."""
+
+    if hidden_states.ndim != 2 or hidden_states.dtype != torch.bfloat16:
+        raise TypeError("sorted MXFP8 quantization requires a rank-2 BF16 input")
+    if sorted_ids.ndim != 1 or sorted_ids.dtype != torch.int32:
+        raise TypeError("sorted MXFP8 quantization requires rank-1 int32 route IDs")
+    if num_valid_ids.ndim != 1 or num_valid_ids.dtype != torch.int32:
+        raise TypeError("sorted MXFP8 quantization requires int32 valid metadata")
+    if hidden_states.shape[1] % 256:
+        raise ValueError("sorted MXFP8 quantization requires K divisible by 256")
+
+    rows = int(sorted_ids.shape[0])
+    k = int(hidden_states.shape[1])
+    scale_cols = k // 32
+    scale_rows = triton.cdiv(rows, 32) * 32
+    output = torch.empty(
+        (rows, k), dtype=torch.float8_e4m3fn, device=hidden_states.device
+    )
+    scales = torch.empty(
+        (scale_rows, scale_cols), dtype=torch.uint8, device=hidden_states.device
+    )
+    if rows == 0:
+        return output, scales
+
+    block_m = 32
+    block_k = 256
+    grid = (triton.cdiv(rows, block_m) * triton.cdiv(k, block_k),)
+    _mxfp8_quantize_sorted_kernel[grid](
+        hidden_states,
+        sorted_ids,
+        num_valid_ids,
+        output,
+        scales,
+        int(hidden_states.shape[0]),
+        k,
+        rows,
+        hidden_states.stride(0),
+        hidden_states.stride(1),
+        output.stride(0),
+        output.stride(1),
+        1,
+        scale_cols * 32,
+        BLOCK_M=block_m,
+        BLOCK_K=block_k,
+        num_warps=4,
+    )
+    return output, scales

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/scale.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/scale.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 
-"""Package-prefill activation-scale gather for the gfx950 A4W4 MoE package.
+"""Package-prefill activation-scale gather for the gfx950 MXFP4-weight package.
 
 The MXFP4 quantizer emits CDNA4-swizzled, token-order activation scales, but the
 package stage kernels need those same bytes in sorted-route row order. This

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/scale_layout.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/scale_layout.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Single source of truth for the gfx950 A4W4 CDNA4 MXFP4 scale layout.
+"""Single source of truth for the gfx950 CDNA4 block-scale layout.
 
 Both scale producers and consumers must agree on the CDNA4 MXFP4 scale-swizzle
 parameters and byte permutation:
@@ -26,9 +26,9 @@ parameters and byte permutation:
 * B-scales (weights): swizzled at load time by the weight preprocessor
   (``mxfp4_gfx950_preprocess._swizzle_mxfp4`` via
   :func:`swizzle_cdna4_mxfp4_scale`).
-* A-scales (activations): emitted in token order by the MXFP4 activation
-  quantizer and re-gathered into sorted-route order by
-  ``mxfp4.scale.gather_package_cdna4_scale``.
+* A-scales (activations): MXFP4 quantization emits token-order scales that
+  ``mxfp4.scale.gather_package_cdna4_scale`` reorders; the EP8 MXFP8 quantizer
+  emits the same swizzle directly in sorted-route order.
 * Consumers: the package stage kernels (``prefill_stage1/2``,
   ``decode_stage1/2``) address the scales with the matching CDNA4 MFMA scale
   layout (``gl.amd.cdna4.get_mfma_scale_layout``).
@@ -81,7 +81,7 @@ MXFP4_BLOCK = 32
 CDNA4_SCALE_N_BLOCK = 32
 CDNA4_SCALE_K_BLOCK = 8
 
-# MFMA non-K dimension used by the a4w4 stage kernels
+# MFMA non-K dimension used by the block-scaled stage kernels
 # (``v_mfma_scale_f32_16x16x128_f8f6f4``). The scale swizzle below is fixed to
 # this shape.
 MFMA_NONK_DIM = 16

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/mxfp4.py
@@ -89,6 +89,12 @@ if platform.is_amd:
     def gluon_mxfp4_gfx950_moe_weights(plan: dict, w: torch.nn.Module):
         return preprocess_gluon_mxfp4_gfx950_moe_weights(plan, w, preshuffle=True)
 
+    def gluon_mxfp4_gfx950_a8w4_situ_ep_weights(plan: dict, w: torch.nn.Module) -> None:
+        if getattr(w, "activation_situ_linear_beta", None) is None:
+            validate_linear_mxfp4_moe_weights(plan, w)
+            return
+        gluon_mxfp4_gfx950_moe_weights(plan, w)
+
     def gluon_mxfp4_gfx1250_moe_weights(plan: dict, w: torch.nn.Module):
         return preprocess_gluon_mxfp4_gfx1250_moe_weights(plan, w)
 
@@ -303,6 +309,96 @@ if platform.is_amd:
         raise ValueError(
             "gfx950 A8W4 SiTU MoE does not support this activation or weight shape"
         )
+
+    @register_kernel(
+        "moe",
+        "apply",
+        name="gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply",
+        solution="gluon",
+        weight_preprocessor=gluon_mxfp4_gfx950_a8w4_situ_ep_weights,
+        capability=CapabilityRequirement(
+            vendors=frozenset({"amd"}),
+            min_arch_version=ArchVersion(9, 5),
+            max_arch_version=ArchVersion(9, 5),
+        ),
+        signatures=format_signatures("x", "dense", {torch.bfloat16}),
+        traits={
+            "weight_dtype": frozenset({"mxfp4"}),
+            "activation": frozenset({"situ"}),
+            "routing_mode": frozenset({"precomputed_topk"}),
+            "supports_deferred_finalize": frozenset({False}),
+            "supports_ep": frozenset({True}),
+            "supports_all_to_all_ep": frozenset({False}),
+            "ep_size": frozenset({8}),
+            "ispp": frozenset({3072}),
+            "internal_activation_dtype": frozenset({"input"}),
+            "supports_bias": frozenset({False}),
+        },
+        priority=Priority.SPECIALIZED + 3,
+    )
+    def gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply(
+        plan: dict,
+        x: torch.Tensor,
+        w: torch.nn.Module,
+        router_logits: torch.Tensor,
+        topk_weights: torch.Tensor | None = None,
+        topk_ids: torch.Tensor | None = None,
+        num_tokens_global: int | None = None,
+        max_num_tokens_per_gpu: int | None = None,
+        do_finalize: bool = True,
+        enable_pdl: bool = False,
+    ):
+        del plan, router_logits, num_tokens_global, max_num_tokens_per_gpu
+        del enable_pdl
+        if not do_finalize:
+            raise ValueError("gfx950 A8W4 SiTU EP MoE cannot defer finalization")
+        if topk_weights is None or topk_ids is None:
+            raise ValueError("gfx950 A8W4 SiTU EP MoE requires precomputed top-k")
+        if x.ndim == 2 and x.shape[0] == 0:
+            if topk_weights.ndim != 2 or topk_ids.shape != topk_weights.shape:
+                raise ValueError("gfx950 A8W4 SiTU EP MoE requires matching top-k")
+            if topk_ids.shape[0] != 0:
+                raise ValueError("empty EP input requires empty top-k tensors")
+            output = getattr(w, "_situ_output_buffer", None)
+            if output is None:
+                return torch.empty_like(x)
+            if (
+                output.shape != x.shape
+                or output.dtype != x.dtype
+                or output.device != x.device
+            ):
+                raise ValueError("empty EP output must match the input tensor")
+            return output
+
+        situ_linear_beta = getattr(w, "activation_situ_linear_beta", None)
+        if situ_linear_beta is None:
+            return _gluon_mxfp4_a16w4_ep_precomputed_moe_apply(
+                x,
+                w,
+                topk_weights,
+                topk_ids,
+                activation="situ",
+                do_finalize=do_finalize,
+            )
+        num_local_experts = int(getattr(w, "num_local_experts"))
+        global_num_experts = int(getattr(w, "num_experts"))
+        out = gluon_mxfp4_fp8_precomputed_situ(
+            x,
+            topk_weights,
+            topk_ids,
+            w.w13_weight_triton_tensor,
+            w.w2_weight_triton_tensor,
+            w13_mx_scale=w.w13_precision_config.b_mx_scale,
+            w2_mx_scale=w.w2_precision_config.b_mx_scale,
+            situ_beta=float(getattr(w, "activation_situ_beta", 1.0)),
+            situ_linear_beta=float(situ_linear_beta),
+            out=getattr(w, "_situ_output_buffer", None),
+            expert_start=int(getattr(w, "ep_rank", 0)) * num_local_experts,
+            global_num_experts=global_num_experts,
+        )
+        if out is None:
+            raise ValueError("gfx950 A8W4 SiTU EP MoE does not support this shape")
+        return out
 
     @register_kernel(
         "moe",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_decode.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/latent_decode.py
@@ -12,6 +12,13 @@ from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
 
+class _UnsetLinearClamp:
+    pass
+
+
+_UNSET_LINEAR_CLAMP = _UnsetLinearClamp()
+
+
 def _selection(
     hidden_states: torch.Tensor,
     w13_weight: torch.Tensor,
@@ -79,11 +86,14 @@ def latent_moe_decode_pipeline_available(
     expert_plan: Mapping[str, Any],
     *,
     topk: int,
+    linear_clamp: float | None | _UnsetLinearClamp = _UNSET_LINEAR_CLAMP,
 ) -> bool:
     """Return whether joint routed/shared small-batch decode is available.
 
     This construction-time probe owns backend, tensor-format, expert-plan, and
-    exact-shape constraints needed by the orchestration-level optimization.
+    exact-shape constraints needed by the orchestration-level optimization. An
+    A8 plan must provide ``linear_clamp`` explicitly; callers of the pre-existing
+    A16 probe may omit it.
     """
     projection_weights = (
         router_weight,
@@ -92,9 +102,16 @@ def latent_moe_decode_pipeline_available(
         shared_down_weight,
     )
     expert_tensors = (w13_weight, w13_scale, w2_weight, w2_scale)
+    apply_kernel_name = expert_plan.get("apply_kernel_name")
+    uses_linear_weights = (
+        apply_kernel_name == "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply"
+        or (
+            apply_kernel_name == "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply"
+            and linear_clamp is None
+        )
+    )
     if not (
-        expert_plan.get("apply_kernel_name")
-        == "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply"
+        uses_linear_weights
         and router_weight.dtype
         == routed_weight.dtype
         == shared_gate_up_weight.dtype

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -34,6 +34,71 @@ if not is_cdna4():
     )
 
 import tokenspeed_kernel  # noqa: E402
+from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (  # noqa: E402
+    quantize_mxfp8_sorted_routes,
+)
+
+
+def _unswizzle_cdna4_route_scales(
+    scales: torch.Tensor,
+    *,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    logical_m = torch.arange(rows, device=scales.device)[:, None]
+    logical_k = torch.arange(cols, device=scales.device)[None, :]
+    m_in_block = logical_m % 32
+    m_hi = m_in_block // 16
+    m_lo = m_in_block % 16
+    k_block = logical_k // 8
+    k_hi = (logical_k % 8) // 4
+    k_lo = logical_k % 4
+    swizzled_k = (((k_block * 4 + k_lo) * 16 + m_lo) * 2 + k_hi) * 2 + m_hi
+    offsets = swizzled_k + (logical_m // 32) * (cols * 32)
+    return scales.view(torch.uint8).flatten()[offsets]
+
+
+def test_sorted_route_mxfp8_quantization_matches_standard_gfx950() -> None:
+    generator = torch.Generator(device="cuda").manual_seed(20260830)
+    hidden_states = torch.randn(
+        (7, 256),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    source_rows = torch.tensor([5, 1, 6, 0, 3], dtype=torch.int32, device="cuda")
+    slots = torch.tensor([2, 4, 1, 0, 3], dtype=torch.int32, device="cuda")
+    valid_rows = int(source_rows.numel())
+    sorted_ids = torch.full((32,), 7, dtype=torch.int32, device="cuda")
+    sorted_ids[:valid_rows] = source_rows | (slots << 24)
+    num_valid_ids = torch.tensor([valid_rows], dtype=torch.int32, device="cuda")
+
+    actual, actual_scales = quantize_mxfp8_sorted_routes(
+        hidden_states,
+        sorted_ids,
+        num_valid_ids,
+    )
+    expected, expected_scales = tokenspeed_kernel.quantize_mxfp8(
+        hidden_states[source_rows.long()],
+        solution="triton",
+    )
+
+    torch.testing.assert_close(
+        actual[:valid_rows].view(torch.uint8),
+        expected.view(torch.uint8),
+        atol=0,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        _unswizzle_cdna4_route_scales(
+            actual_scales,
+            rows=valid_rows,
+            cols=hidden_states.shape[1] // 32,
+        ),
+        expected_scales.view(torch.uint8),
+        atol=0,
+        rtol=0,
+    )
 
 
 def _make_mxfp4_module(
@@ -111,6 +176,19 @@ def test_ep_decode_matches_kimi_k3_shape_gfx950(
         ),
         dim=-1,
     )
+    if num_tokens == 2:
+        ids_storage = torch.empty(
+            (num_tokens, 2 * top_k), dtype=topk_ids.dtype, device="cuda"
+        )
+        weights_storage = torch.empty(
+            (num_tokens, 2 * top_k), dtype=topk_weights.dtype, device="cuda"
+        )
+        ids_storage[:, ::2].copy_(topk_ids)
+        weights_storage[:, ::2].copy_(topk_weights)
+        topk_ids = ids_storage[:, ::2]
+        topk_weights = weights_storage[:, ::2]
+        assert not topk_ids.is_contiguous()
+        assert not topk_weights.is_contiguous()
     router_logits = torch.zeros(
         (num_tokens, num_experts), dtype=torch.float32, device="cuda"
     )
@@ -124,10 +202,14 @@ def test_ep_decode_matches_kimi_k3_shape_gfx950(
         internal_activation_dtype="input",
         solution="gluon",
     )
-    assert (
-        plan["apply_kernel_name"] == "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply"
-    )
+    assert plan["apply_kernel_name"] == "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply"
     tokenspeed_kernel.moe_process_weights(plan, module)
+    output_storage = torch.empty(
+        (num_tokens, latent_size + 7168),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    module._situ_output_buffer = output_storage[:, :latent_size]
     actual = tokenspeed_kernel.moe_apply(
         plan,
         hidden_states,
@@ -159,7 +241,106 @@ def test_ep_decode_matches_kimi_k3_shape_gfx950(
 
     assert actual.shape == (num_tokens, latent_size)
     assert actual.dtype == torch.bfloat16
-    torch.testing.assert_close(actual, expected, atol=2e-4, rtol=2e-2)
+    assert actual.data_ptr() == output_storage.data_ptr()
+    assert actual.stride() == (latent_size + 7168, 1)
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=8e-2)
+
+
+def test_ep_idle_forward_returns_empty_output_gfx950() -> None:
+    hidden_states = torch.empty((0, 3584), dtype=torch.bfloat16, device="cuda")
+    topk_ids = torch.empty((0, 16), dtype=torch.int32, device="cuda")
+    topk_weights = torch.empty((0, 16), dtype=torch.float32, device="cuda")
+    router_logits = torch.empty((0, 896), dtype=torch.float32, device="cuda")
+    output_storage = torch.empty((0, 3584 + 7168), dtype=torch.bfloat16, device="cuda")
+    output = output_storage[:, :3584]
+    module = torch.nn.Module()
+    module._situ_output_buffer = output
+
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="situ",
+        routing_mode="precomputed_topk",
+        ep_size=8,
+        ispp=3072,
+        internal_activation_dtype="input",
+        solution="gluon",
+    )
+    actual = tokenspeed_kernel.moe_apply(
+        plan,
+        hidden_states,
+        module,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+
+    assert actual is output
+
+
+def test_ep_unclipped_situ_uses_a16_fallback_gfx950() -> None:
+    generator = torch.Generator(device="cuda").manual_seed(20260831)
+    num_tokens = 17
+    latent_size = 3584
+    intermediate_size = 3072
+    module, raw = _make_mxfp4_module(
+        num_experts=1,
+        latent_size=latent_size,
+        intermediate_size=intermediate_size,
+        top_k=1,
+        generator=generator,
+    )
+    module.num_experts = 8
+    module.num_local_experts = 1
+    module.ep_size = 8
+    module.ep_rank = 0
+    module.activation_situ_linear_beta = None
+    hidden_states = (
+        torch.randn(
+            (num_tokens, latent_size),
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.1
+    )
+    topk_ids = torch.zeros((num_tokens, 1), dtype=torch.int32, device="cuda")
+    topk_weights = torch.ones((num_tokens, 1), dtype=torch.float32, device="cuda")
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="situ",
+        routing_mode="precomputed_topk",
+        ep_size=8,
+        ispp=intermediate_size,
+        internal_activation_dtype="input",
+        solution="gluon",
+    )
+
+    tokenspeed_kernel.moe_process_weights(plan, module)
+    assert hasattr(module, "w13_weight")
+    actual = tokenspeed_kernel.moe_apply(
+        plan,
+        hidden_states,
+        module,
+        torch.empty((num_tokens, 0), dtype=torch.float32, device="cuda"),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+    expected = mxfp4_moe_reference(
+        hidden_states,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        topk_ids,
+        topk_weights,
+        activation_dtype=torch.bfloat16,
+        situ_beta=4.0,
+        situ_linear_beta=None,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=8e-2)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 2, 4, 8, 16])
@@ -798,6 +979,56 @@ def test_package_prefill_sort_contract_gfx950(
     assert actual_routes == expected_routes
 
 
+def test_package_prefill_sort_localizes_ep_routes_gfx950() -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.moe_sorting import (
+        gluon_moe_sorting,
+    )
+
+    num_tokens, top_k = 19, 16
+    num_local_experts, expert_start = 2, 6
+    global_ids = torch.arange(top_k, dtype=torch.int32).repeat(num_tokens, 1)
+    topk_ids = global_ids.to("cuda")
+    topk_weights = torch.arange(
+        num_tokens * top_k,
+        dtype=torch.float32,
+        device="cuda",
+    ).view(num_tokens, top_k)
+    output = torch.empty(
+        (num_tokens, 32),
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    sorted_ids, sorted_weights, sorted_experts, num_valid, actual_out = (
+        gluon_moe_sorting(
+            topk_ids,
+            topk_weights,
+            num_local_experts,
+            32,
+            torch.bfloat16,
+            64,
+            expert_start=expert_start,
+            out=output,
+        )
+    )
+
+    valid_extent = int(num_valid[0].cpu())
+    assert valid_extent == 128
+    assert actual_out.data_ptr() == output.data_ptr()
+    experts = sorted_experts[: valid_extent // 64].cpu()
+    weights = sorted_weights[:valid_extent].cpu()
+    assert experts.tolist() == [0, 1]
+    for row, packed_tensor in enumerate(sorted_ids[:valid_extent].cpu()):
+        packed = int(packed_tensor)
+        token = packed & 0xFFFFFF
+        if token == num_tokens:
+            continue
+        slot = packed >> 24
+        local_expert = int(experts[row // 64])
+        assert int(global_ids[token, slot]) == expert_start + local_expert
+        assert float(weights[row]) == float(token * top_k + slot)
+
+
 def test_package_prefill_low_density_route_capacity_gfx950() -> None:
     from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.moe_sorting import (
         _max_padded_route_capacity,
@@ -866,6 +1097,75 @@ def test_stage1_quantized_output_rejects_partial_scale_panel_gfx950() -> None:
             out_scale=out_scale,
             output_k=128,
         )
+
+
+def test_package_prefill_supports_192_column_intermediate_padding_gfx950() -> None:
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.fused import (
+        gluon_mxfp4_fp8_precomputed_situ,
+    )
+    from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.weight_preprocess import (
+        preprocess_gluon_mxfp4_gfx950_moe_weights,
+    )
+
+    generator = torch.Generator(device="cuda").manual_seed(20260830)
+    num_tokens, num_experts, top_k = 17, 2, 2
+    latent_size, intermediate_size = 256, 2880
+    module, raw = _make_mxfp4_module(
+        num_experts=num_experts,
+        latent_size=latent_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        generator=generator,
+    )
+    hidden_states = 0.1 * torch.randn(
+        num_tokens,
+        latent_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    topk_ids = (
+        torch.arange(
+            num_tokens * top_k,
+            dtype=torch.int32,
+            device="cuda",
+        ).view(num_tokens, top_k)
+        % num_experts
+    )
+    topk_weights = torch.full(
+        (num_tokens, top_k),
+        1.0 / top_k,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    preprocess_gluon_mxfp4_gfx950_moe_weights({}, module)
+
+    actual = gluon_mxfp4_fp8_precomputed_situ(
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        module.w13_weight_triton_tensor,
+        module.w2_weight_triton_tensor,
+        w13_mx_scale=module.w13_precision_config.b_mx_scale,
+        w2_mx_scale=module.w2_precision_config.b_mx_scale,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+    expected = mxfp4_moe_reference(
+        hidden_states,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        topk_ids,
+        topk_weights,
+        activation_dtype=torch.bfloat16,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+
+    assert isinstance(actual, torch.Tensor)
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=8e-2)
 
 
 @pytest.mark.parametrize(
@@ -946,6 +1246,114 @@ def test_tp_situ_package_prefill_block64_matches_block128_gfx950(
     )
 
     torch.testing.assert_close(block64, block128, atol=0.0, rtol=0.0)
+
+
+def test_ep_situ_package_prefill_matches_reference_gfx950() -> None:
+    generator = torch.Generator(device="cuda").manual_seed(20260830)
+    num_tokens, top_k = 33, 16
+    num_local_experts, num_experts = 2, 16
+    ep_size, ep_rank = 8, 3
+    latent_size, intermediate_size = 3584, 3072
+    module, raw = _make_mxfp4_module(
+        num_experts=num_local_experts,
+        latent_size=latent_size,
+        intermediate_size=intermediate_size,
+        top_k=top_k,
+        generator=generator,
+    )
+    module.num_experts = num_experts
+    module.num_local_experts = num_local_experts
+    module.ep_size = ep_size
+    module.ep_rank = ep_rank
+    hidden_states = 0.1 * torch.randn(
+        num_tokens,
+        latent_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+    global_ids = torch.arange(num_experts, dtype=torch.int32, device="cuda")
+    topk_ids = torch.stack(
+        [torch.roll(global_ids, token) for token in range(num_tokens)]
+    )
+    topk_weights = torch.softmax(
+        torch.randn(
+            num_tokens,
+            top_k,
+            dtype=torch.float32,
+            device="cuda",
+            generator=generator,
+        ),
+        dim=-1,
+    )
+    router_logits = torch.empty((num_tokens, 0), dtype=torch.float32, device="cuda")
+    plan = tokenspeed_kernel.moe_plan(
+        "mxfp4",
+        input_dtype=torch.bfloat16,
+        activation="situ",
+        routing_mode="precomputed_topk",
+        ep_size=ep_size,
+        ispp=intermediate_size,
+        internal_activation_dtype="input",
+        solution="gluon",
+    )
+    assert plan["apply_kernel_name"] == "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply"
+    tokenspeed_kernel.moe_process_weights(plan, module)
+    output_storage = torch.empty(
+        (num_tokens, latent_size + 7168),
+        dtype=hidden_states.dtype,
+        device=hidden_states.device,
+    )
+    output = output_storage[:, :latent_size]
+    assert not output.is_contiguous()
+    module._situ_output_buffer = output
+
+    actual = tokenspeed_kernel.moe_apply(
+        plan,
+        hidden_states,
+        module,
+        router_logits,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+    )
+    expert_start = ep_rank * num_local_experts
+    local_ids = topk_ids - expert_start
+    local_mask = (local_ids >= 0) & (local_ids < num_local_experts)
+    local_ids = torch.where(local_mask, local_ids, torch.full_like(local_ids, -1))
+    local_weights = torch.where(
+        local_mask,
+        topk_weights,
+        torch.zeros_like(topk_weights),
+    )
+    expected = mxfp4_moe_reference(
+        hidden_states,
+        raw["w13_weight"],
+        raw["w13_scale"],
+        raw["w2_weight"],
+        raw["w2_scale"],
+        local_ids,
+        local_weights,
+        activation_dtype=torch.bfloat16,
+        situ_beta=4.0,
+        situ_linear_beta=25.0,
+    )
+
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=8e-2)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = tokenspeed_kernel.moe_apply(
+            plan,
+            hidden_states,
+            module,
+            router_logits,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, expected, atol=2e-3, rtol=8e-2)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 2, 3, 4])

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -66,6 +66,7 @@ import tokenspeed_kernel.ops.moe.gluon as _moe_gluon
 import tokenspeed_kernel.ops.moe.gluon.dsv4 as _moe_gluon_dsv4
 import tokenspeed_kernel.ops.moe.gluon.fp8 as _moe_gluon_fp8
 import tokenspeed_kernel.ops.moe.gluon.sigmoid_topk as _moe_gluon_sigmoid_topk
+import tokenspeed_kernel.ops.moe.latent_decode as _moe_latent_decode
 import tokenspeed_kernel.ops.moe.triton as _moe_triton
 import tokenspeed_kernel.ops.quantization as _quantization_pkg
 import tokenspeed_kernel.ops.quantization.flashinfer as _quantization_flashinfer
@@ -231,6 +232,7 @@ def test_builtin_moe_specialized_offsets_are_intentional() -> None:
     """Only proven same-band overlaps may use specialized priority offsets."""
     registry = KernelRegistry.get()
     expected_offsets = {
+        "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply": Priority.SPECIALIZED + 3,
         "gluon_mxfp4_dynamic_moe_apply": Priority.SPECIALIZED + 1,
         "triton_decode_sigmoid_bias_topk": Priority.SPECIALIZED + 1,
     }
@@ -2378,15 +2380,15 @@ def test_triton_mxfp4_supports_input_activation_dtype(
             8,
             3072,
             None,
-            "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply",
-            "validate_linear_mxfp4_moe_weights",
+            "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply",
+            "gluon_mxfp4_gfx950_a8w4_situ_ep_weights",
         ),
         (
             8,
             3072,
             "gluon",
-            "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply",
-            "validate_linear_mxfp4_moe_weights",
+            "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply",
+            "gluon_mxfp4_gfx950_a8w4_situ_ep_weights",
         ),
     ],
 )
@@ -2460,6 +2462,93 @@ def test_gluon_mxfp4_swiglu_ep_traits_select_matching_kernel(
         registry.clear_cache()
 
     assert plan["apply_kernel_name"] == kernel_name
+
+
+def test_kimi3_mxfp4_situ_ep8_bias_avoids_a8_apply(
+    mi350_platform: PlatformInfo,
+) -> None:
+    registry = KernelRegistry.get()
+    kernel_name = "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply"
+    if registry.get_by_name(kernel_name) is None:
+        pytest.skip(f"{kernel_name} is unavailable")
+    real_platform = Platform.get()
+    try:
+        Platform.override(mi350_platform)
+        registry.clear_cache()
+        plan = tokenspeed_kernel.moe_plan(
+            "mxfp4",
+            input_dtype=torch.bfloat16,
+            activation="situ",
+            routing_mode="precomputed_topk",
+            ep_size=8,
+            ispp=3072,
+            internal_activation_dtype="input",
+            with_bias=True,
+            solution="gluon",
+        )
+    finally:
+        Platform.override(real_platform)
+        registry.clear_cache()
+
+    assert plan["apply_kernel_name"] != kernel_name
+
+
+def test_kimi3_a8_plan_preserves_unclipped_a16_decode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @dataclass
+    class FakeTensor:
+        shape: tuple[int, ...]
+        dtype: torch.dtype
+        is_cuda: bool = True
+
+        def is_contiguous(self) -> bool:
+            return True
+
+    def fake_tensor(dtype: torch.dtype, *shape: int) -> FakeTensor:
+        return FakeTensor(shape, dtype)
+
+    tensors = (
+        fake_tensor(torch.bfloat16, 896, 7168),
+        fake_tensor(torch.bfloat16, 3584, 7168),
+        fake_tensor(torch.bfloat16, 1536, 7168),
+        fake_tensor(torch.bfloat16, 7168, 768),
+        fake_tensor(torch.uint8, 112, 6144, 1792),
+        fake_tensor(torch.uint8, 112, 6144, 112),
+        fake_tensor(torch.uint8, 112, 7168, 1536),
+        fake_tensor(torch.uint8, 112, 7168, 96),
+    )
+    plan = {"apply_kernel_name": "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply"}
+    monkeypatch.setattr(
+        _moe_latent_decode,
+        "select_kernel",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    assert _moe_latent_decode.latent_moe_decode_pipeline_available(
+        *tensors,
+        plan,
+        topk=16,
+        linear_clamp=None,
+    )
+    assert not _moe_latent_decode.latent_moe_decode_pipeline_available(
+        *tensors,
+        plan,
+        topk=16,
+        linear_clamp=25.0,
+    )
+    assert not _moe_latent_decode.latent_moe_decode_pipeline_available(
+        *tensors,
+        plan,
+        topk=16,
+    )
+
+    a16_plan = {"apply_kernel_name": "gluon_mxfp4_a16w4_situ_ep_precomputed_moe_apply"}
+    assert _moe_latent_decode.latent_moe_decode_pipeline_available(
+        *tensors,
+        a16_plan,
+        topk=16,
+    )
 
 
 def test_kimi3_mxfp4_situ_tp_selection_on_cdna5(


### PR DESCRIPTION
## Summary

Optimize Kimi-K3 TP8/EP8 routed-expert prefill with the gfx950 Gluon A8W4 package. Localize global EP routes during sorting, gather and quantize activations directly into the sorted E4M3 layout, consume interleaved W13 tiles, and pipeline activation loads through both expert GEMM stages. Fuse SiTU with intermediate quantization and accumulate weighted local routes directly into the supplied output buffer while preserving existing decode and fallback contracts.

## Testing Plan

- Cover EP8 route localization, stable sorting, remote-only routes, and reduced route padding.
- Compare sorted E4M3 values, scales, and full prefill output against the MXFP4 reference.
- Exercise full gdot intermediate padding, strided outputs, zero-token forwards, and CUDA graph replay.
- Verify clipped and unclipped SiTU selection plus latent decode capability compatibility.

## Benchmark

Routed-expert median latency, 1000 warmup and 10000 measured iterations:

```
Tokens  Main (us)  MoE branch (us)  Improvement
------  ---------  ---------------  -----------
   512     677.67           456.99        32.6%
  1024     721.39           480.40        33.4%
  2048    1005.28           645.34        35.8%
  4096    1398.28           884.14        36.8%
  8192    2553.13          1471.18        42.4%
```

### Real-workload MoE benchmark

Four approximately 50K-token agentic prompts at concurrency 4, using TP8/EP8 and 8192-token chunked prefill. MoE time sums the outlier-filtered median layer spans across all 92 MoE layers using real model routing.
Aggregate MoE time (sans outliers impacted by profiling writeback) goes from 435.99 ms  -> 335.02 ms = 1.301x speedup
