### PR TITLE
perf(k3): accelerate TP8/EP1 EAGLE3 verification

### DIFF
--- a/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
+++ b/test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml
@@ -1,7 +1,8 @@
 api_version: ci.tokenspeed.io/v1
-# Kimi-K3 + EAGLE3 is the per-commit AIME26 gate. The matching speculator-free
-# configuration remains available as a manual control for direct comparison.
-name: eval-kimi-k3-eagle3-mxfp4-tp8ep8-aime26-amd
+# Kimi-K3 + EAGLE3 TP8/EP1 is the per-commit AIME26 gate. Its small target-MoE
+# verification batches use the optimized A8W4 SiTU path; the matching
+# speculator-free configuration remains available as a manual control.
+name: eval-kimi-k3-eagle3-mxfp4-tp8ep1-aime26-amd
 type: eval
 workflow_stage: model-test
 triggers:
@@ -30,7 +31,7 @@ server:
     --speculative-draft-model-quantization unquant
     --eagle3-layers-to-capture 2,46,90
     --tp 8
-    --ep-size 8
+    --ep-size 1
     --attention-backend mla
     --drafter-attention-backend mla
     --moe-backend auto

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -171,14 +171,15 @@ def test_qwen38_flash_next_runs_gsm8k_with_kvstore_enabled():
     assert task["score_threshold"] == 0.90
 
 
-def test_kimi_k3_amd_gates_use_eagle3_tp8ep8():
+def test_kimi_k3_amd_gates_use_eagle3():
     filenames = (
-        "kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-aime26-amd.yaml",
+        "kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml",
         "kimi-k3-eagle3-mxfp4-tp8ep8-evalscope-random-4k-1k-mi35x.yaml",
     )
+    ep_sizes = ("1", "8")
     tasks = []
-    for config_dir, filename in zip(
-        (EVAL_CONFIG_DIR, PERF_CONFIG_DIR), filenames, strict=True
+    for config_dir, filename, ep_size in zip(
+        (EVAL_CONFIG_DIR, PERF_CONFIG_DIR), filenames, ep_sizes, strict=True
     ):
         task = yaml.safe_load((config_dir / filename).read_text(encoding="utf-8"))
         server_tokens = shlex.split(task["server"]["command"])
@@ -194,7 +195,7 @@ def test_kimi_k3_amd_gates_use_eagle3_tp8ep8():
         assert flag_value(server_tokens, "--speculative-eagle-topk") == "1"
         assert flag_value(server_tokens, "--eagle3-layers-to-capture") == "2,46,90"
         assert flag_value(server_tokens, "--tp") == "8"
-        assert flag_value(server_tokens, "--ep-size") == "8"
+        assert flag_value(server_tokens, "--ep-size") == ep_size
         tasks.append(task)
 
     eval_tokens = shlex.split(tasks[0]["eval"]["command"])

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
@@ -18,6 +18,10 @@ The fused dispatch policy (`fused/moe.py`) is the top of the funnel: it calls
 `M >= 9`, staged MFMA decode), so the kernel dependency arrow points from
 `fused/` to the staged files, never back.
 
+For the staged package's second GEMM, TP uses direct atomic accumulation through
+64 tokens and scratch-plus-FP32-reduce at larger sizes; EP uses atomic
+accumulation because each rank owns only a sparse subset of the routed experts.
+
 ## Staged package files
 
 | File | Role |

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/moe.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/moe.py
@@ -1191,9 +1191,11 @@ def _maybe_gluon_package_mxfp4_prefill(
     ):
         raise ValueError("local expert range exceeds global expert count")
     if force_reduce is None:
-        # EP ranks own only a fraction of each token's routes. Combining those
-        # sparse local contributions atomically avoids the full top-k scratch.
-        force_reduce = global_num_experts == n_experts and expert_start == 0
+        # EP ranks own only a fraction of each token's routes. For TP, keep the
+        # faster atomic path within the graph-captured EAGLE3 decode window and
+        # preserve deterministic FP32 reduction for larger batches.
+        is_ep_shard = global_num_experts != n_experts or expert_start != 0
+        force_reduce = False if is_ep_shard else n_tokens > 64
     hidden_dim = int(hidden_states.shape[1])
     inter_dim = int(package_w13.shape[1]) // 2
     if (

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -814,7 +814,7 @@ def test_mxfp4_situ_ep_paths_are_cuda_graph_capturable_gfx950(
     torch.testing.assert_close(captured, eager, atol=3e-4, rtol=3e-2)
 
 
-@pytest.mark.parametrize("num_tokens", [1, 2, 4, 32])
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 32, 64])
 def test_tp_situ_selects_a8w4_and_matches_reference_gfx950(
     num_tokens: int,
 ) -> None:


### PR DESCRIPTION
## Problem

K3 EAGLE3 verification on TP8/EP1 unnecessarily materializes every routed-expert contribution and launches a second reduction kernel, even though its graph-captured target-MoE batches contain at most 64 tokens and are faster with direct atomic accumulation.

## Key changes

- `tokenspeed-kernel-amd/.../mxfp4/fused/moe.py`: use the existing atomic stage-2 combine for TP batches through 64 tokens, while retaining the existing sparse atomic behavior for EP and deterministic FP32 scratch/reduce behavior for larger TP batches.

  ```python
  is_ep_shard = global_num_experts != n_experts or expert_start != 0
  force_reduce = False if is_ep_shard else n_tokens > 64
  ```

- `tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py`: extend the SiTU reference comparison to M=64, the largest target-MoE batch produced by C16 EAGLE3 verification.
- `test/ci/eval/kimi-k3-eagle3-mxfp4-tp8ep1-evalscope-aime26-amd.yaml`: move the per-commit EAGLE3 AIME26 gate from TP8/EP8 to the optimized TP8/EP1 placement; the 4K/1K performance gate remains TP8/EP8.

## Why this boundary

The first-64-forward profile attributed 14.47% of TP8/EP1 GPU dispatch time to the standalone stage-2 reduction. At the real K3 M=64 TP1 shape, direct atomic combine reduces the complete MoE package from approximately 0.515 ms to 0.398 ms per call (1.29x). Keeping M>64 on FP32 reduction also preserves the existing bitwise cross-block determinism contract for larger batches.

## AIME26 validation

Thirty problems, seed 42, EvalScope 1.11.1, C16, EAGLE3 with three speculative steps and four draft tokens:

| Placement | Accuracy | Avg TTFT | Avg TPOT | Avg latency | Output throughput | Eval wall time | Avg output tokens |
|---|---:|---:|---:|---:|---:|---:|---:|
| TP8/EP8 main | 96.7% | 1.773 s | **20.3 ms** | 111.232 s | 48.06 tok/s | 592.24 s | 5,346 |
| TP8/EP1 main | 86.7% | 1.140 s | 23.7 ms | 116.346 s | 50.27 tok/s | 510.28 s | 5,849 |
| TP8/EP1 this PR | **93.3%** | **1.045 s** | 20.8 ms | **94.730 s** | **52.50 tok/s** | **456.88 s** | 4,973 |

This PR improves TP8/EP1 TPOT by 12.2% and output throughput by 4.4%; versus TP8/EP8 it completes the evaluation 22.9% sooner with 41.1% lower TTFT and 9.2% higher output throughput, while per-user TPOT remains 0.5 ms slower. Because sampling changes answer lengths, wall time and latency should be interpreted alongside the output-token column; TPOT and throughput are the normalized signals.

Full benchmark and profile tables: https://github.com/raikonenfnu/tokenspeed/issues/86

## Validation

- `51 passed` — CI configuration tests plus the complete gfx950 SiTU MoE test file
- `pre-commit run --all-files`
- Local graph-compiled TP8/EP1 EAGLE3 AIME26 run: 93.3% accuracy
