### PR TITLE
docs: use Inkling docker tags tokenspeed:tml (drop missing :latest)

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -14,9 +14,9 @@ Blog: https://lightseek.org/blog/tokenspeed-inkling.html
 ## Docker
 
 ### nvidia
-docker pull lightseekorg/tokenspeed:latest
+docker pull lightseekorg/tokenspeed:tml
 ### amd
-docker pull lightseekorg/tokenspeed-amd:latest
+docker pull lightseekorg/tokenspeed-amd:tml
 
 ## Launch command
 


### PR DESCRIPTION
## Summary

The Inkling recipe in `docs/recipes/models.md` tells operators to pull `lightseekorg/tokenspeed:latest` and `lightseekorg/tokenspeed-amd:latest`. Those tags are not published on Docker Hub. The Inkling images are published as `:tml` (see #693 / the Inkling enablement notes). Update the recipe Docker pulls to the tags that exist.

Getting Started already uses `lightseekorg/tokenspeed-runner:latest` and is unchanged.

## Reproduce

```bash
# Docs on main
rg -n 'tokenspeed:latest|tokenspeed-amd:latest' docs/recipes/models.md

# Hub has no :latest for these repos (2026-09-03)
curl -s 'https://hub.docker.com/v2/repositories/lightseekorg/tokenspeed/tags?page_size=50' | jq -r '.results[].name'
# -> 0.1.0, tml, nightly-20260714

curl -s 'https://hub.docker.com/v2/repositories/lightseekorg/tokenspeed-amd/tags?page_size=50' | jq -r '.results[].name'
# -> tml, nightly-20260714
```

## Test plan

- [x] Confirmed Hub tag lists have no `:latest` for `tokenspeed` / `tokenspeed-amd`
- [x] Confirmed #693 documents `tokenspeed:tml` / `tokenspeed-amd:tml` for Inkling
- [x] Diff limited to the two `docker pull` lines in the Inkling recipe
- [x] Left `--block-size` / `--disable-kvstore` / other recipe flags untouched