### PR TITLE
[WIP] feat(memory): reserve the CUDA-graph pools in the KV cache budget

### DIFF
--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -174,6 +174,13 @@ to the kernel page tables that attention kernels consume (the
 happen at **one designated point**; beyond that point, kernels see physical
 page tables and nothing upstream sees them at all.
 
+`create_attn_components` must stay callable more than once for the same
+startup arguments: the CUDA-graph memory probe builds a throwaway arena before
+the real one. The backend overrides it derives from the model architecture are
+idempotent, and the one input they destroy -- the operator's own
+`attention_backend` -- is preserved in `original_attention_backend` on first
+resolution, so a second call resolves the same sub-backends as the first.
+
 Outside the mapping point, Python code should perceive `prefix_granularity`
 and `page_size` as little as possible. If a Python component needs either
 value, that is a design smell to justify, not a default to reach for.

--- a/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
+++ b/python/tokenspeed/runtime/execution/cuda_graph_wrapper.py
@@ -36,6 +36,7 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
+from tokenspeed.runtime.execution.memory_delta import MemoryDeltaObserver
 from tokenspeed.runtime.layers.attention.backends.base import (
     init_backend_cuda_graph_state,
 )
@@ -149,7 +150,7 @@ class DeepEPCudaGraphRunnerAdapter:
         except ImportError:
             return None
 
-    def capture(self):
+    def capture(self) -> None:
         """Call before ``torch.cuda.graph()`` capture."""
         cls = self._get_buffer_cls()
         if cls is None or cls._buffer is None:
@@ -298,12 +299,12 @@ class CudaGraphWrapper:
     # Graph capture
     # ------------------------------------------------------------------
 
-    def capture(self):
+    def capture(self, observer: MemoryDeltaObserver) -> None:
         """
         Capture CUDA graphs for all configured batch sizes.
 
         Args:
-            forward_func: ModelExecutor.forward_step(bs, ctx, sampling_info).
+            observer: Measurement scope entered around each graph capture.
         """
         rank = self.global_rank
         with freeze_gc(self.enable_cudagraph_gc):
@@ -330,7 +331,8 @@ class CudaGraphWrapper:
                     capture_range.set_description(
                         f"Capturing batches ({bs=}{variant_desc} {avail_mem=:.2f} GB)"
                     )
-                graph, output_buffers = self._capture_one(bs, variant=variant)
+                with observer.measure("decode"):
+                    graph, output_buffers = self._capture_one(bs, variant=variant)
                 self.graphs[(variant, bs)] = graph
                 self.output_buffers[(variant, bs)] = output_buffers
 

--- a/python/tokenspeed/runtime/execution/cudagraph_memory.py
+++ b/python/tokenspeed/runtime/execution/cudagraph_memory.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Project the CUDA-graph pool reserve from a throwaway capture measured at startup."""
+
+from __future__ import annotations
+
+import gc
+import weakref
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from statistics import median
+from typing import TYPE_CHECKING
+
+import torch
+
+from tokenspeed.runtime.execution.memory_delta import (
+    MemoryDeltaObserver,
+    memory_delta_observer,
+)
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import ProbeBatch
+from tokenspeed.runtime.utils import get_colorful_logger
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.configs.model_config import ModelConfig
+    from tokenspeed.runtime.execution.model_executor import ModelExecutor
+    from tokenspeed.runtime.execution.model_runner import ModelRunner
+    from tokenspeed.runtime.utils.server_args import ServerArgs
+
+logger = get_colorful_logger(__name__)
+
+
+CUDAGRAPH_FAMILIES = ("prefill", "decode")
+PROBE_CAPTURES_PER_FAMILY = 4
+
+
+@dataclass(frozen=True)
+class CudagraphFamilyEstimate:
+    """Projected bytes for one CUDA-graph pool."""
+
+    first_capture: int
+    extrapolated_rate: int | float
+    total: int | float
+
+
+@dataclass(frozen=True)
+class CudagraphMemoryEstimate:
+    """Projected bytes for the prefill and decode CUDA-graph pools."""
+
+    prefill: CudagraphFamilyEstimate
+    decode: CudagraphFamilyEstimate
+    total: int | float
+
+
+def _estimate_family(
+    family: str, samples: Sequence[int], entry_count: int
+) -> CudagraphFamilyEstimate:
+    """Project one pool from the captures actually sampled out of its ladder."""
+    if entry_count == 0:
+        if samples:
+            raise ValueError(f"{family} projection got samples for no entries")
+        return CudagraphFamilyEstimate(0, 0, 0)
+
+    required = min(2, entry_count)
+    if not required <= len(samples) <= entry_count:
+        raise ValueError(
+            f"{family} projection got {len(samples)} samples for "
+            f"{entry_count} entries, expected between {required} and {entry_count}"
+        )
+
+    first, *marginals = samples
+    # The median keeps a one-off allocator growth step out of the extrapolated rate.
+    rate = max(median(marginals), 0) if marginals else 0
+
+    # Net samples go negative when the allocator releases segments mid-capture,
+    # so only the extrapolation and the projection itself are floored.
+    remaining = entry_count - len(samples)
+    total = max(first + sum(marginals) + rate * remaining, 0)
+
+    return CudagraphFamilyEstimate(first, rate, total)
+
+
+def estimate_cudagraph_memory(
+    samples: Mapping[str, Sequence[int]], entry_counts: Mapping[str, int]
+) -> CudagraphMemoryEstimate:
+    """Project the prefill and decode pools, which are disjoint and so add up."""
+    unknown = sorted(set(samples) - set(CUDAGRAPH_FAMILIES))
+    if unknown:
+        raise ValueError(f"projection got samples for unknown families: {unknown}")
+
+    prefill = _estimate_family(
+        "prefill", samples.get("prefill", ()), entry_counts["prefill"]
+    )
+    decode = _estimate_family(
+        "decode", samples.get("decode", ()), entry_counts["decode"]
+    )
+
+    return CudagraphMemoryEstimate(
+        prefill=prefill, decode=decode, total=prefill.total + decode.total
+    )
+
+
+@dataclass(frozen=True)
+class CudagraphProbeConfig:
+    server_args: ServerArgs
+    model_config: ModelConfig
+    draft_model_config: ModelConfig | None
+    target: ModelRunner
+    draft: ModelRunner | None
+    gpu_id: int
+    global_rank: int
+    gpu_memory: int
+    overlap_schedule_depth: int
+    decode_input_tokens: int
+    max_batch_size: int
+
+
+@dataclass(frozen=True)
+class CudagraphProbe:
+    """A throwaway executor whose captures are measured and then released."""
+
+    executor: ModelExecutor
+    entry_counts: dict[str, int]
+
+    def release(self, device: str) -> list[tuple[str, weakref.ReferenceType[object]]]:
+        """Drop the probe's graphs and private pool, naming what must now be dead."""
+        from tokenspeed.runtime.execution import cuda_graph_wrapper
+        from tokenspeed.runtime.execution.workspace import workspace_pool
+
+        liveness = [
+            ("executor", weakref.ref(self.executor)),
+            ("prefill_graph", weakref.ref(self.executor.prefill_graph)),
+            ("decode_graph_wrapper", weakref.ref(self.executor.forward_step)),
+        ]
+        drafter = self.executor.drafter
+        if drafter is not None:
+            liveness.append(("drafter", weakref.ref(drafter)))
+            drafter.unwire_target(self.executor.model_runner.model)
+
+        self.executor.shutdown()
+        workspace_pool(device).unfreeze()
+        cuda_graph_wrapper.global_graph_memory_pool = None
+
+        return liveness
+
+
+def probe_batch(config: CudagraphProbeConfig) -> ProbeBatch:
+    """The widest dummy forward the probe captures, prefill or decode.
+
+    A prefill bucket spreads one chunked-prefill budget over
+    ``ceil(tokens / context_len)`` requests; a decode capture runs the batch
+    ladder, whose top is the runtime's own maximum. The arena has to hold the
+    wider of the two: a linear-attention backend replaying raw gates uses the
+    pool's own conv_state rows as its verify scratch, so an arena sized for
+    fewer requests than the ladder captures leaves that scratch too narrow.
+    """
+    tokens = max(1, int(config.server_args.chunked_prefill_size or 0))
+    context_len = max(1, int(config.model_config.context_len))
+    prefill_requests = max(1, -(-tokens // context_len))
+    requests = max(prefill_requests, int(config.max_batch_size))
+    return ProbeBatch(requests=requests, tokens=requests)
+
+
+def _reconcile_cudagraph_reserve(
+    config: CudagraphProbeConfig, total: int | float
+) -> int | float:
+    """Size every rank's KV cache for the hungriest rank's projection."""
+    from tokenspeed.runtime.distributed.process_group_manager import (
+        process_group_manager as pg_manager,
+    )
+
+    world_group = config.server_args.mapping.world_group
+    if world_group is None or config.server_args.mapping.world_size == 1:
+        return total
+
+    reduced = torch.tensor(total, dtype=torch.float64)
+    torch.distributed.all_reduce(
+        reduced,
+        op=torch.distributed.ReduceOp.MAX,
+        group=pg_manager.get_process_group("gloo", world_group),
+    )
+    return int(reduced.item())
+
+
+def _assert_probe_released(
+    liveness: list[tuple[str, weakref.ReferenceType[object]]],
+) -> None:
+    """Fail loudly if the probe's graphs or private pool outlive its teardown."""
+    alive = [name for name, ref in liveness if ref() is not None]
+    if alive:
+        raise RuntimeError(
+            f"CUDA-graph memory probe leaked objects: {', '.join(alive)} "
+            "survived teardown, so their captured graphs and private pool still "
+            "hold device memory the real capture was projected to reuse"
+        )
+
+
+def measure_cudagraph_reserve(
+    config: CudagraphProbeConfig,
+    observer: MemoryDeltaObserver,
+    probe: CudagraphProbe,
+) -> int | float:
+    """Project the runtime pool reserve from a captured throwaway probe."""
+    device_module = torch.get_device_module(config.server_args.device)
+    entry_counts = probe.entry_counts
+    estimate = estimate_cudagraph_memory(observer.samples, entry_counts)
+    liveness = probe.release(config.server_args.device)
+
+    # This frame's own reference would keep the probe alive past the check below.
+    del probe
+    gc.collect()
+    device_module.empty_cache()
+    device_module.synchronize()
+    _assert_probe_released(liveness)
+
+    reserve = _reconcile_cudagraph_reserve(config, estimate.total)
+    logger.info(
+        "CUDA-graph memory reserve: %d bytes "
+        "(prefill %d over %d entries, decode %d over %d entries)",
+        reserve,
+        estimate.prefill.total,
+        entry_counts["prefill"],
+        estimate.decode.total,
+        entry_counts["decode"],
+    )
+    return reserve

--- a/python/tokenspeed/runtime/execution/device.py
+++ b/python/tokenspeed/runtime/execution/device.py
@@ -72,6 +72,7 @@ See ``forward_thread.py`` for the capture contract each closure must satisfy.
 from __future__ import annotations
 
 import contextlib
+import copy
 import enum
 import os
 from collections import deque
@@ -82,14 +83,110 @@ from typing import Any
 import torch
 from torch.utils._python_dispatch import TorchDispatchMode
 
+from tokenspeed.runtime.execution.cudagraph_memory import (
+    PROBE_CAPTURES_PER_FAMILY,
+    CudagraphProbe,
+    CudagraphProbeConfig,
+    measure_cudagraph_reserve,
+    probe_batch,
+)
+from tokenspeed.runtime.execution.memory_delta import (
+    MemoryDeltaObserver,
+    memory_delta_observer,
+)
 from tokenspeed.runtime.execution.types import (
     DpForwardMetadata,
     PendingExecution,
     PlannedForward,
 )
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import ProbeBatch
 from tokenspeed.runtime.utils import get_colorful_logger
 
 logger = get_colorful_logger(__name__)
+
+
+def _build_cudagraph_probe(
+    config: CudagraphProbeConfig, observer: MemoryDeltaObserver
+) -> CudagraphProbe:
+    """Build an executor over a minimal arena, capturing a few graphs per family."""
+    batch = probe_batch(config)
+    from tokenspeed.runtime.execution.cuda_graph_wrapper import (
+        get_batch_sizes_to_capture,
+    )
+    from tokenspeed.runtime.execution.factory import (
+        ModelExecutorConfig,
+        create_model_executor,
+    )
+    from tokenspeed.runtime.execution.prefill_graph import get_prefill_token_buckets
+    from tokenspeed.runtime.layers.attention.registry import create_attn_components
+
+    (
+        attn_backend,
+        token_to_kv_pool,
+        draft_attn_backend,
+        draft_token_to_kv_pool,
+        _cache_storage,
+    ) = create_attn_components(
+        config.server_args,
+        config.model_config,
+        config.gpu_id,
+        config.global_rank,
+        config.gpu_memory,
+        config.server_args.enable_memory_saver,
+        config.draft_model_config,
+        decode_input_tokens=config.decode_input_tokens,
+        overlap_schedule_depth=config.overlap_schedule_depth,
+        probe_batch=batch,
+    )
+    if token_to_kv_pool.arena.plan.num_lcm_blocks < 1:
+        raise RuntimeError(
+            "CUDA-graph probe arena allocated no parent blocks, so the recipe "
+            f"ignored the {batch} the probe asked it to hold"
+        )
+
+    executor_config = ModelExecutorConfig.from_server_args(
+        server_args=config.server_args,
+        model_config=config.model_config,
+        max_req_pool_size=config.max_batch_size + 1,
+        gpu_id=config.gpu_id,
+        global_rank=config.global_rank,
+        prefix_granularity=token_to_kv_pool.arena.prefix_granularity,
+        overlap_schedule_depth=config.overlap_schedule_depth,
+    )
+    decode_entries = get_batch_sizes_to_capture(executor_config)
+    prefill_entries = get_prefill_token_buckets(executor_config)
+
+    probe_config = copy.copy(executor_config)
+    probe_config.cudagraph_capture_sizes = sorted(decode_entries, reverse=True)[
+        :PROBE_CAPTURES_PER_FAMILY
+    ]
+    probe_config.prefill_graph_capture_sizes = sorted(prefill_entries, reverse=True)[
+        :PROBE_CAPTURES_PER_FAMILY
+    ]
+
+    executor = create_model_executor(
+        server_args=config.server_args,
+        config=probe_config,
+        model_runner=config.target,
+        draft_model_runner=config.draft,
+        attn_backend=attn_backend,
+        token_to_kv_pool=token_to_kv_pool,
+        draft_attn_backend=draft_attn_backend,
+        draft_token_to_kv_pool=draft_token_to_kv_pool,
+        memory_observer=observer,
+    )
+
+    # Counts follow PrefillGraph/CudaGraphWrapper disable rules, not the ladder.
+    entry_counts = {
+        "prefill": 0 if executor.prefill_graph.disable else len(prefill_entries),
+        "decode": (
+            0
+            if executor.forward_step.disable
+            else len(decode_entries) * len(executor.forward_step.graph_variants)
+        ),
+    }
+
+    return CudagraphProbe(executor=executor, entry_counts=entry_counts)
 
 
 @dataclass(frozen=True)
@@ -670,6 +767,35 @@ def build_device_side(
     if server_args.disaggregation_mode in ("null", "prefill"):
         target.prepare_multimodal_runtime()
 
+    graph_reserve_bytes = 0
+    # enforce_eager disables both graph families, so a probe would capture
+    # nothing; disable_prefill_graph leaves the decode pools to project.
+    if (
+        not server_args.disable_cudagraph_memory_reserve
+        and not server_args.enforce_eager
+    ):
+        probe_config = CudagraphProbeConfig(
+            server_args=server_args,
+            model_config=model_config,
+            draft_model_config=draft_model_config,
+            target=target,
+            draft=draft,
+            gpu_id=gpu_id,
+            global_rank=global_rank,
+            gpu_memory=min_per_gpu_mem,
+            overlap_schedule_depth=overlap_schedule_depth,
+            decode_input_tokens=decode_input_tokens,
+            max_batch_size=max_batch_size,
+        )
+        observer = memory_delta_observer(
+            record=True,
+            device_module=torch.get_device_module(server_args.device),
+            gpu_id=gpu_id,
+        )
+        graph_reserve_bytes = measure_cudagraph_reserve(
+            probe_config, observer, _build_cudagraph_probe(probe_config, observer)
+        )
+
     (
         attn_backend,
         token_to_kv_pool,
@@ -686,6 +812,7 @@ def build_device_side(
         draft_model_config,
         decode_input_tokens=decode_input_tokens,
         overlap_schedule_depth=overlap_schedule_depth,
+        graph_reserve_bytes=graph_reserve_bytes,
     )
 
     cache_geometry = scheduler_cache_geometry_from_pool(token_to_kv_pool)

--- a/python/tokenspeed/runtime/execution/drafter/base.py
+++ b/python/tokenspeed/runtime/execution/drafter/base.py
@@ -87,6 +87,18 @@ class BaseDrafter:
                 speculates for.
         """
 
+    def unwire_target(self, target_model: torch.nn.Module) -> None:
+        """Undo :meth:`wire_target` so a discarded drafter leaves nothing behind.
+
+        The CUDA-graph memory probe builds a drafter it throws away before the
+        KV cache is sized. Anything this drafter installed on the shared target
+        outlives the throw-away and keeps the drafter, and its buffers, out of
+        that sizing. Subclasses that install callbacks or buffers override this.
+
+        Args:
+            target_model: The same module :meth:`wire_target` was given.
+        """
+
     @abstractmethod
     def get_candidates(
         self,

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -269,6 +269,11 @@ class DFlash(BaseDrafter):
         )
         self._wire_aux_hidden_stream(target_model)
 
+    def unwire_target(self, target_model) -> None:
+        target_model.set_dflash_layers_to_capture(
+            self.target_layer_ids, incremental_callback=None, slot_bufs=None
+        )
+
     def _wire_aux_hidden_stream(self, target_model) -> None:
         """Tell the target which residual stream the draft was trained on."""
         stream = _resolve_aux_hidden_stream(self.model.config)

--- a/python/tokenspeed/runtime/execution/factory.py
+++ b/python/tokenspeed/runtime/execution/factory.py
@@ -27,6 +27,10 @@ from typing import TYPE_CHECKING
 import tokenspeed.runtime.layers.attention.backends  # noqa: F401  # trigger register_backend() calls
 from tokenspeed.runtime.configs.model_config import ModelConfig
 from tokenspeed.runtime.execution.drafter import get_drafter_impl
+from tokenspeed.runtime.execution.memory_delta import (
+    MemoryDeltaObserver,
+    memory_delta_observer,
+)
 from tokenspeed.runtime.execution.model_executor import (
     ModelExecutor,
     ModelExecutorConfig,
@@ -151,6 +155,7 @@ def create_model_executor(
     draft_model_runner: ModelRunner | None = None,
     draft_attn_backend: AttentionBackend | None = None,
     draft_token_to_kv_pool: CachePool | None = None,
+    memory_observer: MemoryDeltaObserver = memory_delta_observer(record=False),
 ) -> ModelExecutor:
     """Create the model executor with its sampler configuration."""
     if server_args.enable_nvtx:
@@ -182,4 +187,5 @@ def create_model_executor(
         draft_model_runner=draft_model_runner,
         draft_attn_backend=draft_attn_backend,
         draft_token_to_kv_pool=draft_token_to_kv_pool,
+        memory_observer=memory_observer,
     )

--- a/python/tokenspeed/runtime/execution/memory_delta.py
+++ b/python/tokenspeed/runtime/execution/memory_delta.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Observe what a named region of execution costs in device memory."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+class MemoryDeltaObserver(Protocol):
+    """Record how many bytes each named region takes from driver-free memory."""
+
+    samples: dict[str, list[int]]
+
+    def measure(self, series: str) -> AbstractContextManager[None]: ...
+
+
+@dataclass
+class _DeviceMemoryDeltaObserver:
+    """Measure regions against driver-free memory and the caching allocator.
+
+    A region served from segments the allocator already holds moves no driver
+    memory at all. That is not free: at serving time those segments are the KV
+    cache, so the region will have to take memory of its own. The larger of the
+    two deltas is what it really costs.
+    """
+
+    device_module: object
+    gpu_id: int
+    samples: dict[str, list[int]] = field(default_factory=dict)
+
+    @contextmanager
+    def measure(self, series: str) -> Iterator[None]:
+        self.device_module.synchronize()
+        free_before = int(self.device_module.mem_get_info(self.gpu_id)[0])
+        allocated_before = int(self.device_module.memory_allocated(self.gpu_id))
+
+        yield
+
+        self.device_module.synchronize()
+        free_after = int(self.device_module.mem_get_info(self.gpu_id)[0])
+        allocated_after = int(self.device_module.memory_allocated(self.gpu_id))
+        self.samples.setdefault(series, []).append(
+            max(free_before - free_after, allocated_after - allocated_before)
+        )
+
+
+@dataclass(frozen=True)
+class _NullMemoryDeltaObserver:
+    """Measure nothing, for the paths that only ever capture."""
+
+    samples: dict[str, list[int]] = field(default_factory=dict)
+
+    @contextmanager
+    def measure(self, series: str) -> Iterator[None]:
+        del series
+
+        yield
+
+
+_NULL_OBSERVER: MemoryDeltaObserver = _NullMemoryDeltaObserver()
+
+
+def memory_delta_observer(
+    *, record: bool, device_module: object | None = None, gpu_id: int | None = None
+) -> MemoryDeltaObserver:
+    """Return an observer that records driver-memory deltas, or one that ignores them."""
+    if not record:
+        return _NULL_OBSERVER
+    return _DeviceMemoryDeltaObserver(device_module, gpu_id)

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -50,6 +50,7 @@ from tokenspeed.runtime.execution.forward_batch_info import (
 )
 from tokenspeed.runtime.execution.forward_thread import ForwardThread
 from tokenspeed.runtime.execution.input_buffer import InputBuffers
+from tokenspeed.runtime.execution.memory_delta import MemoryDeltaObserver
 from tokenspeed.runtime.execution.model_runner import ModelRunner
 from tokenspeed.runtime.execution.multimodal_runtime import MultimodalRuntime
 from tokenspeed.runtime.execution.nan_guard import NanGuard
@@ -335,7 +336,9 @@ class ModelExecutor:
         draft_model_runner: ModelRunner | None = None,
         draft_attn_backend: AttentionBackend | None = None,
         draft_token_to_kv_pool: CachePool | None = None,
-    ):
+        *,
+        memory_observer: MemoryDeltaObserver,
+    ) -> None:
         self.device = config.device
         self.config = config
         self.model_runner = model_runner
@@ -566,9 +569,9 @@ class ModelExecutor:
         workspace_pool(self.device).freeze()
 
         if not self.forward_step.disable:
-            self.forward_step.capture()
+            self.forward_step.capture(memory_observer)
         if not self.prefill_graph.disable:
-            self.prefill_graph.capture(self.forward_step)
+            self.prefill_graph.capture(self.forward_step, memory_observer)
 
         # Encoder graphs are installed before KV-cache sizing and retained by
         # the model runner; preserve the executor-level handle for callers.
@@ -601,6 +604,10 @@ class ModelExecutor:
         set_random_seed(48)
 
         logger.info("ModelExecutor initialized")
+
+    def shutdown(self) -> None:
+        """Stop the owned forward thread during explicit executor teardown."""
+        self.forward_thread.shutdown()
 
     def _autotune(self) -> None:
         """Profile tunable kernels over one dummy prefill before graph capture.

--- a/python/tokenspeed/runtime/execution/prefill_graph.py
+++ b/python/tokenspeed/runtime/execution/prefill_graph.py
@@ -61,6 +61,7 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
+from tokenspeed.runtime.execution.memory_delta import MemoryDeltaObserver
 from tokenspeed.runtime.layers.attention.backends.cache_metadata import (
     CacheBatchMetadata,
 )
@@ -271,18 +272,20 @@ class PrefillGraph:
     # Graph capture
     # ------------------------------------------------------------------
 
-    def capture(self, decode_wrapper: CudaGraphWrapper | None = None) -> None:
+    def capture(
+        self, decode_wrapper: CudaGraphWrapper | None, observer: MemoryDeltaObserver
+    ) -> None:
         """Capture one breakable graph per token bucket (no-op when disabled).
 
         ``decode_wrapper`` supplies the shared capture stream (used here only,
-        not stored). Buckets share
-        one PRIVATE mempool (first capture
-        allocates it), so graph memory stays ~the largest bucket's peak --
-        but never the decode graphs' pool: eager ops cache raw pointers to
-        buffers they lazily allocated inside a decode capture (flashinfer's
-        trtllm-gen MoE runner), and a prefill capture reusing those freed
-        blocks means every replay rewrites them, corrupting the next eager
-        call (IMA; A/B-proven on qwen3.5 MTP).
+        not stored) and ``observer`` measures each bucket capture. Buckets
+        share one PRIVATE mempool (first capture allocates it), so graph
+        memory stays ~the largest bucket's peak -- but never the decode
+        graphs' pool: eager ops cache raw pointers to buffers they lazily
+        allocated inside a decode capture (flashinfer's trtllm-gen MoE
+        runner), and a prefill capture reusing those freed blocks means every
+        replay rewrites them, corrupting the next eager call (IMA; A/B-proven
+        on qwen3.5 MTP).
 
         Runs under inference mode like serving forwards (in-place updates on
         inference-mode model state buffers are only legal there). There is no
@@ -310,9 +313,13 @@ class PrefillGraph:
                 max_bs=int(self.page_table.shape[0]),
             )
         with maybe_inference_mode():
-            self._capture_all_buckets(decode_wrapper)
+            self._capture_all_buckets(decode_wrapper, observer)
 
-    def _capture_all_buckets(self, decode_wrapper: CudaGraphWrapper | None) -> None:
+    def _capture_all_buckets(
+        self,
+        decode_wrapper: CudaGraphWrapper | None,
+        observer: MemoryDeltaObserver,
+    ) -> None:
         rank = self.config.global_rank
         buckets = sorted(self.capture_buckets, reverse=True)
         capture_range = tqdm.tqdm(buckets) if rank == 0 else buckets
@@ -324,17 +331,18 @@ class PrefillGraph:
                 capture_range.set_description(
                     f"Capturing prefill buckets ({bucket=} {avail_mem=:.2f} GB)"
                 )
-            self._ctx = self.make_dummy_batch(bucket)
-            self._land_input_embeds(
-                self._embed_tokens(self.input_buffers.input_ids_buf[:bucket]), bucket
-            )
-            self._captured_hidden_mode = self._ctx.capture_hidden_mode
-            # Breaks record the ambient dummy ctx; it is rebound live at replay.
-            try:
+            with observer.measure("prefill"):
+                self._ctx = self.make_dummy_batch(bucket)
+                self._land_input_embeds(
+                    self._embed_tokens(self.input_buffers.input_ids_buf[:bucket]),
+                    bucket,
+                )
+                self._captured_hidden_mode = self._ctx.capture_hidden_mode
+                # Breaks record the ambient dummy ctx; it is rebound live at replay.
                 with active_forward(self._ctx):
                     self._capture_bucket(bucket, decode_wrapper)
-            finally:
-                self._ctx = None
+
+            self._ctx = None
         if self.config.global_rank == 0:
             sample = next(iter(self._captures.values()), None)
             logger.info(

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/base.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -55,6 +56,14 @@ if TYPE_CHECKING:
 CacheGroupDeclaration = tuple[CacheGroupSpec, tuple[CacheFieldSpec, ...]]
 
 
+@dataclass(frozen=True)
+class ProbeBatch:
+    """The concurrency a throwaway probe arena holds, not the server's."""
+
+    requests: int
+    tokens: int
+
+
 class CacheRecipe(ABC):
     """One model family's cache recipe.
 
@@ -83,6 +92,7 @@ class CacheRecipe(ABC):
         cache_budget_bytes: int,
         decode_input_tokens: int,
         overlap_schedule_depth: int,
+        probe_batch: ProbeBatch | None = None,
     ) -> None:
         self.server_args = server_args
         self.model_config = model_config
@@ -92,6 +102,7 @@ class CacheRecipe(ABC):
         self.cache_budget_bytes = cache_budget_bytes
         self.decode_input_tokens = decode_input_tokens
         self.overlap_schedule_depth = overlap_schedule_depth
+        self.probe_batch = probe_batch
 
     # ------------------------------------------------------------------
     # The pipeline. One place, one order.
@@ -113,7 +124,11 @@ class CacheRecipe(ABC):
             max_padding_fraction=self.max_padding_fraction,
         )
         self.check_layout(layout)
-        num_lcm_blocks = self.num_lcm_blocks(layout)
+        num_lcm_blocks = (
+            self.num_lcm_blocks(layout)
+            if self.probe_batch is None
+            else self.parents_needed(layout, self.probe_batch.tokens)
+        )
         return CacheSetup(
             spec=CachePoolSpec(
                 family=self.family,
@@ -128,7 +143,12 @@ class CacheRecipe(ABC):
                 pool_options=self.pool_options(),
             ),
             num_draft_layers=self.num_draft_layers,
-            cache_budget_bytes=self.cache_budget_bytes,
+            cache_budget_bytes=(
+                self.cache_budget_bytes
+                if self.probe_batch is None
+                else self.workspace_bytes()
+                + (num_lcm_blocks + 1) * layout.lcm_block_bytes
+            ),
             fixed_workspace_bytes=self.workspace_bytes(),
         )
 
@@ -312,10 +332,17 @@ class CacheRecipe(ABC):
         The one place a recipe reads the scheduler's limits, so per-group page
         demand and the capacity search cannot size against different numbers.
         """
+        live_requests = self.attn_config.max_bs
+        scheduled_tokens = max(0, int(self.server_args.chunked_prefill_size))
+        context_len = self.attn_config.context_len
+        if self.probe_batch is not None:
+            live_requests = self.probe_batch.requests
+            scheduled_tokens = self.probe_batch.tokens
+            context_len = self.probe_batch.tokens
         return {
-            "max_live_requests": self.attn_config.max_bs,
-            "max_scheduled_tokens": max(0, int(self.server_args.chunked_prefill_size)),
-            "max_context_len": self.attn_config.context_len,
+            "max_live_requests": live_requests,
+            "max_scheduled_tokens": scheduled_tokens,
+            "max_context_len": context_len,
             "decode_input_tokens": self.decode_input_tokens,
             "overlap_schedule_depth": self.overlap_schedule_depth,
         }

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/setup.py
@@ -28,7 +28,10 @@ from functools import partial
 from typing import Literal
 
 from tokenspeed.runtime.layers.attention.configs.base import AttnConfig
-from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import CacheRecipe
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import (
+    CacheRecipe,
+    ProbeBatch,
+)
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.deepseek_v4 import (
     DeepseekV4Recipe,
 )
@@ -182,6 +185,7 @@ def prepare_cache_setup(
     cache_budget_bytes: int,
     decode_input_tokens: int,
     overlap_schedule_depth: int,
+    probe_batch: ProbeBatch | None = None,
 ) -> CacheSetup:
     """Apply one model recipe and size target/draft arenas from one budget."""
     recipe = _RECIPES.get(family)
@@ -196,4 +200,5 @@ def prepare_cache_setup(
         cache_budget_bytes=cache_budget_bytes,
         decode_input_tokens=decode_input_tokens,
         overlap_schedule_depth=overlap_schedule_depth,
+        probe_batch=probe_batch,
     ).setup()

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -20,6 +20,7 @@
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import logging
 from typing import TYPE_CHECKING
@@ -51,6 +52,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.factory import (
     create_cache_arena,
     create_cache_pool,
 )
+from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import ProbeBatch
 from tokenspeed.runtime.layers.attention.kv_cache.recipes.setup import (
     CacheModelFamily,
     CachePoolSpec,
@@ -770,6 +772,9 @@ def create_attn_components(
     draft_model_config: ModelConfig | None = None,
     decode_input_tokens: int = 1,
     overlap_schedule_depth: int = 0,
+    *,
+    graph_reserve_bytes: int = 0,
+    probe_batch: ProbeBatch | None = None,
 ) -> tuple[
     AttentionBackend,
     CachePool,
@@ -803,6 +808,7 @@ def create_attn_components(
         and not is_dspark_draft_model
         and is_deepseek_v4(draft_model_config.hf_config)
     )
+    server_args = copy.copy(server_args)
     original_attn_backend = server_args.attention_backend
     if is_deepseek_v4_model:
         server_args.attention_backend = "deepseek_v4"
@@ -939,14 +945,18 @@ def create_attn_components(
         cache_family,
         draft_cache_family,
     )
-    cache_memory = profile_available_cache_memory_bytes(
-        attn_config=config,
-        gpu_id=gpu_id,
-        tp_size=server_args.mapping.world_size,
-        gpu_memory_utilization=server_args.gpu_memory_utilization,
-        total_gpu_memory=gpu_memory,
-        world_group=server_args.mapping.world_group,
-    )
+    if probe_batch is None:
+        cache_memory = profile_available_cache_memory_bytes(
+            attn_config=config,
+            gpu_id=gpu_id,
+            tp_size=server_args.mapping.world_size,
+            gpu_memory_utilization=server_args.gpu_memory_utilization,
+            total_gpu_memory=gpu_memory,
+            graph_reserve_bytes=graph_reserve_bytes,
+            world_group=server_args.mapping.world_group,
+        )
+    else:
+        cache_memory = 0
     cache_setup = prepare_cache_setup(
         family=cache_family,
         server_args=server_args,
@@ -957,6 +967,7 @@ def create_attn_components(
         cache_budget_bytes=cache_memory,
         decode_input_tokens=decode_input_tokens,
         overlap_schedule_depth=overlap_schedule_depth,
+        probe_batch=probe_batch,
     )
     spec = cache_setup.spec
     target_spec = spec

--- a/python/tokenspeed/runtime/layers/attention/utils.py
+++ b/python/tokenspeed/runtime/layers/attention/utils.py
@@ -95,6 +95,8 @@ def profile_available_cache_memory_bytes(
     tp_size: int,
     gpu_memory_utilization: float,
     total_gpu_memory: int,
+    *,
+    graph_reserve_bytes: int = 0,
     world_group=None,
 ) -> int:
     cpu_group = (
@@ -108,7 +110,9 @@ def profile_available_cache_memory_bytes(
         distributed=tp_size > 1,
         cpu_group=cpu_group,
     )
-    cache_memory = available_gpu_memory - total_gpu_memory * (
-        1 - gpu_memory_utilization
+    cache_memory = (
+        available_gpu_memory
+        - total_gpu_memory * (1 - gpu_memory_utilization)
+        - graph_reserve_bytes / (1 << 30)
     )
     return int(cache_memory * (1 << 30))

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -293,6 +293,7 @@ class ServerArgs:
     disable_cuda_graph_padding: bool = False
     disable_autotune: bool = False
     enable_cudagraph_gc: bool = False
+    disable_cudagraph_memory_reserve: bool = False
     disable_nccl_nvls: bool = False
     disable_symm_mem: bool = False
     disable_overlap_schedule: bool = False
@@ -464,21 +465,6 @@ class ServerArgs:
         else:
             # GPU memory is not known yet or no GPU is available.
             gpu_mem = None
-
-        # Set GPU memory utilization, which depends on the tensor parallelism size.
-        self._gpu_memory_utilization_defaulted = False
-        if self.gpu_memory_utilization is None:
-            if self.mapping.world_size >= 16:
-                self.gpu_memory_utilization = 0.79
-            elif self.mapping.world_size >= 8:
-                self.gpu_memory_utilization = 0.81
-            elif self.mapping.world_size >= 4:
-                self.gpu_memory_utilization = 0.95
-            elif self.mapping.world_size >= 2:
-                self.gpu_memory_utilization = 0.87
-            else:
-                self.gpu_memory_utilization = 0.88
-            self._gpu_memory_utilization_defaulted = True
 
         # Set the chunked prefill token budget.
         if self.chunked_prefill_size is None:
@@ -833,6 +819,14 @@ class ServerArgs:
                     "multiple independent encode servers for horizontal scale."
                 )
             self.enable_prefix_caching = False
+
+        self._gpu_memory_utilization_defaulted = False
+        if self.gpu_memory_utilization is None:
+            # Both opt-outs capture graphs the budget cannot see, so they keep
+            # ordinary headroom instead of the fraction the projection earns.
+            unguarded = self.enforce_eager or self.disable_cudagraph_memory_reserve
+            self.gpu_memory_utilization = 0.9 if unguarded else 0.95
+            self._gpu_memory_utilization_defaulted = True
 
         # Prefill graph disable logic is handled by AttnInitializer.modify_args
         # after the attention backend is resolved.
@@ -1852,6 +1846,11 @@ class ServerArgs:
             "--disable-cuda-graph-padding",
             action="store_true",
             help="Disable cuda graph when padding is needed. Still uses cuda graph when padding is not needed.",
+        )
+        parser.add_argument(
+            "--disable-cudagraph-memory-reserve",
+            action="store_true",
+            help="Do not reserve the projected CUDA-graph pool memory in the KV cache budget.",
         )
         parser.add_argument(
             "--disable-autotune",

--- a/test/ci/eval/deepseek-v4-flash-evalscope-gsm8k.yaml
+++ b/test/ci/eval/deepseek-v4-flash-evalscope-gsm8k.yaml
@@ -24,7 +24,7 @@ server:
     --max-model-len 4096
     --max-total-tokens 16384
     --chunked-prefill-size 8192
-    --gpu-memory-utilization 0.9
+    --gpu-memory-utilization 0.95
     --disable-kvstore
     --trust-remote-code
     --host 127.0.0.1

--- a/test/ci/eval/deepseek-v4-flash-mtp-evalscope-gsm8k-amd.yaml
+++ b/test/ci/eval/deepseek-v4-flash-mtp-evalscope-gsm8k-amd.yaml
@@ -22,7 +22,7 @@ server:
     --max-total-tokens 16384
     --chunked-prefill-size 8192
     --prefill-graph-max-tokens 8192
-    --gpu-memory-utilization 0.9
+    --gpu-memory-utilization 0.95
     --disable-kvstore
     --trust-remote-code
     --speculative-algorithm MTP

--- a/test/ci/eval/deepseek-v4-flash-mtp-evalscope-gsm8k.yaml
+++ b/test/ci/eval/deepseek-v4-flash-mtp-evalscope-gsm8k.yaml
@@ -24,7 +24,7 @@ server:
     --max-model-len 4096
     --max-total-tokens 16384
     --chunked-prefill-size 8192
-    --gpu-memory-utilization 0.9
+    --gpu-memory-utilization 0.95
     --disable-kvstore
     --trust-remote-code
     --speculative-algorithm MTP

--- a/test/ci/eval/deepseek-v4-pro-evalscope-gsm8k-amd.yaml
+++ b/test/ci/eval/deepseek-v4-pro-evalscope-gsm8k-amd.yaml
@@ -25,7 +25,7 @@ server:
     --max-total-tokens 16384
     --chunked-prefill-size 8192
     --prefill-graph-max-tokens 8192
-    --gpu-memory-utilization 0.9
+    --gpu-memory-utilization 0.95
     --disable-kvstore
     --trust-remote-code
     --host 127.0.0.1

--- a/test/ci/eval/glm-5.3-flash-fp8-mtp-evalscope-aime26.yaml
+++ b/test/ci/eval/glm-5.3-flash-fp8-mtp-evalscope-aime26.yaml
@@ -28,7 +28,7 @@ server:
     --chunked-prefill-size 4096
     --max-cudagraph-capture-size 16
     --cudagraph-capture-sizes 1 2 4 8 16
-    --gpu-memory-utilization 0.90
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --sampling-backend flashinfer
     --disable-kvstore

--- a/test/ci/eval/kimi-k3-deepswe-b300.yaml
+++ b/test/ci/eval/kimi-k3-deepswe-b300.yaml
@@ -38,7 +38,7 @@ server:
     --cudagraph-capture-sizes 1 2 4
     --max-prefill-tokens 32768
     --chunked-prefill-size 32768
-    --gpu-memory-utilization 0.90
+    --gpu-memory-utilization 0.95
     --disable-kvstore
     --disable-autotune
     --enable-allreduce-fusion

--- a/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -41,7 +41,7 @@ server:
     --max-cudagraph-capture-size 16
     --cudagraph-capture-sizes 1 2 4 8 16
     --disable-prefill-graph
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --sampling-backend greedy
     --disable-kvstore

--- a/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-mmmu-pro-vision-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-mmmu-pro-vision-gb300-slurm.yaml
@@ -30,7 +30,7 @@ server:
     --tensor-parallel-size 8
     --mm-encoder-tp-mode data
     --moe-backend flashinfer_trtllm
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --max-num-seqs 16
     --disable-prefill-graph
     --disable-kvstore

--- a/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-ocr-bench-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-dspark-tp8-two-node-kvv-ocr-bench-gb300-slurm.yaml
@@ -30,7 +30,7 @@ server:
     --tensor-parallel-size 8
     --mm-encoder-tp-mode data
     --moe-backend flashinfer_trtllm
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --max-num-seqs 16
     --disable-prefill-graph
     --disable-kvstore

--- a/test/ci/eval/kimi-k3-mxfp4-tp16-four-node-evalscope-aime26-slurm.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp16-four-node-evalscope-aime26-slurm.yaml
@@ -25,7 +25,7 @@ server:
     --tensor-parallel-size 16
     --mm-encoder-tp-mode data
     --moe-backend flashinfer_trtllm
-    --gpu-memory-utilization 0.94
+    --gpu-memory-utilization 0.95
     --max-num-seqs 16
     --disable-kvstore
     --host 0.0.0.0

--- a/test/ci/eval/kimi-k3-mxfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -25,7 +25,7 @@ server:
     --tensor-parallel-size 8
     --mm-encoder-tp-mode data
     --moe-backend flashinfer_trtllm
-    --gpu-memory-utilization 0.94
+    --gpu-memory-utilization 0.95
     --max-num-seqs 16
     --disable-kvstore
     --host 0.0.0.0

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
@@ -38,7 +38,7 @@ server:
     --max-cudagraph-capture-size 16
     --cudagraph-capture-sizes 1 2 4 8 16
     --disable-prefill-graph
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --sampling-backend greedy
     --disable-kvstore

--- a/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml
@@ -29,7 +29,7 @@ server:
     --max-cudagraph-capture-size 16
     --cudagraph-capture-sizes 1 2 4 8 16
     --disable-prefill-graph
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --sampling-backend greedy
     --disable-kvstore

--- a/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-dspark-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -38,7 +38,7 @@ server:
     --tensor-parallel-size 8
     --mm-encoder-tp-mode data
     --moe-backend flashinfer_trtllm
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --max-num-seqs 16
     --disable-prefill-graph
     --disable-kvstore

--- a/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
+++ b/test/ci/eval/kimi-k3-nvfp4-tp8-two-node-evalscope-aime26-gb300-slurm.yaml
@@ -30,7 +30,7 @@ server:
     --tensor-parallel-size 8
     --mm-encoder-tp-mode data
     --moe-backend flashinfer_trtllm
-    --gpu-memory-utilization 0.94
+    --gpu-memory-utilization 0.95
     --max-num-seqs 16
     --disable-kvstore
     --host 0.0.0.0

--- a/test/ci/eval/qwen3.5-122b-a10b-nvfp4-evalscope-ocr-bench.yaml
+++ b/test/ci/eval/qwen3.5-122b-a10b-nvfp4-evalscope-ocr-bench.yaml
@@ -22,7 +22,7 @@ server:
     --max-num-seqs 16
     --chunked-prefill-size 8192
     --max-prefill-tokens 8192
-    --gpu-memory-utilization 0.9
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --attention-backend trtllm
     --moe-backend flashinfer_trtllm

--- a/test/ci/perf/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -42,7 +42,7 @@ server:
     --max-cudagraph-capture-size 1
     --cudagraph-capture-sizes 1
     --disable-prefill-graph
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --sampling-backend greedy
     --disable-kvstore

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
@@ -49,7 +49,7 @@ server:
     --max-cudagraph-capture-size 1
     --cudagraph-capture-sizes 1
     --disable-prefill-graph
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --sampling-backend greedy
     --disable-kvstore

--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml
@@ -29,7 +29,7 @@ server:
     --max-cudagraph-capture-size 1
     --cudagraph-capture-sizes 1
     --disable-prefill-graph
-    --gpu-memory-utilization 0.92
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --sampling-backend greedy
     --disable-kvstore

--- a/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml
+++ b/test/ci/perf/qwen3.5-397b-a17b-nvfp4-evalscope-longctx.yaml
@@ -21,7 +21,7 @@ server:
     --max-model-len 1048576
     --hf-overrides '{"max_position_embeddings": 1048576}'
     --max-num-seqs 4
-    --gpu-memory-utilization 0.8
+    --gpu-memory-utilization 0.95
     --trust-remote-code
     --attention-backend trtllm
     --moe-backend flashinfer_trtllm

--- a/test/runtime/test_cache_setup.py
+++ b/test/runtime/test_cache_setup.py
@@ -1,5 +1,13 @@
+import os
+import sys
 from dataclasses import fields, replace
 from types import SimpleNamespace
+
+# CI registration (parsed via AST, runtime no-op).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
 import pytest
 import torch
@@ -606,6 +614,7 @@ def test_deepseek_v4_draft_pd_is_rejected_for_an_ordinary_target(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     import tokenspeed.runtime.layers.attention.registry as registry
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import ProbeBatch
 
     monkeypatch.setattr(
         registry,
@@ -638,7 +647,117 @@ def test_deepseek_v4_draft_pd_is_rejected_for_an_ordinary_target(
             rank=0,
             gpu_memory=0,
             draft_model_config=draft,
+            graph_reserve_bytes=0,
         )
+
+
+def test_create_attn_components_resolves_identically_when_called_twice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tokenspeed.runtime.layers.attention.registry as registry
+    from tokenspeed.runtime.layers.attention.kv_cache.recipes.base import ProbeBatch
+
+    config = _mla_config()
+    memory_plan = SimpleNamespace(
+        prefix_granularity=64,
+        num_lcm_blocks=1,
+        lcm_block_bytes=128,
+        groups=(),
+    )
+    spec = SimpleNamespace(
+        memory_plan=memory_plan,
+        token_capacity=64,
+        layer_types=("full_attention",),
+    )
+    cache_setup = SimpleNamespace(
+        spec=spec,
+        num_draft_layers=0,
+        num_target_layers=1,
+        cache_budget_bytes=128,
+        fixed_workspace_bytes=0,
+    )
+    mapping = SimpleNamespace(world_size=1, world_group=None, has_pp=False, rank=3)
+    server_args = SimpleNamespace(
+        attention_backend="tokenspeed_mla",
+        drafter_attention_backend=None,
+        disaggregation_mode=None,
+        speculative_algorithm=None,
+        gpu_memory_utilization=0.9,
+        mapping=mapping,
+    )
+    model_config = SimpleNamespace(
+        hf_config=SimpleNamespace(
+            architectures=("KimiK3ForConditionalGeneration",),
+        )
+    )
+    backend = SimpleNamespace(set_cache_pool=lambda pool: None)
+    pool = SimpleNamespace()
+    cache_storage: dict[str, int] = {"allocated_bytes": 128}
+    generated_args: list[SimpleNamespace] = []
+    full_backend_inputs: list[str | None] = []
+
+    def create_config(
+        args: SimpleNamespace,
+        model: SimpleNamespace,
+        is_draft: bool = False,
+    ) -> AttnConfig:
+        generated_args.append(args)
+        return config
+
+    def resolve_full_backend(name: str | None, **kwargs: object) -> str:
+        full_backend_inputs.append(name)
+        return "tokenspeed_mla"
+
+    monkeypatch.setattr(registry, "_create_attn_config", create_config)
+    monkeypatch.setattr(
+        registry, "_resolve_hybrid_full_backend_name", resolve_full_backend
+    )
+    monkeypatch.setattr(registry, "prepare_cache_setup", lambda **kwargs: cache_setup)
+    monkeypatch.setattr(
+        registry, "_validate_lcm_page_size", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        registry, "create_cache_arena", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        registry,
+        "_create_target_components",
+        lambda **kwargs: (backend, pool),
+    )
+    monkeypatch.setattr(
+        registry,
+        "_create_draft_components",
+        lambda **kwargs: (None, None),
+    )
+    monkeypatch.setattr(registry, "_prepare_verify_workspace", lambda **kwargs: None)
+    monkeypatch.setattr(
+        registry, "_cache_storage_report", lambda **kwargs: cache_storage
+    )
+    first = registry.create_attn_components(
+        server_args,
+        model_config,
+        gpu_id=0,
+        rank=0,
+        gpu_memory=0,
+        probe_batch=ProbeBatch(requests=1, tokens=1),
+    )
+    second = registry.create_attn_components(
+        server_args,
+        model_config,
+        gpu_id=0,
+        rank=0,
+        gpu_memory=0,
+        probe_batch=ProbeBatch(requests=1, tokens=1),
+    )
+
+    assert first == second
+    assert server_args.mapping is mapping
+    assert server_args.mapping.rank == 3
+    assert [args.attention_backend for args in generated_args] == [
+        "hybrid_linear_attn",
+        "hybrid_linear_attn",
+    ]
+    assert full_backend_inputs == ["tokenspeed_mla", "tokenspeed_mla"]
 
 
 def test_hybrid_draft_layers_share_plan_with_disjoint_views() -> None:

--- a/test/runtime/test_cudagraph_memory_projection.py
+++ b/test/runtime/test_cudagraph_memory_projection.py
@@ -1,0 +1,343 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from ci_system.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, suite="runtime-1gpu")
+
+from tokenspeed.runtime.execution.cudagraph_memory import (
+    estimate_cudagraph_memory,
+    probe_batch,
+)
+from tokenspeed.runtime.execution.memory_delta import memory_delta_observer
+from tokenspeed.runtime.layers.attention.utils import (
+    profile_available_cache_memory_bytes,
+)
+
+
+class _FakeDeviceModule:
+    """Replays paired driver-free and allocator readings for one GPU."""
+
+    def __init__(self, *, free: tuple[int, ...], allocated: tuple[int, ...]) -> None:
+        self._free = iter(free)
+        self._allocated = iter(allocated)
+        self.synchronizations = 0
+
+    def synchronize(self) -> None:
+        self.synchronizations += 1
+
+    def mem_get_info(self, gpu_id: int) -> tuple[int, int]:
+        self._assert_gpu_id(gpu_id)
+        return next(self._free), 2000
+
+    def memory_allocated(self, gpu_id: int) -> int:
+        self._assert_gpu_id(gpu_id)
+        return next(self._allocated)
+
+    @staticmethod
+    def _assert_gpu_id(gpu_id: int) -> None:
+        if gpu_id != 2:
+            raise AssertionError(f"unexpected GPU id {gpu_id}")
+
+
+class TestCudagraphMemoryProjection(unittest.TestCase):
+    def test_observer_measure_records_samples(self) -> None:
+        device_module = _FakeDeviceModule(
+            free=(1000, 900, 900, 850), allocated=(0, 0, 0, 0)
+        )
+        observer = memory_delta_observer(
+            record=True, device_module=device_module, gpu_id=2
+        )
+        with observer.measure("phase"):
+            pass
+        with observer.measure("phase"):
+            pass
+        self.assertEqual(observer.samples["phase"], [100, 50])
+        self.assertEqual(device_module.synchronizations, 4)
+
+    def test_observer_charges_a_region_the_allocator_alone_paid_for(self) -> None:
+        """Reusing a held segment moves no driver memory but still costs."""
+        device_module = _FakeDeviceModule(free=(1000, 1000), allocated=(0, 300))
+        observer = memory_delta_observer(
+            record=True, device_module=device_module, gpu_id=2
+        )
+        with observer.measure("decode"):
+            pass
+        self.assertEqual(observer.samples["decode"], [300])
+
+    def test_observer_takes_the_larger_of_the_two_readings(self) -> None:
+        device_module = _FakeDeviceModule(free=(1000, 600), allocated=(0, 120))
+        observer = memory_delta_observer(
+            record=True, device_module=device_module, gpu_id=2
+        )
+        with observer.measure("prefill"):
+            pass
+        self.assertEqual(observer.samples["prefill"], [400])
+
+    def test_null_observer_records_nothing(self) -> None:
+        observer = memory_delta_observer(record=False)
+        with observer.measure("decode"):
+            pass
+        self.assertEqual(observer.samples, {})
+
+    def test_probe_batch_covers_the_decode_ladder_it_captures(self) -> None:
+        """Raw-gate replay reuses pool conv_state rows as its verify scratch."""
+
+        def batch(chunk: int, context_len: int, max_batch_size: int) -> tuple[int, int]:
+            b = probe_batch(
+                SimpleNamespace(
+                    server_args=SimpleNamespace(chunked_prefill_size=chunk),
+                    model_config=SimpleNamespace(context_len=context_len),
+                    max_batch_size=max_batch_size,
+                )
+            )
+            return b.requests, b.tokens
+
+        # One prefill request, but the decode ladder still climbs to 16.
+        self.assertEqual(batch(8192, 102400, 16), (16, 16))
+        # A short context makes prefill the wider of the two.
+        self.assertEqual(batch(8192, 256, 8), (32, 32))
+        # One token per request keeps each row at a single page.
+        self.assertEqual(batch(0, 512, 1), (1, 1))
+
+    def test_the_unguarded_paths_keep_ordinary_headroom(self) -> None:
+        """A budget nothing reserves against gets headroom, not the ladder."""
+        path = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "python/tokenspeed/runtime/utils/server_args.py"
+        )
+        source = path.read_text()
+        self.assertIn(
+            "unguarded = self.enforce_eager or self.disable_cudagraph_memory_reserve",
+            source,
+        )
+        self.assertIn("0.9 if unguarded else 0.95", source)
+        # The topology ladder the projection replaces must be gone for good.
+        for stale in ("0.79", "0.81", "0.87", "0.88"):
+            self.assertNotIn(f"gpu_memory_utilization = {stale}", source)
+
+    def test_dflash_unwire_drops_the_reference_it_gave_the_target(self) -> None:
+        """A probe drafter left wired keeps its buffers out of the KV budget."""
+        from tokenspeed.runtime.execution.drafter.dflash import DFlashDrafter
+
+        class Target:
+            def __init__(self) -> None:
+                self.wiring: dict[str, object] = {}
+
+            def set_dflash_layers_to_capture(
+                self, layer_ids, incremental_callback=None, slot_bufs=None
+            ) -> None:
+                self.wiring = {
+                    "layer_ids": layer_ids,
+                    "incremental_callback": incremental_callback,
+                    "slot_bufs": slot_bufs,
+                }
+
+        drafter = DFlashDrafter.__new__(DFlashDrafter)
+        drafter.target_layer_ids = [2, 46]
+        target = Target()
+        target.set_dflash_layers_to_capture(
+            [2, 46], incremental_callback=lambda: None, slot_bufs=[object()]
+        )
+        self.assertIsNotNone(target.wiring["incremental_callback"])
+
+        drafter.unwire_target(target)
+        self.assertIsNone(target.wiring["incremental_callback"])
+        self.assertIsNone(target.wiring["slot_bufs"])
+        self.assertEqual(target.wiring["layer_ids"], [2, 46])
+
+    def test_estimator_sums_disjoint_families(self) -> None:
+        estimate = estimate_cudagraph_memory(
+            {"prefill": (100, 7, 9, 8), "decode": (30, 5, 4)},
+            {"prefill": 5, "decode": 3},
+        )
+        self.assertEqual(
+            (
+                estimate.prefill.first_capture,
+                estimate.prefill.extrapolated_rate,
+                estimate.prefill.total,
+            ),
+            (100, 8, 132),
+        )
+        self.assertEqual(
+            (
+                estimate.decode.first_capture,
+                estimate.decode.extrapolated_rate,
+                estimate.decode.total,
+            ),
+            (30, 4.5, 39),
+        )
+        self.assertEqual(estimate.total, 171)
+
+    def test_one_off_growth_step_is_charged_but_not_extrapolated(self) -> None:
+        """A single allocator growth step must not become a per-entry rate."""
+        estimates = estimate_cudagraph_memory(
+            {"prefill": (2530, 40, 650, 40), "decode": ()},
+            {"prefill": 48, "decode": 0},
+        )
+        first = estimates.prefill.first_capture
+        rate = estimates.prefill.extrapolated_rate
+        estimate = estimates.prefill.total
+        self.assertEqual(first, 2530)
+        self.assertEqual(rate, 40, "the growth step must not set the rate")
+        self.assertEqual(estimate, 5020)
+        self.assertLess(estimate, 33080, "must not extrapolate the step")
+        self.assertGreater(estimate, 4670, "must not under-project the actual")
+
+    def test_a_later_variants_first_capture_is_charged_where_it_happens(self) -> None:
+        """Decode samples retain pool-creating captures from later variants."""
+        variant_major = (100, 10, 10, 10, 500, 10, 10, 10)
+        estimates = estimate_cudagraph_memory(
+            {"prefill": (), "decode": variant_major},
+            {"prefill": 0, "decode": 8},
+        )
+        first = estimates.decode.first_capture
+        rate = estimates.decode.extrapolated_rate
+        estimate = estimates.decode.total
+        self.assertEqual(rate, 10, "one 500 step must not become the rate")
+        self.assertEqual(estimate, sum(variant_major))
+        self.assertGreater(estimate, 170)
+
+    def test_sample_count_contract(self) -> None:
+        """Extrapolation needs two samples and rejects excess samples."""
+        with self.assertRaises(ValueError):  # one sample cannot give a rate
+            estimate_cudagraph_memory(
+                {"prefill": (100,), "decode": ()},
+                {"prefill": 40, "decode": 0},
+            )
+        with self.assertRaises(ValueError):  # more samples than entries
+            estimate_cudagraph_memory(
+                {"prefill": (100, 7, 9), "decode": ()},
+                {"prefill": 2, "decode": 0},
+            )
+        estimates = estimate_cudagraph_memory(
+            {"prefill": (100, 7), "decode": ()},
+            {"prefill": 40, "decode": 0},
+        )
+        self.assertEqual(estimates.prefill.total, 100 + 7 + 7 * 38)
+
+    def test_allocator_churn_is_charged_but_never_extrapolated_negative(self) -> None:
+        """Negative observations are charged but never extrapolated."""
+        estimates = estimate_cudagraph_memory(
+            {"prefill": (100, -48, -50, -46), "decode": ()},
+            {"prefill": 40, "decode": 0},
+        )
+        first = estimates.prefill.first_capture
+        rate = estimates.prefill.extrapolated_rate
+        estimate = estimates.prefill.total
+        self.assertEqual(rate, 0, "an all-negative sample must not project a shrink")
+        self.assertEqual(estimate, 0)
+
+    def test_pool_creating_capture_may_come_out_negative(self) -> None:
+        """The pool-creating capture may have a negative net observation."""
+        estimates = estimate_cudagraph_memory(
+            {"prefill": (), "decode": (-48, 26, 30, 26)},
+            {"prefill": 0, "decode": 10},
+        )
+        first = estimates.decode.first_capture
+        rate = estimates.decode.extrapolated_rate
+        estimate = estimates.decode.total
+        self.assertEqual(first, -48)
+        self.assertEqual(rate, 26)
+        self.assertEqual(estimate, -48 + 26 + 30 + 26 + 26 * 6)
+
+    def test_estimate_never_goes_negative(self) -> None:
+        estimates = estimate_cudagraph_memory(
+            {"prefill": (-100, -5, -6, -7), "decode": ()},
+            {"prefill": 4, "decode": 0},
+        )
+        self.assertEqual(estimates.prefill.total, 0)
+        self.assertEqual(estimates.total, 0)
+
+    def test_reserve_defaults_to_zero_so_old_callers_get_main_behaviour(self) -> None:
+        """The parameter is public API; omitting it must mean "no projection"."""
+        config = type("Config", (), {"device": "cuda"})()
+        with patch(
+            "tokenspeed.runtime.layers.attention.utils.get_available_gpu_memory",
+            return_value=10.0,
+        ):
+            omitted = profile_available_cache_memory_bytes(config, 0, 1, 0.9, 20)
+            explicit_zero = profile_available_cache_memory_bytes(
+                config, 0, 1, 0.9, 20, graph_reserve_bytes=0
+            )
+        self.assertEqual(omitted, explicit_zero)
+
+    def test_profile_subtracts_graph_reserve(self) -> None:
+        config = type("Config", (), {"device": "cuda"})()
+        with patch(
+            "tokenspeed.runtime.layers.attention.utils.get_available_gpu_memory",
+            return_value=10.0,
+        ):
+            without = profile_available_cache_memory_bytes(
+                config, 0, 1, 0.9, 20, graph_reserve_bytes=0
+            )
+            with_reserve = profile_available_cache_memory_bytes(
+                config, 0, 1, 0.9, 20, graph_reserve_bytes=12345
+            )
+        self.assertEqual(without - with_reserve, 12345)
+
+    def test_disabled_gate_dominates_probe_call(self) -> None:
+        path = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "python/tokenspeed/runtime/execution/device.py"
+        )
+        tree = ast.parse(path.read_text())
+        build = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "build_device_side"
+        )
+        calls = [
+            node
+            for node in ast.walk(build)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "measure_cudagraph_reserve"
+        ]
+        self.assertEqual(len(calls), 1)
+        parent_if = next(
+            node
+            for node in ast.walk(build)
+            if isinstance(node, ast.If) and calls[0] in list(ast.walk(node))
+        )
+        negated = {
+            operand.attr
+            for node in ast.walk(parent_if.test)
+            if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not)
+            for operand in [node.operand]
+            if isinstance(operand, ast.Attribute)
+        }
+        # disable_prefill_graph is deliberately absent: the decode pools still
+        # need projecting when only the prefill buckets are turned off.
+        self.assertEqual(negated, {"disable_cudagraph_memory_reserve", "enforce_eager"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/runtime/test_prefill_graph.py
+++ b/test/runtime/test_prefill_graph.py
@@ -21,6 +21,8 @@ from ci_system.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
+from tokenspeed.runtime.execution.memory_delta import memory_delta_observer
+
 
 def _spec(
     group_id: str,
@@ -690,7 +692,7 @@ class CaptureFailureIsLoudTest(unittest.TestCase):
             weight=self.torch.zeros(2, 8, dtype=self.torch.float32)
         )
 
-        def _capture_all_buckets(_decode_wrapper):
+        def _capture_all_buckets(_decode_wrapper, _observer):
             if raises is not None:
                 raise raises
 
@@ -704,18 +706,18 @@ class CaptureFailureIsLoudTest(unittest.TestCase):
         cause = RuntimeError("backend refused the dummy batch")
         pg = self._bare(raises=cause)
         with self.assertRaises(RuntimeError) as caught:
-            pg.capture(None)
+            pg.capture(None, memory_delta_observer(record=False))
         self.assertIs(caught.exception, cause)
 
     def test_successful_capture_does_not_raise(self):
-        self._bare().capture(None)
+        self._bare().capture(None, memory_delta_observer(record=False))
 
     def test_oom_propagates(self):
         """OOM keeps its own type and message. The capture pool not fitting is
         an operator-visible sizing failure, not something to recover from."""
         pg = self._bare(raises=self.torch.cuda.OutOfMemoryError("no room"))
         with self.assertRaises(self.torch.cuda.OutOfMemoryError):
-            pg.capture(None)
+            pg.capture(None, memory_delta_observer(record=False))
 
 
 class TrtllmPrefillGraphSeamsTest(unittest.TestCase):


### PR DESCRIPTION
profile_available_cache_memory_bytes sizes the KV cache from driver free memory at call time, and both CUDA-graph pools are allocated after that out of the same remainder. Nothing told the budget they exist, so raising the prefill-graph ceiling OOMed during capture instead of shrinking the cache, and even when it fit the graphs ate the headroom the operator asked for: on Inkling-NVFP4 TP4 at utilization 0.95, Device free landed at 4.53 GB against the 9.22 GB that setting promises.

A throwaway probe now runs before the budget, captures the largest few entries of each graph family against a minimal arena and a private pool, measures driver-level deltas, tears everything down, and subtracts a projection:

    estimate = first + sum(marginals) + max(median(marginals), 0) * remaining

summed across families, because the prefill and decode pools are disjoint at runtime; only pools sharing one runtime allocation may be combined with a max.

The median is what keeps a one-off allocator growth step out of the rate. A step of 0.650 GB against a 0.046 GB mean appears on one 48-entry ladder; extrapolating the max over-projects it by 608% and the mean of two samples by 301%. Observations are charged at their net value, including negative ones -- a decode family sampled (-48, +26, +30, +26) MiB when a segment release landed on the pool-creating capture -- because the budget is derived from driver free memory. Only the extrapolated rate and the final estimate are floored at zero.

`--disable-cudagraph-memory-reserve` turns the probe off. The gate sits at the call site, so the disabled path builds no probe, arena, executor or captures and subtracts a literal zero.

Accuracy, cross-checked by differencing two boots rather than by instrumenting one: the pools cost 3.96 GB at the default Inkling ceiling and this projects 4.16 GB, +5%. At ceiling 8192, where main dies at bucket 21 of 56, the branch captures all 56 and serves. Device free returns to 9.53 GB on Inkling and 18.78 GB on Qwen3-8B, against promises of 9.22 and 18.43. With the flag off, KV bytes, Device free and max_total_num_tokens match main exactly on both.

Known limits: a growth step landing outside the sampled window is not bounded by the estimator; the probe leaves ~1 GB of lazy module loads, library workspaces and fragmentation that it cannot return, charged to the budget once; and the 3-parent probe arena is unexercised on paged-state families.


## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
