### PR TITLE
fix(ci): avoid redundant simulator fetches

### DIFF
--- a/test/ci_system/setup_mi450_sim.sh
+++ b/test/ci_system/setup_mi450_sim.sh
@@ -39,7 +39,19 @@ if [ ! -d "${SOURCE_ROOT}/.git" ]; then
         emulation/rocjitsu \
         shared/machine-readable-isa/isa
 fi
-git -C "${SOURCE_ROOT}" fetch --depth 1 origin "${ROCM_SYSTEMS_REF}"
+if ! git -C "${SOURCE_ROOT}" cat-file -e "${ROCM_SYSTEMS_REF}^{commit}"; then
+    for attempt in 1 2 3; do
+        if git -C "${SOURCE_ROOT}" fetch --depth 1 origin "${ROCM_SYSTEMS_REF}"; then
+            break
+        fi
+        if [ "${attempt}" -eq 3 ]; then
+            echo "Failed to fetch rocm-systems after ${attempt} attempts" >&2
+            exit 1
+        fi
+        echo "rocm-systems fetch attempt ${attempt} failed; retrying in 10s..." >&2
+        sleep 10
+    done
+fi
 git -C "${SOURCE_ROOT}" checkout --detach "${ROCM_SYSTEMS_REF}"
 
 # HIP initialization needs the KMD simulator to remain alive for the full


### PR DESCRIPTION
## Summary
- use the cached pinned rocm-systems commit without an unconditional network fetch
- retry the fetch three times when the commit is absent from the cache
- preserve the existing detached checkout behavior

## Context
The MI450 simulator job in https://github.com/lightseekorg/tokenspeed/actions/runs/33660992214/job/100373169762 failed before tests because an anonymous fetch from ROCm/rocm-systems could not authenticate. The simulator cache had restored successfully and was keyed by the same pinned commit, so the fetch was unnecessary.

## Testing
- `bash -n test/ci_system/setup_mi450_sim.sh`
- `git diff --check`
- `pre-commit run --all-files`