### PR TITLE
ci(kimi-k3): materialize the tokenizer and refresh the stale tp8ep1 perf reference

### DIFF
--- a/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
+++ b/test/ci/perf/kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml
@@ -21,6 +21,10 @@ api_version: ci.tokenspeed.io/v1
 # CPU-only test/runtime/test_kimi_k3_moe_fork_warmup.py, which is narrower --
 # it pins the call site, not the stream behaviour. Run this job by hand when
 # touching the MoE stream fork, the A8W4 SiTU kernel, or graph capture.
+#
+# Being manual is why the tokenizer defect below went unnoticed for so long: a
+# cold-runner failure in a job nobody runs on a schedule looks like bad luck the
+# one time someone does run it.
 name: perf-kimi-k3-mxfp4-tp8ep1-random-4k-1k-mi35x
 type: perf
 workflow_stage: model-test
@@ -74,13 +78,24 @@ perf:
     # Keep the load generator aligned with the version used to establish the
     # perf_reference below; EvalScope 1.10 changed its metric semantics.
     - python3 -m uv venv --seed --clear /tmp/evalscope-perf && python3 -m uv pip install --python /tmp/evalscope-perf/bin/python 'evalscope[perf]==1.9.1'
+  # EvalScope resolves remote tokenizer paths through ModelScope even when the
+  # dataset source is Hugging Face, so materialize the HF tokenizer locally.
+  # Passing the remote ID instead depends on a warm ModelScope cache. Observed
+  # on a cold runner as "Couldn't instantiate the backend tokenizer", raised
+  # inside modelscope's AutoTokenizer patcher partway through the run with the
+  # server already healthy and serving; a re-run minutes later passed against
+  # the now warm cache, so it reads as flaky while being a real cold-start
+  # dependency. The tp8ep8 sibling has materialized the tokenizer since it was
+  # written; this job was missed.
   command: >-
     REPO_ROOT=$PWD &&
     MODEL=kimi-k3 &&
     URL=http://127.0.0.1:21000/v1/completions &&
     OUTPUTS_DIR=/tmp/tokenspeed-kimi-k3-ep1-mi35x-perf &&
+    TOKENIZER_PATH="$OUTPUTS_DIR/tokenizer" &&
     trap 'rm -rf "$OUTPUTS_DIR"' EXIT &&
     rm -rf "$OUTPUTS_DIR" &&
+    /tmp/evalscope-perf/bin/python -c 'import sys; from transformers import AutoTokenizer; AutoTokenizer.from_pretrained("moonshotai/Kimi-K3", trust_remote_code=True).save_pretrained(sys.argv[1])' "$TOKENIZER_PATH" &&
     set +e &&
     echo "==================================================" &&
     echo ">>> input=4k output=1k conc=1" &&
@@ -90,7 +105,8 @@ perf:
     --url "$URL"
     --api openai
     --dataset random
-    --tokenizer-path moonshotai/Kimi-K3
+    --data-source huggingface
+    --tokenizer-path "$TOKENIZER_PATH"
     --min-prompt-length 4096
     --max-prompt-length 4096
     --prefix-length 0
@@ -116,15 +132,25 @@ report:
 perf_threshold: 0.9
 # Values are [Latency (tps/user), Throughput (tps/gpu)]; gate fails any conc whose actual falls below ref * perf_threshold.
 #
-# PROVISIONAL -- these have not been established on this runner. They are set
-# deliberately loose so the job reports rather than gates while it settles, and
-# should be replaced by the documented convention (rounded down from the median
-# of the three most recent passing runs) once there are three.
+# PROVISIONAL. Set from a single run on the CI runner -- 75.64 tps/user and
+# 9.16 tps/gpu -- so replace it with the documented convention (median of the
+# three most recent passing runs, rounded down) once there are three.
 #
-# The starting point is a hand measurement on an 8x MI355X box: EP1 sustained
-# 53.98 tok/s at concurrency 1 against EP8's 73.84 on the same commit. EP1 is
-# expected to be SLOWER here -- its advantage is at batch (it overtook EP8 by
-# ~28% at concurrency 16) and concurrency 1 is its worst case. Do not copy the
-# tp8ep8 reference into this file.
+# 65/7.8 is deliberately well under that measurement. With perf_threshold 0.9
+# the gate trips below 58.5, some 23% under the observed value, against the
+# 3.5% spread across the tp8ep8 job's own three reference runs. The previous
+# 45/5.4 predated the symmetric MoE tail reduction (#1353, via #1358) and the
+# fused input projection (#1358) and would now pass a 40% regression.
+#
+# The note this replaces said tp8ep1 is expected to be slower than tp8ep8 at
+# concurrency 1, citing a pre-fusion hand measurement of 53.98 against 73.84.
+# That is no longer true and should not be carried forward: tp8ep1 now leads at
+# every concurrency measured -- 77.59 against 73.89 at concurrency 1 on an 8x
+# MI355X box, and 75.64 tps/user here against the tp8ep8 job's own reference of
+# 65.
+#
+# Still do not copy the tp8ep8 reference wholesale in future. The two jobs run
+# different server configurations, not just a different MoE placement; the match
+# at 65/7.8 is a coincidence of the current numbers rather than an invariant.
 perf_reference:
-  1: [45, 5.4]
+  1: [65, 7.8]

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -230,3 +230,37 @@ def test_kvv_configs_use_pinned_upstream_and_local_api():
         assert flag_value(command, "--max-tokens") == max_tokens
         assert "--thinking" in command
         assert flag_value(command, "--thinking-effort") == "max"
+
+
+def test_kimi_k3_perf_configs_materialize_the_tokenizer_locally():
+    """EvalScope perf jobs must not pass a remote tokenizer ID.
+
+    EvalScope resolves remote tokenizer paths through ModelScope even when the
+    dataset source is Hugging Face, so passing the model ID makes the benchmark
+    depend on a warm ModelScope cache. On a cold runner it fails partway through
+    with "Couldn't instantiate the backend tokenizer" while the server is
+    already healthy, and a re-run against the now-warm cache passes -- so the
+    failure reads as flaky and the cause is easy to miss.
+
+    Every Kimi-K3 perf job therefore saves the Hugging Face tokenizer locally
+    first and points EvalScope at the directory. Pinning it here because
+    reverting to the model ID reintroduces a failure that only appears on a cold
+    runner, which is exactly the kind nobody reproduces on demand.
+    """
+    filenames = (
+        "kimi-k3-mxfp4-tp8ep1-evalscope-random-4k-1k-mi35x.yaml",
+        "kimi-k3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml",
+        "kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml",
+    )
+    for filename in filenames:
+        task = yaml.safe_load((PERF_CONFIG_DIR / filename).read_text(encoding="utf-8"))
+        command = task["perf"]["command"]
+        tokens = shlex.split(command)
+
+        assert "save_pretrained" in command, filename
+        assert flag_value(tokens, "--data-source") == "huggingface", filename
+
+        tokenizer_path = flag_value(tokens, "--tokenizer-path")
+        # A local directory built by the materialization step, not a hub id.
+        assert tokenizer_path == "$TOKENIZER_PATH", filename
+        assert "/" not in tokenizer_path.lstrip("$"), filename


### PR DESCRIPTION
Two independent defects in the tp8ep1 perf job. Both are present today and both
are worth fixing regardless of what this job's trigger ends up being — split out
of #1374 deliberately so they are not held up by the question of which MoE
placement should gate commits.

## 1. Cold-runner tokenizer failure

EvalScope resolves remote tokenizer paths through **ModelScope** even when the
dataset source is Hugging Face, so passing the model ID depends on a warm
ModelScope cache. On a cold runner the benchmark dies with:

```
ValueError: Couldn't instantiate the backend tokenizer from one of: ...
```

raised inside `modelscope/utils/hf_util/patcher.py`, partway through the run,
**with the server already healthy and serving**. A re-run minutes later passes
against the now-warm cache — which is what makes it read as flaky rather than as
the cold-start dependency it is.

The tp8ep8 sibling has materialized the Hugging Face tokenizer locally since it
was written (`save_pretrained` into the outputs dir, then `--data-source
huggingface` and the local path). This job was missed. Same fix applied verbatim.

Worth noting *why* it stayed hidden: a cold-start failure in a manually-triggered
job looks like bad luck the one time someone runs it. It only became legible
after two runs minutes apart, one red and one green.

## 2. Stale perf reference

```yaml
perf_reference:
  1: [45, 5.4]      # -> [65, 7.8]
```

The old value predates the symmetric MoE tail reduction and the fused input
projection. Against the **75.64 tps/user** this job now measures on the CI
runner, it would pass a **40% regression**.

65/7.8 sits 23% under that measurement, against the 3.5% spread across the
tp8ep8 job's own three reference runs — margin to spare, while still meaning
something. Still provisional: the documented convention is the median of three
passing runs, and this job has one.

## Also: a claim that is no longer true

The reference comment asserted that tp8ep1 is structurally slower than tp8ep8 at
concurrency 1, citing a pre-fusion hand measurement of 53.98 against 73.84. That
has been overtaken:

| concurrency | tp8ep1 | tp8ep8 |
|---|---|---|
| 1 | **77.59** | 73.89 |
| 8 | **358.13** | 266.45 |
| 16 | **533.28** | 429.59 |

8×MI355X decode; on the CI runner tp8ep1 reads 75.64 tps/user against tp8ep8's
own reference of 65.

Recorded as a note only. **This PR changes no triggers.** Which placement should
gate commits is a separate question, and one for the code owners — #1379 has
just consolidated the AMD gates onto EAGLE3 + tp8ep8 and pinned that with a
test, so it is emphatically not something to slip in through a comment edit.

## Verification

* `test/ci_system` — 201 passed.
* `pre-commit run --all-files` — clean.
* Single file changed.