### PR TITLE
perf(v4): reduce decode path overhead

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -755,6 +755,15 @@ and `--tool-call-parser deepseek_v4`, and auto-sets `block_size=256` (pass
 `--block-size N` with `N != 64` to override). Requires
 `tokenspeed-deepgemm>=2.5.0.post20260629` and `tokenspeed-flashmla`.
 
+`TOKENSPEED_DSV4_TRUST_VALIDATED_HASH_TABLE=1` is an opt-in profiling path for
+the immutable token-to-expert tables used by V4 hash-routed layers. After all
+checkpoint weights load, every table entry is checked once against the model's
+expert count before kernel warmup or CUDA Graph capture. A successful check
+lets decode skip the repeated table gather and expert-ID assertion; dynamic
+token IDs remain range-checked on every call. The default keeps the per-call
+table-value check until matched endpoint and graph measurements establish a
+deployment benefit.
+
 **V4-Flash** — 4× B200 (SM100), data-parallel + expert-parallel:
 
 ```bash
@@ -856,6 +865,38 @@ DSpark weights are incomplete, the replay capability is missing, KVStore is
 enabled, or the draft checkpoint contains only MTP/NextN weights. External
 DSpark checkpoints that do not advertise this capability keep the generic
 scheduler behavior.
+
+Same-checkpoint DSpark materializes a stable FP32 view of the local target
+LM-head shard before cache sizing. Public FP32 Markov logits then reuse this
+buffer instead of converting the complete shard during every CUDA Graph
+replay. In-place target weight updates refresh the existing buffer outside the
+replay, preserving the address captured by CUDA Graph.
+
+The CUDA draft path also preserves the checkpoint's UE8M0-scaled FP8 activation
+round-trip with a fused `tokenspeed-kernel` operation. It computes the same
+per-group power-of-two scale and returns dequantized values in the input dtype;
+the fusion removes intermediate reduction and elementwise launches but does not
+change the model's quantization contract.
+
+DSpark attention RMSNorm uses the platform kernel on CUDA while retaining its
+explicit FP32-accumulating PyTorch expression as the CPU reference. The fused
+path preserves the existing output dtype and is safe to capture and replay in
+the target CUDA Graph.
+
+For DSpark profiling experiments on an unpadded base-only vocabulary,
+`TOKENSPEED_DSPARK_REPLICATE_VOCAB_HEADS=1` replicates the target embedding,
+target LM head, and Markov embedding/projection on every attention-TP rank. The
+candidate removes the per-step Markov embedding reduction and global-argmax
+gathers at the cost of several GiB of persistent memory per GPU. It fails
+closed for padded or added-vocabulary layouts and remains opt-in until matched
+endpoint and CUDA Graph measurements establish a deployment benefit.
+
+`TOKENSPEED_DSPARK_REPLICATE_MARKOV_EMBEDDING=1` is a narrower profiling
+variant. It replicates only the FP32 low-rank Markov embedding while leaving
+the target embedding, target LM head, and Markov projection vocabulary-sharded.
+This removes the Markov embedding reduction without expanding the
+full-vocabulary projection or argmax workload. The full-head flag implies this
+setting; both variants remain opt-in and require matched endpoint validation.
 
 For a two-node TP8 deployment, run one process per node with four local workers
 and the same command on both nodes. See [Multi-Node](../serving/parallelism.md#multi-node)

--- a/python/tokenspeed/runtime/execution/drafter/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/execution/drafter/deepseek_v4_dspark.py
@@ -21,9 +21,17 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import torch
+from tokenspeed_kernel.ops.sampling.cute_dsl import _invoke_kernel as _cute_local_argmax
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    is_available as _local_cute_argmax_available,
+)
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    supports_dist_argmax_shape as _supports_dist_argmax_shape,
+)
 
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.execution.drafter.base import BaseDrafter
@@ -31,9 +39,11 @@ from tokenspeed.runtime.execution.forward_batch_info import (
     CaptureHiddenMode,
     ForwardMode,
 )
+from tokenspeed.runtime.layers.logits_processor import _force_deterministic_rsag
 from tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads import (
     sample_dspark_block_greedy,
 )
+from tokenspeed.runtime.utils import get_colorful_logger
 from tokenspeed.runtime.utils.nvtx import nvtx_range
 
 if TYPE_CHECKING:
@@ -41,6 +51,13 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.execution.model_runner import ModelRunner
     from tokenspeed.runtime.execution.runtime_states import RuntimeStates
     from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
+
+
+logger = get_colorful_logger(__name__)
+_DIST_ARGMAX_UNSET = object()
+_LOCAL_ARGMAX_UNSET = object()
+_DSPARK_DIST_ARGMAX_ENV = "TOKENSPEED_DSPARK_DISTRIBUTED_ARGMAX"
+_DSPARK_LOCAL_ARGMAX_ENV = "TOKENSPEED_DSPARK_LOCAL_CUTE_ARGMAX"
 
 
 def _dspark_decode_position_plan(
@@ -187,17 +204,141 @@ class DeepseekV4DSpark(BaseDrafter):
         self.gathered_ids = torch.empty(
             (tp_size, max_bs), dtype=torch.int64, device=self.device
         )
+        self._dist_argmax_state: object = _DIST_ARGMAX_UNSET
+        self._dist_argmax_max = torch.empty(
+            (max_bs,), dtype=torch.float32, device=self.device
+        )
+        self._dist_argmax_ids = torch.empty(
+            (max_bs,), dtype=torch.int32, device=self.device
+        )
+        self._local_argmax_ready: object = _LOCAL_ARGMAX_UNSET
+        self._local_argmax_max = torch.empty(
+            (self.block_size, max_bs), dtype=torch.float32, device=self.device
+        )
+        self._local_argmax_ids = torch.empty(
+            (self.block_size, max_bs), dtype=torch.int64, device=self.device
+        )
 
     def wire_target(self, target_model) -> None:
         self.target_model = target_model
-        self.lm_head = target_model.lm_head
-        self.tp_group = target_model.logits_processor.tp_group
+        # Model wiring may replace the draft head with a reconstructed full
+        # vocabulary tensor. Keep the draft module so sampling metadata and
+        # refreshes describe the exact weight used by local_base_logits.
+        self.lm_head = self.draft_model.lm_head
+        self.logits_processor = target_model.logits_processor
+        self.tp_group = self.logits_processor.tp_group
         if not hasattr(target_model, "set_dspark_layers_to_capture"):
             raise ValueError(
                 "DSPARK requires the target model to support "
                 "set_dspark_layers_to_capture."
             )
         target_model.set_dspark_layers_to_capture(self.target_layer_ids)
+
+    def _probe_dist_argmax_state(self):
+        """Create the optional FP32 DSpark state outside graph capture."""
+        head = self.lm_head
+        shard = getattr(head, "shard_indices", None)
+        tp_size = int(self.logits_processor.tp_size)
+        enabled = os.getenv(_DSPARK_DIST_ARGMAX_ENV, "0") == "1"
+        local_vocab = int(getattr(shard, "num_org_elements", 0))
+        local_padded = int(getattr(shard, "num_org_elements_padded", -1))
+        added = int(getattr(shard, "num_added_elements", -1))
+        org_vocab = int(getattr(head, "org_vocab_size", 0))
+        base_only = (
+            shard is not None
+            and added == 0
+            and local_padded == local_vocab
+            and int(head.weight.shape[0]) == local_vocab
+            and int(getattr(head, "num_embeddings", 0)) == org_vocab
+            and local_vocab * tp_size == org_vocab
+        )
+        eligible = (
+            enabled
+            and not _force_deterministic_rsag()
+            and 2 <= tp_size <= 32
+            and base_only
+            and _supports_dist_argmax_shape(local_vocab, torch.float32, tp_size)
+        )
+        state = None
+        if eligible:
+            state = self.logits_processor.acquire_dist_argmax_state(
+                head,
+                max_M=int(self.input_buffers.max_bs),
+                skip_ping_pong=False,
+                dtype=torch.float32,
+            )
+        logger.info(
+            "DSPARK_DISTRIBUTED_ARGMAX rank=%d requested=%s enabled=%s "
+            "dtype=float32 local_vocab=%d tp=%d base_only=%s",
+            int(self.draft_model.mapping.rank),
+            enabled,
+            state is not None,
+            local_vocab,
+            tp_size,
+            base_only,
+        )
+        return state
+
+    def _ensure_dist_argmax_state(self):
+        """Probe once during warmup; never rendezvous from graph capture."""
+        if self._dist_argmax_state is _DIST_ARGMAX_UNSET:
+            if torch.cuda.is_current_stream_capturing():
+                return None
+            self._dist_argmax_state = self._probe_dist_argmax_state()
+        return self._dist_argmax_state
+
+    def _probe_local_argmax_ready(self, local_logits: torch.Tensor) -> bool:
+        """Compile the optional local CuTe argmax before graph capture."""
+        head = self.lm_head
+        shard = getattr(head, "shard_indices", None)
+        requested = os.getenv(_DSPARK_LOCAL_ARGMAX_ENV, "0") == "1"
+        dist_requested = os.getenv(_DSPARK_DIST_ARGMAX_ENV, "0") == "1"
+        local_vocab = int(getattr(shard, "num_org_elements", 0))
+        local_padded = int(getattr(shard, "num_org_elements_padded", -1))
+        added = int(getattr(shard, "num_added_elements", -1))
+        probe_logits = local_logits.contiguous()
+        eligible = (
+            requested
+            and not dist_requested
+            and _local_cute_argmax_available()
+            and probe_logits.is_cuda
+            and probe_logits.ndim == 2
+            and probe_logits.dtype == torch.float32
+            and probe_logits.shape[0] > 0
+            and probe_logits.shape[1] == local_vocab
+            and local_vocab == local_padded
+            and added == 0
+            and local_vocab >= 4096
+            and local_vocab % 32 == 0
+        )
+        if eligible:
+            rows = probe_logits.shape[0]
+            _cute_local_argmax(
+                probe_logits,
+                self._local_argmax_max[0, :rows],
+                self._local_argmax_ids[0, :rows],
+            )
+            torch.cuda.synchronize(self.device)
+        logger.info(
+            "DSPARK_LOCAL_CUTE_ARGMAX rank=%d requested=%s enabled=%s "
+            "dtype=%s local_vocab=%d tp=%d base_only=%s",
+            int(self.draft_model.mapping.rank),
+            requested,
+            eligible,
+            str(probe_logits.dtype).removeprefix("torch."),
+            local_vocab,
+            int(self.logits_processor.tp_size),
+            local_vocab == local_padded and added == 0,
+        )
+        return eligible
+
+    def _ensure_local_argmax_ready(self, local_logits: torch.Tensor) -> bool:
+        """Probe once during warmup; never compile from graph capture."""
+        if self._local_argmax_ready is _LOCAL_ARGMAX_UNSET:
+            if torch.cuda.is_current_stream_capturing():
+                return False
+            self._local_argmax_ready = self._probe_local_argmax_ready(local_logits)
+        return bool(self._local_argmax_ready)
 
     def prepare_request_state(
         self,
@@ -206,6 +347,9 @@ class DeepseekV4DSpark(BaseDrafter):
         num_extends: int,
     ) -> None:
         """Refresh request-to-window slots outside CUDA Graph replay."""
+
+        if hasattr(self, "lm_head"):
+            self.model.refresh_local_base_logits_head(self.lm_head.weight)
 
         if len(request_ids) != len(request_pool_indices):
             raise ValueError("DSPARK request IDs and pool indices must align.")
@@ -405,7 +549,9 @@ class DeepseekV4DSpark(BaseDrafter):
             slots,
             draft_ctx,
         )
-        local_logits = self.model.local_base_logits(draft_hidden, self.lm_head)
+        local_logits = self.model.local_base_logits(draft_hidden)
+        dist_argmax_state = self._ensure_dist_argmax_state()
+        local_cute_argmax = self._ensure_local_argmax_ready(local_logits[:, 0])
         sample_dspark_block_greedy(
             local_logits,
             bonus,
@@ -415,6 +561,12 @@ class DeepseekV4DSpark(BaseDrafter):
             self.gathered_values,
             self.gathered_ids,
             self.draft_tokens_buf[:num_decodes],
+            dist_argmax_state,
+            self._dist_argmax_max,
+            self._dist_argmax_ids,
+            local_cute_argmax,
+            self._local_argmax_max,
+            self._local_argmax_ids,
         )
         next_tokens[num_extends:, 1:].copy_(self.draft_tokens_buf[:num_decodes])
 

--- a/python/tokenspeed/runtime/layers/attention/backends/specific/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/specific/deepseek_v4.py
@@ -27,6 +27,7 @@ from tokenspeed_kernel.ops.attention.triton.dsv4 import (
     dsv4_combine_dense_swa_indices,
     dsv4_combine_topk_swa_indices,
     dsv4_compute_global_topk_indices_and_lens,
+    dsv4_decode_dense_compressed_indices_and_lens,
     dsv4_decode_swa_indices_and_lens,
     dsv4_dequantize_and_gather_k_cache,
     dsv4_indexer_decode_metadata_compute,
@@ -166,6 +167,8 @@ def _refresh_decode_indexer_schedule_metadata(
     metadata: DeepseekV4ForwardMetadata,
 ) -> None:
     indexer_metadata = metadata.indexer
+    refreshed_keys = indexer_metadata.decode_schedule_metadata_refreshed_keys
+    refreshed_keys.clear()
     if not indexer_metadata.decode_schedule_metadata_cache:
         return
     for (
@@ -211,6 +214,8 @@ def _refresh_decode_indexer_schedule_metadata(
         )
         if refreshed is not None and refreshed is not schedule_metadata:
             indexer_metadata.decode_schedule_metadata_cache[key] = refreshed
+        if refreshed is not None:
+            refreshed_keys.add(key)
 
 
 class DeepseekV4AttentionBackend(AttentionBackend):
@@ -267,6 +272,12 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         self._prefill_workspace_rows = 0
         self._prefill_workspace_head_dim = 0
         self._prefill_dense_compressed_indices_buffer: torch.Tensor | None = None
+        # FlashMLA SM100 decode requires a padded query-head width. Calls using
+        # one backend are stream ordered, so only the valid prefix needs to be
+        # refreshed after the zero-tailed workspace is initialized.
+        self._decode_q_padding_workspaces: dict[
+            tuple[torch.device, torch.dtype, int, int, int, int], torch.Tensor
+        ] = {}
         self._swa_window_size = 0
         self._swa_block_size = 0
         self.speculative_num_steps = int(config.speculative_num_steps)
@@ -947,7 +958,6 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         if compress_ratio <= 1:
             return None, None
         num_tokens = positions.numel()
-        req_idx = metadata.token_to_req_indices[:num_tokens].to(torch.int64)
         page_table = metadata.cache.compressed_page_table(compress_ratio)
         is_valid_token = (
             metadata.is_valid_token[:num_tokens]
@@ -984,35 +994,16 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             return cached
 
         width = self._dense_compressed_indices_width(compress_ratio)
-        compressed_lens = torch.div(
-            positions.to(torch.int64) + 1,
-            compress_ratio,
-            rounding_mode="floor",
-        ).clamp(0, width)
-        offsets = torch.arange(width, dtype=torch.int64, device=positions.device)
-        local = offsets[None, :].expand(num_tokens, -1)
-        valid = offsets[None, :] < compressed_lens[:, None]
-        if is_valid_token is not None:
-            valid = valid & is_valid_token.to(torch.bool)[:, None]
-        lens = compressed_lens.to(torch.int32)
-        if is_valid_token is not None:
-            lens = torch.where(
-                is_valid_token.to(torch.bool),
-                lens,
-                torch.zeros_like(lens),
-            )
-
-        safe_local = torch.where(valid, local, torch.zeros_like(local))
-        pages = torch.div(safe_local, block_size, rounding_mode="floor")
-        page_offsets = safe_local % block_size
-        page_ids = safe_page_ids(page_table, req_idx[:, None], pages.long())
-        slots = page_ids * block_size + page_offsets
-        indices_2d = torch.where(
-            valid & (page_ids >= 0),
-            slots,
-            torch.full_like(slots, -1),
+        indices_2d, lens = dsv4_decode_dense_compressed_indices_and_lens(
+            positions=positions,
+            token_to_req_indices=metadata.token_to_req_indices[:num_tokens],
+            block_table=page_table,
+            block_size=block_size,
+            compress_ratio=compress_ratio,
+            width=width,
+            is_valid_token=is_valid_token,
         )
-        indices = indices_2d.to(torch.int32).unsqueeze(1)
+        indices = indices_2d.unsqueeze(1)
         dense_indices_cache[cache_key] = (indices, lens)
         if capturing:
             capture_safe_keys.add(cache_key)
@@ -1024,6 +1015,46 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         width = max(1, (self.context_len + compress_ratio - 1) // compress_ratio)
         alignment = DEEPSEEK_V4_SPARSE_PREFILL_TOPK_ALIGNMENT
         return ((width + alignment - 1) // alignment) * alignment
+
+    def _pad_decode_query(
+        self,
+        q: torch.Tensor,
+        *,
+        padded_heads: int,
+    ) -> torch.Tensor:
+        """Return a FlashMLA query with an invariant zero-padded head tail."""
+        if q.ndim != 3:
+            raise ValueError(
+                "DeepSeek V4 decode query must have shape "
+                f"[tokens, heads, head_dim], got {tuple(q.shape)}"
+            )
+        num_heads = q.shape[1]
+        if num_heads > padded_heads:
+            raise ValueError(
+                "DeepSeek V4 decode padded_heads must cover all local heads: "
+                f"local_heads={num_heads}, padded_heads={padded_heads}"
+            )
+        if num_heads == padded_heads:
+            return q.contiguous()
+
+        key = (
+            q.device,
+            q.dtype,
+            q.shape[0],
+            num_heads,
+            padded_heads,
+            q.shape[2],
+        )
+        workspace = self._decode_q_padding_workspaces.get(key)
+        if workspace is None:
+            workspace = torch.zeros(
+                (q.shape[0], padded_heads, q.shape[2]),
+                dtype=q.dtype,
+                device=q.device,
+            )
+            self._decode_q_padding_workspaces[key] = workspace
+        workspace[:, :num_heads].copy_(q)
+        return workspace
 
     def _dense_prefill_local_compressed_indices(
         self,
@@ -1092,15 +1123,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 f"metadata_tokens={metadata.token_to_req_indices.numel()}, "
                 f"q_tokens={q.shape[0]}"
             )
-        if q.shape[1] == padded_heads:
-            q_padded = q.contiguous()
-        else:
-            q_padded = torch.zeros(
-                (q.shape[0], padded_heads, q.shape[2]),
-                dtype=q.dtype,
-                device=q.device,
-            )
-            q_padded[:, : q.shape[1]].copy_(q)
+        q_padded = self._pad_decode_query(q, padded_heads=padded_heads)
         swa_block_size = token_to_kv_pool.swa_block_size
         attention_metadata = metadata.attention
         if (

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4/metadata.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4/metadata.py
@@ -111,6 +111,9 @@ class DeepseekV4IndexerMetadata:
         default_factory=dict
     )
     decode_plan_refreshed_keys: set[tuple[int, int, int]] = field(default_factory=set)
+    decode_schedule_metadata_refreshed_keys: set[tuple[int, int, int]] = field(
+        default_factory=set
+    )
     prefill_plan_cache: dict[tuple[int, ...], DeepseekV4IndexerPrefillMetadata] = field(
         default_factory=dict
     )

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4/slot_mappings.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4/slot_mappings.py
@@ -52,6 +52,13 @@ class DeepseekV4ForwardSlotMappings:
     def clear(self) -> None:
         self._entries.clear()
 
+    def first_use(self, key: Hashable) -> bool:
+        """Return whether ``key`` is observed for the first time this forward."""
+        if key in self._entries:
+            return False
+        self._entries[key] = True
+        return True
+
     def get_or_compute(self, key: Hashable, compute: Callable[[], T]) -> T:
         """Return the mapping memoized under ``key``, computing it on the
         first request of the forward.

--- a/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
+++ b/python/tokenspeed/runtime/layers/attention/deepseek_v4_ops.py
@@ -82,6 +82,7 @@ def fused_qnorm_rope_kv_insert(
     rms_norm_eps: float,
     block_size: int,
     q_out: torch.Tensor | None = None,
+    validate_positions: bool = True,
 ) -> None:
     """Run the DeepSeek V4 fused SWA cache insert op.
 
@@ -104,6 +105,7 @@ def fused_qnorm_rope_kv_insert(
         rms_norm_eps=rms_norm_eps,
         page_size=block_size,
         q_out=q_out,
+        validate_positions=validate_positions,
     )
 
 
@@ -174,6 +176,7 @@ def deepseek_v4_prepare_indexer_q_mxfp4(
         weights=weights,
         softmax_scale=softmax_scale,
         head_scale=head_scale,
+        prefer_serial_four_block=True,
     )
 
 

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
@@ -91,13 +91,33 @@ class CacheArena:
         self._fields: dict[str, torch.Tensor] = {
             field.field_id: self._bind(field) for field in plan.fields
         }
+        plan_groups = {group.group_id: group for group in plan.groups}
+        self._block_segment_geometry_by_group = {
+            group_id: (
+                plan_groups[group_id].page_count,
+                tuple(
+                    (
+                        self.field_block_byte_offset(field.field_id, 0),
+                        field.page_stride_bytes,
+                        field.payload_bytes,
+                    )
+                    for field in plan.fields
+                    if field.group_id == group_id
+                ),
+            )
+            for group_id in plan_groups
+        }
+        logger.info(
+            "Cached cache zero-segment geometry: groups=%d fields=%d",
+            len(self._block_segment_geometry_by_group),
+            len(plan.fields),
+        )
         # The contract joins the recipe's logical specs with the plan's
         # physical facts for the same groups. The plan owns page counts and
         # packing; the contract carries them beside the specs rather than
         # copying them in, and the recipe packs the plan from the same
         # (spec, fields) pairs these specs come from, so both name one group
         # set by construction.
-        plan_groups = {group.group_id: group for group in plan.groups}
         self.runtime_contract = CacheRuntimeContract(
             # The identity axis comes from the plan, never read back out of
             # view state. Per-group CacheBlock spans live in the group specs
@@ -234,15 +254,26 @@ class CacheArena:
     def block_byte_segments(
         self, group_id: str, block_ids: list[int]
     ) -> list[tuple[int, int]]:
-        self.plan.group(group_id)
-        fields = [field for field in self.plan.fields if field.group_id == group_id]
+        try:
+            page_count, fields = self._block_segment_geometry_by_group[group_id]
+        except KeyError:
+            self.plan.group(group_id)
+            raise AssertionError("plan group exists without cached geometry") from None
+        for block_id in block_ids:
+            if (
+                isinstance(block_id, bool)
+                or not isinstance(block_id, int)
+                or block_id < 0
+                or block_id >= page_count
+            ):
+                raise IndexError(
+                    f"page_id {block_id} outside [0, {page_count}) for "
+                    f"group {group_id!r}"
+                )
         return [
-            (
-                self.field_block_byte_offset(field.field_id, block_id),
-                field.payload_bytes,
-            )
+            (base_offset + block_id * page_stride, payload_bytes)
             for block_id in block_ids
-            for field in fields
+            for base_offset, page_stride, payload_bytes in fields
         ]
 
     @property

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -387,6 +387,7 @@ class LogitsProcessor(nn.Module):
         *,
         max_M: int,
         skip_ping_pong: bool,
+        dtype: torch.dtype | None = None,
     ) -> DistArgmaxState | None:
         """Build this TP group's distributed-argmax state, or None to fall back.
 
@@ -401,17 +402,27 @@ class LogitsProcessor(nn.Module):
             max_M: Largest row count the caller will ever pass.
             skip_ping_pong: Pin the slot band instead of alternating; only
                 when the caller synchronizes across ranks between calls.
+            dtype: Value dtype of the logits. Defaults to the LM-head weight
+                dtype; callers with an FP32 correction path may override it.
 
         Returns:
             The state, or None when this group must use the gather path.
         """
-        key = (self.tp_group, lm_head.weight.size(0), max_M, skip_ping_pong)
+        resolved_dtype = dtype or lm_head.weight.dtype
+        device = lm_head.weight.device
+        key = (
+            self.tp_group,
+            lm_head.weight.size(0),
+            max_M,
+            skip_ping_pong,
+            resolved_dtype,
+            device,
+        )
         if key in self._LOGITS_DIST_ARGMAX_STATES:
             return self._LOGITS_DIST_ARGMAX_STATES[key]
         if torch.cuda.is_current_stream_capturing():
             return None  # never rendezvous inside capture; warmup probes first
 
-        device = lm_head.weight.device
         group = pg_manager.get_process_group("nccl", self.tp_group)
         if self._agree_across_tp(
             current_platform().is_nvidia and dist_argmax_available(), group, device
@@ -420,7 +431,7 @@ class LogitsProcessor(nn.Module):
                 group=group,
                 rank_in_group=self.tp_rank,
                 max_M=max_M,
-                dtype=lm_head.weight.dtype,
+                dtype=resolved_dtype,
                 device=device,
                 skip_ping_pong=skip_ping_pong,
             )

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -28,6 +28,7 @@ until the HCA/CSA cache kernels are wired into TokenSpeed.
 from __future__ import annotations
 
 import gc
+import os
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -61,6 +62,9 @@ from tokenspeed_kernel import (
 from tokenspeed_kernel import mhc_fused_hc as fast_mhc_fused_hc
 from tokenspeed_kernel import mhc_post as fast_mhc_post
 from tokenspeed_kernel import mhc_pre as fast_mhc_pre
+from tokenspeed_kernel import (
+    pack_topk_router_logits,
+)
 from tokenspeed_kernel.ops.attention.triton.dsv4 import (
     dsv4_indexer_decode_metadata_compute,
 )
@@ -249,6 +253,8 @@ def mhc_pre(
     rms_eps: float,
     hc_eps: float,
     sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     return fast_mhc_pre(
         residual,
@@ -258,6 +264,8 @@ def mhc_pre(
         rms_eps,
         hc_eps,
         sinkhorn_iters,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
     )
 
 
@@ -281,6 +289,8 @@ def mhc_fused_hc(
     rms_eps: float,
     hc_eps: float,
     sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     return fast_mhc_fused_hc(
         x_prev,
@@ -293,6 +303,8 @@ def mhc_fused_hc(
         rms_eps,
         hc_eps,
         sinkhorn_iters,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
     )
 
 
@@ -326,15 +338,7 @@ def pack_topk_as_router_logits(
     selected ids and weights without changing the shared backend.
     """
 
-    router_logits = torch.full(
-        (topk_ids.shape[0], num_experts),
-        -1e20,
-        dtype=torch.float32,
-        device=topk_weights.device,
-    )
-    safe_weights = topk_weights.clamp_min(torch.finfo(torch.float32).tiny)
-    router_logits.scatter_(1, topk_ids.long(), safe_weights.log())
-    return router_logits
+    return pack_topk_router_logits(topk_weights, topk_ids, num_experts)
 
 
 @dataclass(frozen=True)
@@ -906,9 +910,24 @@ def _deepseek_v4_indexer_decode_schedule_metadata(
         if indexer_metadata is None
         else indexer_metadata.decode_schedule_metadata_cache
     )
+    refreshed_keys = (
+        None
+        if indexer_metadata is None
+        else indexer_metadata.decode_schedule_metadata_refreshed_keys
+    )
     schedule_metadata = (
         schedule_cache.get(schedule_key) if schedule_cache is not None else None
     )
+    # The attention backend refreshes cached schedule buffers once after the
+    # decode metadata changes.  Every indexer layer sees the same positions and
+    # geometry, so re-planning and copying the same schedule per layer only adds
+    # graph work without changing the result.
+    if (
+        schedule_metadata is not None
+        and refreshed_keys is not None
+        and schedule_key in refreshed_keys
+    ):
+        return schedule_metadata
 
     with nvtx_range("indexer_decode_schedule_metadata"):
         refreshed = dsv4_plan(
@@ -925,13 +944,19 @@ def _deepseek_v4_indexer_decode_schedule_metadata(
         ):
             with torch.inference_mode():
                 schedule_metadata.copy_(refreshed)
+            if refreshed_keys is not None:
+                refreshed_keys.add(schedule_key)
             return schedule_metadata
         if schedule_cache is not None:
             schedule_cache[schedule_key] = refreshed
+        if refreshed_keys is not None:
+            refreshed_keys.add(schedule_key)
         return refreshed
     schedule_metadata = refreshed
     if schedule_cache is not None:
         schedule_cache[schedule_key] = schedule_metadata
+    if refreshed_keys is not None:
+        refreshed_keys.add(schedule_key)
     return schedule_metadata
 
 
@@ -1537,6 +1562,7 @@ def dsv4_select_experts(
     hash_indices_table: torch.Tensor | None = None,
     input_ids: torch.Tensor | None = None,
     need_scores: bool = True,
+    hash_table_values_validated: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Use an accelerator router when available, otherwise run eager routing."""
     try:
@@ -1548,6 +1574,7 @@ def dsv4_select_experts(
             hash_indices_table,
             input_ids,
             need_scores,
+            hash_table_values_validated=hash_table_values_validated,
         )
     except (NoKernelFoundError, AttributeError, RuntimeError):
         pass
@@ -1627,6 +1654,17 @@ class DeepseekV4MoEGate(nn.Module):
         else:
             self.register_parameter("tid2eid", None)
             self.e_score_correction_bias = None
+
+    def validate_hash_indices_table(self, num_experts: int) -> None:
+        """Validate the complete immutable hash-routing table after loading."""
+
+        if self.tid2eid is None:
+            return
+        valid = ((self.tid2eid >= 0) & (self.tid2eid < num_experts)).all()
+        if not bool(valid.item()):
+            raise ValueError(
+                f"hash_indices_table entries must be in [0, {num_experts})"
+            )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return dsv4_linear_fp32(
@@ -1836,6 +1874,7 @@ class DeepseekV4MoE(nn.Module):
         self.layer_index = layer_index
         self.n_shared_experts = config.n_shared_experts
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+        self._hash_table_values_validated = False
         self.scoring_func = getattr(config, "scoring_func", "sqrtsoftplus")
         if self.scoring_func != "sqrtsoftplus":
             raise ValueError(
@@ -1943,7 +1982,15 @@ class DeepseekV4MoE(nn.Module):
                 activation="swiglu",
                 swiglu_limit=getattr(config, "swiglu_limit", None),
                 with_bias=False,
-                routing_mode="precomputed_topk",
+                # FlashInfer's standard MXFP4 kernel performs routing in-kernel.
+                # Keep precomputed top-k for backends that require it; for
+                # FlashInfer, MoELayer repacks the already-selected routes into
+                # router logits before invoking the kernel.
+                routing_mode=(
+                    None
+                    if get_moe_backend().is_flashinfer_trtllm()
+                    else "precomputed_topk"
+                ),
                 routing_config={
                     "routed_scaling_factor": self.routed_scaling_factor,
                     "normalize_topk_weights": config.norm_topk_prob,
@@ -1958,6 +2005,23 @@ class DeepseekV4MoE(nn.Module):
                 routed_scaling_factor=self.routed_scaling_factor,
                 output_format=self.experts.topk_output_format,
             )
+
+    def process_hash_routing_table_after_loading(self) -> None:
+        """Optionally validate an immutable hash table before graph capture."""
+
+        if not self.gate.is_hash_moe:
+            return
+        requested = os.getenv("TOKENSPEED_DSV4_TRUST_VALIDATED_HASH_TABLE", "0") == "1"
+        if requested:
+            self.gate.validate_hash_indices_table(self.config.n_routed_experts)
+            self._hash_table_values_validated = True
+        logger.info(
+            "DSV4_HASH_TABLE_VALIDATION rank=%d layer=%d requested=%s enabled=%s",
+            int(self.mapping.rank),
+            int(self.layer_index),
+            requested,
+            self._hash_table_values_validated,
+        )
 
     def _select_experts(
         self,
@@ -1975,6 +2039,7 @@ class DeepseekV4MoE(nn.Module):
             hash_indices_table=self.gate.tid2eid,
             input_ids=input_ids,
             need_scores=need_scores,
+            hash_table_values_validated=self._hash_table_values_validated,
         )
 
     def _make_topk_output(
@@ -2999,6 +3064,7 @@ class DeepseekV4Attention(nn.Module):
         positions: torch.Tensor,
         cos_sin_cache: torch.Tensor,
         block_size: int,
+        validate_positions: bool,
     ) -> None:
         # slot_mapping arrives pre-sanitized from _deepseek_v4_swa_slot_mapping
         # (invalid tokens and out-of-capacity slots masked to -1); sanitizing
@@ -3014,6 +3080,7 @@ class DeepseekV4Attention(nn.Module):
             cos_sin_cache=cos_sin_cache,
             rms_norm_eps=self.q_norm.variance_epsilon,
             block_size=block_size,
+            validate_positions=validate_positions,
         )
 
     def _project_attention_output(
@@ -3079,6 +3146,14 @@ class DeepseekV4Attention(nn.Module):
                 hidden_states,
             )
 
+        # Every layer sees the same position values.  Keep the public kernel
+        # check enabled, but execute its five comparison/reduction/assert
+        # launches only once per distinct RoPE-cache capacity in this forward.
+        position_capacity = int(cos_sin_cache.shape[0])
+        validate_positions = slot_mappings.first_use(
+            ("position_capacity", position_capacity)
+        )
+
         # --- Phase 1: pre-compute input GEMMs in parallel ---
         # Q/KV projection on main stream; compressor GEMM(s) on aux stream.
         # After this phase, each compressor's forward() receives its
@@ -3118,6 +3193,7 @@ class DeepseekV4Attention(nn.Module):
                     positions=positions,
                     cos_sin_cache=cos_sin_cache,
                     block_size=pool.swa_block_size,
+                    validate_positions=validate_positions,
                 )
 
         def run_compressor() -> None:
@@ -3356,6 +3432,8 @@ class DeepseekV4DecoderLayer(nn.Module):
                     self.rms_norm_eps,
                     self.hc_eps,
                     self.hc_sinkhorn_iters,
+                    norm_weight=self.attn_norm.weight,
+                    norm_eps=self.attn_norm.variance_epsilon,
                 )
         else:
             residual = hidden_states
@@ -3368,9 +3446,9 @@ class DeepseekV4DecoderLayer(nn.Module):
                     self.rms_norm_eps,
                     self.hc_eps,
                     self.hc_sinkhorn_iters,
+                    norm_weight=self.attn_norm.weight,
+                    norm_eps=self.attn_norm.variance_epsilon,
                 )
-        with nvtx_range("attn_norm"):
-            hidden_states = self.attn_norm(hidden_states)
 
         with nvtx_range("attn_total"):
             hidden_states = self.attn(positions, hidden_states, ctx)
@@ -3387,9 +3465,9 @@ class DeepseekV4DecoderLayer(nn.Module):
                 self.rms_norm_eps,
                 self.hc_eps,
                 self.hc_sinkhorn_iters,
+                norm_weight=self.ffn_norm.weight,
+                norm_eps=self.ffn_norm.variance_epsilon,
             )
-        with nvtx_range("ffn_norm"):
-            hidden_states = self.ffn_norm(hidden_states)
 
         ffn_input_ids = input_ids
         use_mega_moe = getattr(self.ffn, "use_mega_moe", False)
@@ -3783,7 +3861,9 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
 
     def post_load_weights(self):
         for module in self.modules():
-            if isinstance(module, DeepseekV4Compressor):
+            if isinstance(module, DeepseekV4MoE):
+                module.process_hash_routing_table_after_loading()
+            elif isinstance(module, DeepseekV4Compressor):
                 module.process_weights_after_loading()
             elif isinstance(module, DeepseekV4MegaMoEExperts):
                 module.finalize_weights()

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
@@ -17,6 +17,7 @@ from tokenspeed_kernel import mhc_fused_hc, mhc_post, mhc_pre
 from torch import nn
 from transformers import PretrainedConfig
 
+from tokenspeed.runtime.distributed.comm_ops import all_gather
 from tokenspeed.runtime.distributed.mapping import Mapping
 from tokenspeed.runtime.execution.context import ForwardContext
 from tokenspeed.runtime.layers.layernorm import RMSNorm
@@ -116,10 +117,66 @@ _ZERO_INITIALIZED_EXPERT_BIAS_SUFFIXES = (
     ".experts.w13_weight_bias",
     ".experts.w2_weight_bias",
 )
+_REPLICATE_VOCAB_HEADS_ENV = "TOKENSPEED_DSPARK_REPLICATE_VOCAB_HEADS"
+_REPLICATE_MARKOV_EMBEDDING_ENV = "TOKENSPEED_DSPARK_REPLICATE_MARKOV_EMBEDDING"
 
 
 def _is_zero_initialized_expert_bias(name: str) -> bool:
     return name.endswith(_ZERO_INITIALIZED_EXPERT_BIAS_SUFFIXES)
+
+
+def _replicate_dspark_vocab_weight(
+    local_weight: torch.Tensor,
+    module: VocabParallelEmbedding,
+    mapping: Mapping,
+    *,
+    label: str,
+) -> torch.Tensor:
+    """Reconstruct an unpadded vocabulary weight in TP-rank order.
+
+    This candidate intentionally supports only the DeepSeek V4 checkpoint
+    layout with no base-vocabulary padding or added vocabulary. Other layouts
+    need an explicit reindexing step and therefore fail closed here.
+    """
+
+    tp_size = int(mapping.attn.tp_size)
+    if int(module.tp_size) != 1:
+        raise ValueError(f"Replicated DSpark {label} module must use tp_size=1.")
+    if local_weight.ndim != 2:
+        raise ValueError(
+            f"DSpark target {label} weight must be rank 2; "
+            f"got {tuple(local_weight.shape)}."
+        )
+    if int(module.num_added_embeddings) != 0 or int(
+        module.org_vocab_size_padded
+    ) != int(module.org_vocab_size):
+        raise ValueError(
+            f"Replicated DSpark {label} requires an unpadded base-only vocabulary."
+        )
+    expected_full_rows = int(module.num_embeddings_padded)
+    if expected_full_rows % tp_size != 0:
+        raise ValueError(
+            f"Replicated DSpark {label} vocabulary size {expected_full_rows} "
+            f"is not divisible by TP size {tp_size}."
+        )
+    expected_local_rows = expected_full_rows // tp_size
+    if local_weight.shape[0] != expected_local_rows:
+        raise ValueError(
+            f"DSpark target {label} shard has {local_weight.shape[0]} rows; "
+            f"expected {expected_local_rows} for TP{tp_size}."
+        )
+    full_weight = all_gather(
+        local_weight.contiguous(),
+        mapping.attn.tp_group,
+        dim=0,
+    )
+    expected_shape = (expected_full_rows, local_weight.shape[1])
+    if tuple(full_weight.shape) != expected_shape:
+        raise RuntimeError(
+            f"DSpark replicated {label} shape mismatch: "
+            f"expected {expected_shape}, got {tuple(full_weight.shape)}."
+        )
+    return full_weight.contiguous()
 
 
 def count_dspark_stages(
@@ -310,6 +367,22 @@ class DeepseekV4DSparkModel(nn.Module):
                 "Week-0 DSpark supports only the vanilla Markov head; "
                 f"got {markov_kind!r}."
             )
+        self.replicate_vocab_heads = os.getenv(_REPLICATE_VOCAB_HEADS_ENV, "0") == "1"
+        self.replicate_markov_embedding = self.replicate_vocab_heads or (
+            os.getenv(_REPLICATE_MARKOV_EMBEDDING_ENV, "0") == "1"
+        )
+        target_vocab_parallel_kwargs = (
+            {}
+            if self.replicate_vocab_heads
+            else {
+                "tp_rank": mapping.attn.tp_rank,
+                "tp_size": mapping.attn.tp_size,
+                "tp_group": mapping.attn.tp_group,
+            }
+        )
+        markov_embedding_parallel_kwargs = (
+            {} if self.replicate_markov_embedding else target_vocab_parallel_kwargs
+        )
 
         self.stages = nn.ModuleList(
             [
@@ -328,33 +401,36 @@ class DeepseekV4DSparkModel(nn.Module):
         self.embed_tokens = VocabParallelEmbedding(
             int(config.vocab_size),
             self.hidden_size,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
             prefix=add_prefix("embed_tokens", prefix),
+            **target_vocab_parallel_kwargs,
         )
         self.markov_embedding = VocabParallelEmbedding(
             int(config.vocab_size),
             self.markov_rank,
             params_dtype=torch.float32,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
             prefix=add_prefix("markov_embedding", prefix),
+            **markov_embedding_parallel_kwargs,
         )
         self.markov_projection = ParallelLMHead(
             int(config.vocab_size),
             self.markov_rank,
             params_dtype=torch.float32,
             quant_config=None,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
             prefix=add_prefix("markov_projection", prefix),
+            **target_vocab_parallel_kwargs,
         )
         self.markov_head = DSparkVanillaMarkov(
             self.markov_embedding,
             self.markov_projection,
+        )
+        logger.info(
+            "DSPARK_VOCAB_LAYOUT rank=%d target_embedding_tp=%d "
+            "target_lm_head_tp=pending markov_embedding_tp=%d "
+            "markov_projection_tp=%d",
+            mapping.rank,
+            self.embed_tokens.tp_size,
+            self.markov_embedding.tp_size,
+            self.markov_projection.tp_size,
         )
         self.confidence_projection = ReplicatedLinear(
             self.hidden_size + self.markov_rank,
@@ -365,6 +441,9 @@ class DeepseekV4DSparkModel(nn.Module):
             prefix=add_prefix("confidence_projection", prefix),
         )
         self.confidence_head = DSparkConfidenceHead(self.confidence_projection)
+        self.register_buffer("_local_base_head_fp32", None, persistent=False)
+        self._local_base_head_source_ptr: int | None = None
+        self._local_base_head_source_version: int | None = None
 
         head_dim = int(getattr(config, "head_dim"))
         self.attention_params = {
@@ -531,9 +610,66 @@ class DeepseekV4DSparkModel(nn.Module):
     def local_base_logits(
         self,
         hidden_states: torch.Tensor,
-        lm_head: nn.Module,
+        lm_head: nn.Module | None = None,
     ) -> torch.Tensor:
-        return torch.matmul(hidden_states.float(), lm_head.weight.float().T)
+        """Compute public FP32 base logits from the local vocabulary shard.
+
+        Production DSpark replay uses a stable FP32 head buffer initialized by
+        ``set_embed_and_head``. The optional head keeps the uncached reference
+        path available for callers that do not wire a target model.
+        """
+
+        if lm_head is not None:
+            head_fp32 = lm_head.weight.float()
+        else:
+            head_fp32 = getattr(self, "_local_base_head_fp32", None)
+            if head_fp32 is None:
+                raise RuntimeError(
+                    "DSpark local base logits require a cached target LM head."
+                )
+        return torch.matmul(hidden_states.float(), head_fp32.T)
+
+    def refresh_local_base_logits_head(self, head: torch.Tensor) -> bool:
+        """Refresh the stable FP32 local-head buffer after a weight update.
+
+        Returns ``True`` when the buffer was initialized or updated. Once the
+        buffer exists, its storage address and shape stay fixed so CUDA Graph
+        replays remain valid.
+        """
+
+        if head.ndim != 2:
+            raise ValueError(
+                "DSpark target LM-head weight must be rank 2; "
+                f"got shape {tuple(head.shape)}."
+            )
+        source_ptr = head.data_ptr()
+        source_version = int(head._version)
+        cached = self._local_base_head_fp32
+        if cached is None:
+            cached = torch.empty(
+                head.shape,
+                dtype=torch.float32,
+                device=head.device,
+            )
+            with torch.no_grad():
+                cached.copy_(head)
+            self._local_base_head_fp32 = cached
+        elif (
+            source_ptr == self._local_base_head_source_ptr
+            and source_version == self._local_base_head_source_version
+        ):
+            return False
+        else:
+            if cached.shape != head.shape or cached.device != head.device:
+                raise RuntimeError(
+                    "DSpark target LM-head shape or device changed after the "
+                    "FP32 replay buffer was initialized."
+                )
+            with torch.no_grad():
+                cached.copy_(head)
+        self._local_base_head_source_ptr = source_ptr
+        self._local_base_head_source_version = source_version
+        return True
 
     def write_context_windows_batched(
         self,
@@ -605,10 +741,21 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
             int(config.vocab_size),
             int(config.hidden_size),
             quant_config=quant_config,
-            tp_rank=mapping.attn.tp_rank,
-            tp_size=mapping.attn.tp_size,
-            tp_group=mapping.attn.tp_group,
             prefix=add_prefix("lm_head", prefix),
+            **(
+                {}
+                if self.model.replicate_vocab_heads
+                else {
+                    "tp_rank": mapping.attn.tp_rank,
+                    "tp_size": mapping.attn.tp_size,
+                    "tp_group": mapping.attn.tp_group,
+                }
+            ),
+        )
+        logger.info(
+            "DSPARK_TARGET_LM_HEAD_LAYOUT rank=%d target_lm_head_tp=%d",
+            mapping.rank,
+            self.lm_head.tp_size,
         )
 
     def get_hot_token_id(self):
@@ -618,10 +765,32 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed: torch.Tensor, head: torch.Tensor) -> None:
+        if self.model.replicate_vocab_heads:
+            embed = _replicate_dspark_vocab_weight(
+                embed,
+                self.model.embed_tokens,
+                self.mapping,
+                label="embedding",
+            )
+            head = _replicate_dspark_vocab_weight(
+                head,
+                self.lm_head,
+                self.mapping,
+                label="LM head",
+            )
+            logger.info(
+                "DSPARK_REPLICATED_VOCAB_HEADS_PASS rank=%d tp=%d "
+                "embedding_shape=%s head_shape=%s",
+                self.mapping.rank,
+                self.mapping.attn.tp_size,
+                tuple(embed.shape),
+                tuple(head.shape),
+            )
         del self.model.embed_tokens.weight
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
+        self.model.refresh_local_base_logits_head(head)
         torch.cuda.empty_cache()
         torch.cuda.synchronize()
 

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/attention.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/attention.py
@@ -17,6 +17,9 @@ from __future__ import annotations
 
 import torch
 import torch.nn.functional as F
+from tokenspeed_kernel import fp8_quantize_dequantize
+from tokenspeed_kernel.ops.layernorm import grouped_rmsnorm as kernel_grouped_rmsnorm
+from tokenspeed_kernel.ops.layernorm import rmsnorm as kernel_rmsnorm
 
 
 def dspark_fp8_quant_dequant(
@@ -30,6 +33,8 @@ def dspark_fp8_quant_dequant(
             "DSpark FP8 activation width must be divisible by block_size; "
             f"got width={x.shape[-1]}, block_size={block_size}."
         )
+    if x.is_cuda:
+        return fp8_quantize_dequantize(x, group_size=block_size)
     original_dtype = x.dtype
     blocks = x.float().unflatten(-1, (-1, block_size))
     absmax = blocks.abs().amax(dim=-1, keepdim=True).clamp_min(1e-4)
@@ -178,11 +183,37 @@ def dspark_sparse_attn(
     return output.to(q.dtype)
 
 
-def _rmsnorm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+def _rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Apply DSpark RMSNorm through the platform kernel on accelerators."""
+
+    if x.is_cuda:
+        return kernel_rmsnorm(x, weight, eps)
     original_dtype = x.dtype
     normalized = x.float()
     normalized.mul_(torch.rsqrt(normalized.square().mean(-1, keepdim=True) + eps))
     return (weight.float() * normalized).to(original_dtype)
+
+
+# Public name for direct contract tests while preserving the historical private
+# helper imported by the DSpark model implementation.
+dspark_rmsnorm = _rmsnorm
+
+
+def _normalize_query_per_head(
+    query: torch.Tensor,
+    head_dim: int,
+    eps: float,
+) -> torch.Tensor:
+    """Normalize every query head without materializing intermediate tensors."""
+
+    if query.is_cuda:
+        return kernel_grouped_rmsnorm(query, head_dim, eps, out=query)
+    query.mul_(torch.rsqrt(query.square().mean(-1, keepdim=True) + eps))
+    return query
 
 
 def _rope_last_dims_batched(
@@ -239,7 +270,7 @@ def dspark_attention_forward_batched(
     )
     block_freqs = freqs_cis[block_positions]
 
-    main_kv = _rmsnorm(_dspark_fp8_linear(main_x, wkv), kv_norm_w, eps)
+    main_kv = dspark_rmsnorm(_dspark_fp8_linear(main_x, wkv), kv_norm_w, eps)
     main_kv = _rope_last_dims_batched(
         main_kv,
         rope_head_dim,
@@ -247,16 +278,16 @@ def dspark_attention_forward_batched(
     )
     main_kv = _quantize_dspark_non_rope(main_kv, rope_head_dim)
 
-    query = _rmsnorm(_dspark_fp8_linear(x, wq_a), q_norm_w, eps)
+    query = dspark_rmsnorm(_dspark_fp8_linear(x, wq_a), q_norm_w, eps)
     query = _dspark_fp8_linear(query, wq_b).unflatten(-1, (n_heads, head_dim))
-    query.mul_(torch.rsqrt(query.square().mean(-1, keepdim=True) + eps))
+    query = _normalize_query_per_head(query, head_dim, eps)
     query = _rope_last_dims_batched(
         query,
         rope_head_dim,
         block_freqs,
     )
 
-    block_kv = _rmsnorm(_dspark_fp8_linear(x, wkv), kv_norm_w, eps)
+    block_kv = dspark_rmsnorm(_dspark_fp8_linear(x, wkv), kv_norm_w, eps)
     block_kv = _rope_last_dims_batched(
         block_kv,
         rope_head_dim,

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/heads.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/heads.py
@@ -7,6 +7,13 @@
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    DistArgmaxState,
+)
+from tokenspeed_kernel.ops.sampling.cute_dsl import _invoke_kernel as _cute_local_argmax
+from tokenspeed_kernel.ops.sampling.cute_dsl import (
+    distributed_argmax,
+)
 from torch import nn
 
 from tokenspeed.runtime.distributed.comm_ops import all_gather_into_tensor
@@ -18,22 +25,14 @@ def _local_vocab_argmax(
     tp_group,
     gathered_values: torch.Tensor,
     gathered_ids: torch.Tensor,
+    dist_argmax_state: DistArgmaxState | None = None,
+    dist_argmax_max: torch.Tensor | None = None,
+    dist_argmax_ids: torch.Tensor | None = None,
+    local_cute_argmax: bool = False,
+    local_argmax_max: torch.Tensor | None = None,
+    local_argmax_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Return global argmax IDs for vocab-sharded logits."""
-
-    if (
-        gathered_values.ndim != 2
-        or gathered_ids.ndim != 2
-        or gathered_values.shape != gathered_ids.shape
-        or gathered_values.shape[1] < local_logits.shape[0]
-    ):
-        raise ValueError(
-            "DSpark TP gather workspaces must be matching [tp_size, capacity] "
-            "tensors with capacity for every active row."
-        )
-    if not gathered_values.is_contiguous() or not gathered_ids.is_contiguous():
-        raise ValueError("DSpark TP gather workspaces must be contiguous.")
-
     shard = lm_head.shard_indices
     num_org = int(shard.num_org_elements)
     num_org_padded = int(shard.num_org_elements_padded)
@@ -42,7 +41,58 @@ def _local_vocab_argmax(
     added_vocab_start = int(shard.added_vocab_start_index)
     rows = local_logits.shape[0]
 
-    if num_org > 0:
+    if dist_argmax_state is not None:
+        if (
+            num_added != 0
+            or num_org_padded != num_org
+            or local_logits.shape[1] != num_org
+        ):
+            raise ValueError(
+                "DSpark distributed argmax requires an unpadded base-only "
+                "local vocabulary shard."
+            )
+        if dist_argmax_max is None or dist_argmax_ids is None:
+            raise ValueError(
+                "DSpark distributed argmax requires preallocated max/id scratch."
+            )
+        max_out = dist_argmax_max[:rows]
+        ids_out = dist_argmax_ids[:rows]
+        _, global_ids = distributed_argmax(
+            dist_argmax_state,
+            local_logits.contiguous(),
+            out_max=max_out,
+            out_idx=ids_out,
+        )
+        return global_ids.to(torch.int32)
+
+    if local_cute_argmax:
+        if dist_argmax_state is not None:
+            raise ValueError(
+                "DSpark local and distributed CuTe argmax paths are mutually exclusive."
+            )
+        if (
+            num_added != 0
+            or num_org_padded != num_org
+            or local_logits.shape[1] != num_org
+        ):
+            raise ValueError(
+                "DSpark local CuTe argmax requires an unpadded base-only local "
+                "vocabulary shard."
+            )
+        if local_argmax_max is None or local_argmax_ids is None:
+            raise ValueError(
+                "DSpark local CuTe argmax requires preallocated max/id scratch."
+            )
+        if local_argmax_max.dtype != torch.float32:
+            raise ValueError("DSpark local CuTe argmax max scratch must be float32.")
+        if local_argmax_ids.dtype != torch.int64:
+            raise ValueError("DSpark local CuTe argmax ID scratch must be int64.")
+        if not local_logits.is_contiguous():
+            raise ValueError("DSpark local CuTe argmax logits must be contiguous.")
+        local_max = local_argmax_max[:rows]
+        local_arg = local_argmax_ids[:rows]
+        _cute_local_argmax(local_logits, local_max, local_arg)
+    elif num_org > 0:
         local_max, local_arg = torch.max(local_logits[:, :num_org], dim=-1)
     else:
         local_max = torch.full(
@@ -81,9 +131,23 @@ def _local_vocab_argmax(
             local_arg[~is_base] - num_org_padded
         )
 
-    tp_size = gathered_values.shape[0]
+    tp_size = int(getattr(lm_head, "tp_size", gathered_values.shape[0]))
     if tp_size == 1:
         return global_ids.to(torch.int32)
+
+    if (
+        gathered_values.ndim != 2
+        or gathered_ids.ndim != 2
+        or gathered_values.shape != gathered_ids.shape
+        or gathered_values.shape[0] != tp_size
+        or gathered_values.shape[1] < local_logits.shape[0]
+    ):
+        raise ValueError(
+            "DSpark TP gather workspaces must be matching [tp_size, capacity] "
+            "tensors with capacity for every active row."
+        )
+    if not gathered_values.is_contiguous() or not gathered_ids.is_contiguous():
+        raise ValueError("DSpark TP gather workspaces must be contiguous.")
 
     flat_values = gathered_values.reshape(-1)[: tp_size * rows]
     flat_ids = gathered_ids.reshape(-1)[: tp_size * rows]
@@ -153,6 +217,12 @@ def sample_dspark_block_greedy(
     gathered_values: torch.Tensor,
     gathered_ids: torch.Tensor,
     output: torch.Tensor,
+    dist_argmax_state: DistArgmaxState | None = None,
+    dist_argmax_max: torch.Tensor | None = None,
+    dist_argmax_ids: torch.Tensor | None = None,
+    local_cute_argmax: bool = False,
+    local_argmax_max: torch.Tensor | None = None,
+    local_argmax_ids: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Apply the trained Markov correction and greedily sample a fixed block."""
 
@@ -165,6 +235,12 @@ def sample_dspark_block_greedy(
             tp_group,
             gathered_values,
             gathered_ids,
+            dist_argmax_state,
+            dist_argmax_max,
+            dist_argmax_ids,
+            local_cute_argmax,
+            None if local_argmax_max is None else local_argmax_max[step],
+            None if local_argmax_ids is None else local_argmax_ids[step],
         )
         output[:, step] = previous
     return output

--- a/test/runtime/execution/test_draft_target_wiring.py
+++ b/test/runtime/execution/test_draft_target_wiring.py
@@ -209,6 +209,8 @@ def test_dflash_wire_target_installs_capture_layers():
 def test_dspark_wire_target_installs_capture_layers():
     drafter = mock.MagicMock(spec=DeepseekV4DSpark)
     drafter.target_layer_ids = [10, 20]
+    draft_head = mock.MagicMock()
+    drafter.draft_model = mock.MagicMock(lm_head=draft_head)
     target_model = mock.MagicMock(
         spec=["lm_head", "logits_processor", "set_dspark_layers_to_capture"]
     )
@@ -216,7 +218,7 @@ def test_dspark_wire_target_installs_capture_layers():
     DeepseekV4DSpark.wire_target(drafter, target_model)
 
     target_model.set_dspark_layers_to_capture.assert_called_once_with([10, 20])
-    assert drafter.lm_head is target_model.lm_head
+    assert drafter.lm_head is draft_head
 
 
 # --------------------------------------------------------------------------

--- a/test/runtime/test_cache_pool.py
+++ b/test/runtime/test_cache_pool.py
@@ -104,6 +104,28 @@ class CacheArenaContractTest(unittest.TestCase):
         # 2 parents * 2 history blocks per parent * P=4.
         self.assertEqual(arena.size, 16)
 
+    def test_block_segments_match_the_canonical_plan_geometry(self):
+        arena = _arena()
+
+        expected = [
+            (
+                arena.plan.field_page_byte_offset(field.field_id, block_id),
+                field.payload_bytes,
+            )
+            for block_id in (0, 2)
+            for field in arena.plan.fields
+            if field.group_id == "history"
+        ]
+
+        self.assertEqual(arena.block_byte_segments("history", [0, 2]), expected)
+
+    def test_block_segments_reject_invalid_ids_before_expansion(self):
+        arena = _arena()
+
+        for invalid in (-1, True, arena.plan.group("history").page_count):
+            with self.subTest(invalid=invalid), self.assertRaises(IndexError):
+                arena.block_byte_segments("history", [invalid])
+
 
 class CachePoolViewTest(unittest.TestCase):
     def test_a_pool_reports_the_arena_it_views(self):

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 from io import StringIO
 from types import MethodType, SimpleNamespace
 from typing import ClassVar
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -109,6 +109,10 @@ from tokenspeed.runtime.layers.quantization import (
     Fp8Config,
     Mxfp4Config,
 )
+from tokenspeed.runtime.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
 from tokenspeed.runtime.models import deepseek_v4 as deepseek_v4_model
 from tokenspeed.runtime.models.deepseek_v4 import (
     DeepseekV4ForCausalLM,
@@ -143,15 +147,21 @@ from tokenspeed.runtime.models.deepseek_v4_dspark import (
     DeepseekV4ForCausalLMDSpark,
     _apply_dspark_hc_head,
     _is_zero_initialized_expert_bias,
+    _replicate_dspark_vocab_weight,
     count_dspark_stages,
 )
 from tokenspeed.runtime.models.deepseek_v4_dspark_ops.attention import (
     _dspark_output_projection,
+    _normalize_query_per_head,
     _quantize_dspark_non_rope,
     dspark_fp8_quant_dequant,
+    dspark_rmsnorm,
     get_dspark_topk_idxs_batched,
 )
-from tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads import _local_vocab_argmax
+from tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads import (
+    DSparkVanillaMarkov,
+    _local_vocab_argmax,
+)
 from tokenspeed.runtime.models.deepseek_v4_next import DeepseekV4ForCausalLMNextN
 from tokenspeed.runtime.pd.cache_protocol import build_cache_fields_by_producer_step
 from tokenspeed.runtime.utils.cuda_stream import StreamFork
@@ -1963,6 +1973,140 @@ class TestDeepseekV4Config(unittest.TestCase):
                 gathered_ids[:, :1],
             )
 
+    def test_dspark_replicated_argmax_bypasses_collective_workspaces(self):
+        local_logits = torch.tensor([[1.0, 7.0, 3.0, 4.0]])
+        lm_head = SimpleNamespace(
+            tp_size=1,
+            shard_indices=SimpleNamespace(
+                num_org_elements=4,
+                num_org_elements_padded=4,
+                num_added_elements=0,
+                org_vocab_start_index=0,
+                added_vocab_start_index=4,
+            ),
+        )
+
+        with patch(
+            "tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads.all_gather_into_tensor"
+        ) as gather:
+            token_ids = _local_vocab_argmax(
+                local_logits,
+                lm_head,
+                object(),
+                torch.empty(0),
+                torch.empty(0, dtype=torch.int64),
+            )
+
+        gather.assert_not_called()
+        self.assertTrue(torch.equal(token_ids, torch.tensor([1], dtype=torch.int32)))
+
+    def test_dspark_replicated_markov_embedding_preserves_local_projection(self):
+        full_embedding = torch.arange(192, dtype=torch.float32).reshape(64, 3)
+        full_projection = torch.arange(192, 384, dtype=torch.float32).reshape(64, 3)
+        embedding = VocabParallelEmbedding(
+            64,
+            3,
+            params_dtype=torch.float32,
+        )
+        projection = ParallelLMHead(
+            64,
+            3,
+            params_dtype=torch.float32,
+            tp_rank=1,
+            tp_size=2,
+            tp_group=(0, 1),
+        )
+        with torch.no_grad():
+            embedding.weight.copy_(full_embedding)
+            projection.weight.copy_(full_projection[32:])
+        markov = DSparkVanillaMarkov(embedding, projection)
+
+        with patch(
+            "tokenspeed.runtime.layers.vocab_parallel_embedding.all_reduce"
+        ) as reduce:
+            actual = markov.local_bias(torch.tensor([1, 46], dtype=torch.int32))
+
+        reduce.assert_not_called()
+        expected = full_embedding[[1, 46]] @ full_projection[32:].T
+        self.assertTrue(torch.equal(actual, expected))
+        self.assertEqual(embedding.tp_size, 1)
+        self.assertEqual(projection.tp_size, 2)
+
+    def test_dspark_vocab_replication_reconstructs_tp_rank_order(self):
+        local_weight = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+        module = SimpleNamespace(
+            tp_size=1,
+            num_added_embeddings=0,
+            org_vocab_size=8,
+            org_vocab_size_padded=8,
+            num_embeddings_padded=8,
+        )
+        mapping = SimpleNamespace(
+            attn=SimpleNamespace(tp_size=2, tp_group=(0, 1)),
+        )
+
+        def fake_all_gather(weight, group, dim):
+            self.assertTrue(weight.is_contiguous())
+            self.assertEqual(group, (0, 1))
+            self.assertEqual(dim, 0)
+            return torch.cat((weight, weight + 100), dim=0)
+
+        with patch(
+            "tokenspeed.runtime.models.deepseek_v4_dspark.all_gather",
+            side_effect=fake_all_gather,
+        ) as gather:
+            full_weight = _replicate_dspark_vocab_weight(
+                local_weight,
+                module,
+                mapping,
+                label="LM head",
+            )
+
+        gather.assert_called_once()
+        self.assertTrue(
+            torch.equal(
+                full_weight,
+                torch.cat((local_weight, local_weight + 100), dim=0),
+            )
+        )
+
+    def test_dspark_vocab_replication_rejects_padded_layout(self):
+        module = SimpleNamespace(
+            tp_size=1,
+            num_added_embeddings=0,
+            org_vocab_size=7,
+            org_vocab_size_padded=8,
+            num_embeddings_padded=8,
+        )
+        mapping = SimpleNamespace(
+            attn=SimpleNamespace(tp_size=2, tp_group=(0, 1)),
+        )
+        with self.assertRaisesRegex(ValueError, "unpadded base-only"):
+            _replicate_dspark_vocab_weight(
+                torch.ones(4, 3),
+                module,
+                mapping,
+                label="embedding",
+            )
+
+    def test_dspark_wire_target_keeps_reconstructed_draft_head(self):
+        draft_head = SimpleNamespace(weight=torch.ones(8, 3), tp_size=1)
+        target_head = SimpleNamespace(weight=torch.ones(4, 3), tp_size=2)
+        drafter = object.__new__(DeepseekV4DSpark)
+        drafter.draft_model = SimpleNamespace(lm_head=draft_head)
+        drafter.target_layer_ids = [1, 3]
+        target_model = SimpleNamespace(
+            lm_head=target_head,
+            logits_processor=SimpleNamespace(tp_group=(0, 1)),
+            set_dspark_layers_to_capture=Mock(),
+        )
+
+        drafter.wire_target(target_model)
+
+        self.assertIs(drafter.lm_head, draft_head)
+        self.assertEqual(drafter.tp_group, (0, 1))
+        target_model.set_dspark_layers_to_capture.assert_called_once_with([1, 3])
+
     def test_dspark_tp_only_contract_uses_resolved_mapping(self):
         mapping = SimpleNamespace(attn=SimpleNamespace(dp_size=1, cp_size=1))
         DeepseekV4DSpark._validate_tp_only_mapping(mapping)
@@ -1979,6 +2123,11 @@ class TestDeepseekV4Config(unittest.TestCase):
     def test_dspark_padding_slots_reset_before_every_graph_replay(self):
         drafter = object.__new__(DeepseekV4DSpark)
         drafter.device = torch.device("cpu")
+        drafter.lm_head = SimpleNamespace(weight=torch.ones(2, 2))
+        refresh_head = Mock(return_value=False)
+        drafter.model = SimpleNamespace(
+            refresh_local_base_logits_head=refresh_head,
+        )
         drafter.first_padding_slot = 3
         drafter.padding_slots = torch.arange(3, 7, dtype=torch.int64)
         drafter.slot_indices_buf = drafter.padding_slots.clone()
@@ -2035,6 +2184,8 @@ class TestDeepseekV4Config(unittest.TestCase):
                 torch.zeros_like(drafter.context_lengths[3:]),
             )
         )
+        self.assertEqual(refresh_head.call_count, 11)
+        refresh_head.assert_called_with(drafter.lm_head.weight)
 
     def test_dspark_fp8_quant_dequant_matches_ue8m0_reference(self):
         values = torch.linspace(-7.0, 7.0, 256, dtype=torch.float32).reshape(2, 128)
@@ -2055,6 +2206,46 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.equal(actual, expected))
         with self.assertRaisesRegex(ValueError, "must be divisible"):
             dspark_fp8_quant_dequant(values[:, :-1], 64)
+
+    def test_dspark_rmsnorm_cpu_matches_reference(self):
+        values = torch.linspace(-7.0, 7.0, 1024, dtype=torch.bfloat16).reshape(2, 512)
+        weight = torch.linspace(-0.5, 0.5, 512, dtype=torch.bfloat16)
+
+        actual = dspark_rmsnorm(values, weight, 1e-6)
+        normalized = values.float()
+        normalized.mul_(torch.rsqrt(normalized.square().mean(-1, keepdim=True) + 1e-6))
+        expected = (weight.float() * normalized).to(values.dtype)
+
+        self.assertTrue(torch.equal(actual, expected))
+
+    def test_dspark_query_per_head_norm_cpu_matches_reference(self):
+        values = torch.linspace(-7.0, 7.0, 2 * 3 * 4 * 8).reshape(2, 3, 4, 8)
+        expected = values * torch.rsqrt(values.square().mean(-1, keepdim=True) + 1e-6)
+
+        actual = _normalize_query_per_head(values.clone(), head_dim=8, eps=1e-6)
+
+        self.assertTrue(torch.equal(actual, expected))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_dspark_rmsnorm_cuda_graph_replays_exact_reference(self):
+        torch.manual_seed(7)
+        values = torch.randn((8, 5, 512), device="cuda", dtype=torch.bfloat16)
+        weight = torch.randn((512,), device="cuda", dtype=torch.bfloat16)
+
+        dspark_rmsnorm(values, weight, 1e-6)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            actual = dspark_rmsnorm(values, weight, 1e-6)
+
+        values.copy_(torch.randn_like(values))
+        graph.replay()
+        torch.cuda.synchronize()
+        normalized = values.float()
+        normalized.mul_(torch.rsqrt(normalized.square().mean(-1, keepdim=True) + 1e-6))
+        expected = (weight.float() * normalized).to(values.dtype)
+
+        self.assertTrue(torch.equal(actual, expected))
 
     def test_dspark_kv_quantizes_only_non_rope_channels(self):
         tensor = torch.linspace(-8.0, 8.0, 512, dtype=torch.float32).reshape(1, 1, 512)
@@ -2128,6 +2319,86 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         self.assertEqual(logits.dtype, torch.float32)
         self.assertTrue(torch.equal(logits, hidden.float() @ head.weight.float().T))
+
+    def test_dspark_base_logits_reuse_and_refresh_stable_fp32_head(self):
+        model = object.__new__(DeepseekV4DSparkModel)
+        torch.nn.Module.__init__(model)
+        model.register_buffer("_local_base_head_fp32", None, persistent=False)
+        model._local_base_head_source_ptr = None
+        model._local_base_head_source_version = None
+        hidden = torch.tensor([[1.0, -2.0]], dtype=torch.bfloat16)
+        head = torch.tensor(
+            [[0.5, 0.25], [-1.0, 2.0]],
+            dtype=torch.bfloat16,
+        )
+
+        self.assertTrue(model.refresh_local_base_logits_head(head))
+        cached_ptr = model._local_base_head_fp32.data_ptr()
+        self.assertFalse(model.refresh_local_base_logits_head(head))
+        self.assertEqual(model._local_base_head_fp32.data_ptr(), cached_ptr)
+        self.assertTrue(
+            torch.equal(
+                model.local_base_logits(hidden),
+                hidden.float() @ head.float().T,
+            )
+        )
+
+        head.add_(1)
+        self.assertTrue(model.refresh_local_base_logits_head(head))
+        self.assertEqual(model._local_base_head_fp32.data_ptr(), cached_ptr)
+        self.assertTrue(
+            torch.equal(
+                model.local_base_logits(hidden),
+                hidden.float() @ head.float().T,
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "shape or device changed"):
+            model.refresh_local_base_logits_head(torch.ones(3, 2))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "requires CUDA")
+    def test_dspark_cached_base_logits_survive_cuda_graph_refresh(self):
+        model = object.__new__(DeepseekV4DSparkModel)
+        torch.nn.Module.__init__(model)
+        model.register_buffer("_local_base_head_fp32", None, persistent=False)
+        model._local_base_head_source_ptr = None
+        model._local_base_head_source_version = None
+        hidden = torch.tensor(
+            [[1.0, -2.0]],
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        head = torch.tensor(
+            [[0.5, 0.25], [-1.0, 2.0]],
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        model.refresh_local_base_logits_head(head)
+        cached_ptr = model._local_base_head_fp32.data_ptr()
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(3):
+                model.local_base_logits(hidden)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            logits = model.local_base_logits(hidden)
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertTrue(
+            torch.equal(logits, hidden.float() @ head.float().T),
+        )
+
+        head.add_(1)
+        model.refresh_local_base_logits_head(head)
+        self.assertEqual(model._local_base_head_fp32.data_ptr(), cached_ptr)
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertTrue(
+            torch.equal(logits, hidden.float() @ head.float().T),
+        )
 
     def test_dspark_speculative_config_uses_block_plus_bonus_width(self):
         server_args = ServerArgs(
@@ -2466,6 +2737,86 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(
             torch.equal(slots, torch.tensor([640, 641, 642, 1344, 1345, 1346]))
         )
+
+    def test_deepseek_v4_decode_query_padding_reuses_zero_tailed_workspace(self):
+        backend = _v4_backend(
+            SimpleNamespace(
+                prefix_granularity=64,
+                kernel_page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=4,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+        first_q = torch.arange(2 * 16 * 4, dtype=torch.bfloat16).view(2, 16, 4)
+        first_padded = backend._pad_decode_query(first_q, padded_heads=64)
+
+        self.assertEqual(first_padded.shape, (2, 64, 4))
+        self.assertTrue(torch.equal(first_padded[:, :16], first_q))
+        self.assertTrue(torch.count_nonzero(first_padded[:, 16:]) == 0)
+
+        second_q = torch.full_like(first_q, 7)
+        second_padded = backend._pad_decode_query(second_q, padded_heads=64)
+
+        self.assertEqual(second_padded.data_ptr(), first_padded.data_ptr())
+        self.assertTrue(torch.equal(second_padded[:, :16], second_q))
+        self.assertTrue(torch.count_nonzero(second_padded[:, 16:]) == 0)
+
+        different_shape = backend._pad_decode_query(first_q[:1], padded_heads=64)
+        self.assertNotEqual(different_shape.data_ptr(), first_padded.data_ptr())
+        self.assertEqual(len(backend._decode_q_padding_workspaces), 2)
+
+    def test_deepseek_v4_decode_query_padding_validates_shape_and_head_width(self):
+        backend = _v4_backend(
+            SimpleNamespace(
+                prefix_granularity=64,
+                kernel_page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=4,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "must have shape"):
+            backend._pad_decode_query(torch.empty(16, 4), padded_heads=64)
+        with self.assertRaisesRegex(ValueError, "must cover all local heads"):
+            backend._pad_decode_query(torch.empty(1, 65, 4), padded_heads=64)
+
+    def test_deepseek_v4_decode_query_padding_keeps_native_width_contiguous(self):
+        backend = _v4_backend(
+            SimpleNamespace(
+                prefix_granularity=64,
+                kernel_page_size=64,
+                device="cpu",
+                num_attention_heads=64,
+                num_kv_heads=1,
+                attn_tp_size=1,
+                dtype=torch.bfloat16,
+                is_draft=False,
+                speculative_num_draft_tokens=1,
+                head_dim=512,
+                context_len=4096,
+            )
+        )
+        q = torch.empty(2, 64, 4, dtype=torch.bfloat16)
+
+        padded = backend._pad_decode_query(q, padded_heads=64)
+
+        self.assertEqual(padded.data_ptr(), q.data_ptr())
+        self.assertTrue(padded.is_contiguous())
+        self.assertFalse(backend._decode_q_padding_workspaces)
 
     def test_deepseek_v4_lcm_graph_tables_keep_absolute_logical_positions(self):
         backend = _v4_backend(
@@ -4991,6 +5342,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             (2, 1),
             dtype=torch.int32,
         )
+        metadata.indexer.decode_schedule_metadata_refreshed_keys.add((8, 8, 8))
 
         with patch.object(deepseek_v4_backend, "dsv4_plan", side_effect=fake_dsv4_plan):
             deepseek_v4_backend._refresh_decode_indexer_schedule_metadata(metadata)
@@ -5010,6 +5362,36 @@ class TestDeepseekV4Config(unittest.TestCase):
                 torch.full((2, 1), 9, dtype=torch.int32),
             )
         )
+        self.assertEqual(
+            metadata.indexer.decode_schedule_metadata_refreshed_keys,
+            {key},
+        )
+
+    def test_deepseek_v4_indexer_schedule_metadata_reuses_refreshed_cache(self):
+        key = (4, 4, 2)
+        metadata = _make_deepseek_v4_forward_metadata(
+            page_size=64,
+            page_table=torch.tensor([[0], [0]], dtype=torch.int32),
+            seq_lens=torch.tensor([5, 1], dtype=torch.int32),
+            query_lens=torch.tensor([1, 1], dtype=torch.int32),
+            query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+            token_to_req_indices=torch.tensor([0, 1], dtype=torch.int32),
+        )
+        cached = torch.full((2, 1), 7, dtype=torch.int32)
+        metadata.indexer.decode_schedule_metadata_cache[key] = cached
+        metadata.indexer.decode_schedule_metadata_refreshed_keys.add(key)
+
+        with patch.object(deepseek_v4_model, "dsv4_plan") as plan:
+            actual = deepseek_v4_model._deepseek_v4_indexer_decode_schedule_metadata(
+                positions=torch.tensor([4, 0], dtype=torch.int64),
+                cache_block_size=4,
+                compress_ratio=4,
+                metadata=metadata,
+                context_lens=torch.tensor([[1], [0]], dtype=torch.int32),
+            )
+
+        self.assertIs(actual, cached)
+        plan.assert_not_called()
 
     def test_deepseek_v4_cuda_graph_decode_uses_packed_metadata(self):
         backend = _v4_backend(
@@ -6097,6 +6479,65 @@ class TestDeepseekV4Config(unittest.TestCase):
 
         self.assertTrue(torch.equal(topk_ids, expected_ids))
         self.assertTrue(torch.allclose(topk_weights, expected_weights))
+
+    def test_deepseek_v4_hash_gate_validates_complete_loaded_table(self):
+        config = SimpleNamespace(
+            n_routed_experts=4,
+            hidden_size=8,
+            num_hash_layers=1,
+            vocab_size=3,
+            num_experts_per_tok=2,
+            topk_method=None,
+        )
+        gate = DeepseekV4MoEGate(config, layer_index=0)
+        with torch.no_grad():
+            gate.tid2eid.copy_(
+                torch.tensor([[0, 1], [2, 3], [1, 2]], dtype=torch.int32)
+            )
+        gate.validate_hash_indices_table(config.n_routed_experts)
+
+        for invalid in (-1, config.n_routed_experts):
+            with torch.no_grad():
+                gate.tid2eid[1, 0] = invalid
+            with self.assertRaisesRegex(ValueError, r"entries must be in \[0, 4\)"):
+                gate.validate_hash_indices_table(config.n_routed_experts)
+
+    def test_deepseek_v4_hash_router_forwards_validated_table_contract(self):
+        logits = torch.tensor([[0.5, 1.0, -0.5, 0.1]], dtype=torch.float32)
+        input_ids = torch.tensor([1], dtype=torch.long)
+        table = torch.tensor([[0, 1], [3, 2]], dtype=torch.int32)
+        observed = []
+
+        def fake_kernel(*args, **kwargs):
+            observed.append(kwargs["hash_table_values_validated"])
+            selected = args[4][args[5].reshape(-1).long()]
+            weights = torch.ones(selected.shape, dtype=torch.float32)
+            return weights, selected, args[0]
+
+        original = deepseek_v4_model._kernel_dsv4_select_experts
+        deepseek_v4_model._kernel_dsv4_select_experts = fake_kernel
+        try:
+            default = dsv4_select_experts(
+                logits,
+                top_k=2,
+                renormalize=True,
+                hash_indices_table=table,
+                input_ids=input_ids,
+            )
+            trusted = dsv4_select_experts(
+                logits,
+                top_k=2,
+                renormalize=True,
+                hash_indices_table=table,
+                input_ids=input_ids,
+                hash_table_values_validated=True,
+            )
+        finally:
+            deepseek_v4_model._kernel_dsv4_select_experts = original
+
+        self.assertEqual(observed, [False, True])
+        for default_tensor, trusted_tensor in zip(default, trusted, strict=True):
+            self.assertTrue(torch.equal(default_tensor, trusted_tensor))
 
     def test_deepseek_v4_gate_cpu_returns_fp32_logits(self):
         config = SimpleNamespace(

--- a/test/runtime/test_deepseek_v4_slot_mappings.py
+++ b/test/runtime/test_deepseek_v4_slot_mappings.py
@@ -67,6 +67,17 @@ def test_clear_starts_a_fresh_forward():
     assert torch.equal(second, torch.ones(2, dtype=torch.int64))
 
 
+def test_first_use_is_once_per_key_and_resets_with_forward():
+    memo = DeepseekV4ForwardSlotMappings()
+
+    assert memo.first_use(("position_capacity", 4096))
+    assert not memo.first_use(("position_capacity", 4096))
+    assert memo.first_use(("position_capacity", 8192))
+
+    memo.clear()
+    assert memo.first_use(("position_capacity", 4096))
+
+
 def test_forward_context_carries_no_v4_memo_fields():
     names = {f.name for f in fields(ForwardContext)}
     assert not {"dsa_swa_slot_mapping", "dsa_compressor_slot_cache"} & names

--- a/test/runtime/test_dspark_proposal.py
+++ b/test/runtime/test_dspark_proposal.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import tokenspeed.runtime.models.deepseek_v4_dspark_ops.heads as v4_heads
 from tokenspeed.runtime.execution.drafter.deepseek_v4_dspark import DeepseekV4DSpark
 from tokenspeed.runtime.execution.drafter.dspark import DSpark
 from tokenspeed.runtime.models.dspark import VanillaMarkov
@@ -339,6 +340,126 @@ def test_proposals_are_valid_token_ids() -> None:
         torch.zeros((1, spec), dtype=torch.int32),
     )
     assert int(out.min()) >= 0
+
+
+def test_v4_markov_walk_routes_every_step_through_distributed_argmax(
+    monkeypatch,
+) -> None:
+    """The opt-in V4 path preserves the Markov chain and reuses graph scratch."""
+    rows, steps, local_vocab, rank = 3, 5, 8, 2
+    torch.manual_seed(17)
+    local_base = torch.randn(rows, steps, local_vocab)
+    bonus = torch.tensor([1, 2, 3], dtype=torch.int32)
+    projection = SimpleNamespace(
+        weight=torch.randn(local_vocab, RANK, dtype=torch.float32)
+    )
+    embedding_weight = torch.randn(64, RANK, dtype=torch.float32)
+    markov = SimpleNamespace(
+        local_bias=lambda ids: embedding_weight[ids.long()] @ projection.weight.T
+    )
+    shard = SimpleNamespace(
+        num_org_elements=local_vocab,
+        num_org_elements_padded=local_vocab,
+        num_added_elements=0,
+        org_vocab_start_index=0,
+        added_vocab_start_index=64,
+    )
+    lm_head = SimpleNamespace(shard_indices=shard, tp_size=4)
+    output = torch.empty((rows, steps), dtype=torch.int32)
+    max_scratch = torch.empty(rows, dtype=torch.float32)
+    id_scratch = torch.empty(rows, dtype=torch.int32)
+    calls = []
+
+    def fake_dist(state, logits, *, out_max, out_idx):
+        del state
+        calls.append(logits.clone())
+        max_values, ids = logits.max(dim=-1)
+        out_max.copy_(max_values)
+        out_idx.copy_(ids)
+        return out_max, out_idx
+
+    monkeypatch.setattr(v4_heads, "distributed_argmax", fake_dist)
+    v4_heads.sample_dspark_block_greedy(
+        local_base,
+        bonus,
+        markov,
+        lm_head,
+        tp_group=(0, 1, 2, 3),
+        gathered_values=torch.empty((4, rows)),
+        gathered_ids=torch.empty((4, rows), dtype=torch.int64),
+        output=output,
+        dist_argmax_state=object(),
+        dist_argmax_max=max_scratch,
+        dist_argmax_ids=id_scratch,
+    )
+
+    previous = bonus
+    expected = []
+    for step in range(steps):
+        corrected = local_base[:, step] + markov.local_bias(previous)
+        previous = corrected.argmax(dim=-1).to(torch.int32)
+        expected.append(previous)
+    assert len(calls) == steps
+    assert torch.equal(output, torch.stack(expected, dim=1))
+
+
+def test_v4_markov_walk_routes_every_step_through_local_cute_argmax(
+    monkeypatch,
+) -> None:
+    """The opt-in local path reuses per-step scratch and preserves chaining."""
+    rows, steps, local_vocab = 3, 5, 8
+    torch.manual_seed(23)
+    local_base = torch.randn(rows, steps, local_vocab)
+    bonus = torch.tensor([1, 2, 3], dtype=torch.int32)
+    projection = SimpleNamespace(
+        weight=torch.randn(local_vocab, RANK, dtype=torch.float32)
+    )
+    embedding_weight = torch.randn(64, RANK, dtype=torch.float32)
+    markov = SimpleNamespace(
+        local_bias=lambda ids: embedding_weight[ids.long()] @ projection.weight.T
+    )
+    shard = SimpleNamespace(
+        num_org_elements=local_vocab,
+        num_org_elements_padded=local_vocab,
+        num_added_elements=0,
+        org_vocab_start_index=0,
+        added_vocab_start_index=64,
+    )
+    lm_head = SimpleNamespace(shard_indices=shard, tp_size=1)
+    output = torch.empty((rows, steps), dtype=torch.int32)
+    max_scratch = torch.empty((steps, rows), dtype=torch.float32)
+    id_scratch = torch.empty((steps, rows), dtype=torch.int64)
+    calls = []
+
+    def fake_local(logits, out_max, out_idx):
+        calls.append(logits.clone())
+        max_values, ids = logits.max(dim=-1)
+        out_max.copy_(max_values)
+        out_idx.copy_(ids)
+
+    monkeypatch.setattr(v4_heads, "_cute_local_argmax", fake_local)
+    v4_heads.sample_dspark_block_greedy(
+        local_base,
+        bonus,
+        markov,
+        lm_head,
+        tp_group=None,
+        gathered_values=torch.empty((1, rows)),
+        gathered_ids=torch.empty((1, rows), dtype=torch.int64),
+        output=output,
+        local_cute_argmax=True,
+        local_argmax_max=max_scratch,
+        local_argmax_ids=id_scratch,
+    )
+
+    previous = bonus
+    expected = []
+    for step in range(steps):
+        corrected = local_base[:, step] + markov.local_bias(previous)
+        previous = corrected.argmax(dim=-1).to(torch.int32)
+        expected.append(previous)
+    assert len(calls) == steps
+    assert torch.equal(output, torch.stack(expected, dim=1))
 
 
 # --------------------------------------------------------------------------

--- a/test/runtime/test_logits_processor.py
+++ b/test/runtime/test_logits_processor.py
@@ -214,6 +214,67 @@ def test_dist_argmax_probe_failure_falls_back_and_latches(monkeypatch):
     assert len(calls) == 1
 
 
+def test_dist_argmax_state_cache_separates_logits_dtypes(monkeypatch):
+    """An FP32 corrected-logits user must not reuse a BF16 sampler state."""
+    monkeypatch.setattr(logits_processor_module, "dist_argmax_available", lambda: True)
+    monkeypatch.setattr(
+        logits_processor_module,
+        "current_platform",
+        lambda: SimpleNamespace(is_nvidia=True),
+    )
+    monkeypatch.setattr(
+        logits_processor_module.torch.cuda,
+        "is_current_stream_capturing",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        logits_processor_module.pg_manager,
+        "get_process_group",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        logits_processor_module.torch.distributed,
+        "all_reduce",
+        lambda tensor, **k: None,
+    )
+    created = []
+
+    def fake_create(**kwargs):
+        created.append(kwargs["dtype"])
+        return SimpleNamespace(dtype=kwargs["dtype"])
+
+    monkeypatch.setattr(
+        logits_processor_module, "try_create_dist_argmax_state", fake_create
+    )
+    monkeypatch.setattr(LogitsProcessor, "_LOGITS_DIST_ARGMAX_STATES", {})
+    processor = LogitsProcessor(
+        config=SimpleNamespace(model_type="test", vocab_size=8192),
+        tp_rank=0,
+        tp_size=2,
+        tp_group=(0, 1),
+    )
+    lm_head = SimpleNamespace(weight=torch.ones((4096, 2), dtype=torch.bfloat16))
+
+    bf16_state = processor.acquire_dist_argmax_state(
+        lm_head, max_M=8, skip_ping_pong=False
+    )
+    fp32_state = processor.acquire_dist_argmax_state(
+        lm_head, max_M=8, skip_ping_pong=False, dtype=torch.float32
+    )
+    assert bf16_state.dtype == torch.bfloat16
+    assert fp32_state.dtype == torch.float32
+    assert created == [torch.bfloat16, torch.float32]
+
+    # Both verdicts are independently cached.
+    assert (
+        processor.acquire_dist_argmax_state(
+            lm_head, max_M=8, skip_ping_pong=False, dtype=torch.float32
+        )
+        is fp32_state
+    )
+    assert len(created) == 2
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
 def test_fused_softcap_handles_large_logits_without_nan():
     cap = 30.0

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -418,6 +418,13 @@ KERNEL_GROUPS = [
         [],
     ),
     (
+        "mhc_big_fuse",
+        [
+            CUDA_CSRC_DIR / "mhc_big_fuse.cu",
+        ],
+        [],
+    ),
+    (
         "flashinfer_softmax",
         [
             CUDA_CSRC_DIR / "flashinfer_softmax.cu",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/__init__.py
@@ -111,8 +111,10 @@ from tokenspeed_kernel.ops.moe import (
     moe_sigmoid_bias_topk,
     moe_softmax_topk,
     native_latent_moe_available,
+    pack_topk_router_logits,
 )
 from tokenspeed_kernel.ops.quantization import (
+    fp8_quantize_dequantize,
     quantize_fp8,
     quantize_fp8_with_scale,
     quantize_mxfp4,
@@ -147,6 +149,8 @@ __all__ = [
     "prepare_fp8_linear",
     "prepare_nvfp4_a16_weights",
     "warmup_prepared_fp8_linears",
+    # quantization
+    "fp8_quantize_dequantize",
     # hyperconnection
     "gated_residual_combine",
     "gated_residual_mix",
@@ -209,6 +213,7 @@ __all__ = [
     "moe_plan",
     "moe_process_weights",
     "moe_sigmoid_bias_topk",
+    "pack_topk_router_logits",
     "moe_softmax_topk",
     # mhc
     "mhc_fused_hc",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -3453,6 +3453,7 @@ def dsv4_swa_cache_insert(
     q_out: torch.Tensor | None = None,
     override: str | None = None,
     solution: str | None = None,
+    validate_positions: bool = True,
 ) -> None:
     """Normalize/rotate Q and rotate/quantize/insert DeepSeek V4 SWA K/V.
 
@@ -3471,6 +3472,9 @@ def dsv4_swa_cache_insert(
             When provided, ``q`` is left unchanged.
         override: Optional exact registered kernel name.
         solution: Optional registered solution name.
+        validate_positions: Check that every position indexes ``cos_sin_cache``.
+            Runtime integrations may disable this only after validating the same
+            positions once for an equal cache capacity in the current forward.
 
     Returns:
         None. Q and the selected cache rows are written in place.
@@ -3517,13 +3521,16 @@ def dsv4_swa_cache_insert(
     tensors = (kv, swa_kv_cache, slot_mapping, positions, cos_sin_cache)
     if any(tensor.device != q.device for tensor in tensors):
         raise ValueError("all DeepSeek V4 SWA cache tensors must share a device")
-    positions_valid = ((positions >= 0) & (positions < cos_sin_cache.shape[0])).all()
-    position_error = "positions entries must index cos_sin_cache"
-    if positions.device.type == "cpu":
-        if not bool(positions_valid.item()):
-            raise ValueError(position_error)
-    else:
-        torch._assert_async(positions_valid, position_error)
+    if validate_positions:
+        positions_valid = (
+            (positions >= 0) & (positions < cos_sin_cache.shape[0])
+        ).all()
+        position_error = "positions entries must index cos_sin_cache"
+        if positions.device.type == "cpu":
+            if not bool(positions_valid.item()):
+                raise ValueError(position_error)
+        else:
+            torch._assert_async(positions_valid, position_error)
     if q_out is not None and (
         q_out.shape != q.shape
         or q_out.dtype != q.dtype

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsv4.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsv4.py
@@ -54,8 +54,11 @@ __all__ = [
     "dsv4_build_dense_prefill_local_compressed_indices",
     "dsv4_combine_dense_swa_indices",
     "dsv4_combine_topk_swa_indices",
+    "dsv4_compact_compressed_slot_mapping",
     "dsv4_compressed_slot_mapping",
+    "dsv4_group_slot_mapping",
     "dsv4_compute_global_topk_indices_and_lens",
+    "dsv4_decode_dense_compressed_indices_and_lens",
     "dsv4_decode_swa_indices_and_lens",
     "dsv4_dequantize_and_gather_k_cache",
     "dsv4_fused_csa_indexer_fp8_cache_insert",
@@ -823,6 +826,213 @@ def _dsv4_fused_indexer_q_rope_hadamard_mxfp4_kernel(
     )
 
 
+@triton.jit
+def _dsv4_fused_indexer_q_rope_hadamard_mxfp4_serial_four_block_kernel(
+    positions_ptr,
+    index_q_ptr,
+    index_q_stride0,
+    index_q_stride1,
+    cos_sin_cache_ptr,
+    cos_sin_cache_stride,
+    q_packed_ptr,
+    q_packed_stride0,
+    q_packed_stride1,
+    q_scale_ptr,
+    q_scale_stride0,
+    q_scale_stride1,
+    weights_ptr,
+    weights_stride,
+    weights_softmax_scale,
+    weights_head_scale,
+    weights_out_ptr,
+    weights_out_stride,
+    HEAD_DIM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+    QUANT_BLOCK: tl.constexpr,
+    HALF_BLOCK: tl.constexpr,
+    NUM_QUANT_BLOCKS: tl.constexpr,
+    HADAMARD_SCALE: tl.constexpr,
+    TRITON_BLOCK_SIZE: tl.constexpr,
+):
+    """Reuse Q/RoPE setup while producing the four fixed MXFP4 blocks."""
+
+    token_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    pos = tl.load(positions_ptr + token_idx)
+    dim = tl.arange(0, TRITON_BLOCK_SIZE)
+    q_base = index_q_ptr + token_idx * index_q_stride0 + head_idx * index_q_stride1
+    q = tl.load(q_base + dim, mask=dim < HEAD_DIM, other=0.0).to(tl.float32)
+
+    NOPE_DIM: tl.constexpr = HEAD_DIM - ROPE_DIM
+    HALF_ROPE: tl.constexpr = ROPE_DIM // 2
+    NUM_PAIRS: tl.constexpr = TRITON_BLOCK_SIZE // 2
+    NOPE_PAIRS: tl.constexpr = NOPE_DIM // 2
+
+    pair_2d = tl.reshape(q, (NUM_PAIRS, 2))
+    even, odd = tl.split(pair_2d)
+    pair_idx = tl.arange(0, NUM_PAIRS)
+    rope_pair = pair_idx - NOPE_PAIRS
+    is_rope = rope_pair >= 0
+    cs_idx = tl.maximum(rope_pair, 0)
+    cs_base = cos_sin_cache_ptr + pos * cos_sin_cache_stride
+    cos_v = tl.load(cs_base + cs_idx, mask=is_rope, other=1.0).to(tl.float32)
+    sin_v = tl.load(cs_base + HALF_ROPE + cs_idx, mask=is_rope, other=0.0).to(
+        tl.float32
+    )
+    rotated_even = even * cos_v - odd * sin_v
+    rotated_odd = odd * cos_v + even * sin_v
+    rotated = tl.interleave(rotated_even, rotated_odd)
+    rotated = rotated.to(tl.bfloat16).to(tl.float32)
+
+    in_idx = tl.arange(0, TRITON_BLOCK_SIZE)
+    for quant_block_idx in tl.static_range(0, NUM_QUANT_BLOCKS):
+        out_idx = quant_block_idx * QUANT_BLOCK + tl.arange(0, QUANT_BLOCK)
+        bits = (in_idx[:, None] & out_idx[None, :]).to(tl.int32)
+        parity = bits ^ (bits >> 4)
+        parity = parity ^ (parity >> 2)
+        parity = parity ^ (parity >> 1)
+        parity = parity & 1
+        signs = tl.where(parity == 0, 1.0, -1.0)
+        hadamard = tl.sum(rotated[:, None] * signs, axis=0) * HADAMARD_SCALE
+        hadamard = hadamard.to(tl.bfloat16).to(tl.float32)
+
+        hadamard_2d = tl.reshape(hadamard, (HALF_BLOCK, 2))
+        x_lo, x_hi = tl.split(hadamard_2d)
+        amax = tl.maximum(tl.max(tl.abs(x_lo)), tl.max(tl.abs(x_hi)))
+        amax = tl.maximum(amax, 1.0e-4)
+        exponent = tl.ceil(tl.log2(amax / 6.0))
+        exponent = tl.minimum(tl.maximum(exponent, -127.0), 127.0)
+        inv_scale = tl.exp2(-exponent)
+        lo = _dsv4_mxfp4_e2m1_nibble(x_lo * inv_scale)
+        hi = _dsv4_mxfp4_e2m1_nibble(x_hi * inv_scale)
+        packed = lo | (hi << 4)
+        scale = (exponent + 127.0).to(tl.uint8)
+
+        packed_base = (
+            q_packed_ptr
+            + token_idx * q_packed_stride0
+            + head_idx * q_packed_stride1
+            + quant_block_idx * HALF_BLOCK
+        )
+        scale_base = (
+            q_scale_ptr
+            + token_idx * q_scale_stride0
+            + head_idx * q_scale_stride1
+            + quant_block_idx
+        )
+        tl.store(packed_base + tl.arange(0, HALF_BLOCK), packed)
+        tl.store(scale_base, scale)
+
+    weights = tl.load(weights_ptr + token_idx * weights_stride + head_idx).to(
+        tl.float32
+    )
+    weights = weights * weights_softmax_scale * weights_head_scale
+    tl.store(weights_out_ptr + token_idx * weights_out_stride + head_idx, weights)
+
+
+def _dsv4_use_serial_four_block_indexer_q(
+    *,
+    num_tokens: int,
+    head_dim: int,
+    rope_dim: int,
+    quant_block: int,
+    is_cuda: bool,
+    is_hip: bool,
+    capability: tuple[int, int] | None,
+    shapes_valid: bool,
+    dtypes_valid: bool,
+    devices_valid: bool,
+    inner_strides: tuple[int, int, int, int],
+) -> bool:
+    """Return whether the exact 8192-token SM100 specialization is eligible."""
+
+    return (
+        num_tokens == 8192
+        and head_dim == DEEPSEEK_V4_INDEXER_DIM
+        and rope_dim == DEEPSEEK_V4_ROPE_DIM
+        and quant_block == DEEPSEEK_V4_MXFP4_BLOCK_SIZE
+        and is_cuda
+        and not is_hip
+        and capability == (10, 0)
+        and shapes_valid
+        and dtypes_valid
+        and devices_valid
+        and inner_strides == (1, 1, 1, 1)
+    )
+
+
+@functools.cache
+def _dsv4_indexer_q_cuda_capability(
+    device: torch.device | int | None,
+) -> tuple[int, int] | None:
+    try:
+        if not torch.cuda.is_available() or getattr(torch.version, "hip", None):
+            return None
+        return torch.cuda.get_device_capability(device)
+    except (AssertionError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+@functools.cache
+def _log_serial_four_block_indexer_q_selection(capability: tuple[int, int]) -> None:
+    logger.info(
+        "DeepSeek V4 Indexer-Q launch selection: serial_four_block=True "
+        "tokens=8192 capability=%s",
+        capability,
+    )
+
+
+def _dsv4_serial_four_block_indexer_q_supported(
+    index_q: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    weights: torch.Tensor,
+) -> bool:
+    if index_q.dim() != 3:
+        return False
+    num_tokens, num_heads, head_dim = index_q.shape
+    capability = (
+        _dsv4_indexer_q_cuda_capability(index_q.device) if num_tokens == 8192 else None
+    )
+    supported = _dsv4_use_serial_four_block_indexer_q(
+        num_tokens=num_tokens,
+        head_dim=head_dim,
+        rope_dim=DEEPSEEK_V4_ROPE_DIM,
+        quant_block=DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+        is_cuda=index_q.is_cuda,
+        is_hip=getattr(torch.version, "hip", None) is not None,
+        capability=capability,
+        shapes_valid=(
+            positions.shape == (num_tokens,)
+            and cos_sin_cache.dim() == 2
+            and cos_sin_cache.shape[1] == DEEPSEEK_V4_ROPE_DIM
+            and weights.shape == (num_tokens, num_heads)
+        ),
+        dtypes_valid=(
+            index_q.dtype == torch.bfloat16
+            and positions.dtype == torch.int64
+            and cos_sin_cache.dtype == torch.float32
+            and weights.dtype in (torch.bfloat16, torch.float32)
+        ),
+        devices_valid=(
+            positions.device == index_q.device
+            and cos_sin_cache.device == index_q.device
+            and weights.device == index_q.device
+        ),
+        inner_strides=(
+            index_q.stride(-1),
+            positions.stride(-1) if positions.dim() == 1 else 0,
+            cos_sin_cache.stride(-1) if cos_sin_cache.dim() == 2 else 0,
+            weights.stride(-1) if weights.dim() == 2 else 0,
+        ),
+    )
+    if supported:
+        assert capability is not None
+        _log_serial_four_block_indexer_q_selection(capability)
+    return supported
+
+
 def dsv4_fused_indexer_q_rope_hadamard_mxfp4(
     *,
     index_q: torch.Tensor,
@@ -831,6 +1041,7 @@ def dsv4_fused_indexer_q_rope_hadamard_mxfp4(
     weights: torch.Tensor,
     softmax_scale: float,
     head_scale: float,
+    prefer_serial_four_block: bool = False,
 ) -> tuple[tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
     num_tokens, num_heads, head_dim = index_q.shape
     q_packed = torch.empty(
@@ -847,9 +1058,36 @@ def dsv4_fused_indexer_q_rope_hadamard_mxfp4(
     if num_tokens == 0:
         return (q_packed, q_scale_bytes.view(torch.int32).squeeze(-1)), weights_out
 
-    _dsv4_fused_indexer_q_rope_hadamard_mxfp4_kernel[
-        (num_tokens, num_heads, head_dim // DEEPSEEK_V4_MXFP4_BLOCK_SIZE)
-    ](
+    use_serial_four_block = prefer_serial_four_block and (
+        _dsv4_serial_four_block_indexer_q_supported(
+            index_q,
+            positions,
+            cos_sin_cache,
+            weights,
+        )
+    )
+    kernel = (
+        _dsv4_fused_indexer_q_rope_hadamard_mxfp4_serial_four_block_kernel
+        if use_serial_four_block
+        else _dsv4_fused_indexer_q_rope_hadamard_mxfp4_kernel
+    )
+    grid = (
+        (num_tokens, num_heads)
+        if use_serial_four_block
+        else (num_tokens, num_heads, head_dim // DEEPSEEK_V4_MXFP4_BLOCK_SIZE)
+    )
+    launch_kwargs = {
+        "HEAD_DIM": head_dim,
+        "ROPE_DIM": DEEPSEEK_V4_ROPE_DIM,
+        "QUANT_BLOCK": DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
+        "HALF_BLOCK": DEEPSEEK_V4_MXFP4_BLOCK_SIZE // 2,
+        "HADAMARD_SCALE": head_dim**-0.5,
+        "TRITON_BLOCK_SIZE": triton.next_power_of_2(head_dim),
+        "num_warps": 4,
+    }
+    if use_serial_four_block:
+        launch_kwargs["NUM_QUANT_BLOCKS"] = head_dim // DEEPSEEK_V4_MXFP4_BLOCK_SIZE
+    kernel[grid](
         positions,
         index_q,
         index_q.stride(0),
@@ -868,13 +1106,7 @@ def dsv4_fused_indexer_q_rope_hadamard_mxfp4(
         head_scale,
         weights_out,
         weights_out.stride(0),
-        HEAD_DIM=head_dim,
-        ROPE_DIM=DEEPSEEK_V4_ROPE_DIM,
-        QUANT_BLOCK=DEEPSEEK_V4_MXFP4_BLOCK_SIZE,
-        HALF_BLOCK=DEEPSEEK_V4_MXFP4_BLOCK_SIZE // 2,
-        HADAMARD_SCALE=head_dim**-0.5,
-        TRITON_BLOCK_SIZE=triton.next_power_of_2(head_dim),
-        num_warps=4,
+        **launch_kwargs,
     )
     return (
         q_packed,
@@ -2170,6 +2402,232 @@ def dsv4_compute_global_topk_indices_and_lens(
     return global_topk_indices, topk_lens
 
 
+@triton.jit(do_not_specialize=["block_table_stride", "max_blocks_per_seq"])
+def _dsv4_decode_dense_compressed_indices_and_lens_kernel(
+    indices_ptr,
+    indices_stride,
+    lens_ptr,
+    positions_ptr,
+    token_to_req_indices_ptr,
+    is_valid_token_ptr,
+    block_table_ptr,
+    block_table_base_offsets_ptr,
+    block_table_stride,
+    num_reqs,
+    max_blocks_per_seq,
+    has_valid_token: tl.constexpr,
+    has_block_table_base_offsets: tl.constexpr,
+    block_size: tl.constexpr,
+    compress_ratio: tl.constexpr,
+    width: tl.constexpr,
+    candidate_block: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    token_is_valid = tl.full((), True, tl.int1)
+    if has_valid_token:
+        token_is_valid = tl.load(is_valid_token_ptr + token_idx)
+
+    req_idx = tl.load(token_to_req_indices_ptr + token_idx).to(tl.int32)
+    req_is_valid = (req_idx >= 0) & (req_idx < num_reqs)
+    position = tl.load(positions_ptr + token_idx).to(tl.int64)
+    compressed_len = tl.minimum(
+        tl.maximum((position + 1) // compress_ratio, 0),
+        width,
+    ).to(tl.int32)
+    compressed_len = tl.where(token_is_valid, compressed_len, 0)
+    tl.store(lens_ptr + token_idx, compressed_len)
+
+    base_page = tl.zeros((), dtype=tl.int32)
+    if has_block_table_base_offsets:
+        base_page = tl.load(
+            block_table_base_offsets_ptr + req_idx,
+            mask=req_is_valid,
+            other=0,
+        ).to(tl.int32)
+
+    for start in range(0, width, candidate_block):
+        offsets = start + tl.arange(0, candidate_block)
+        store_mask = offsets < width
+        entry_is_valid = store_mask & token_is_valid & (offsets < compressed_len)
+        logical_page = offsets // block_size
+        table_page = logical_page - base_page
+        page_is_valid = (
+            entry_is_valid
+            & req_is_valid
+            & (table_page >= 0)
+            & (table_page < max_blocks_per_seq)
+        )
+        block_number = tl.load(
+            block_table_ptr + req_idx * block_table_stride + table_page,
+            mask=page_is_valid,
+            other=-1,
+        ).to(tl.int32)
+        slot = block_number * block_size + offsets % block_size
+        value = tl.where(page_is_valid & (block_number >= 0), slot, -1)
+        tl.store(
+            indices_ptr + token_idx * indices_stride + offsets,
+            value,
+            mask=store_mask,
+        )
+
+
+def dsv4_decode_dense_compressed_indices_and_lens(
+    *,
+    positions: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    compress_ratio: int,
+    width: int,
+    block_table_base_offsets: torch.Tensor | None = None,
+    is_valid_token: torch.Tensor | None = None,
+    out_indices: torch.Tensor | None = None,
+    out_lens: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build dense compressed decode KV slots and per-token lengths.
+
+    The result matches the logical dense-prefix mapping previously expressed
+    as a chain of PyTorch div/clamp/where/index operations.  On CUDA, one
+    Triton launch constructs physical cache slots directly so a first HCA
+    layer cannot permanently capture that elementwise chain into every graph
+    replay.
+    """
+
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+    if compress_ratio <= 0:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    if width < 0:
+        raise ValueError(f"width must be non-negative, got {width}")
+    num_tokens = positions.numel()
+    if token_to_req_indices.numel() < num_tokens:
+        raise ValueError(
+            "token_to_req_indices must cover every position: "
+            f"positions={num_tokens}, request_indices={token_to_req_indices.numel()}"
+        )
+    if block_table.dim() != 2:
+        raise ValueError(f"block_table must be 2-D, got {tuple(block_table.shape)}")
+    if out_indices is None:
+        out_indices = torch.empty(
+            (num_tokens, width),
+            dtype=torch.int32,
+            device=positions.device,
+        )
+    if out_lens is None:
+        out_lens = torch.empty(
+            num_tokens,
+            dtype=torch.int32,
+            device=positions.device,
+        )
+    if out_indices.shape != (num_tokens, width) or out_indices.dtype != torch.int32:
+        raise ValueError(
+            "out_indices must be int32 with shape "
+            f"{(num_tokens, width)}, got {tuple(out_indices.shape)} {out_indices.dtype}"
+        )
+    if out_lens.shape != (num_tokens,) or out_lens.dtype != torch.int32:
+        raise ValueError(
+            "out_lens must be int32 with shape "
+            f"{(num_tokens,)}, got {tuple(out_lens.shape)} {out_lens.dtype}"
+        )
+    if num_tokens == 0 or width == 0:
+        return out_indices, out_lens
+
+    if is_valid_token is not None:
+        is_valid_token = is_valid_token[:num_tokens].to(
+            device=positions.device,
+            dtype=torch.bool,
+        )
+    if positions.is_cuda:
+        if is_valid_token is None:
+            is_valid_token = torch.empty(
+                0,
+                dtype=torch.bool,
+                device=positions.device,
+            )
+        block_table_i32 = _as_int32_block_table(block_table)
+        candidate_block = min(1024, triton.next_power_of_2(max(1, width)))
+        _dsv4_decode_dense_compressed_indices_and_lens_kernel[(num_tokens,)](
+            out_indices,
+            out_indices.stride(0),
+            out_lens,
+            positions,
+            token_to_req_indices.to(torch.int32),
+            is_valid_token,
+            block_table_i32,
+            (
+                block_table_base_offsets.to(torch.int32)
+                if block_table_base_offsets is not None
+                else None
+            ),
+            block_table_i32.stride(0),
+            block_table_i32.shape[0],
+            block_table_i32.shape[1],
+            is_valid_token.numel() != 0,
+            block_table_base_offsets is not None,
+            block_size=block_size,
+            compress_ratio=compress_ratio,
+            width=width,
+            candidate_block=candidate_block,
+        )
+        return out_indices, out_lens
+
+    req_idx = token_to_req_indices[:num_tokens].to(torch.int64)
+    compressed_lens = torch.div(
+        positions.to(torch.int64) + 1,
+        compress_ratio,
+        rounding_mode="floor",
+    ).clamp(0, width)
+    if is_valid_token is not None:
+        compressed_lens = torch.where(
+            is_valid_token,
+            compressed_lens,
+            torch.zeros_like(compressed_lens),
+        )
+    offsets = torch.arange(width, dtype=torch.int64, device=positions.device)
+    valid = offsets[None, :] < compressed_lens[:, None]
+    safe_local = torch.where(
+        valid, offsets[None, :], torch.zeros_like(offsets)[None, :]
+    )
+    pages = torch.div(safe_local, block_size, rounding_mode="floor")
+    if block_table_base_offsets is not None:
+        rows = int(block_table_base_offsets.shape[0])
+        valid_req = (req_idx >= 0) & (req_idx < rows)
+        safe_req = req_idx.clamp(0, max(0, rows - 1))
+        if rows <= 0:
+            pages = torch.full_like(pages, -1)
+        else:
+            base_pages = block_table_base_offsets.to(torch.int64)[safe_req]
+            pages = torch.where(valid_req[:, None], pages - base_pages[:, None], -1)
+    page_offsets = safe_local % block_size
+    rows = int(block_table.shape[0])
+    cols = int(block_table.shape[1])
+    if rows <= 0 or cols <= 0:
+        page_ids = torch.full_like(pages, -1)
+    else:
+        page_valid = (
+            (req_idx[:, None] >= 0)
+            & (req_idx[:, None] < rows)
+            & (pages >= 0)
+            & (pages < cols)
+        )
+        safe_req = req_idx.clamp(0, rows - 1)
+        safe_page = pages.clamp(0, cols - 1)
+        page_ids = torch.where(
+            page_valid,
+            block_table.to(torch.int64)[safe_req[:, None], safe_page],
+            torch.full_like(pages, -1),
+        )
+    out_indices.copy_(
+        torch.where(
+            valid & (page_ids >= 0),
+            page_ids * block_size + page_offsets,
+            torch.full_like(page_ids, -1),
+        ).to(torch.int32)
+    )
+    out_lens.copy_(compressed_lens.to(torch.int32))
+    return out_indices, out_lens
+
+
 @triton.jit
 def _dsv4_combine_topk_swa_indices_kernel(
     combined_indices_ptr,
@@ -2724,6 +3182,426 @@ def dsv4_compressed_slot_mapping(
         pad_id=-1,
         candidate_block=1024,
     )
+    return slot_mapping
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_tokens",
+        "num_reqs",
+        "max_blocks_per_seq",
+    ]
+)
+def _dsv4_compact_compressed_slot_mapping_kernel(
+    slot_mapping_ptr,
+    token_to_req_indices_ptr,
+    token_to_req_indices_stride,
+    query_start_loc_ptr,
+    query_start_loc_stride,
+    seq_lens_ptr,
+    seq_lens_stride,
+    is_valid_token_ptr,
+    is_valid_token_stride,
+    block_table_ptr,
+    block_table_stride,
+    block_table_base_offsets_ptr,
+    block_table_base_offsets_stride,
+    num_tokens,
+    num_reqs,
+    max_blocks_per_seq,
+    has_valid_token: tl.constexpr,
+    has_block_table_base_offsets: tl.constexpr,
+    block_size: tl.constexpr,
+    compress_ratio: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    token_is_valid = token_idx < num_tokens
+    if has_valid_token:
+        token_is_valid &= tl.load(
+            is_valid_token_ptr + token_idx * is_valid_token_stride,
+            mask=token_is_valid,
+            other=False,
+        )
+
+    req_idx = tl.load(
+        token_to_req_indices_ptr + token_idx * token_to_req_indices_stride,
+        mask=token_is_valid,
+        other=-1,
+    ).to(tl.int32)
+    req_is_valid = token_is_valid & (req_idx >= 0) & (req_idx < num_reqs)
+    query_start = tl.load(
+        query_start_loc_ptr + req_idx * query_start_loc_stride,
+        mask=req_is_valid,
+        other=0,
+    ).to(tl.int64)
+    query_end = tl.load(
+        query_start_loc_ptr + (req_idx + 1) * query_start_loc_stride,
+        mask=req_is_valid,
+        other=0,
+    ).to(tl.int64)
+    seq_len = tl.load(
+        seq_lens_ptr + req_idx * seq_lens_stride,
+        mask=req_is_valid,
+        other=0,
+    ).to(tl.int64)
+    position = seq_len - (query_end - query_start) + token_idx - query_start
+    compressed_position = position // compress_ratio
+    logical_page = compressed_position // block_size
+    offset = compressed_position % block_size
+
+    base_page = tl.zeros((), dtype=tl.int64)
+    if has_block_table_base_offsets:
+        base_page = tl.load(
+            block_table_base_offsets_ptr + req_idx * block_table_base_offsets_stride,
+            mask=req_is_valid,
+            other=0,
+        ).to(tl.int64)
+    table_page = logical_page - base_page
+    page_is_valid = (
+        req_is_valid
+        & (position >= 0)
+        & ((position + 1) % compress_ratio == 0)
+        & (table_page >= 0)
+        & (table_page < max_blocks_per_seq)
+    )
+    page_id = tl.load(
+        block_table_ptr + req_idx * block_table_stride + table_page,
+        mask=page_is_valid,
+        other=-1,
+    ).to(tl.int64)
+    slot = page_id * block_size + offset
+    tl.store(
+        slot_mapping_ptr + token_idx, tl.where(page_is_valid & (page_id >= 0), slot, -1)
+    )
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_tokens",
+        "num_reqs",
+        "max_blocks_per_req",
+    ]
+)
+def _dsv4_group_slot_mapping_kernel(
+    out_ptr,
+    positions_ptr,
+    positions_stride,
+    req_indices_ptr,
+    req_indices_stride,
+    block_table_ptr,
+    block_table_stride,
+    base_offsets_ptr,
+    base_offsets_stride,
+    valid_token_ptr,
+    valid_token_stride,
+    num_tokens,
+    num_reqs,
+    max_blocks_per_req,
+    req_repeat: tl.constexpr,
+    valid_repeat: tl.constexpr,
+    has_base_offsets: tl.constexpr,
+    has_valid_token: tl.constexpr,
+    rows_per_block: tl.constexpr,
+    entry_stride_tokens: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    token_in_range = token_idx < num_tokens
+    position = tl.load(
+        positions_ptr + token_idx * positions_stride,
+        mask=token_in_range,
+        other=-1,
+    ).to(tl.int64)
+    req_value_idx = token_idx // req_repeat
+    req_idx = tl.load(
+        req_indices_ptr + req_value_idx * req_indices_stride,
+        mask=token_in_range,
+        other=-1,
+    ).to(tl.int64)
+    req_is_valid = token_in_range & (req_idx >= 0) & (req_idx < num_reqs)
+
+    token_is_valid = req_is_valid
+    if has_valid_token:
+        valid_value_idx = token_idx // valid_repeat
+        token_is_valid &= tl.load(
+            valid_token_ptr + valid_value_idx * valid_token_stride,
+            mask=token_in_range,
+            other=False,
+        )
+
+    logical_row = position // entry_stride_tokens
+    logical_block = logical_row // rows_per_block
+    row_offset = logical_row % rows_per_block
+    base_block = tl.zeros((), dtype=tl.int64)
+    if has_base_offsets:
+        base_block = tl.load(
+            base_offsets_ptr + req_idx * base_offsets_stride,
+            mask=req_is_valid,
+            other=0,
+        ).to(tl.int64)
+    table_block = logical_block - base_block
+    table_entry_is_valid = (
+        token_is_valid
+        & (position >= 0)
+        & (table_block >= 0)
+        & (table_block < max_blocks_per_req)
+    )
+    block_id = tl.load(
+        block_table_ptr + req_idx * block_table_stride + table_block,
+        mask=table_entry_is_valid,
+        other=-1,
+    ).to(tl.int64)
+    slot = block_id * rows_per_block + row_offset
+    tl.store(
+        out_ptr + token_idx,
+        tl.where(table_entry_is_valid & (block_id >= 0), slot, -1),
+        mask=token_in_range,
+    )
+
+
+def dsv4_group_slot_mapping(
+    *,
+    positions: torch.Tensor,
+    req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    rows_per_block: int,
+    entry_stride_tokens: int = 1,
+    base_offsets: torch.Tensor | None = None,
+    is_valid_token: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Map logical token positions to physical rows of a cache block table.
+
+    Request indices and validity values may either have one entry per token or
+    evenly expand across packed token groups. Invalid requests, table entries,
+    positions, pages, and graph-padding tokens map to ``-1``.
+    """
+
+    if rows_per_block <= 0:
+        raise ValueError(f"rows_per_block must be positive, got {rows_per_block}")
+    if entry_stride_tokens <= 0:
+        raise ValueError(
+            f"entry_stride_tokens must be positive, got {entry_stride_tokens}"
+        )
+    if positions.dim() != 1 or req_indices.dim() != 1:
+        raise ValueError("positions and req_indices must be 1-D")
+    if block_table.dim() != 2:
+        raise ValueError(f"block_table must be 2-D, got {tuple(block_table.shape)}")
+    num_tokens = positions.numel()
+    if not positions.is_cuda:
+        raise ValueError("dsv4_group_slot_mapping requires CUDA tensors")
+    out = torch.empty(num_tokens, dtype=torch.int64, device=positions.device)
+    if num_tokens == 0:
+        return out
+    if req_indices.numel() <= 0 or num_tokens % req_indices.numel() != 0:
+        raise ValueError(
+            "req_indices must evenly expand across positions: "
+            f"tokens={num_tokens}, request_indices={req_indices.numel()}"
+        )
+    if base_offsets is not None and base_offsets.dim() != 1:
+        raise ValueError("base_offsets must be 1-D")
+    if is_valid_token is not None:
+        if is_valid_token.dim() != 1:
+            raise ValueError("is_valid_token must be 1-D")
+        if is_valid_token.numel() <= 0 or num_tokens % is_valid_token.numel() != 0:
+            raise ValueError(
+                "is_valid_token must evenly expand across positions: "
+                f"tokens={num_tokens}, validity={is_valid_token.numel()}"
+            )
+    if block_table.shape[0] == 0 or block_table.shape[1] == 0:
+        out.fill_(-1)
+        return out
+    dummy = positions
+    base_arg = dummy if base_offsets is None else base_offsets
+    valid_arg = dummy if is_valid_token is None else is_valid_token
+    _dsv4_group_slot_mapping_kernel[(num_tokens,)](
+        out,
+        positions,
+        positions.stride(0),
+        req_indices,
+        req_indices.stride(0),
+        block_table,
+        block_table.stride(0),
+        base_arg,
+        base_arg.stride(0),
+        valid_arg,
+        valid_arg.stride(0),
+        num_tokens,
+        block_table.shape[0],
+        block_table.shape[1],
+        req_repeat=num_tokens // req_indices.numel(),
+        valid_repeat=(
+            1 if is_valid_token is None else num_tokens // is_valid_token.numel()
+        ),
+        has_base_offsets=base_offsets is not None,
+        has_valid_token=is_valid_token is not None,
+        rows_per_block=rows_per_block,
+        entry_stride_tokens=entry_stride_tokens,
+    )
+    return out
+
+
+def dsv4_compact_compressed_slot_mapping(
+    *,
+    num_tokens: int,
+    token_to_req_indices: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    compress_ratio: int,
+    block_table_base_offsets: torch.Tensor | None = None,
+    is_valid_token: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build slots for a compact DeepSeek V4 compressed-cache page table.
+
+    Args:
+        num_tokens: Number of packed query tokens to map.
+        token_to_req_indices: Request row for each packed token.
+        query_start_loc: Exclusive-prefix query offsets for request rows.
+        seq_lens: Sequence length for each request row after this query.
+        block_table: Compact physical page ids indexed by request and local page.
+        block_size: Number of compressed rows stored by each physical page.
+        compress_ratio: Number of logical tokens represented by one compressed row.
+        block_table_base_offsets: Optional first logical compressed-page index for
+            each compact request row.
+        is_valid_token: Optional graph-padding validity mask for packed tokens.
+        out: Optional reusable int64 output buffer with at least ``num_tokens``
+            elements. Elements beyond ``num_tokens`` are reset to ``-1``.
+
+    Returns:
+        The first ``num_tokens`` entries of the physical compressed-slot mapping.
+        Non-boundary, invalid, missing-page, and graph-padding entries are ``-1``.
+    """
+
+    if num_tokens < 0:
+        raise ValueError(f"num_tokens must be non-negative, got {num_tokens}")
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}")
+    if compress_ratio <= 0:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    if token_to_req_indices.numel() < num_tokens:
+        raise ValueError(
+            "token_to_req_indices must cover every token: "
+            f"tokens={num_tokens}, request_indices={token_to_req_indices.numel()}"
+        )
+    if query_start_loc.dim() != 1 or seq_lens.dim() != 1:
+        raise ValueError("query_start_loc and seq_lens must be 1-D")
+    if block_table.dim() != 2:
+        raise ValueError(f"block_table must be 2-D, got {tuple(block_table.shape)}")
+    if block_table_base_offsets is not None and block_table_base_offsets.dim() != 1:
+        raise ValueError("block_table_base_offsets must be 1-D")
+    if is_valid_token is not None:
+        if is_valid_token.numel() != num_tokens:
+            if is_valid_token.numel() <= 0 or num_tokens % is_valid_token.numel() != 0:
+                raise ValueError(
+                    "is_valid_token must cover or evenly expand across every token: "
+                    f"tokens={num_tokens}, validity={is_valid_token.numel()}"
+                )
+            is_valid_token = is_valid_token.repeat_interleave(
+                num_tokens // is_valid_token.numel()
+            )
+        is_valid_token = is_valid_token.to(
+            device=seq_lens.device,
+            dtype=torch.bool,
+        )
+    if out is None:
+        out = torch.empty(num_tokens, dtype=torch.int64, device=seq_lens.device)
+    if out.dim() != 1 or out.dtype != torch.int64 or out.numel() < num_tokens:
+        raise ValueError(
+            "out must be a 1-D int64 tensor with at least num_tokens entries, got "
+            f"shape={tuple(out.shape)} dtype={out.dtype} tokens={num_tokens}"
+        )
+    if out.stride(0) != 1:
+        raise ValueError("out must be contiguous")
+
+    slot_mapping = out[:num_tokens]
+    if out.numel() == 0:
+        return slot_mapping
+
+    num_reqs = min(
+        seq_lens.numel(),
+        max(0, query_start_loc.numel() - 1),
+        block_table.shape[0],
+        (
+            block_table_base_offsets.numel()
+            if block_table_base_offsets is not None
+            else seq_lens.numel()
+        ),
+    )
+    if seq_lens.is_cuda:
+        req_indices_i32 = token_to_req_indices.to(torch.int32)
+        query_start_i32 = query_start_loc.to(torch.int32)
+        seq_lens_i32 = seq_lens.to(torch.int32)
+        block_table_i32 = _as_int32_block_table(block_table)
+        validity_arg = seq_lens_i32 if is_valid_token is None else is_valid_token
+        base_offsets_arg = (
+            seq_lens_i32
+            if block_table_base_offsets is None
+            else block_table_base_offsets.to(torch.int32)
+        )
+        _dsv4_compact_compressed_slot_mapping_kernel[(out.numel(),)](
+            out,
+            req_indices_i32,
+            req_indices_i32.stride(0),
+            query_start_i32,
+            query_start_i32.stride(0),
+            seq_lens_i32,
+            seq_lens_i32.stride(0),
+            validity_arg,
+            validity_arg.stride(0),
+            block_table_i32,
+            block_table_i32.stride(0),
+            base_offsets_arg,
+            base_offsets_arg.stride(0),
+            num_tokens,
+            num_reqs,
+            block_table_i32.shape[1],
+            has_valid_token=is_valid_token is not None,
+            has_block_table_base_offsets=block_table_base_offsets is not None,
+            block_size=block_size,
+            compress_ratio=compress_ratio,
+        )
+        return slot_mapping
+
+    out.fill_(-1)
+    if num_tokens == 0 or num_reqs == 0:
+        return slot_mapping
+    req_idx = token_to_req_indices[:num_tokens].to(torch.int64)
+    valid_req = (req_idx >= 0) & (req_idx < num_reqs)
+    safe_req = req_idx.clamp(0, num_reqs - 1)
+    query_starts = query_start_loc[safe_req].to(torch.int64)
+    query_lens = query_start_loc[safe_req + 1].to(torch.int64) - query_starts
+    positions = (
+        seq_lens[safe_req].to(torch.int64)
+        - query_lens
+        + torch.arange(num_tokens, dtype=torch.int64, device=seq_lens.device)
+        - query_starts
+    )
+    compressed_positions = torch.div(positions, compress_ratio, rounding_mode="floor")
+    table_pages = torch.div(
+        compressed_positions,
+        block_size,
+        rounding_mode="floor",
+    )
+    if block_table_base_offsets is not None:
+        table_pages -= block_table_base_offsets[safe_req].to(torch.int64)
+    valid_page = (
+        valid_req
+        & (positions >= 0)
+        & (((positions + 1) % compress_ratio) == 0)
+        & (table_pages >= 0)
+        & (table_pages < block_table.shape[1])
+    )
+    safe_page = table_pages.clamp(0, max(0, block_table.shape[1] - 1))
+    if block_table.shape[1] == 0:
+        page_ids = torch.full_like(table_pages, -1)
+    else:
+        page_ids = block_table.to(torch.int64)[safe_req, safe_page]
+    valid_page &= page_ids >= 0
+    if is_valid_token is not None:
+        valid_page &= is_valid_token[:num_tokens]
+    slots = page_ids * block_size + compressed_positions % block_size
+    slot_mapping.copy_(torch.where(valid_page, slots, torch.full_like(slots, -1)))
     return slot_mapping
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -26,7 +26,10 @@
 
 from __future__ import annotations
 
+import atexit
+import logging
 import os
+import threading
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
@@ -37,11 +40,187 @@ _ALL_LAYER_GRID_CAP = int(os.environ.get("TOKENSPEED_KV_ALL_LAYER_GRID_CAP", "32
 _HOST_CACHE_GRID_CAP = int(os.environ.get("TOKENSPEED_HOST_CACHE_GRID_CAP", "64"))
 _HOST_CACHE_BLOCK_SIZE = 4096
 
+
+def _parse_boolean_env(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean, got {value!r}")
+
+
+_ZERO_RANGE_STAGING_ENABLED = _parse_boolean_env(
+    "TOKENSPEED_ZERO_CACHE_RANGE_TABLE_STAGING", False
+)
+_ZERO_RANGE_STAGING_CAPACITY = int(
+    os.environ.get("TOKENSPEED_ZERO_CACHE_RANGE_TABLE_CAPACITY", "256")
+)
+_ZERO_RANGE_STAGING_MIN_ROWS = int(
+    os.environ.get("TOKENSPEED_ZERO_CACHE_RANGE_TABLE_MIN_ROWS", "0")
+)
+if _ZERO_RANGE_STAGING_ENABLED and _ZERO_RANGE_STAGING_CAPACITY <= 0:
+    raise ValueError("TOKENSPEED_ZERO_CACHE_RANGE_TABLE_CAPACITY must be positive")
+if _ZERO_RANGE_STAGING_ENABLED and _ZERO_RANGE_STAGING_MIN_ROWS < 0:
+    raise ValueError("TOKENSPEED_ZERO_CACHE_RANGE_TABLE_MIN_ROWS must be nonnegative")
+
+logger = logging.getLogger(__name__)
+
 _is_nvidia = current_platform().is_nvidia
 
 
 def _use_pdl(enable_pdl: bool | None) -> bool:
     return bool((pdl_enabled() if enable_pdl is None else enable_pdl) and _is_nvidia)
+
+
+class _ZeroRangeTableSlot:
+    __slots__ = ("host", "device", "event", "event_recorded", "reserved")
+
+    def __init__(self, device: torch.device, capacity: int) -> None:
+        self.host = torch.empty(
+            (capacity, 2), dtype=torch.int64, device="cpu", pin_memory=True
+        )
+        self.device = torch.empty((capacity, 2), dtype=torch.int64, device=device)
+        self.event = torch.cuda.Event(enable_timing=False, blocking=False)
+        self.event_recorded = False
+        self.reserved = False
+
+    def available(self) -> bool:
+        return not self.reserved and (not self.event_recorded or self.event.query())
+
+
+class _ZeroRangeTableStager:
+    """Stage descriptors without reusing any of four in-flight buffers."""
+
+    def __init__(self, capacity: int) -> None:
+        self.capacity = capacity
+        self._lock = threading.Lock()
+        self._slots_by_device: dict[tuple[str, int], list[_ZeroRangeTableSlot]] = {}
+        self._next_by_device: dict[tuple[str, int], int] = {}
+        self.stats = {
+            "staged": 0,
+            "busy_fallback": 0,
+            "oversize_fallback": 0,
+            "capture_fallback": 0,
+        }
+
+    @staticmethod
+    def _device_key(device: torch.device) -> tuple[str, int]:
+        index = device.index
+        if index is None:
+            index = torch.cuda.current_device()
+        return device.type, int(index)
+
+    def _slots(
+        self, device: torch.device
+    ) -> tuple[tuple[str, int], list[_ZeroRangeTableSlot]]:
+        key = self._device_key(device)
+        slots = self._slots_by_device.get(key)
+        if slots is None:
+            slots = [_ZeroRangeTableSlot(device, self.capacity) for _ in range(4)]
+            self._slots_by_device[key] = slots
+            self._next_by_device[key] = 0
+        return key, slots
+
+    def _record_fallback(self, kind: str, message: str) -> None:
+        with self._lock:
+            self.stats[kind] += 1
+            if self.stats[kind] == 1:
+                logger.warning(message)
+
+    def try_stage(
+        self, ranges: list[tuple[int, int]], device: torch.device
+    ) -> tuple[torch.Tensor, _ZeroRangeTableSlot, torch.cuda.Stream] | None:
+        count = len(ranges)
+        if count > self.capacity:
+            self._record_fallback(
+                "oversize_fallback",
+                "ZERO_CACHE_RANGE_TABLE_STAGING fallback=oversize "
+                f"rows={count} capacity={self.capacity}",
+            )
+            return None
+        if torch.cuda.is_current_stream_capturing():
+            self._record_fallback(
+                "capture_fallback", "ZERO_CACHE_RANGE_TABLE_STAGING fallback=capture"
+            )
+            return None
+        with self._lock:
+            key, slots = self._slots(device)
+            start = self._next_by_device[key]
+            selected = None
+            for offset in range(4):
+                slot_index = (start + offset) % 4
+                if slots[slot_index].available():
+                    selected = slots[slot_index]
+                    selected.reserved = True
+                    self._next_by_device[key] = (slot_index + 1) % 4
+                    break
+            if selected is None:
+                self.stats["busy_fallback"] += 1
+                if self.stats["busy_fallback"] == 1:
+                    logger.warning("ZERO_CACHE_RANGE_TABLE_STAGING fallback=busy")
+                return None
+        stream = torch.cuda.current_stream(device)
+        try:
+            cpu_values = torch.as_tensor(ranges, dtype=torch.int64, device="cpu")
+            selected.host[:count].copy_(cpu_values)
+            selected.device[:count].copy_(selected.host[:count], non_blocking=True)
+        except Exception:
+            self.finish(selected, stream)
+            raise
+        with self._lock:
+            self.stats["staged"] += 1
+            if self.stats["staged"] == 1:
+                logger.warning(
+                    "ZERO_CACHE_RANGE_TABLE_STAGING staged_first rows=%d device=%s",
+                    count,
+                    device,
+                )
+        return selected.device[:count], selected, stream
+
+    def finish(self, slot: _ZeroRangeTableSlot, stream: torch.cuda.Stream) -> None:
+        slot.event.record(stream)
+        with self._lock:
+            slot.event_recorded = True
+            slot.reserved = False
+
+    def snapshot_stats(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self.stats)
+
+
+_ZERO_RANGE_TABLE_STAGER = _ZeroRangeTableStager(_ZERO_RANGE_STAGING_CAPACITY)
+
+
+def _log_zero_range_staging_summary() -> None:
+    stats = _ZERO_RANGE_TABLE_STAGER.snapshot_stats()
+    logger.warning(
+        "ZERO_CACHE_RANGE_TABLE_STAGING summary capacity=%d min_rows=%d slots=4 "
+        "staged=%d busy_fallback=%d oversize_fallback=%d capture_fallback=%d",
+        _ZERO_RANGE_STAGING_CAPACITY,
+        _ZERO_RANGE_STAGING_MIN_ROWS,
+        stats["staged"],
+        stats["busy_fallback"],
+        stats["oversize_fallback"],
+        stats["capture_fallback"],
+    )
+
+
+if _ZERO_RANGE_STAGING_ENABLED:
+    logger.warning(
+        "ZERO_CACHE_RANGE_TABLE_STAGING enabled capacity=%d min_rows=%d slots=4",
+        _ZERO_RANGE_STAGING_CAPACITY,
+        _ZERO_RANGE_STAGING_MIN_ROWS,
+    )
+    atexit.register(_log_zero_range_staging_summary)
+
+
+def _should_stage_zero_ranges(count: int) -> bool:
+    """Return whether this descriptor table is large enough for reuse."""
+    return _ZERO_RANGE_STAGING_ENABLED and count >= _ZERO_RANGE_STAGING_MIN_ROWS
 
 
 __all__ = [
@@ -199,23 +378,35 @@ def zero_byte_ranges(backing: torch.Tensor, ranges: list[tuple[int, int]]) -> No
     ):
         raise ValueError("ranges must be non-empty and lie within backing")
 
-    range_table = (
-        torch.tensor(ranges, dtype=torch.int64)
-        .pin_memory()
-        .to(backing.device, non_blocking=True)
+    staged = (
+        _ZERO_RANGE_TABLE_STAGER.try_stage(ranges, backing.device)
+        if _should_stage_zero_ranges(len(ranges))
+        else None
     )
+    if staged is None:
+        range_table = (
+            torch.tensor(ranges, dtype=torch.int64)
+            .pin_memory()
+            .to(backing.device, non_blocking=True)
+        )
+        staging_slot = None
+        staging_stream = None
+    else:
+        range_table, staging_slot, staging_stream = staged
 
-    block_size = 1024
-    max_size = max(size for _, size in ranges)
-
-    grid = (len(ranges), triton.cdiv(max_size, block_size))
-
-    _zero_byte_ranges_kernel[grid](
-        backing,
-        range_table,
-        BLOCK_SIZE=block_size,
-        num_warps=4,
-    )
+    try:
+        block_size = 1024
+        max_size = max(size for _, size in ranges)
+        grid = (len(ranges), triton.cdiv(max_size, block_size))
+        _zero_byte_ranges_kernel[grid](
+            backing,
+            range_table,
+            BLOCK_SIZE=block_size,
+            num_warps=4,
+        )
+    finally:
+        if staging_slot is not None:
+            _ZERO_RANGE_TABLE_STAGER.finish(staging_slot, staging_stream)
 
 
 # -----------------------------------------------------------------------------

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/__init__.py
@@ -26,6 +26,7 @@ import torch
 from tokenspeed_kernel.ops.layernorm.triton import (
     grouped_gemma_rmsnorm as _grouped_gemma_rmsnorm,
 )
+from tokenspeed_kernel.ops.layernorm.triton import grouped_rmsnorm as _grouped_rmsnorm
 from tokenspeed_kernel.platform import current_platform
 
 _platform = current_platform()
@@ -132,4 +133,26 @@ def grouped_gemma_rmsnorm(
     return _grouped_gemma_rmsnorm(x, weight, effective_group_size, eps, out=out)
 
 
-__all__ = ["grouped_gemma_rmsnorm", "qk_rmsnorm", "rmsnorm"]
+def grouped_rmsnorm(
+    x: torch.Tensor,
+    group_size: int,
+    eps: float,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply weight-free RMSNorm to contiguous groups of the last dimension.
+
+    Args:
+        x: GPU input shaped ``[..., width]``.
+        group_size: Number of contiguous values sharing one RMS statistic.
+        eps: Epsilon added before reciprocal square root.
+        out: Optional contiguous output matching ``x``; may alias ``x``.
+
+    Returns:
+        Normalized tensor matching ``x`` shape and dtype.
+    """
+    if not x.is_cuda:
+        raise ValueError("grouped_rmsnorm requires GPU tensors")
+    return _grouped_rmsnorm(x, int(group_size), eps, out=out)
+
+
+__all__ = ["grouped_gemma_rmsnorm", "grouped_rmsnorm", "qk_rmsnorm", "rmsnorm"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/layernorm/triton.py
@@ -232,6 +232,99 @@ def grouped_gemma_rmsnorm(
 
 
 @triton.jit
+def _grouped_rmsnorm_kernel(
+    x_ptr,
+    out_ptr,
+    row_stride,
+    out_row_stride,
+    eps: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offsets = tl.arange(0, BLOCK)
+    mask = offsets < GROUP_SIZE
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+    x = tl.load(
+        x_ptr + row * row_stride + offsets,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    variance = tl.sum(x * x, axis=0) / GROUP_SIZE
+    normalized = x * tl.rsqrt(variance + eps)
+    tl.store(
+        out_ptr + row * out_row_stride + offsets,
+        normalized,
+        mask=mask,
+    )
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+
+def grouped_rmsnorm(
+    x: torch.Tensor,
+    group_size: int,
+    eps: float,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply weight-free RMSNorm independently to last-dimension groups.
+
+    Args:
+        x: GPU input shaped ``[..., width]``.
+        group_size: Number of contiguous last-dimension values sharing one RMS
+            statistic. The last dimension must be divisible by this value.
+        eps: Epsilon added before reciprocal square root.
+        out: Optional contiguous output matching ``x``. ``out=x`` is supported
+            for graph-safe in-place normalization.
+
+    Returns:
+        Normalized tensor matching ``x`` shape and dtype.
+    """
+    if x.ndim < 1:
+        raise ValueError("x must have at least one dimension")
+    width = int(x.shape[-1])
+    if group_size <= 0 or width % group_size:
+        raise ValueError(
+            f"group_size must divide the last dimension ({width}), got {group_size}"
+        )
+    if out is None:
+        out = torch.empty(x.shape, dtype=x.dtype, device=x.device)
+    elif out.shape != x.shape or out.dtype != x.dtype or out.device != x.device:
+        raise ValueError("out must match x shape, dtype, and device")
+    elif not out.is_contiguous():
+        raise ValueError("out must be contiguous")
+    if x.numel() == 0:
+        return out
+    if not x.is_contiguous():
+        x = x.contiguous()
+
+    rows = x.numel() // group_size
+    x_2d = x.view(rows, group_size)
+    out_2d = out.view(rows, group_size)
+    block = triton.next_power_of_2(group_size)
+    if block > 65536:
+        raise ValueError("group_size is too large for the Triton reduction")
+    enable_pdl = pdl_enabled()
+    launch_kwargs = (
+        {"launch_pdl": True} if enable_pdl and current_platform().is_nvidia else {}
+    )
+    _grouped_rmsnorm_kernel[(rows,)](
+        x_2d,
+        out_2d,
+        x_2d.stride(0),
+        out_2d.stride(0),
+        eps=eps,
+        GROUP_SIZE=group_size,
+        BLOCK=block,
+        ENABLE_PDL=enable_pdl,
+        **launch_kwargs,
+    )
+    return out
+
+
+@triton.jit
 def _fused_qk_rmsnorm_kernel(
     q_in_ptr,
     k_in_ptr,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/__init__.py
@@ -36,6 +36,8 @@ def mhc_pre(
     rms_eps: float,
     hc_eps: float,
     sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
     override: str | None = None,
     solution: str | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -98,6 +100,8 @@ def mhc_pre(
             rms_eps,
             hc_eps,
             sinkhorn_iters,
+            norm_weight,
+            norm_eps,
         )
 
 
@@ -167,6 +171,8 @@ def mhc_fused_hc(
     rms_eps: float,
     hc_eps: float,
     sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Compose the registered previous post-mapping and current pre-mapping.
 
@@ -199,6 +205,8 @@ def mhc_fused_hc(
         rms_eps,
         hc_eps,
         sinkhorn_iters,
+        norm_weight,
+        norm_eps,
     )
     return residual_cur, layer_input, post_cur, comb_cur
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/deep_gemm.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/deep_gemm.py
@@ -35,6 +35,11 @@ try:
 except Exception:
     tf32_hc_prenorm_gemm = None  # type: ignore[assignment]
 
+try:
+    from tokenspeed_kernel.thirdparty.cuda.mhc import mhc_big_fuse
+except Exception:
+    mhc_big_fuse = None  # type: ignore[assignment]
+
 
 if tf32_hc_prenorm_gemm is not None:
 
@@ -68,6 +73,8 @@ if tf32_hc_prenorm_gemm is not None:
         rms_eps: float,
         hc_eps: float,
         sinkhorn_iters: int,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Run mHC pre-mapping with DeepGEMM prenorm and Triton mixing."""
         if get_pdl() != pdl_enabled():
@@ -81,4 +88,7 @@ if tf32_hc_prenorm_gemm is not None:
             hc_eps,
             sinkhorn_iters,
             tf32_hc_prenorm_gemm,
+            pre_reduce_apply_impl=mhc_big_fuse,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/gluon.py
@@ -77,6 +77,8 @@ if current_platform().is_amd:
         rms_eps: float,
         hc_eps: float,
         sinkhorn_iters: int,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Run split-K prenorm with a GFX950 Gluon reduction/Sinkhorn stage."""
         return _mhc_pre_impl(
@@ -89,4 +91,6 @@ if current_platform().is_amd:
             sinkhorn_iters,
             _mhc_prenorm_gemm_triton,
             pre_reduce_apply_impl=_mhc_pre_reduce_apply_impl,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
         )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/mhc/triton.py
@@ -46,6 +46,13 @@ def _compute_num_split(
     return max(split_k, 1)
 
 
+def _pre_reduce_apply_is_supported(pre_reduce_apply_impl, n_splits: int) -> bool:
+    if pre_reduce_apply_impl is None:
+        return False
+    supported = getattr(pre_reduce_apply_impl, "supported_n_splits", None)
+    return supported is None or n_splits in supported
+
+
 @triton.jit
 def _mhc_prenorm_gemm_triton_kernel(
     x,
@@ -416,6 +423,8 @@ def _mhc_pre_impl(
     prenorm_gemm,
     pre_mix_impl=None,
     pre_reduce_apply_impl=None,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if residual.dtype != torch.bfloat16 or fn.dtype != torch.float32:
         raise RuntimeError("fast mHC requires bf16 residual and fp32 weights")
@@ -458,9 +467,12 @@ def _mhc_pre_impl(
     post_mix = torch.empty(
         num_tokens, hc_mult, dtype=torch.float32, device=residual.device
     )
+    use_pre_reduce_apply = _pre_reduce_apply_is_supported(
+        pre_reduce_apply_impl, n_splits
+    )
     pre_mix = (
         None
-        if pre_reduce_apply_impl is not None
+        if use_pre_reduce_apply
         else torch.empty(
             num_tokens, hc_mult, dtype=torch.float32, device=residual.device
         )
@@ -487,7 +499,11 @@ def _mhc_pre_impl(
         n_splits,
     )
     block_h = 1024
-    if pre_reduce_apply_impl is not None:
+    fused_norm = bool(
+        norm_weight is not None
+        and getattr(pre_reduce_apply_impl, "supports_fused_norm", False)
+    )
+    if use_pre_reduce_apply:
         pre_reduce_apply_impl(
             gemm_out_mul,
             gemm_out_sqrsum,
@@ -503,6 +519,8 @@ def _mhc_pre_impl(
             sinkhorn_iters,
             n_splits,
             num_tokens,
+            norm_weight=norm_weight if fused_norm else None,
+            norm_eps=0.0 if norm_eps is None else norm_eps,
         )
     else:
         if pre_mix_impl is None:
@@ -550,6 +568,13 @@ def _mhc_pre_impl(
             hc_mult=hc_mult,
             block_h=block_h,
             num_warps=4,
+        )
+
+    if norm_weight is not None and not fused_norm:
+        if norm_eps is None:
+            raise ValueError("norm_eps is required when norm_weight is provided")
+        layer_input = torch.nn.functional.rms_norm(
+            layer_input, (hidden_size,), norm_weight, norm_eps
         )
 
     return (
@@ -667,11 +692,13 @@ def triton_mhc_pre(
     rms_eps: float,
     hc_eps: float,
     sinkhorn_iters: int,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Run the portable Triton mHC pre-mapping."""
     num_tokens = residual.numel() // (residual.shape[-2] * residual.shape[-1])
     if residual.shape[-2] == 4 and num_tokens > 256:
-        return _tiled_mhc_pre_hc4(
+        layer_input, post_mix, comb_mix = _tiled_mhc_pre_hc4(
             residual,
             fn,
             hc_scale,
@@ -680,6 +707,13 @@ def triton_mhc_pre(
             hc_eps,
             sinkhorn_iters,
         )
+        if norm_weight is not None:
+            if norm_eps is None:
+                raise ValueError("norm_eps is required when norm_weight is provided")
+            layer_input = torch.nn.functional.rms_norm(
+                layer_input, (residual.shape[-1],), norm_weight, norm_eps
+            )
+        return layer_input, post_mix, comb_mix
     return _mhc_pre_impl(
         residual,
         fn,
@@ -689,6 +723,8 @@ def triton_mhc_pre(
         hc_eps,
         sinkhorn_iters,
         _mhc_prenorm_gemm_triton,
+        norm_weight=norm_weight,
+        norm_eps=norm_eps,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
@@ -47,6 +47,7 @@ __all__ = [
     "latent_moe_input_projections",
     "moe_apply",
     "moe_plan",
+    "pack_topk_router_logits",
     "moe_process_weights",
     "moe_sigmoid_bias_topk",
     "moe_softmax_topk",
@@ -60,6 +61,7 @@ from tokenspeed_kernel.ops.moe.latent_input import (  # noqa: E402
     latent_moe_input_projections,
 )
 from tokenspeed_kernel.ops.moe.native import native_latent_moe_available  # noqa: E402
+from tokenspeed_kernel.ops.moe.pack_topk import pack_topk_router_logits  # noqa: E402
 from tokenspeed_kernel.ops.moe.sigmoid_topk import moe_sigmoid_bias_topk  # noqa: E402
 from tokenspeed_kernel.ops.moe.softmax_topk import moe_softmax_topk  # noqa: E402
 
@@ -358,6 +360,7 @@ def dsv4_select_experts(
     need_scores: bool = True,
     override: str | None = None,
     solution: str | None = None,
+    hash_table_values_validated: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Select DeepSeek V4 experts from sqrt-softplus router scores.
 
@@ -375,6 +378,9 @@ def dsv4_select_experts(
             kernels avoid materializing it when false.
         override: Optional exact registered kernel name.
         solution: Optional registered solution name.
+        hash_table_values_validated: Whether the caller has already validated
+            every expert id in the immutable hash table. This only skips the
+            repeated table-value check; runtime token ids are always checked.
 
     Returns:
         FP32 weights, INT32 expert ids, and a tensor shaped [tokens, experts].
@@ -389,6 +395,10 @@ def dsv4_select_experts(
     tokens, experts = router_logits.shape
     if not 0 < top_k <= experts:
         raise ValueError(f"top_k must be in [1, {experts}], got {top_k}")
+    if not isinstance(hash_table_values_validated, bool):
+        raise TypeError("hash_table_values_validated must be a bool")
+    if hash_table_values_validated and hash_indices_table is None:
+        raise ValueError("hash_table_values_validated requires hash_indices_table")
     if correction_bias is not None and correction_bias.shape != (experts,):
         raise ValueError(f"correction_bias must have shape [{experts}]")
     if hash_indices_table is not None:
@@ -414,8 +424,9 @@ def dsv4_select_experts(
             raise ValueError("input_ids must be on the same device as router_logits")
         _assert_indices_in_range(input_ids, hash_indices_table.shape[0], "input_ids")
         safe_input_ids = input_ids.clamp(0, hash_indices_table.shape[0] - 1)
-        selected_experts = hash_indices_table[safe_input_ids.reshape(-1).long()]
-        _assert_indices_in_range(selected_experts, experts, "hash_indices_table")
+        if not hash_table_values_validated:
+            selected_experts = hash_indices_table[safe_input_ids.reshape(-1).long()]
+            _assert_indices_in_range(selected_experts, experts, "hash_indices_table")
         input_ids = safe_input_ids
 
     routing_kind = _routing_kind(correction_bias, hash_indices_table)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/pack_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/pack_topk.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Pack precomputed top-k routes into dense router logits in one launch."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+
+
+@triton.jit
+def _pack_topk_router_logits_kernel(
+    topk_weights,
+    topk_ids,
+    output,
+    num_experts: tl.constexpr,
+    top_k: tl.constexpr,
+    block_experts: tl.constexpr,
+):
+    token = tl.program_id(0)
+    expert_offsets = tl.arange(0, block_experts)
+    logits = tl.full((block_experts,), -1.0e20, tl.float32)
+    route_base = token * top_k
+    for route in tl.static_range(0, top_k):
+        expert = tl.load(topk_ids + route_base + route)
+        weight = tl.load(topk_weights + route_base + route).to(tl.float32)
+        log_weight = tl.log(tl.maximum(weight, 1.1754943508222875e-38))
+        logits = tl.where(expert_offsets == expert, log_weight, logits)
+    tl.store(
+        output + token * num_experts + expert_offsets,
+        logits,
+        mask=expert_offsets < num_experts,
+    )
+
+
+def pack_topk_router_logits(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    num_experts: int,
+) -> torch.Tensor:
+    """Encode selected routes as dense FP32 log-probabilities.
+
+    CUDA inputs use one Triton launch, replacing the fill, clamp, cast, log and
+    scatter chain emitted by the PyTorch expression. CPU remains a reference
+    fallback for configuration tests.
+    """
+    if topk_weights.ndim != 2 or topk_ids.shape != topk_weights.shape:
+        raise ValueError("topk weights and ids must have the same 2D shape")
+    if topk_weights.device != topk_ids.device:
+        raise ValueError("topk weights and ids must be on the same device")
+    if topk_weights.dtype != torch.float32:
+        raise TypeError("topk weights must be float32")
+    if topk_ids.dtype not in (torch.int32, torch.int64):
+        raise TypeError("topk ids must be int32 or int64")
+    if not topk_weights.is_contiguous() or not topk_ids.is_contiguous():
+        raise ValueError("topk weights and ids must be contiguous")
+    if num_experts <= 0:
+        raise ValueError("num_experts must be positive")
+
+    tokens, top_k = topk_ids.shape
+    if tokens == 0:
+        return torch.empty(
+            (0, num_experts), dtype=torch.float32, device=topk_weights.device
+        )
+    if not topk_weights.is_cuda:
+        output = torch.full(
+            (tokens, num_experts),
+            -1.0e20,
+            dtype=torch.float32,
+            device=topk_weights.device,
+        )
+        output.scatter_(
+            1,
+            topk_ids.long(),
+            topk_weights.clamp_min(torch.finfo(torch.float32).tiny).log(),
+        )
+        return output
+
+    block_experts = triton.next_power_of_2(num_experts)
+    output = torch.empty(
+        (tokens, num_experts), dtype=torch.float32, device=topk_weights.device
+    )
+    _pack_topk_router_logits_kernel[(tokens,)](
+        topk_weights,
+        topk_ids,
+        output,
+        num_experts=num_experts,
+        top_k=top_k,
+        block_experts=block_experts,
+        num_warps=4,
+    )
+    return output
+
+
+__all__ = ["pack_topk_router_logits"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/__init__.py
@@ -24,12 +24,85 @@ from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
 __all__ = [
+    "fp8_quantize_dequantize",
     "quantize_fp8",
     "quantize_fp8_with_scale",
     "quantize_mxfp8",
     "quantize_nvfp4",
     "quantize_mxfp4",
 ]
+
+
+def fp8_quantize_dequantize(
+    x: torch.Tensor,
+    group_size: int,
+    scale_encoding: Literal["ue8m0"] = "ue8m0",
+    *,
+    override: str | None = None,
+    solution: str | None = None,
+) -> torch.Tensor:
+    """Simulate grouped FP8 quantization and return the dequantized tensor.
+
+    Each contiguous group on the last dimension receives an independently
+    computed scale.  The result has the same shape and dtype as ``x``.  This
+    operation is intended for models whose published inference contract
+    requires an explicit FP8 round trip before a higher-precision operation.
+
+    Args:
+        x: Input tensor with a contiguous last dimension.
+        group_size: Number of consecutive values that share a scale.
+        scale_encoding: Scale selection contract.  ``"ue8m0"`` chooses the
+            next power-of-two scale needed for finite E4M3 values.
+        override: Optional exact kernel name override.
+        solution: Optional registered solution to select.
+
+    Returns:
+        The grouped FP8-quantized and dequantized tensor in ``x.dtype``.
+    """
+
+    if group_size <= 0 or x.shape[-1] % group_size != 0:
+        raise ValueError(
+            "FP8 quantize/dequantize requires the last dimension to be "
+            f"divisible by a positive group_size; got shape={tuple(x.shape)}, "
+            f"group_size={group_size}."
+        )
+    traits = {
+        "group_size": group_size,
+        "scale_encoding": scale_encoding,
+    }
+    signature = format_signature(x=dense_tensor_format(x.dtype))
+    kernel = select_kernel(
+        "quantization",
+        "fp8_quantize_dequantize",
+        signature,
+        traits=traits,
+        solution=solution,
+        override=override,
+    )
+    shape_params = {
+        "shape": tuple(x.shape),
+        "group_size": group_size,
+        "scale_encoding": scale_encoding,
+    }
+    ShapeCapture.get().record(
+        "quantization",
+        "fp8_quantize_dequantize",
+        kernel.name,
+        x.dtype,
+        shape_params,
+    )
+    with kernel_scope(
+        "quantization",
+        "fp8_quantize_dequantize",
+        x.dtype,
+        kernel_name=kernel.name,
+        **shape_params,
+    ):
+        return kernel(
+            x,
+            group_size=group_size,
+            scale_encoding=scale_encoding,
+        )
 
 
 def quantize_fp8(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/quantization/triton.py
@@ -267,6 +267,77 @@ def _fp8_token_group_quantize(
     return out, scales
 
 
+@triton.jit
+def _fp8_quantize_dequantize_kernel(
+    x_ptr,
+    out_ptr,
+    x_row_stride,
+    out_row_stride,
+    groups_per_row: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+):
+    group_id = tl.program_id(0)
+    row = group_id // groups_per_row
+    column_group = group_id - row * groups_per_row
+    columns = column_group * GROUP_SIZE + tl.arange(0, GROUP_SIZE)
+    x = tl.load(x_ptr + row * x_row_stride + columns).to(tl.float32)
+
+    absmax = tl.maximum(tl.max(tl.abs(x), axis=0), 1.0e-4)
+    scale = tl.exp2(tl.ceil(tl.log2(absmax / 448.0)))
+    quantized = tl.clamp(x / scale, -448.0, 448.0).to(tl.float8e4nv)
+    dequantized = quantized.to(tl.float32) * scale
+    tl.store(out_ptr + row * out_row_stride + columns, dequantized)
+
+
+@register_kernel(
+    "quantization",
+    "fp8_quantize_dequantize",
+    name="triton_fp8_quantize_dequantize",
+    solution="triton",
+    capability=CapabilityRequirement(vendors=frozenset({"amd", "nvidia"})),
+    signatures=format_signatures(
+        "x", "dense", {torch.bfloat16, torch.float16, torch.float32}
+    ),
+    traits={
+        "group_size": frozenset({64, 128}),
+        "scale_encoding": frozenset({"ue8m0"}),
+    },
+    priority=Priority.PORTABLE,
+)
+def triton_fp8_quantize_dequantize(
+    x: torch.Tensor,
+    group_size: int,
+    scale_encoding: str = "ue8m0",
+) -> torch.Tensor:
+    if group_size not in {64, 128}:
+        raise ValueError(f"unsupported FP8 round-trip group_size: {group_size}")
+    if scale_encoding != "ue8m0":
+        raise ValueError(
+            f"unsupported FP8 round-trip scale encoding: {scale_encoding!r}"
+        )
+
+    rows, width, x_row_stride = _flatten_to_2d(x)
+    if width % group_size != 0:
+        raise ValueError(
+            f"last dimension {width} must be divisible by group_size {group_size}"
+        )
+    out = torch.empty_like(x, memory_format=torch.contiguous_format)
+    out_rows, _, out_row_stride = _flatten_to_2d(out)
+    assert out_rows == rows
+    groups_per_row = width // group_size
+    _fp8_quantize_dequantize_kernel[(rows * groups_per_row,)](
+        x,
+        out,
+        x_row_stride,
+        out_row_stride,
+        groups_per_row=groups_per_row,
+        GROUP_SIZE=group_size,
+        num_warps=1,
+        num_stages=1,
+    )
+    return out
+
+
 @register_kernel(
     "quantization",
     "fp8",
@@ -548,6 +619,7 @@ def triton_quantize_mxfp4(
 __all__ = [
     "fp8_quantize",
     "mxfp4_quantize",
+    "triton_fp8_quantize_dequantize",
     "triton_quantize_mxfp4",
     "triton_quantize_fp8_with_scale",
 ]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/mhc_big_fuse.cu
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/mhc_big_fuse.cu
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026 LightSeek Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include "tvm_ffi_utils.h"
+
+namespace tokenspeed {
+
+template <int NumSplits, int BlockSize>
+__launch_bounds__(BlockSize) __global__ void MhcBigFuseKernel(
+    const float* __restrict__ projection, const float* __restrict__ square_sum,
+    const __nv_bfloat16* __restrict__ residual, const float* __restrict__ hc_scale,
+    const float* __restrict__ hc_base, float* __restrict__ post_mix,
+    float* __restrict__ comb_mix, __nv_bfloat16* __restrict__ layer_input,
+    int num_tokens, int hidden_size, float rms_eps, float hc_eps,
+    int sinkhorn_iters, const __nv_bfloat16* __restrict__ norm_weight,
+    float norm_eps, bool fuse_norm) {
+  constexpr int kHc = 4;
+  constexpr int kProjection = 24;
+  constexpr int kWarp = 32;
+  constexpr int kVec = 8;
+  const int token = blockIdx.x;
+  const int tid = threadIdx.x;
+  const int warp = tid / kWarp;
+  const int lane = tid % kWarp;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  asm volatile("griddepcontrol.wait;");
+#endif
+
+  __shared__ float projection_reduced[kProjection];
+  __shared__ float rstd_shared;
+  __shared__ float pre_mix[kHc];
+  __shared__ float norm_warp_sums[16];
+  __shared__ float norm_rstd;
+  float comb[kHc];
+  float norm_square_acc = 0.0f;
+  if (warp == 0) {
+    if (lane < kProjection) {
+      float projection_sum = 0.0f;
+#pragma unroll
+      for (int split = 0; split < NumSplits; ++split) {
+        const float* row =
+            projection + (split * num_tokens + token) * kProjection;
+        projection_sum += row[lane];
+      }
+      projection_reduced[lane] = projection_sum;
+    }
+    if (lane == 0) {
+      float square_sum_reduced = 0.0f;
+#pragma unroll
+      for (int split = 0; split < NumSplits; ++split) {
+        square_sum_reduced += square_sum[split * num_tokens + token];
+      }
+      rstd_shared = rsqrtf(
+          square_sum_reduced / static_cast<float>(kHc * hidden_size) + rms_eps);
+    }
+    __syncwarp();
+    if (lane < kHc) {
+      const float rstd = rstd_shared;
+      float value =
+          projection_reduced[lane] * rstd * hc_scale[0] + hc_base[lane];
+      pre_mix[lane] = 1.0f / (1.0f + expf(-value)) + hc_eps;
+      value = projection_reduced[kHc + lane] * rstd * hc_scale[1] +
+              hc_base[kHc + lane];
+      post_mix[token * kHc + lane] = 2.0f / (1.0f + expf(-value));
+#pragma unroll
+      for (int column = 0; column < kHc; ++column) {
+        const int index = 2 * kHc + lane * kHc + column;
+        comb[column] =
+            projection_reduced[index] * rstd * hc_scale[2] + hc_base[index];
+      }
+    }
+  }
+  __syncthreads();
+
+  if (warp == 0 && lane < kHc) {
+    constexpr unsigned kLaneMask = 0x0f;
+    const float row_max = fmaxf(fmaxf(comb[0], comb[1]), fmaxf(comb[2], comb[3]));
+#pragma unroll
+    for (int column = 0; column < kHc; ++column) {
+      comb[column] = expf(comb[column] - row_max);
+    }
+    float inverse_row_sum = 1.0f / (comb[0] + comb[1] + comb[2] + comb[3]);
+#pragma unroll
+    for (int column = 0; column < kHc; ++column) {
+      comb[column] = comb[column] * inverse_row_sum + hc_eps;
+      float column_sum = comb[column];
+      column_sum += __shfl_xor_sync(kLaneMask, column_sum, 1);
+      column_sum += __shfl_xor_sync(kLaneMask, column_sum, 2);
+      comb[column] *= 1.0f / (column_sum + hc_eps);
+    }
+    for (int iteration = 1; iteration < sinkhorn_iters; ++iteration) {
+      inverse_row_sum = 1.0f / (comb[0] + comb[1] + comb[2] + comb[3] + hc_eps);
+#pragma unroll
+      for (int column = 0; column < kHc; ++column) {
+        comb[column] *= inverse_row_sum;
+      }
+#pragma unroll
+      for (int column = 0; column < kHc; ++column) {
+        float column_sum = comb[column];
+        column_sum += __shfl_xor_sync(kLaneMask, column_sum, 1);
+        column_sum += __shfl_xor_sync(kLaneMask, column_sum, 2);
+        comb[column] *= 1.0f / (column_sum + hc_eps);
+      }
+    }
+#pragma unroll
+    for (int column = 0; column < kHc; ++column) {
+      comb_mix[token * kHc * kHc + lane * kHc + column] = comb[column];
+    }
+  }
+
+  if (warp > 0) {
+    float mix[kHc];
+#pragma unroll
+    for (int index = 0; index < kHc; ++index) {
+      mix[index] = pre_mix[index];
+    }
+    const __nv_bfloat16* residual_row = residual + token * kHc * hidden_size;
+    __nv_bfloat16* output_row = layer_input + token * hidden_size;
+    const int apply_tid = tid - kWarp;
+    constexpr int kApplyThreads = BlockSize - kWarp;
+    for (int hidden = apply_tid * kVec; hidden < hidden_size;
+         hidden += kApplyThreads * kVec) {
+      float accumulator[kVec] = {};
+#pragma unroll
+      for (int stream = 0; stream < kHc; ++stream) {
+        const uint4 raw = *reinterpret_cast<const uint4*>(
+            residual_row + stream * hidden_size + hidden);
+        const __nv_bfloat162* pairs = reinterpret_cast<const __nv_bfloat162*>(&raw);
+#pragma unroll
+        for (int pair = 0; pair < kVec / 2; ++pair) {
+          const float2 value = __bfloat1622float2(pairs[pair]);
+          accumulator[pair * 2] += mix[stream] * value.x;
+          accumulator[pair * 2 + 1] += mix[stream] * value.y;
+        }
+      }
+      uint4 raw;
+      __nv_bfloat162* pairs = reinterpret_cast<__nv_bfloat162*>(&raw);
+#pragma unroll
+      for (int pair = 0; pair < kVec / 2; ++pair) {
+        pairs[pair] = __float22bfloat162_rn(
+            make_float2(accumulator[pair * 2], accumulator[pair * 2 + 1]));
+        if (fuse_norm) {
+          const float2 rounded = __bfloat1622float2(pairs[pair]);
+          norm_square_acc += rounded.x * rounded.x + rounded.y * rounded.y;
+        }
+      }
+      *reinterpret_cast<uint4*>(output_row + hidden) = raw;
+    }
+    if (fuse_norm) {
+#pragma unroll
+      for (int offset = kWarp / 2; offset > 0; offset /= 2) {
+        norm_square_acc +=
+            __shfl_down_sync(0xffffffff, norm_square_acc, offset);
+      }
+      if (lane == 0) norm_warp_sums[warp] = norm_square_acc;
+    }
+  }
+  if (fuse_norm) {
+    __syncthreads();
+    const __nv_bfloat16* output_row = layer_input + token * hidden_size;
+    if (warp == 0) {
+      constexpr int kApplyWarps = BlockSize / kWarp - 1;
+      float block_sum =
+          lane < kApplyWarps ? norm_warp_sums[lane + 1] : 0.0f;
+#pragma unroll
+      for (int offset = kWarp / 2; offset > 0; offset /= 2) {
+        block_sum += __shfl_down_sync(0xffffffff, block_sum, offset);
+      }
+      if (lane == 0) {
+        norm_rstd = rsqrtf(block_sum / static_cast<float>(hidden_size) + norm_eps);
+      }
+    }
+    __syncthreads();
+    for (int hidden = tid * kVec; hidden < hidden_size;
+         hidden += BlockSize * kVec) {
+      const uint4 output_raw =
+          *reinterpret_cast<const uint4*>(output_row + hidden);
+      const uint4 weight_raw =
+          *reinterpret_cast<const uint4*>(norm_weight + hidden);
+      const __nv_bfloat162* output_pairs =
+          reinterpret_cast<const __nv_bfloat162*>(&output_raw);
+      const __nv_bfloat162* weight_pairs =
+          reinterpret_cast<const __nv_bfloat162*>(&weight_raw);
+      uint4 normalized_raw;
+      __nv_bfloat162* normalized_pairs =
+          reinterpret_cast<__nv_bfloat162*>(&normalized_raw);
+#pragma unroll
+      for (int pair = 0; pair < kVec / 2; ++pair) {
+        const float2 output_value = __bfloat1622float2(output_pairs[pair]);
+        const float2 weight_value = __bfloat1622float2(weight_pairs[pair]);
+        normalized_pairs[pair] = __float22bfloat162_rn(make_float2(
+            output_value.x * norm_rstd * weight_value.x,
+            output_value.y * norm_rstd * weight_value.y));
+      }
+      *reinterpret_cast<uint4*>(layer_input + token * hidden_size + hidden) =
+          normalized_raw;
+    }
+  }
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+template <int NumSplits>
+cudaError_t LaunchMhcBigFuse(
+    const float* projection, const float* square_sum, const __nv_bfloat16* residual,
+    const float* hc_scale, const float* hc_base, float* post_mix, float* comb_mix,
+    __nv_bfloat16* layer_input, int num_tokens, int hidden_size, float rms_eps,
+    float hc_eps, int sinkhorn_iters, const __nv_bfloat16* norm_weight,
+    float norm_eps, bool fuse_norm, int block_size, bool enable_pdl,
+    cudaStream_t stream) {
+  cudaLaunchConfig_t config{};
+  config.gridDim = dim3(num_tokens);
+  config.dynamicSmemBytes = 0;
+  config.stream = stream;
+  cudaLaunchAttribute attribute{};
+  attribute.id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  attribute.val.programmaticStreamSerializationAllowed = enable_pdl;
+  config.attrs = &attribute;
+  config.numAttrs = 1;
+#define LAUNCH(BlockSize)                                                        \
+  do {                                                                           \
+    config.blockDim = dim3(BlockSize);                                            \
+    auto kernel = MhcBigFuseKernel<NumSplits, BlockSize>;                         \
+    return cudaLaunchKernelEx(&config, kernel, projection, square_sum, residual,  \
+                              hc_scale, hc_base, post_mix, comb_mix, layer_input, \
+                              num_tokens, hidden_size, rms_eps, hc_eps,            \
+                              sinkhorn_iters, norm_weight, norm_eps, fuse_norm);   \
+  } while (false)
+  if (block_size == 128) LAUNCH(128);
+  if (block_size == 256) LAUNCH(256);
+  LAUNCH(512);
+#undef LAUNCH
+}
+
+}  // namespace tokenspeed
+
+void mhc_big_fuse(
+    TensorView projection, TensorView square_sum, TensorView hc_scale,
+    TensorView hc_base, TensorView residual, TensorView layer_input,
+    TensorView post_mix, TensorView comb_mix, int64_t hidden_size, double rms_eps,
+    double hc_eps, int64_t sinkhorn_iters, int64_t n_splits, int64_t num_tokens,
+    TensorView norm_weight, double norm_eps, bool fuse_norm, int64_t block_size,
+    bool enable_pdl) {
+  CHECK_INPUT(projection);
+  CHECK_INPUT(square_sum);
+  CHECK_INPUT(hc_scale);
+  CHECK_INPUT(hc_base);
+  CHECK_INPUT(residual);
+  CHECK_INPUT(layer_input);
+  CHECK_INPUT(post_mix);
+  CHECK_INPUT(comb_mix);
+  CHECK_INPUT(norm_weight);
+  CHECK_DEVICE(square_sum, projection);
+  CHECK_DEVICE(hc_scale, projection);
+  CHECK_DEVICE(hc_base, projection);
+  CHECK_DEVICE(residual, projection);
+  CHECK_DEVICE(layer_input, projection);
+  CHECK_DEVICE(post_mix, projection);
+  CHECK_DEVICE(comb_mix, projection);
+  CHECK_DEVICE(norm_weight, projection);
+  CHECK_DIM(3, projection);
+  CHECK_DIM(2, square_sum);
+  CHECK_DIM(1, hc_scale);
+  CHECK_DIM(1, hc_base);
+  CHECK_DIM(3, residual);
+  CHECK_DIM(2, layer_input);
+  CHECK_DIM(2, post_mix);
+  CHECK_DIM(2, comb_mix);
+  CHECK_DIM(1, norm_weight);
+  TVM_FFI_ICHECK_EQ(projection.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(square_sum.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(hc_scale.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(hc_base.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(residual.dtype(), dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(layer_input.dtype(), dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(post_mix.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(comb_mix.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(norm_weight.dtype(), dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(projection.size(0), n_splits);
+  TVM_FFI_ICHECK_EQ(projection.size(1), num_tokens);
+  TVM_FFI_ICHECK_EQ(projection.size(2), 24);
+  TVM_FFI_ICHECK_EQ(square_sum.size(0), n_splits);
+  TVM_FFI_ICHECK_EQ(square_sum.size(1), num_tokens);
+  TVM_FFI_ICHECK_EQ(residual.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(residual.size(1), 4);
+  TVM_FFI_ICHECK_EQ(residual.size(2), hidden_size);
+  TVM_FFI_ICHECK_EQ(layer_input.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(layer_input.size(1), hidden_size);
+  TVM_FFI_ICHECK_EQ(post_mix.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(post_mix.size(1), 4);
+  TVM_FFI_ICHECK_EQ(comb_mix.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(comb_mix.size(1), 16);
+  TVM_FFI_ICHECK_EQ(hc_scale.size(0), 3);
+  TVM_FFI_ICHECK_EQ(hc_base.size(0), 24);
+  TVM_FFI_ICHECK_EQ(norm_weight.size(0), hidden_size);
+  TVM_FFI_ICHECK_GT(num_tokens, 0);
+  TVM_FFI_ICHECK_GT(sinkhorn_iters, 0);
+  TVM_FFI_ICHECK_EQ(hidden_size % 8, 0);
+  TVM_FFI_ICHECK(block_size == 128 || block_size == 256 || block_size == 512);
+  TVM_FFI_ICHECK(n_splits == 1 || n_splits == 2 || n_splits == 4 ||
+                 n_splits == 8 || n_splits == 16 || n_splits == 32 ||
+                 n_splits == 64)
+      << "unsupported n_splits=" << n_splits;
+
+  cudaSetDevice(projection.device().device_id);
+  const cudaStream_t stream = get_stream(projection.device());
+  cudaError_t status = cudaErrorInvalidValue;
+#define DISPATCH(Splits)                                                          \
+  status = tokenspeed::LaunchMhcBigFuse<Splits>(                                  \
+      static_cast<const float*>(projection.data_ptr()),                           \
+      static_cast<const float*>(square_sum.data_ptr()),                           \
+      static_cast<const __nv_bfloat16*>(residual.data_ptr()),                     \
+      static_cast<const float*>(hc_scale.data_ptr()),                             \
+      static_cast<const float*>(hc_base.data_ptr()),                              \
+      static_cast<float*>(post_mix.data_ptr()),                                   \
+      static_cast<float*>(comb_mix.data_ptr()),                                   \
+      static_cast<__nv_bfloat16*>(layer_input.data_ptr()),                        \
+      static_cast<int>(num_tokens), static_cast<int>(hidden_size),                \
+      static_cast<float>(rms_eps), static_cast<float>(hc_eps),                    \
+      static_cast<int>(sinkhorn_iters),                                           \
+      static_cast<const __nv_bfloat16*>(norm_weight.data_ptr()),                  \
+      static_cast<float>(norm_eps), fuse_norm, static_cast<int>(block_size),       \
+      enable_pdl, stream)
+  switch (n_splits) {
+    case 1: DISPATCH(1); break;
+    case 2: DISPATCH(2); break;
+    case 4: DISPATCH(4); break;
+    case 8: DISPATCH(8); break;
+    case 16: DISPATCH(16); break;
+    case 32: DISPATCH(32); break;
+    case 64: DISPATCH(64); break;
+  }
+#undef DISPATCH
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "mhc_big_fuse launch failed: " << cudaGetErrorString(status);
+}
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(mhc_big_fuse, mhc_big_fuse);

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/mhc.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/mhc.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""CUDA implementation of fused mHC reduction, mixing, and residual apply."""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+
+import torch
+from tokenspeed_kernel.platform import pdl_enabled
+
+
+@functools.cache
+def _load_mhc_module():
+    import tvm_ffi
+
+    so_path = Path(__file__).parent / "objs" / "mhc_big_fuse" / "mhc_big_fuse.so"
+    if not so_path.exists():
+        raise RuntimeError(
+            f"tokenspeed_kernel mHC library not found at {so_path}. "
+            "Run: pip install -e tokenspeed_kernel/python/"
+        )
+    return tvm_ffi.load_module(str(so_path))
+
+
+def mhc_big_fuse(
+    projection: torch.Tensor,
+    square_sum: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    residual: torch.Tensor,
+    layer_input: torch.Tensor,
+    post_mix: torch.Tensor,
+    comb_mix: torch.Tensor,
+    hidden_size: int,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+    n_splits: int,
+    num_tokens: int,
+    *,
+    norm_weight: torch.Tensor | None = None,
+    norm_eps: float = 0.0,
+    block_size: int = 512,
+    enable_pdl: bool | None = None,
+) -> None:
+    """Reduce split-K mHC projections and emit all pre-mapping outputs.
+
+    The input/output tensors are preallocated by the mHC dispatcher.  This
+    function replaces the separate pre-mix and residual-apply kernels with one
+    CUDA launch. ``block_size`` supports 128, 256, or 512 threads.
+    """
+    enable_pdl = pdl_enabled() if enable_pdl is None else enable_pdl
+    norm_weight_arg = (
+        norm_weight
+        if norm_weight is not None
+        else layer_input.reshape(-1)[:hidden_size]
+    )
+    _load_mhc_module().mhc_big_fuse(
+        projection,
+        square_sum,
+        hc_scale,
+        hc_base,
+        residual,
+        layer_input,
+        post_mix,
+        comb_mix,
+        int(hidden_size),
+        float(rms_eps),
+        float(hc_eps),
+        int(sinkhorn_iters),
+        int(n_splits),
+        int(num_tokens),
+        norm_weight_arg,
+        float(norm_eps),
+        norm_weight is not None,
+        int(block_size),
+        bool(enable_pdl),
+    )
+
+
+# Decode uses 64 splits on GB200. Prefill graph buckets can produce arbitrary
+# split counts, so callers must retain the established Triton fallback there.
+mhc_big_fuse.supported_n_splits = frozenset({1, 2, 4, 8, 16, 32, 64})
+mhc_big_fuse.supports_fused_norm = True

--- a/tokenspeed-kernel/test/ops/test_attention_dsv4.py
+++ b/tokenspeed-kernel/test/ops/test_attention_dsv4.py
@@ -22,17 +22,23 @@ from tokenspeed_kernel.ops.attention.cuda.dsv4 import (
     persistent_topk,
 )
 from tokenspeed_kernel.ops.attention.triton.dsv4 import (
+    _dsv4_decode_dense_compressed_indices_and_lens_kernel,
     _dsv4_decode_swa_indices_and_lens_kernel,
     _dsv4_dequantize_and_gather_k_kernel,
     _dsv4_fused_csa_indexer_mxfp4_cache_kernel,
     _dsv4_fused_sparse_compress_cache_kernel,
     _dsv4_gather_launch_config,
+    _dsv4_use_serial_four_block_indexer_q,
     dsv4_combine_dense_swa_indices,
     dsv4_combine_topk_swa_indices,
+    dsv4_compact_compressed_slot_mapping,
     dsv4_compressed_slot_mapping,
     dsv4_compute_global_topk_indices_and_lens,
+    dsv4_decode_dense_compressed_indices_and_lens,
     dsv4_decode_swa_indices_and_lens,
     dsv4_dequantize_and_gather_k_cache,
+    dsv4_fused_indexer_q_rope_hadamard_mxfp4,
+    dsv4_group_slot_mapping,
     write_dsv4_indexer_mxfp4_cache_cuda,
 )
 from tokenspeed_kernel.ops.transform import hadamard_transform
@@ -530,6 +536,39 @@ def _expected_overlap_normed(
 
 
 class DeepseekV4AttentionOpsCpuValidationTest(unittest.TestCase):
+    def test_indexer_q_serial_four_block_selector_is_fail_closed(self):
+        valid = {
+            "num_tokens": 8192,
+            "head_dim": 128,
+            "rope_dim": 64,
+            "quant_block": 32,
+            "is_cuda": True,
+            "is_hip": False,
+            "capability": (10, 0),
+            "shapes_valid": True,
+            "dtypes_valid": True,
+            "devices_valid": True,
+            "inner_strides": (1, 1, 1, 1),
+        }
+        self.assertTrue(_dsv4_use_serial_four_block_indexer_q(**valid))
+        invalid_overrides = (
+            {"num_tokens": 8191},
+            {"head_dim": 64},
+            {"rope_dim": 32},
+            {"quant_block": 64},
+            {"is_cuda": False},
+            {"is_hip": True},
+            {"capability": (9, 0)},
+            {"shapes_valid": False},
+            {"dtypes_valid": False},
+            {"devices_valid": False},
+            {"inner_strides": (2, 1, 1, 1)},
+        )
+        for override in invalid_overrides:
+            case = valid | override
+            with self.subTest(override=override):
+                self.assertFalse(_dsv4_use_serial_four_block_indexer_q(**case))
+
     def test_v4_table_kernels_do_not_specialize_runtime_geometry(self):
         cases = (
             (
@@ -542,6 +581,10 @@ class DeepseekV4AttentionOpsCpuValidationTest(unittest.TestCase):
             ),
             (
                 _dsv4_dequantize_and_gather_k_kernel,
+                ("block_table_stride", "max_blocks_per_seq"),
+            ),
+            (
+                _dsv4_decode_dense_compressed_indices_and_lens_kernel,
                 ("block_table_stride", "max_blocks_per_seq"),
             ),
             (
@@ -1877,6 +1920,44 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             )
         )
 
+    def test_indexer_q_serial_four_block_is_bitwise_equal_at_production_shape(self):
+        if torch.cuda.get_device_capability() != (10, 0):
+            self.skipTest("exact serial-four-block specialization requires SM100")
+        torch.manual_seed(9125)
+        device = torch.device("cuda")
+        num_tokens = 8192
+        num_heads = 64
+        positions = torch.arange(num_tokens, device=device, dtype=torch.int64)
+        cos_sin = torch.randn(num_tokens, ROPE_DIM, device=device, dtype=torch.float32)
+        q = torch.randn(num_tokens, num_heads, 128, device=device, dtype=torch.bfloat16)
+        weights = torch.randn(num_tokens, num_heads, device=device, dtype=torch.float32)
+
+        baseline = dsv4_fused_indexer_q_rope_hadamard_mxfp4(
+            index_q=q,
+            positions=positions,
+            cos_sin_cache=cos_sin,
+            weights=weights,
+            softmax_scale=0.25,
+            head_scale=num_heads**-0.5,
+            prefer_serial_four_block=False,
+        )
+        serial = dsv4_fused_indexer_q_rope_hadamard_mxfp4(
+            index_q=q,
+            positions=positions,
+            cos_sin_cache=cos_sin,
+            weights=weights,
+            softmax_scale=0.25,
+            head_scale=num_heads**-0.5,
+            prefer_serial_four_block=True,
+        )
+        torch.cuda.synchronize()
+
+        (baseline_packed, baseline_scales), baseline_weights = baseline
+        (serial_packed, serial_scales), serial_weights = serial
+        self.assertTrue(torch.equal(serial_packed, baseline_packed))
+        self.assertTrue(torch.equal(serial_scales, baseline_scales))
+        self.assertTrue(torch.equal(serial_weights, baseline_weights))
+
     def test_sparse_prefill_combine_topk_swa_indices_matches_reference(self):
         device = torch.device("cuda")
         topk_indices = torch.tensor(
@@ -2072,6 +2153,89 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             compact_lens.cpu(), actual_lens.cpu(), atol=0, rtol=0
         )
 
+    def test_decode_dense_compressed_indices_and_lens_matches_reference(self):
+        device = torch.device("cuda")
+        positions = torch.tensor([5, 9], device=device, dtype=torch.int64)
+        token_to_req_indices = torch.tensor([0, 1], device=device, dtype=torch.int32)
+        block_table = torch.tensor(
+            [[10, 11], [20, 21]],
+            device=device,
+            dtype=torch.int32,
+        )
+        out_indices = torch.full((2, 8), -123, device=device, dtype=torch.int32)
+        out_lens = torch.empty((2,), device=device, dtype=torch.int32)
+
+        actual, actual_lens = dsv4_decode_dense_compressed_indices_and_lens(
+            positions=positions,
+            token_to_req_indices=token_to_req_indices,
+            block_table=block_table,
+            block_size=4,
+            compress_ratio=2,
+            width=8,
+            out_indices=out_indices,
+            out_lens=out_lens,
+        )
+        torch.cuda.synchronize()
+
+        self.assertEqual(actual.data_ptr(), out_indices.data_ptr())
+        self.assertEqual(actual_lens.data_ptr(), out_lens.data_ptr())
+        self.assertTrue(
+            torch.equal(
+                actual.cpu(),
+                torch.tensor(
+                    [
+                        [40, 41, 42, -1, -1, -1, -1, -1],
+                        [80, 81, 82, 83, 84, -1, -1, -1],
+                    ],
+                    dtype=torch.int32,
+                ),
+            )
+        )
+        self.assertTrue(
+            torch.equal(actual_lens.cpu(), torch.tensor([3, 5], dtype=torch.int32))
+        )
+
+    def test_decode_dense_compressed_indices_masks_invalid_and_compact_pages(self):
+        device = torch.device("cuda")
+        positions = torch.tensor([9, 9], device=device, dtype=torch.int64)
+        token_to_req_indices = torch.tensor([0, 1], device=device, dtype=torch.int32)
+        is_valid_token = torch.tensor([True, False], device=device)
+        compact_table = torch.tensor(
+            [[11], [21]],
+            device=device,
+            dtype=torch.int32,
+        )
+
+        actual, actual_lens = dsv4_decode_dense_compressed_indices_and_lens(
+            positions=positions,
+            token_to_req_indices=token_to_req_indices,
+            block_table=compact_table,
+            block_size=4,
+            compress_ratio=2,
+            width=8,
+            block_table_base_offsets=torch.tensor(
+                [1, 1], device=device, dtype=torch.int32
+            ),
+            is_valid_token=is_valid_token,
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(
+            torch.equal(
+                actual.cpu(),
+                torch.tensor(
+                    [
+                        [-1, -1, -1, -1, 44, -1, -1, -1],
+                        [-1, -1, -1, -1, -1, -1, -1, -1],
+                    ],
+                    dtype=torch.int32,
+                ),
+            )
+        )
+        self.assertTrue(
+            torch.equal(actual_lens.cpu(), torch.tensor([5, 0], dtype=torch.int32))
+        )
+
     def test_decode_swa_indices_and_lens_masks_invalid_tokens(self):
         device = torch.device("cuda")
         query_start_loc = torch.tensor([0, 1, 2], device=device, dtype=torch.int32)
@@ -2237,6 +2401,175 @@ class DeepseekV4AttentionOpsTest(unittest.TestCase):
             )
         )
         self.assertTrue(torch.equal(out[5:].cpu(), torch.full((3,), -1)))
+
+    def test_compact_compressed_slot_mapping_matches_reference_and_replay(self):
+        device = torch.device("cuda")
+        token_to_req_indices = torch.tensor(
+            [0, 0, 0, 1, 1, -1], device=device, dtype=torch.int32
+        )
+        query_start_loc = torch.tensor([0, 3, 5], device=device, dtype=torch.int32)
+        seq_lens = torch.tensor([264, 520], device=device, dtype=torch.int32)
+        block_table = torch.tensor(
+            [[20, 21], [30, -1]], device=device, dtype=torch.int32
+        )
+        base_offsets = torch.tensor([1, 2], device=device, dtype=torch.int32)
+        is_valid_token = torch.tensor(
+            [True, True, True, True, False, True], device=device, dtype=torch.bool
+        )
+        out = torch.full((8,), 1234, device=device, dtype=torch.int64)
+
+        actual = dsv4_compact_compressed_slot_mapping(
+            num_tokens=6,
+            token_to_req_indices=token_to_req_indices,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            block_table=block_table,
+            block_size=64,
+            compress_ratio=4,
+            block_table_base_offsets=base_offsets,
+            is_valid_token=is_valid_token,
+            out=out,
+        )
+        torch.cuda.synchronize()
+
+        self.assertEqual(actual.data_ptr(), out.data_ptr())
+        self.assertTrue(
+            torch.equal(
+                actual.cpu(),
+                torch.tensor([-1, -1, 20 * 64 + 1, -1, -1, -1]),
+            )
+        )
+        self.assertTrue(torch.equal(out[6:].cpu(), torch.full((2,), -1)))
+
+        # Capture the exact metadata update, mutate its inputs, and verify that
+        # replay reads the new values without allocating or replacing `out`.
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            dsv4_compact_compressed_slot_mapping(
+                num_tokens=6,
+                token_to_req_indices=token_to_req_indices,
+                query_start_loc=query_start_loc,
+                seq_lens=seq_lens,
+                block_table=block_table,
+                block_size=64,
+                compress_ratio=4,
+                block_table_base_offsets=base_offsets,
+                is_valid_token=is_valid_token,
+                out=out,
+            )
+        seq_lens.copy_(torch.tensor([268, 524], device=device, dtype=torch.int32))
+        block_table[0, 0] = 22
+        is_valid_token[4] = True
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertTrue(
+            torch.equal(
+                out[:6].cpu(),
+                torch.tensor([-1, -1, 22 * 64 + 2, -1, 30 * 64 + 2, -1]),
+            )
+        )
+        self.assertTrue(torch.equal(out[6:].cpu(), torch.full((2,), -1)))
+
+    def test_compact_compressed_slot_mapping_c128_missing_page(self):
+        device = torch.device("cuda")
+        actual = dsv4_compact_compressed_slot_mapping(
+            num_tokens=4,
+            token_to_req_indices=torch.tensor(
+                [0, 0, 1, 1], device=device, dtype=torch.int32
+            ),
+            query_start_loc=torch.tensor([0, 2, 4], device=device, dtype=torch.int32),
+            seq_lens=torch.tensor([256, 512], device=device, dtype=torch.int32),
+            block_table=torch.tensor(
+                [[40, 41], [-1, 50]], device=device, dtype=torch.int32
+            ),
+            block_size=64,
+            compress_ratio=128,
+            block_table_base_offsets=torch.tensor(
+                [0, 0], device=device, dtype=torch.int32
+            ),
+        )
+        torch.cuda.synchronize()
+        self.assertTrue(
+            torch.equal(
+                actual.cpu(),
+                torch.tensor([-1, 40 * 64 + 1, -1, -1]),
+            )
+        )
+
+    def test_group_slot_mapping_matches_reference_and_replay(self):
+        device = torch.device("cuda")
+        positions = torch.tensor(
+            [0, 63, 64, 255, 256, 511, -1, 64],
+            device=device,
+            dtype=torch.int64,
+        )
+        req_indices = torch.tensor([0, 0, 1, -1], device=device, dtype=torch.int32)
+        block_table = torch.tensor(
+            [[10, 11], [20, -1]], device=device, dtype=torch.int32
+        )
+        base_offsets = torch.tensor([0, 1], device=device, dtype=torch.int32)
+        is_valid_token = torch.tensor(
+            [True, True, True, False], device=device, dtype=torch.bool
+        )
+
+        actual = dsv4_group_slot_mapping(
+            positions=positions,
+            req_indices=req_indices,
+            block_table=block_table,
+            rows_per_block=64,
+            entry_stride_tokens=4,
+            base_offsets=base_offsets,
+            is_valid_token=is_valid_token,
+        )
+        torch.cuda.synchronize()
+        expected = torch.tensor(
+            [640, 655, 656, 703, 1280, 1343, -1, -1], dtype=torch.int64
+        )
+        self.assertTrue(torch.equal(actual.cpu(), expected))
+
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            replayed = dsv4_group_slot_mapping(
+                positions=positions,
+                req_indices=req_indices,
+                block_table=block_table,
+                rows_per_block=64,
+                entry_stride_tokens=4,
+                base_offsets=base_offsets,
+                is_valid_token=is_valid_token,
+            )
+        block_table[0, 0] = 12
+        is_valid_token[2] = False
+        graph.replay()
+        torch.cuda.synchronize()
+        self.assertTrue(
+            torch.equal(
+                replayed.cpu(),
+                torch.tensor([768, 783, 784, 831, -1, -1, -1, -1]),
+            )
+        )
+
+    def test_group_slot_mapping_rejects_non_expanding_request_shape(self):
+        with self.assertRaisesRegex(ValueError, "evenly expand"):
+            dsv4_group_slot_mapping(
+                positions=torch.arange(5, device="cuda", dtype=torch.int64),
+                req_indices=torch.tensor([0, 1], device="cuda", dtype=torch.int32),
+                block_table=torch.tensor(
+                    [[10], [20]], device="cuda", dtype=torch.int32
+                ),
+                rows_per_block=64,
+            )
+
+    def test_group_slot_mapping_accepts_empty_decode_batch(self):
+        actual = dsv4_group_slot_mapping(
+            positions=torch.empty(0, device="cuda", dtype=torch.int64),
+            req_indices=torch.empty(0, device="cuda", dtype=torch.int32),
+            block_table=torch.empty((0, 0), device="cuda", dtype=torch.int32),
+            rows_per_block=64,
+        )
+
+        self.assertEqual(tuple(actual.shape), (0,))
+        self.assertEqual(actual.dtype, torch.int64)
 
     def test_sparse_prefill_dequantize_and_gather_matches_reference(self):
         torch.manual_seed(9234)

--- a/tokenspeed-kernel/test/ops/test_dsv4_router_validation.py
+++ b/tokenspeed-kernel/test/ops/test_dsv4_router_validation.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.moe import dsv4_select_experts
+
+
+@pytest.mark.parametrize("invalid", [-1, 4])
+def test_default_hash_router_rejects_invalid_table_values(invalid: int) -> None:
+    logits = torch.zeros((1, 4), dtype=torch.float32)
+    table = torch.tensor([[0, invalid]], dtype=torch.int32)
+    input_ids = torch.zeros((1,), dtype=torch.int64)
+
+    with pytest.raises(ValueError, match=r"entries must be in \[0, 4\)"):
+        dsv4_select_experts(
+            logits,
+            top_k=2,
+            renormalize=True,
+            hash_indices_table=table,
+            input_ids=input_ids,
+        )
+
+
+def test_trusted_hash_table_still_checks_runtime_input_ids() -> None:
+    logits = torch.zeros((1, 4), dtype=torch.float32)
+    table = torch.tensor([[0, 1]], dtype=torch.int32)
+    input_ids = torch.ones((1,), dtype=torch.int64)
+
+    with pytest.raises(ValueError, match=r"input_ids entries must be in \[0, 1\)"):
+        dsv4_select_experts(
+            logits,
+            top_k=2,
+            renormalize=True,
+            hash_indices_table=table,
+            input_ids=input_ids,
+            hash_table_values_validated=True,
+        )
+
+
+def test_hash_table_validation_contract_rejects_invalid_option_use() -> None:
+    logits = torch.zeros((1, 4), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="requires hash_indices_table"):
+        dsv4_select_experts(
+            logits,
+            top_k=2,
+            renormalize=True,
+            hash_table_values_validated=True,
+        )
+    with pytest.raises(TypeError, match="must be a bool"):
+        dsv4_select_experts(
+            logits,
+            top_k=2,
+            renormalize=True,
+            hash_table_values_validated=1,
+        )

--- a/tokenspeed-kernel/test/ops/test_layernorm.py
+++ b/tokenspeed-kernel/test/ops/test_layernorm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 import torch
+from tokenspeed_kernel.ops.layernorm import grouped_rmsnorm
 from tokenspeed_kernel.ops.layernorm.triton import (
     fused_qk_rmsnorm_rope,
     fused_qk_rmsnorm_rope_gate,
@@ -54,6 +55,49 @@ def test_rmsnorm_with_residual(
     ref = (x_float * torch.rsqrt(variance + eps) * weight).to(dtype)
     torch.testing.assert_close(out, ref, atol=2e-2, rtol=2e-2)
     torch.testing.assert_close(residual_out, ref_residual, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("shape", [(2, 7, 16, 512), (1, 2, 64, 512)])
+def test_grouped_rmsnorm_matches_per_head_reference(
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    device: str,
+) -> None:
+    eps = 1e-6
+    x = torch.randn(shape, device=device, dtype=dtype)
+    reference_input = x.clone()
+
+    actual = grouped_rmsnorm(x, shape[-1], eps, out=x)
+
+    reference_float = reference_input.float()
+    reference = reference_float * torch.rsqrt(
+        reference_float.square().mean(-1, keepdim=True) + eps
+    )
+    assert actual is x
+    torch.testing.assert_close(actual, reference.to(dtype), atol=2e-2, rtol=2e-2)
+
+
+def test_grouped_rmsnorm_cuda_graph_replays(device: str) -> None:
+    shape = (2, 8, 16, 512)
+    eps = 1e-6
+    x = torch.randn(shape, device=device, dtype=torch.bfloat16)
+    grouped_rmsnorm(x, shape[-1], eps, out=x)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        grouped_rmsnorm(x, shape[-1], eps, out=x)
+
+    x.copy_(torch.randn_like(x))
+    reference_input = x.clone()
+    graph.replay()
+    torch.cuda.synchronize()
+    reference_float = reference_input.float()
+    reference = reference_float * torch.rsqrt(
+        reference_float.square().mean(-1, keepdim=True) + eps
+    )
+    torch.testing.assert_close(x, reference.to(x.dtype), atol=2e-2, rtol=2e-2)
 
 
 def _gemma_ref(

--- a/tokenspeed-kernel/test/ops/test_mhc_big_fuse.py
+++ b/tokenspeed-kernel/test/ops/test_mhc_big_fuse.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.mhc.triton import _pre_reduce_apply_is_supported
+
+
+def reference(
+    projection: torch.Tensor,
+    square_sum: torch.Tensor,
+    scale: torch.Tensor,
+    base: torch.Tensor,
+    residual: torch.Tensor,
+    rms_eps: float,
+    hc_eps: float,
+    sinkhorn_iters: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    values = projection.sum(dim=0)
+    rstd = torch.rsqrt(square_sum.sum(dim=0) / (4 * residual.shape[-1]) + rms_eps)
+    pre = torch.sigmoid(values[:, :4] * rstd[:, None] * scale[0] + base[:4]) + hc_eps
+    post = torch.sigmoid(values[:, 4:8] * rstd[:, None] * scale[1] + base[4:8]) * 2
+    comb = (values[:, 8:] * rstd[:, None] * scale[2] + base[8:]).view(-1, 4, 4)
+    comb = torch.softmax(comb, dim=2) + hc_eps
+    comb = comb / (comb.sum(dim=1, keepdim=True) + hc_eps)
+    for _ in range(1, sinkhorn_iters):
+        comb = comb / (comb.sum(dim=2, keepdim=True) + hc_eps)
+        comb = comb / (comb.sum(dim=1, keepdim=True) + hc_eps)
+    layer = torch.einsum("mi,mih->mh", pre, residual.float()).bfloat16()
+    return layer, post, comb
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 4, 6, 8])
+@pytest.mark.parametrize("n_splits", [1, 2, 4, 32, 64])
+@pytest.mark.parametrize("block_size", [128, 256, 512])
+def test_mhc_big_fuse_matches_reference(
+    num_tokens: int, n_splits: int, block_size: int
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    from tokenspeed_kernel.thirdparty.cuda.mhc import mhc_big_fuse
+
+    torch.manual_seed(7)
+    device = torch.device("cuda")
+    hidden_size = 4096
+    projection = torch.randn(
+        n_splits, num_tokens, 24, device=device, dtype=torch.float32
+    )
+    square_sum = torch.rand(
+        n_splits, num_tokens, device=device, dtype=torch.float32
+    ) * (4 * hidden_size)
+    scale = torch.randn(3, device=device, dtype=torch.float32) * 0.1
+    base = torch.randn(24, device=device, dtype=torch.float32) * 0.1
+    residual = torch.randn(
+        num_tokens, 4, hidden_size, device=device, dtype=torch.bfloat16
+    )
+    layer = torch.empty(num_tokens, hidden_size, device=device, dtype=torch.bfloat16)
+    post = torch.empty(num_tokens, 4, device=device, dtype=torch.float32)
+    comb = torch.empty(num_tokens, 16, device=device, dtype=torch.float32)
+    mhc_big_fuse(
+        projection,
+        square_sum,
+        scale,
+        base,
+        residual,
+        layer,
+        post,
+        comb,
+        hidden_size,
+        1e-6,
+        1e-6,
+        20,
+        n_splits,
+        num_tokens,
+        block_size=block_size,
+        enable_pdl=False,
+    )
+    expected_layer, expected_post, expected_comb = reference(
+        projection, square_sum, scale, base, residual, 1e-6, 1e-6, 20
+    )
+    torch.testing.assert_close(layer, expected_layer, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(post, expected_post, rtol=2e-5, atol=2e-5)
+    torch.testing.assert_close(
+        comb.view(num_tokens, 4, 4), expected_comb, rtol=2e-4, atol=2e-4
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4, 8])
+@pytest.mark.parametrize("n_splits", [32, 64])
+@pytest.mark.parametrize("block_size", [128, 256, 512])
+def test_mhc_big_fuse_norm_matches_reference(
+    num_tokens: int, n_splits: int, block_size: int
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    from tokenspeed_kernel.thirdparty.cuda.mhc import mhc_big_fuse
+
+    torch.manual_seed(17)
+    device = torch.device("cuda")
+    hidden_size = 4096
+    projection = torch.randn(
+        n_splits, num_tokens, 24, device=device, dtype=torch.float32
+    )
+    square_sum = torch.rand(
+        n_splits, num_tokens, device=device, dtype=torch.float32
+    ) * (4 * hidden_size)
+    scale = torch.randn(3, device=device, dtype=torch.float32) * 0.1
+    base = torch.randn(24, device=device, dtype=torch.float32) * 0.1
+    residual = torch.randn(
+        num_tokens, 4, hidden_size, device=device, dtype=torch.bfloat16
+    )
+    norm_weight = torch.randn(hidden_size, device=device, dtype=torch.bfloat16)
+    layer = torch.empty(num_tokens, hidden_size, device=device, dtype=torch.bfloat16)
+    post = torch.empty(num_tokens, 4, device=device, dtype=torch.float32)
+    comb = torch.empty(num_tokens, 16, device=device, dtype=torch.float32)
+    mhc_big_fuse(
+        projection,
+        square_sum,
+        scale,
+        base,
+        residual,
+        layer,
+        post,
+        comb,
+        hidden_size,
+        1e-6,
+        1e-6,
+        20,
+        n_splits,
+        num_tokens,
+        norm_weight=norm_weight,
+        norm_eps=1e-6,
+        block_size=block_size,
+        enable_pdl=False,
+    )
+    expected_layer, expected_post, expected_comb = reference(
+        projection, square_sum, scale, base, residual, 1e-6, 1e-6, 20
+    )
+    expected_layer = torch.nn.functional.rms_norm(
+        expected_layer, (hidden_size,), norm_weight, 1e-6
+    )
+    torch.testing.assert_close(layer, expected_layer, rtol=3e-2, atol=3e-2)
+    torch.testing.assert_close(post, expected_post, rtol=2e-5, atol=2e-5)
+    torch.testing.assert_close(
+        comb.view(num_tokens, 4, 4), expected_comb, rtol=2e-4, atol=2e-4
+    )
+
+
+def test_mhc_big_fuse_rejects_unsupported_splits() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    from tokenspeed_kernel.thirdparty.cuda.mhc import mhc_big_fuse
+
+    device = torch.device("cuda")
+    hidden_size = 4096
+    n_splits = 3
+    projection = torch.zeros(n_splits, 1, 24, device=device, dtype=torch.float32)
+    square_sum = torch.ones(n_splits, 1, device=device, dtype=torch.float32)
+    scale = torch.ones(3, device=device, dtype=torch.float32)
+    base = torch.zeros(24, device=device, dtype=torch.float32)
+    residual = torch.zeros(1, 4, hidden_size, device=device, dtype=torch.bfloat16)
+    layer = torch.empty(1, hidden_size, device=device, dtype=torch.bfloat16)
+    post = torch.empty(1, 4, device=device, dtype=torch.float32)
+    comb = torch.empty(1, 16, device=device, dtype=torch.float32)
+    with pytest.raises(RuntimeError, match="unsupported n_splits=3"):
+        mhc_big_fuse(
+            projection,
+            square_sum,
+            scale,
+            base,
+            residual,
+            layer,
+            post,
+            comb,
+            hidden_size,
+            1e-6,
+            1e-6,
+            20,
+            n_splits,
+            1,
+            block_size=512,
+            enable_pdl=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("supported", "n_splits", "expected"),
+    [
+        (None, 5, True),
+        (frozenset({4, 64}), 64, True),
+        (frozenset({4, 64}), 5, False),
+    ],
+)
+def test_pre_reduce_apply_capability_gate(
+    supported: frozenset[int] | None, n_splits: int, expected: bool
+) -> None:
+    def implementation() -> None:
+        pass
+
+    if supported is not None:
+        implementation.supported_n_splits = supported
+    assert _pre_reduce_apply_is_supported(implementation, n_splits) is expected

--- a/tokenspeed-kernel/test/ops/test_pack_topk_router_logits.py
+++ b/tokenspeed-kernel/test/ops/test_pack_topk_router_logits.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.moe.pack_topk import pack_topk_router_logits
+
+
+def _inputs(device: str):
+    return (
+        torch.tensor([[0.7, 0.3], [0.55, 0.45]], dtype=torch.float32, device=device),
+        torch.tensor([[3, 1], [2, 0]], dtype=torch.int32, device=device),
+    )
+
+
+def test_cpu_reference_recovers_selected_weights():
+    weights, ids = _inputs("cpu")
+    packed = pack_topk_router_logits(weights, ids, 4)
+    recovered = packed.softmax(dim=-1).gather(1, ids.long())
+    torch.testing.assert_close(recovered, weights)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+@pytest.mark.parametrize("tokens", [1, 2, 4, 8])
+def test_cuda_matches_reference(tokens):
+    torch.manual_seed(19)
+    ids = torch.stack(
+        [torch.randperm(256, device="cuda")[:8] for _ in range(tokens)]
+    ).to(torch.int32)
+    weights = torch.rand(tokens, 8, device="cuda", dtype=torch.float32)
+    weights /= weights.sum(dim=1, keepdim=True)
+    actual = pack_topk_router_logits(weights, ids, 256)
+    expected = torch.full_like(actual, -1.0e20)
+    expected.scatter_(1, ids.long(), weights.log())
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ("weights", "ids", "message"),
+    [
+        (torch.ones(2), torch.ones(2, dtype=torch.int32), "same 2D shape"),
+        (
+            torch.ones(1, 2, dtype=torch.bfloat16),
+            torch.ones(1, 2, dtype=torch.int32),
+            "float32",
+        ),
+        (torch.ones(1, 2), torch.ones(1, 2, dtype=torch.int16), "int32 or int64"),
+    ],
+)
+def test_rejects_invalid_inputs(weights, ids, message):
+    with pytest.raises((TypeError, ValueError), match=message):
+        pack_topk_router_logits(weights, ids, 4)

--- a/tokenspeed-kernel/test/ops/test_quantization.py
+++ b/tokenspeed-kernel/test/ops/test_quantization.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import pytest
 import torch
 from tokenspeed_kernel import (
+    fp8_quantize_dequantize,
     quantize_fp8,
     quantize_fp8_with_scale,
     quantize_mxfp4,
@@ -59,6 +60,69 @@ def _dequantize_mxfp4(packed: torch.Tensor, scale: torch.Tensor) -> torch.Tensor
     out[..., 1::2] = _e2m1_values(packed >> 4)
     scale_values = torch.pow(2.0, scale.to(torch.int32) - 127).to(torch.float32)
     return out * scale_values.repeat_interleave(32, dim=-1)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("group_size", [64, 128])
+def test_fp8_quantize_dequantize_ue8m0(
+    device: str,
+    dtype: torch.dtype,
+    group_size: int,
+    require,
+) -> None:
+    require("quantization", "fp8_quantize_dequantize", "triton", dtype, "x")
+    torch.manual_seed(41)
+    base = torch.randn(3, 2, group_size * 3 + 17, device=device, dtype=dtype)
+    x = base[..., : group_size * 3]
+    assert not x.is_contiguous()
+    blocks = x.float().unflatten(-1, (-1, group_size))
+    absmax = blocks.abs().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+    scales = torch.exp2(torch.ceil(torch.log2(absmax / 448.0)))
+    expected = (
+        torch.clamp(blocks / scales, -448.0, 448.0)
+        .to(torch.float8_e4m3fn)
+        .float()
+        .mul(scales)
+        .flatten(-2)
+        .to(dtype)
+    )
+
+    actual = fp8_quantize_dequantize(
+        x,
+        group_size=group_size,
+        solution="triton",
+    )
+    torch.cuda.synchronize()
+
+    assert actual.shape == x.shape
+    assert actual.dtype == x.dtype
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_fp8_quantize_dequantize_cuda_graph_replay(device: str, require) -> None:
+    dtype = torch.bfloat16
+    require("quantization", "fp8_quantize_dequantize", "triton", dtype, "x")
+    x = torch.randn(8, 384, device=device, dtype=dtype)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = fp8_quantize_dequantize(x, group_size=128, solution="triton")
+
+    x.copy_(torch.linspace(-9.0, 9.0, x.numel(), device=device).reshape_as(x))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    blocks = x.float().unflatten(-1, (-1, 128))
+    absmax = blocks.abs().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+    scales = torch.exp2(torch.ceil(torch.log2(absmax / 448.0)))
+    expected = (
+        torch.clamp(blocks / scales, -448.0, 448.0)
+        .to(torch.float8_e4m3fn)
+        .float()
+        .mul(scales)
+        .flatten(-2)
+        .to(dtype)
+    )
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("solution", ["triton"])

--- a/tokenspeed-kernel/test/ops/test_zero_byte_ranges.py
+++ b/tokenspeed-kernel/test/ops/test_zero_byte_ranges.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.kvcache import triton as kvcache_triton
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+
+
+def test_zero_range_staging_min_rows_bypasses_small_tables(monkeypatch):
+    monkeypatch.setattr(kvcache_triton, "_ZERO_RANGE_STAGING_ENABLED", True)
+    monkeypatch.setattr(kvcache_triton, "_ZERO_RANGE_STAGING_MIN_ROWS", 3)
+
+    assert not kvcache_triton._should_stage_zero_ranges(2)
+    assert kvcache_triton._should_stage_zero_ranges(3)
+
+
+def test_zero_range_stager_rejects_oversize_without_allocating_slots():
+    stager = kvcache_triton._ZeroRangeTableStager(capacity=1)
+
+    assert stager.try_stage([(0, 4), (8, 4)], torch.device("cuda", 0)) is None
+    assert stager.snapshot_stats() == {
+        "staged": 0,
+        "busy_fallback": 0,
+        "oversize_fallback": 1,
+        "capture_fallback": 0,
+    }
+    assert stager._slots_by_device == {}
+
+
+def test_zero_range_stager_rejects_capture_without_allocating_slots(monkeypatch):
+    stager = kvcache_triton._ZeroRangeTableStager(capacity=1)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    assert stager.try_stage([(0, 4)], torch.device("cuda", 0)) is None
+    assert stager.snapshot_stats() == {
+        "staged": 0,
+        "busy_fallback": 0,
+        "oversize_fallback": 0,
+        "capture_fallback": 1,
+    }
+    assert stager._slots_by_device == {}
+
+
+@requires_cuda
+def test_zero_byte_ranges_reuses_four_slot_staging_without_data_corruption(
+    monkeypatch,
+):
+    stager = kvcache_triton._ZeroRangeTableStager(capacity=4)
+    monkeypatch.setattr(kvcache_triton, "_ZERO_RANGE_STAGING_ENABLED", True)
+    monkeypatch.setattr(kvcache_triton, "_ZERO_RANGE_STAGING_MIN_ROWS", 0)
+    monkeypatch.setattr(kvcache_triton, "_ZERO_RANGE_TABLE_STAGER", stager)
+    backing = torch.full((256,), 7, dtype=torch.uint8, device="cuda")
+
+    for index in range(12):
+        offset = index * 8
+        kvcache_triton.zero_byte_ranges(backing, [(offset, 4), (128 + offset, 4)])
+    torch.cuda.synchronize()
+
+    expected = torch.full((256,), 7, dtype=torch.uint8)
+    for index in range(12):
+        offset = index * 8
+        expected[offset : offset + 4] = 0
+        expected[128 + offset : 132 + offset] = 0
+    assert torch.equal(backing.cpu(), expected)
+    assert stager.snapshot_stats() == {
+        "staged": 12,
+        "busy_fallback": 0,
+        "oversize_fallback": 0,
+        "capture_fallback": 0,
+    }

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -381,6 +381,11 @@ def _quantize_mxfp8() -> tuple[torch.Tensor, torch.Tensor]:
     return tokenspeed_kernel.quantize_mxfp8(x)
 
 
+def _fp8_quantize_dequantize() -> torch.Tensor:
+    x = torch.empty((4, 128), dtype=torch.bfloat16)
+    return tokenspeed_kernel.fp8_quantize_dequantize(x, group_size=128)
+
+
 def _mm_dense() -> torch.Tensor:
     a = torch.empty((4, 16), dtype=torch.bfloat16)
     b = torch.empty((32, 16), dtype=torch.bfloat16)
@@ -1428,6 +1433,55 @@ def _attention_dsv4_swa_cache_insert() -> object:
         64,
         q_out=q_out,
     )
+
+
+def test_dsv4_swa_cache_insert_can_reuse_prior_position_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime may skip only the redundant position check, not the insert."""
+    calls: list[dict[str, object]] = []
+
+    class _SelectedKernel:
+        name = "test_dsv4_swa_cache_insert"
+
+        def __call__(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr(
+        _attention_pkg,
+        "select_kernel",
+        lambda *args, **kwargs: _SelectedKernel(),
+    )
+    q = torch.empty((1, 2, 512), dtype=torch.bfloat16)
+    kv = torch.empty((1, 512), dtype=torch.bfloat16)
+    cache = torch.empty((1, 584), dtype=torch.uint8)
+    slots = torch.zeros((1,), dtype=torch.int64)
+    positions = torch.ones((1,), dtype=torch.int64)
+    cos_sin_cache = torch.empty((1, 64), dtype=torch.float32)
+
+    with pytest.raises(ValueError, match="positions entries must index"):
+        tokenspeed_kernel.dsv4_swa_cache_insert(
+            q,
+            kv,
+            cache,
+            slots,
+            positions,
+            cos_sin_cache,
+            1e-6,
+            1,
+        )
+    tokenspeed_kernel.dsv4_swa_cache_insert(
+        q,
+        kv,
+        cache,
+        slots,
+        positions,
+        cos_sin_cache,
+        1e-6,
+        1,
+        validate_positions=False,
+    )
+    assert len(calls) == 1
 
 
 def _attention_dsa_decode_fp8_dense_rank128_q4(
@@ -4082,6 +4136,14 @@ _CASES = [
         _dsv4_linear_fp32,
     ),
     # Quantization API x architecture golden cases.
+    _case(
+        _is_supported_gpu,
+        "supported-gpu",
+        "quantization",
+        "fp8_quantize_dequantize",
+        "triton_fp8_quantize_dequantize",
+        _fp8_quantize_dequantize,
+    ),
     _case(
         _is_hopper,
         "hopper",

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -89,6 +89,19 @@ std::vector<GroupDemand> makeGroupDemands(std::vector<BlockTable>& tables, Group
     return demands;
 }
 
+void scopeAdmissionHeadroom(std::span<GroupDemand> demands, const CacheCoordinator& coordinator,
+                            std::int32_t decode_reserve) {
+    _assert(demands.size() == static_cast<std::size_t>(coordinator.NumGroups()), "demands/cache groups size mismatch");
+    for (std::size_t i = 0; i < demands.size(); ++i) {
+        if (!coordinator.GroupIsPrefixClosed(static_cast<std::int32_t>(i))) {
+            // Full-history groups must reserve the unscheduled prompt so a
+            // partially prefetched request cannot be stranded. Sliding/state
+            // groups recycle old pages and only need the decode headroom.
+            demands[i].reserve_tokens = decode_reserve;
+        }
+    }
+}
+
 void makeSnapshotStatePrefillSparse(std::span<GroupDemand> demands, std::span<const CacheGroupConfig> cache_groups,
                                     const CacheCoordinator& coordinator, std::int32_t after_tokens) {
     _assert(demands.size() == cache_groups.size(), "demands/cache groups size mismatch");
@@ -346,6 +359,7 @@ std::optional<fsm::SchedulePrefillFirstChunkEvent> Scheduler::schedulePrefillFir
     std::vector<BlockTable> tables(static_cast<std::size_t>(coordinator_.NumGroups()));
     std::vector<GroupDemand> demands =
         makeGroupDemands(tables, GroupDemand{.num_tokens = tokens_this_round, .reserve_tokens = admission_reserve});
+    scopeAdmissionHeadroom(demands, coordinator_, decode_reserve);
     if (source == fsm::PrefillSource::kLocal) {
         makeSnapshotStatePrefillSparse(demands, config_.cache_groups, coordinator_, hit_tokens + tokens_this_round);
         setSnapshotStatePrefillReserve(demands, config_.cache_groups, split_tail_tokens);

--- a/tokenspeed-scheduler/python/tests/test_cache_group_admission.py
+++ b/tokenspeed-scheduler/python/tests/test_cache_group_admission.py
@@ -172,6 +172,104 @@ def test_batch_admission_debits_simulated_free_pages():
     assert len(admitted & {"r0", "r1"}) <= 1
 
 
+def test_v4_long_prompt_does_not_reserve_full_headroom_in_sliding_groups():
+    num_lcm_blocks = 12_383
+    cfg = _base_config(num_device_pages=num_lcm_blocks + 1)
+    cfg.prefix_granularity = 256
+    cfg.max_scheduled_tokens = 8192
+    cfg.max_batch_size = 8
+    cfg.decode_input_tokens = 6
+    cfg.overlap_schedule_depth = 1
+    cfg.disable_prefix_cache = False
+    cfg.prefix_replay_tokens = 128
+
+    def group(
+        group_id: str,
+        rows_per_page: int,
+        entry_stride_tokens: int,
+        packing: int,
+        retention: CacheRetention,
+        family: CacheGroupFamily,
+        sliding_window_tokens: int | None = None,
+    ) -> CacheGroupConfig:
+        return CacheGroupConfig(
+            group_id=group_id,
+            rows_per_page=rows_per_page,
+            entry_stride_tokens=entry_stride_tokens,
+            total_pages=1 + num_lcm_blocks * packing,
+            cache_blocks_per_lcm_block=packing,
+            retention=retention,
+            family=family,
+            sliding_window_tokens=sliding_window_tokens,
+        )
+
+    cfg.cache_groups = [
+        group(
+            "v4.swa_kv",
+            64,
+            1,
+            1,
+            CacheRetention.SlidingWindow,
+            CacheGroupFamily.State,
+            128,
+        ),
+        group(
+            "v4.c4a.compressed_kv",
+            64,
+            4,
+            1,
+            CacheRetention.FullHistory,
+            CacheGroupFamily.History,
+        ),
+        group(
+            "v4.c4a.compressor_state",
+            4,
+            1,
+            2,
+            CacheRetention.SlidingWindow,
+            CacheGroupFamily.State,
+            10,
+        ),
+        group(
+            "v4.c4a.indexer_compressor_state",
+            4,
+            1,
+            8,
+            CacheRetention.SlidingWindow,
+            CacheGroupFamily.State,
+            10,
+        ),
+        group(
+            "v4.c128a.compressed_kv",
+            2,
+            128,
+            32,
+            CacheRetention.FullHistory,
+            CacheGroupFamily.History,
+        ),
+        group(
+            "v4.c128a.compressor_state",
+            8,
+            1,
+            2,
+            CacheRetention.SlidingWindow,
+            CacheGroupFamily.State,
+            128,
+        ),
+    ]
+    scheduler = Scheduler(cfg)
+    request = _make_spec("v4-long", list(range(54_645)))
+    request.max_new_tokens = 500
+    scheduler.submit_requests([request])
+
+    plan = scheduler.next_execution_plan()
+
+    operation = next(op for op in plan.forward if "v4-long" in op.request_ids)
+    assert operation.input_lengths == [8192]
+    assert scheduler.waiting_size() == 0
+    assert scheduler.prefilling_size() == 1
+
+
 def test_group_tables_use_each_groups_block_granularity():
     cfg = _base_config(num_device_pages=17)
     cfg.prefix_granularity = 8


### PR DESCRIPTION
## Summary

- reuse DeepSeek V4 decode metadata and cache staging buffers across a forward pass
- add guarded fused paths for DSpark proposal sampling, router preparation, quantization, grouped normalization, and MHC
- make cache admission headroom account for cache groups and add regression coverage for the optimized paths

## Validation

- `pre-commit run --all-files`
- full dependency and native extension build in the CUDA runner
- focused runtime tests for DeepSeek V4 metadata, cache behavior, DSpark proposal sampling, and logits processing
- focused CUDA tests for DSV4 attention metadata, MHC, router packing, quantization, and grouped normalization
- scheduler cache-group admission tests
