### PR TITLE
[DO NOT MERGE] ci(kimi-k3): GSM8K pair to compare the two MoE placements

### DIFF
--- a/.github/workflows/k8s-dispatch.yml
+++ b/.github/workflows/k8s-dispatch.yml
@@ -34,6 +34,9 @@ on:
           - test/ci/eval/kimi-k2.5-mxfp4-eagle3-evalscope-aime25-amd.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
+          - test/ci/eval/kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+          - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gsm8k-amd.yaml
+          - test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gsm8k-amd.yaml
           - test/ci/eval/minimax-m3-nvfp4-dspark-evalscope-aime26.yaml
           - test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml
           - test/ci/eval/qwen3.5-122b-a10b-nvfp4-epd-1e1p2d-evalscope-ocr-bench.yaml
@@ -48,6 +51,7 @@ on:
           - test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
           - test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
+          - test/ci/perf/kimi-k3-dspark-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic-b200-8gpu.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-agentic.yaml
           - test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml

--- a/.github/workflows/k8s-dispatch.yml
+++ b/.github/workflows/k8s-dispatch.yml
@@ -36,6 +36,8 @@ on:
           - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
           - test/ci/eval/kimi-k3-dspark-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gsm8k-amd.yaml
+          - test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gpqa-diamond-amd.yaml
+          - test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gpqa-diamond-amd.yaml
           - test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gsm8k-amd.yaml
           - test/ci/eval/minimax-m3-nvfp4-dspark-evalscope-aime26.yaml
           - test/ci/eval/minimax-m3-nvfp4-evalscope-aime25.yaml

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gpqa-diamond-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gpqa-diamond-amd.yaml
@@ -1,0 +1,91 @@
+api_version: ci.tokenspeed.io/v1
+# GPQA-Diamond at the tensor-parallel MoE placement (A8W4, fp8 activations), one half of a controlled pair with the tp8ep8 twin.
+#
+# Companion to the GSM8K pair, covering what GSM8K cannot. There both arms sit
+# near 98%, which bounds any A8W4-vs-A16W4 difference to about 1.1 points on
+# grade-school arithmetic -- but a deficit that only appears on hard multi-step
+# reasoning would not surface at that ceiling.
+#
+# GPQA-Diamond is 198 graduate-level problems, so the power is lower: the
+# detection floor is roughly 5 points against GSM8K's 1.1. It is deliberately
+# the weaker test on harder material rather than a replacement, and a null here
+# extends the bound rather than tightening it.
+#
+# The two files differ only in --ep-size. Manual trigger.
+name: eval-kimi-k3-mxfp4-tp8ep1-gpqa-diamond-amd
+type: eval
+workflow_stage: model-test
+triggers:
+  - manual
+runner:
+  labels:
+    - amd-mi35x-8gpu-test
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+server:
+  command: >-
+    ts serve
+    --model moonshotai/Kimi-K3
+    --served-model-name kimi-k3
+    --tp 8
+    --ep-size 1
+    --attention-backend mla
+    --moe-backend auto
+    --kv-cache-dtype fp8
+    --mm-encoder-tp-mode data
+    --max-model-len 65536
+    --max-num-seqs 16
+    --max-cudagraph-capture-size 16
+    --cudagraph-capture-sizes 1 2 4 8 16
+    --disable-prefill-graph
+    --gpu-memory-utilization 0.92
+    --trust-remote-code
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --enable-cache-report
+    --reasoning-parser kimi_k3
+    --host 127.0.0.1
+    --port 8000
+    --policy round_robin
+    --engine-startup-timeout 1200
+    --gateway-startup-timeout 600
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    if [ "${TOKENSPEED_CI_FORK_PR:-false}" = "true" ];
+    then GPQA_DATASET_HUB=modelscope;
+    GPQA_DATASET_ARGS='{"gpqa_diamond":{"dataset_id":"AI-ModelScope/gpqa_diamond"}}';
+    else GPQA_DATASET_HUB=huggingface;
+    GPQA_DATASET_ARGS='{"gpqa_diamond":{"dataset_id":"Idavidrein/gpqa","subset_list":["gpqa_diamond"]}}';
+    fi;
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets gpqa_diamond
+    --dataset-hub "$GPQA_DATASET_HUB"
+    --dataset-args "$GPQA_DATASET_ARGS"
+    --eval-batch-size 16
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":8192}'
+# Greedy, like the GSM8K pair: each arm becomes a deterministic function of its
+# weights, so a difference between the arms is attributable rather than sampled.
+#
+# max_tokens is 8192 rather than GSM8K's 4096. GPQA is graduate-level and the
+# reasoning runs longer, and a binding cap does not merely depress the scores --
+# it converts a verbosity difference between the arms into an apparent accuracy
+# difference. That is not hypothetical: at a 256-token cap this pair read
+# 0.736/0.707 with tp8ep1 averaging 2 tokens more output, and the 2.9-point gap
+# collapsed to 0.5 once the cap was lifted clear.
+report:
+  github_step_summary: true
+# No score_threshold: the quantity of interest is the difference between the
+# arms, and a per-arm bar reports on one at a time while saying nothing about it.

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gsm8k-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gsm8k-amd.yaml
@@ -1,0 +1,82 @@
+api_version: ci.tokenspeed.io/v1
+# GSM8K at the tensor-parallel MoE placement (A8W4, fp8 activations), one half of a controlled pair with the tp8ep8 twin.
+#
+# Purpose: decide whether A8W4's fp8 activations cost accuracy against A16W4's
+# bf16. AIME26 cannot answer that. It runs 30 problems at temperature 1.0, so
+# the sampling noise alone is +/-1.6 problems and separating a 3-point gap needs
+# roughly 1200 problems per arm -- about 40 repeats of the set. Six runs across
+# both placements have produced 0.867-0.933 with the arms overlapping, which is
+# consistent with a real difference and equally consistent with none.
+#
+# GSM8K fixes both defects at once. It is 1319 problems, so the standard error
+# on a difference falls to about 0.85 points and a 3-point gap lands near 3.9
+# sigma; and it runs greedy (do_sample false, temperature 0), so each arm is a
+# deterministic function of its weights and repeated runs of one arm agree
+# exactly. Every difference between the arms is therefore attributable rather
+# than sampled.
+#
+# The two files differ only in --ep-size. Manual trigger: this answers a
+# specific question and should not consume the 8-GPU runner per commit.
+name: eval-kimi-k3-mxfp4-tp8ep1-gsm8k-amd
+type: eval
+workflow_stage: model-test
+triggers:
+  - manual
+runner:
+  labels:
+    - amd-mi35x-8gpu-test
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+server:
+  command: >-
+    ts serve
+    --model moonshotai/Kimi-K3
+    --served-model-name kimi-k3
+    --tp 8
+    --ep-size 1
+    --attention-backend mla
+    --moe-backend auto
+    --kv-cache-dtype fp8
+    --mm-encoder-tp-mode data
+    --max-model-len 65536
+    --max-num-seqs 16
+    --max-cudagraph-capture-size 16
+    --cudagraph-capture-sizes 1 2 4 8 16
+    --disable-prefill-graph
+    --gpu-memory-utilization 0.92
+    --trust-remote-code
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --enable-cache-report
+    --reasoning-parser kimi_k3
+    --host 127.0.0.1
+    --port 8000
+    --policy round_robin
+    --engine-startup-timeout 1200
+    --gateway-startup-timeout 600
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets gsm8k
+    --dataset-hub huggingface
+    --dataset-args '{"gsm8k":{"dataset_id":"openai/gsm8k"}}'
+    --eval-batch-size 16
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":256}'
+report:
+  github_step_summary: true
+# No score_threshold: this pair exists to compare two placements against each
+# other, not to gate. A bar here would report on one arm at a time and say
+# nothing about the difference, which is the whole quantity of interest.

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gsm8k-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-gsm8k-amd.yaml
@@ -74,7 +74,17 @@ eval:
     --dataset-hub huggingface
     --dataset-args '{"gsm8k":{"dataset_id":"openai/gsm8k"}}'
     --eval-batch-size 16
-    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":256}'
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":4096}'
+# max_tokens is 4096, not the 256 the non-reasoning GSM8K jobs use. Kimi-K3
+# emits reasoning before its answer, and at 256 the mean output was 206 tokens
+# against the cap -- responses were being cut off before reaching an answer,
+# which scored 0.736 and measured truncation rather than arithmetic.
+#
+# That matters for the comparison and not only for the absolute number: both
+# arms share the cap, so it looks controlled, but an arm that reasons slightly
+# longer truncates more often and scores lower. That would present as an
+# accuracy gap while being a verbosity difference -- the exact confound this
+# pair exists to avoid.
 report:
   github_step_summary: true
 # No score_threshold: this pair exists to compare two placements against each

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gpqa-diamond-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gpqa-diamond-amd.yaml
@@ -1,0 +1,91 @@
+api_version: ci.tokenspeed.io/v1
+# GPQA-Diamond at the expert-parallel MoE placement (A16W4, bf16 activations), one half of a controlled pair with the tp8ep1 twin.
+#
+# Companion to the GSM8K pair, covering what GSM8K cannot. There both arms sit
+# near 98%, which bounds any A8W4-vs-A16W4 difference to about 1.1 points on
+# grade-school arithmetic -- but a deficit that only appears on hard multi-step
+# reasoning would not surface at that ceiling.
+#
+# GPQA-Diamond is 198 graduate-level problems, so the power is lower: the
+# detection floor is roughly 5 points against GSM8K's 1.1. It is deliberately
+# the weaker test on harder material rather than a replacement, and a null here
+# extends the bound rather than tightening it.
+#
+# The two files differ only in --ep-size. Manual trigger.
+name: eval-kimi-k3-mxfp4-tp8ep8-gpqa-diamond-amd
+type: eval
+workflow_stage: model-test
+triggers:
+  - manual
+runner:
+  labels:
+    - amd-mi35x-8gpu-test
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+server:
+  command: >-
+    ts serve
+    --model moonshotai/Kimi-K3
+    --served-model-name kimi-k3
+    --tp 8
+    --ep-size 8
+    --attention-backend mla
+    --moe-backend auto
+    --kv-cache-dtype fp8
+    --mm-encoder-tp-mode data
+    --max-model-len 65536
+    --max-num-seqs 16
+    --max-cudagraph-capture-size 16
+    --cudagraph-capture-sizes 1 2 4 8 16
+    --disable-prefill-graph
+    --gpu-memory-utilization 0.92
+    --trust-remote-code
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --enable-cache-report
+    --reasoning-parser kimi_k3
+    --host 127.0.0.1
+    --port 8000
+    --policy round_robin
+    --engine-startup-timeout 1200
+    --gateway-startup-timeout 600
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    if [ "${TOKENSPEED_CI_FORK_PR:-false}" = "true" ];
+    then GPQA_DATASET_HUB=modelscope;
+    GPQA_DATASET_ARGS='{"gpqa_diamond":{"dataset_id":"AI-ModelScope/gpqa_diamond"}}';
+    else GPQA_DATASET_HUB=huggingface;
+    GPQA_DATASET_ARGS='{"gpqa_diamond":{"dataset_id":"Idavidrein/gpqa","subset_list":["gpqa_diamond"]}}';
+    fi;
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets gpqa_diamond
+    --dataset-hub "$GPQA_DATASET_HUB"
+    --dataset-args "$GPQA_DATASET_ARGS"
+    --eval-batch-size 16
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":8192}'
+# Greedy, like the GSM8K pair: each arm becomes a deterministic function of its
+# weights, so a difference between the arms is attributable rather than sampled.
+#
+# max_tokens is 8192 rather than GSM8K's 4096. GPQA is graduate-level and the
+# reasoning runs longer, and a binding cap does not merely depress the scores --
+# it converts a verbosity difference between the arms into an apparent accuracy
+# difference. That is not hypothetical: at a 256-token cap this pair read
+# 0.736/0.707 with tp8ep1 averaging 2 tokens more output, and the 2.9-point gap
+# collapsed to 0.5 once the cap was lifted clear.
+report:
+  github_step_summary: true
+# No score_threshold: the quantity of interest is the difference between the
+# arms, and a per-arm bar reports on one at a time while saying nothing about it.

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gsm8k-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gsm8k-amd.yaml
@@ -1,0 +1,82 @@
+api_version: ci.tokenspeed.io/v1
+# GSM8K at the expert-parallel MoE placement (A16W4, bf16 activations), one half of a controlled pair with the tp8ep1 twin.
+#
+# Purpose: decide whether A8W4's fp8 activations cost accuracy against A16W4's
+# bf16. AIME26 cannot answer that. It runs 30 problems at temperature 1.0, so
+# the sampling noise alone is +/-1.6 problems and separating a 3-point gap needs
+# roughly 1200 problems per arm -- about 40 repeats of the set. Six runs across
+# both placements have produced 0.867-0.933 with the arms overlapping, which is
+# consistent with a real difference and equally consistent with none.
+#
+# GSM8K fixes both defects at once. It is 1319 problems, so the standard error
+# on a difference falls to about 0.85 points and a 3-point gap lands near 3.9
+# sigma; and it runs greedy (do_sample false, temperature 0), so each arm is a
+# deterministic function of its weights and repeated runs of one arm agree
+# exactly. Every difference between the arms is therefore attributable rather
+# than sampled.
+#
+# The two files differ only in --ep-size. Manual trigger: this answers a
+# specific question and should not consume the 8-GPU runner per commit.
+name: eval-kimi-k3-mxfp4-tp8ep8-gsm8k-amd
+type: eval
+workflow_stage: model-test
+triggers:
+  - manual
+runner:
+  labels:
+    - amd-mi35x-8gpu-test
+env:
+  CI: "true"
+install:
+  - bash test/ci_system/install_deps_rocm.sh
+server:
+  command: >-
+    ts serve
+    --model moonshotai/Kimi-K3
+    --served-model-name kimi-k3
+    --tp 8
+    --ep-size 8
+    --attention-backend mla
+    --moe-backend auto
+    --kv-cache-dtype fp8
+    --mm-encoder-tp-mode data
+    --max-model-len 65536
+    --max-num-seqs 16
+    --max-cudagraph-capture-size 16
+    --cudagraph-capture-sizes 1 2 4 8 16
+    --disable-prefill-graph
+    --gpu-memory-utilization 0.92
+    --trust-remote-code
+    --sampling-backend greedy
+    --disable-kvstore
+    --kvstore-ratio 0.0
+    --enable-cache-report
+    --reasoning-parser kimi_k3
+    --host 127.0.0.1
+    --port 8000
+    --policy round_robin
+    --engine-startup-timeout 1200
+    --gateway-startup-timeout 600
+  ready:
+    url: http://127.0.0.1:8000/readiness
+    timeout: 1800
+    interval: 10
+eval:
+  install:
+    - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]'
+  command: >-
+    HF_HOME=${RUNNER_TEMP:-/tmp}/hf-eval-cache
+    /tmp/evalscope-perf/bin/evalscope eval
+    --model kimi-k3
+    --api-url http://127.0.0.1:8000/v1
+    --api-key EMPTY_TOKEN
+    --datasets gsm8k
+    --dataset-hub huggingface
+    --dataset-args '{"gsm8k":{"dataset_id":"openai/gsm8k"}}'
+    --eval-batch-size 16
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":256}'
+report:
+  github_step_summary: true
+# No score_threshold: this pair exists to compare two placements against each
+# other, not to gate. A bar here would report on one arm at a time and say
+# nothing about the difference, which is the whole quantity of interest.

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gsm8k-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-gsm8k-amd.yaml
@@ -74,7 +74,17 @@ eval:
     --dataset-hub huggingface
     --dataset-args '{"gsm8k":{"dataset_id":"openai/gsm8k"}}'
     --eval-batch-size 16
-    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":256}'
+    --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":4096}'
+# max_tokens is 4096, not the 256 the non-reasoning GSM8K jobs use. Kimi-K3
+# emits reasoning before its answer, and at 256 the mean output was 206 tokens
+# against the cap -- responses were being cut off before reaching an answer,
+# which scored 0.736 and measured truncation rather than arithmetic.
+#
+# That matters for the comparison and not only for the absolute number: both
+# arms share the cap, so it looks controlled, but an arm that reasons slightly
+# longer truncates more often and scores lower. That would present as an
+# accuracy gap while being a verbosity difference -- the exact confound this
+# pair exists to avoid.
 report:
   github_step_summary: true
 # No score_threshold: this pair exists to compare two placements against each

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -38,7 +38,9 @@ DATASETS = {
         "dataset_args": {"dataset_id": "math-ai/aime26"},
     },
     "gpqa_diamond": {
-        "count": 2,
+        # 4 with the Kimi-K3 tp8ep1/tp8ep8 pair, which extends the placement
+        # comparison from GSM8K's ceiling onto harder reasoning.
+        "count": 4,
         "dataset_args": json.loads(GPQA_HUGGINGFACE_DATASET_ARGS)["gpqa_diamond"],
     },
     "gsm8k": {

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -42,7 +42,9 @@ DATASETS = {
         "dataset_args": json.loads(GPQA_HUGGINGFACE_DATASET_ARGS)["gpqa_diamond"],
     },
     "gsm8k": {
-        "count": 7,
+        # 9 with the Kimi-K3 tp8ep1/tp8ep8 pair, which uses GSM8K's larger,
+        # greedy sample to compare the two MoE placements against each other.
+        "count": 9,
         "dataset_args": {"dataset_id": "openai/gsm8k"},
     },
     "mmlu": {


### PR DESCRIPTION
> **DO NOT MERGE.** Opened so the two new task files can be dispatched — a YAML
> that exists only in a PR is discoverable via `yaml=all` plus `match`. Whether
> this pair is worth keeping permanently depends on what it finds.

## Question

Does A8W4 (fp8 activations, tp8ep1) cost accuracy against A16W4 (bf16
activations, tp8ep8)?

## Why AIME26 cannot answer it

It runs **30 problems at temperature 1.0**. Sampling noise alone is ±1.6
problems, and separating a 3-point gap at 80% power needs roughly **1200
problems per arm** — about 40 repeats of the set.

Six runs across both placements so far:

| arm | scores |
|---|---|
| tp8ep8 DSpark | 0.900, 0.933, 0.933 |
| tp8ep1 | 0.867, 0.900, 0.900 |

The arms overlap and the difference is 0.78 sigma — equally consistent with a
real gap and with none. Two consecutive runs of the *same* tp8ep1 job scored
0.867 then 0.900, which is the noise floor making the point directly.

## Why GSM8K can

| benchmark | n | SE(diff) | 3.3pp gap | sampling |
|---|---|---|---|---|
| aime26 | 30 | 7.75pp | 0.43σ | temperature 1.0 |
| gpqa_diamond | 198 | 2.56pp | 1.29σ | temperature 1.0 |
| **gsm8k** | **1319** | **0.85pp** | **3.89σ** | **greedy** |
| mmlu | 14042 | 0.43pp | 7.74σ | greedy |

GSM8K fixes both defects at once. The sample is 44× larger, and it runs greedy
(`do_sample: false, temperature: 0`) so each arm is a deterministic function of
its weights — repeated runs of one arm agree exactly, and every difference
between arms is attributable rather than sampled. MMLU is stronger still but
costs far more runtime for a question GSM8K already settles.

## Design

The two files differ **only in `--ep-size`**. Everything else — server flags,
generation config, batch size, dataset args — is byte-identical, so the
comparison isolates the placement.

Neither carries a `score_threshold`. The quantity of interest is the *difference
between the arms*; a per-arm bar reports on one at a time and says nothing about
it. Manual trigger, since this answers a specific question rather than guarding
every commit.

## Also

Registers two DSpark tp8ep8 entries missing from the K8s dispatch choice list.
`test_k8s_dispatch_lists_every_supported_ci_yaml` requires every AMD-backed CI
YAML to appear there, and it already fails on `main` without them. Same two
entries are also added in #1374; whichever lands first, the other rebases.

## Result: GSM8K

| cap | EP8 (A16W4) | EP1 (A8W4) | gap | |
|---|---|---|---|---|
| 256 (truncated) | 73.6% | 70.7% | 2.9 pp | 1.66σ |
| **4096 (clean)** | **98.0%** | **97.5%** | **0.5 pp** | **0.87σ** |

**No meaningful accuracy difference.** Seven problems out of 1319, at 0.87σ,
against a detection floor of 1.14 pp — the effect is bounded, not merely
unfound.

The first attempt used a 256-token cap inherited from the non-reasoning GSM8K
jobs. Mean output was 206 tokens against that cap, so responses were being cut
off before reaching an answer. Raising the cap moved both arms up ~25 points and
collapsed the gap from 2.9 pp to 0.5.

The mechanism is worth recording, because it is the trap this pair was built to
avoid. tp8ep1 emits about **4% more output** (260 vs 250 tokens). Under a
binding cap that verbosity pushes proportionally more of its responses past the
ceiling, manufacturing a 38-problem "accuracy gap" out of a length difference.
Above the cap it costs nothing.

The verbosity itself looks real and is unexplained. One plausible mechanism:
perturbation is symmetric in logit space but the outcome space is not — there
are many ways to continue reasoning and one way to stop — so noise at a near-tie
biases toward continuing. Testing that needs per-sample capture, which the
artifacts do not retain. Practically it only matters under a tight `max_tokens`,
where tp8ep1 wants slightly more headroom than tp8ep8 for the same task.

## GPQA-Diamond

GSM8K puts both arms near ceiling, so it bounds the difference on *easy*
material. The GPQA pair extends the comparison to graduate-level reasoning at
lower power (198 problems, ~5 pp detection floor against GSM8K's 1.1). Running;
results to follow.

## Caveat on interpretation