### PR TITLE
ci(amd): tighten the gfx1250 simulator timeouts

### DIFF
--- a/.github/workflows/run-pr-test-stage.yml
+++ b/.github/workflows/run-pr-test-stage.yml
@@ -42,8 +42,8 @@ jobs:
       matrix: ${{ fromJson(inputs.matrix) }}
     name: ${{ matrix.name }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
-    # Leave setup and reporting headroom around the simulator's 60-minute run.
-    timeout-minutes: ${{ matrix.runner == 'amd-mi45x-cpu-test' && 75 || inputs.timeout_minutes }}
+    # Leave setup and reporting headroom around the simulator's 30-minute run.
+    timeout-minutes: ${{ matrix.runner == 'amd-mi45x-cpu-test' && 45 || inputs.timeout_minutes }}
     continue-on-error: ${{ matrix.optional }}
     env:
       INSTALL_TOKENSPEED_MLA_FROM_SOURCE: ${{ inputs.install_tokenspeed_mla_from_source }}

--- a/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
@@ -13,7 +13,7 @@ env:
   BUILD_AND_DOWNLOAD_PARALLEL: "4"
   CI: "true"
   GFX_ARCH: gfx1250
-  MI450_SIM_RUN_TIMEOUT: "3600"
+  MI450_SIM_RUN_TIMEOUT: "1800"
   # A ceiling on concurrent simulators. A simulator takes two CPU threads.
   MI450_SIM_WORKERS: "16"
   TEST_DESELECTS: |

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -794,14 +794,14 @@ def test_nvidia_arm_model_tests_allow_runner_wait_time():
     assert workflow["jobs"]["model-test"]["with"]["timeout_minutes"] >= 120
 
 
-def test_mi450_sim_uses_direct_runner_and_extended_timeout():
+def test_mi450_sim_uses_direct_runner_and_bounded_timeout():
     workflow = load_yaml(REPO_ROOT / ".github/workflows/run-pr-test-stage.yml")
     job = workflow["jobs"]["test"]
 
     assert job["runs-on"] == "${{ matrix.runner }}"
     assert job["timeout-minutes"] == (
         "${{ matrix.runner == 'amd-mi45x-cpu-test'"
-        " && 75 || inputs.timeout_minutes }}"
+        " && 45 || inputs.timeout_minutes }}"
     )
 
 
@@ -811,7 +811,7 @@ def test_mi450_sim_runs_on_the_cpu_only_pool():
     assert task["runner"]["labels"] == ["amd-mi45x-cpu-test"]
 
 
-def test_mi450_sim_has_one_hour_internal_timeout():
+def test_mi450_sim_has_half_hour_internal_timeout():
     task = load_yaml(REPO_ROOT / "test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml")
 
-    assert task["env"]["MI450_SIM_RUN_TIMEOUT"] == "3600"
+    assert task["env"]["MI450_SIM_RUN_TIMEOUT"] == "1800"


### PR DESCRIPTION
The mi450 simulator job now finishes well inside its budget: a recent run spent 19m14s in the test step and 22m53s end to end on a warm cache, against a 60-minute internal cap and a 75-minute job cap sized for a much slower suite. Those caps no longer bound anything useful, so a wedged emulator holds the runner for the better part of an hour before the digest gets to report what the other workers finished.

Halve both: MI450_SIM_RUN_TIMEOUT to 1800s, which still leaves about 1.5x headroom over the observed run, and the job cap to 45 minutes, leaving roughly 15 minutes of setup and reporting headroom around it. The job-level special case stays because the k8s dispatch path passes a 720-minute stage timeout that mi450 should not inherit; it is now a ceiling below the 60-minute stage default rather than an extension, so rename the covering tests to match.