### PR TITLE
docs: document --enable-mixed-batch in server parameter tables

### DIFF
--- a/docs/configuration/compatible-parameters.md
+++ b/docs/configuration/compatible-parameters.md
@@ -31,6 +31,7 @@ TokenSpeed-specific behavior explicitly.
 | `--chat-template` | Chat template name or path. |
 | `--gpu-memory-utilization` | GPU memory fraction used for weights and KV cache. |
 | `--max-num-seqs` | Maximum concurrent sequences. |
+| `--enable-mixed-batch` | Allow prefill and decode in the same scheduler iteration. |
 | `--block-size` | KV cache block size. |
 | `--enable-prefix-caching` | Enable prefix cache reuse. |
 | `--no-enable-prefix-caching` | Disable prefix cache reuse. |

--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -102,6 +102,7 @@ distributed update mode until that implementation is added.
 | `--max-num-seqs` | Maximum number of active sequences the scheduler may process concurrently. |
 | `--chunked-prefill-size` | Token budget the scheduler may issue in one iteration. Defaults to `8192`. Set `-1` to disable chunked prefill. |
 | `--max-prefill-tokens` | Prefill token budget used when chunked prefill is disabled. Defaults to `8192`. |
+| `--enable-mixed-batch` | Allow the scheduler to issue prefill and decode requests in the same iteration. Defaults to off. |
 | `--max-total-tokens` | Override the automatically calculated token pool size. |
 | `--block-size` | KV cache block size. |
 | `--enable-prefix-caching` / `--no-enable-prefix-caching` | Enable or disable prefix cache reuse. |


### PR DESCRIPTION
## Summary
- Document `--enable-mixed-batch` in `docs/configuration/server.md` (Scheduler And Memory) and `docs/configuration/compatible-parameters.md`.
- Flag is defined in `server_args.py` and already used in DeepSeek V4 recipes under `docs/recipes/models.md`, but was missing from the operator-facing parameter tables.

## Test plan
- [x] Confirmed `--enable-mixed-batch` exists in `python/tokenspeed/runtime/utils/server_args.py` (`action=store_true`, default off; help: allow prefill and decode in the same iteration).
- [x] Confirmed recipes in `docs/recipes/models.md` already pass the flag.
- [x] Diff limited to the two configuration docs tables.