### PR TITLE
deps: update Triton to post20260906

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,7 @@ celerybeat.pid
 .python-version
 .env
 .envrc
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/.skills/bisect-triton-release.md
+++ b/.skills/bisect-triton-release.md
@@ -26,6 +26,9 @@ installing `triton` into it.
    changes.
 6. Once confirmed a upstream commit causes regression, start `git bisect` flow
    to identify the exact root cause.
+   If `git bisect` points to an LLVM bump commit, then bisect the LLVM commit
+   range to find the problematic commit. Ask where the LLVM source codebase
+   is and where the build directory is.
 7. Once identified, reinstall the recorded `triton` (or `triton-rocm` package)
    to the original version and revert local changes.
 
@@ -37,3 +40,6 @@ In Triton codebase, do the following
 pip install -r python/requirements.txt
 pip install .
 ```
+
+To build with custom LLVM, set `LLVM_LIBRARY_DIR` and `LLVM_SYSPATH` to the
+LLVM build directory.

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -108,6 +108,11 @@ runner pod recreation and avoids downloading the same large wheels again on
 that node. Other runner families keep their existing cache behavior because
 their cluster storage layouts may differ.
 
+The MI450 simulator launcher sets `TRITON_LIBHIP_PATH` to the ROCm SDK's
+unversioned `libamdhip64.so` linker name. The gfx1250 PyTorch wheel and
+TokenSpeed use separate Triton distributions in the same process, and this
+path is accepted by both while still resolving to the same TheRock runtime.
+
 To enable `push` and `workflow_dispatch` runs of the three PR test workflows
 outside the official repository, set the `TOKENSPEED_CI_REPOSITORY` repository
 variable at the same settings path to the configured repository's exact

--- a/test/ci_system/run_mi450_rocjitsu.sh
+++ b/test/ci_system/run_mi450_rocjitsu.sh
@@ -12,13 +12,20 @@ ROCJITSU_BUILD_DIR="${SIM_ROOT}/rocjitsu-build"
 launcher="${ROCJITSU_BUILD_DIR}/tools/rocjitsu/rocjitsu"
 config="${ROCJITSU_SOURCE_DIR}/configs/gfx1250_mi455x.json"
 rocm_root="$(rocm-sdk path --root)"
+libhip_path="${rocm_root}/lib/libamdhip64.so"
 
 test -x "${launcher}"
 test -f "${config}"
+test -f "${libhip_path}"
 
 export ROCM_HOME="${rocm_root}"
 export ROCM_PATH="${rocm_root}"
 export LD_LIBRARY_PATH="${rocm_root}/lib:${LD_LIBRARY_PATH:-}"
+# TokenSpeed Proton discovers the versioned TheRock HIP runtime first, but the
+# stock Triton bundled with the gfx1250 PyTorch wheel only accepts the
+# unversioned linker name. Both Triton distributions share this process, so
+# point them at the same SDK runtime before either driver initializes.
+export TRITON_LIBHIP_PATH="${libhip_path}"
 # rocprofiler derives agents from physical KFD sysfs nodes, which do not exist
 # for rocJITsu's synthetic HSA agent. Profiling is not part of this CI lane.
 export ROCPROFILER_REGISTER_ENABLED=0

--- a/test/ci_system/test_dispatch_workflows.py
+++ b/test/ci_system/test_dispatch_workflows.py
@@ -817,3 +817,11 @@ def test_mi450_sim_uses_bounded_smoke_suite():
     assert task["env"]["MI450_SIM_RUN_TIMEOUT"] == "330"
     assert task["env"]["MI450_SIM_TEST_ROOT"] != "tokenspeed-kernel/test"
     assert "tokenspeed-kernel/test/ops/attention" in task["env"]["MI450_SIM_TESTS"]
+
+
+def test_mi450_sim_uses_stock_triton_compatible_libhip_path():
+    script = (REPO_ROOT / "test/ci_system/run_mi450_rocjitsu.sh").read_text()
+
+    assert 'libhip_path="${rocm_root}/lib/libamdhip64.so"' in script
+    assert 'test -f "${libhip_path}"' in script
+    assert 'export TRITON_LIBHIP_PATH="${libhip_path}"' in script

--- a/tokenspeed-kernel-amd/pyproject.toml
+++ b/tokenspeed-kernel-amd/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = [
     "torch",
-    "tokenspeed-triton>=3.8.10.post20260721",
+    "tokenspeed-triton>=3.8.10.post20260906",
 ]
 
 [project.urls]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
@@ -84,6 +84,20 @@ def _swizzle2d(pid, grid_m, grid_n, GROUP_M: gl.constexpr):
 
 
 @gluon.jit
+def _enforce_wave_uniform_i32(value):
+    # Force emitting v_readfirstlane to indicate input value is wave-uniform for
+    # potential compiler optimizations.
+    return gl.inline_asm_elementwise(
+        "v_readfirstlane_b32 $0, $1",
+        "=s,v",
+        [value],
+        dtype=gl.int32,
+        is_pure=True,
+        pack=1,
+    )
+
+
+@gluon.jit
 def compute_pids(
     block_id,
     grid_m,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
@@ -25,6 +25,7 @@ from tokenspeed_kernel_amd._triton import gl, gluon
 from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4._common import (
     MoEConfig,
     MoEPipelinedProgram,
+    _enforce_wave_uniform_i32,
     _situ_gfx1250,
     _swiglu_gfx1250,
     compute_offsets,
@@ -366,7 +367,7 @@ def _matmul_decode(
             layout=SCATTER_SHARED_LAYOUT,
         )
 
-        col_offset = (OUT_BLOCK_N * pid_n).to(cfg.index_type)
+        col_offset = (OUT_BLOCK_N * _enforce_wave_uniform_i32(pid_n)).to(cfg.index_type)
         y_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
             y_desc, add_offsets=[0, col_offset], clamp_bounds=True
         )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
@@ -48,6 +48,7 @@ from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4._common import (
     MoEConfig,
     MoEPipelinedProgram,
     MoEProgramBase,
+    _enforce_wave_uniform_i32,
     _situ_gfx1250,
     _swiglu_gfx1250,
     composition,
@@ -1104,7 +1105,7 @@ def _matmul(
             layout=SCATTER_SHARED_LAYOUT,
         )
 
-        col_offset = (OUT_BLOCK_N * pid_n).to(cfg.index_type)
+        col_offset = (OUT_BLOCK_N * _enforce_wave_uniform_i32(pid_n)).to(cfg.index_type)
         y_desc = gl.amd.gfx1250.tdm.update_tensor_descriptor(
             y_desc, add_offsets=[0, col_offset], clamp_bounds=True
         )

--- a/tokenspeed-kernel/python/requirements/cuda.txt
+++ b/tokenspeed-kernel/python/requirements/cuda.txt
@@ -5,8 +5,8 @@ numpy
 # torch version needs to pinned here for CUDA builds
 torch==2.13.0
 apache-tvm-ffi==0.1.13.post3
-tokenspeed-proton>=3.8.10.post20260721
-tokenspeed-triton>=3.8.10.post20260721
+tokenspeed-proton>=3.8.10.post20260906
+tokenspeed-triton>=3.8.10.post20260906
 nvidia-cutlass-dsl[cu13]==4.7.1
 nvidia-cutlass-dsl-libs-cu13==4.7.1
 flashinfer-python==0.6.18

--- a/tokenspeed-kernel/python/requirements/rocm.txt
+++ b/tokenspeed-kernel/python/requirements/rocm.txt
@@ -3,5 +3,5 @@ wheel
 psutil
 numpy
 torch
-tokenspeed-proton>=3.8.10.post20260721
-tokenspeed-triton>=3.8.10.post20260721
+tokenspeed-proton>=3.8.10.post20260906
+tokenspeed-triton>=3.8.10.post20260906

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gated_delta_rule.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/gated_delta_rule.py
@@ -38,8 +38,7 @@ expensive here).
 from __future__ import annotations
 
 import torch
-import triton
-import triton.language as tl
+from tokenspeed_kernel._triton import tl, triton
 from tokenspeed_kernel.ops.attention import (
     GdnCheckpointLayout,
     GdnChunkPrefillResult,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 import os
 
 import torch
-import triton
-import triton.language as tl
+from tokenspeed_kernel._triton import tl, triton
 
 
 @triton.jit

--- a/tokenspeed-kernel/test/test_triton_adapter.py
+++ b/tokenspeed-kernel/test/test_triton_adapter.py
@@ -1,0 +1,44 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_kernel_sources_use_tokenspeed_triton_adapter():
+    source_root = ROOT / "tokenspeed-kernel/python/tokenspeed_kernel"
+    adapter = source_root / "_triton.py"
+    # These helpers intentionally interact with framework-owned stock Triton;
+    # neither defines TokenSpeed Triton kernels.
+    stock_triton_interop = {
+        source_root / "thirdparty/fla.py",
+        source_root / "thirdparty/msa/cute/src/common/cute_dsl_utils.py",
+    }
+    direct_imports = {}
+
+    for path in source_root.rglob("*.py"):
+        if path == adapter or path in stock_triton_interop:
+            continue
+        tree = ast.parse(path.read_text(), filename=str(path))
+        lines = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = (alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module is not None:
+                names = (node.module,)
+            else:
+                continue
+            if any(
+                name == "triton"
+                or name.startswith("triton.")
+                or name == "tokenspeed_triton"
+                or name.startswith("tokenspeed_triton.")
+                for name in names
+            ):
+                lines.append(node.lineno)
+        if lines:
+            direct_imports[str(path.relative_to(ROOT))] = lines
+
+    assert direct_imports == {}, (
+        "TokenSpeed kernel sources must import Triton through "
+        f"tokenspeed_kernel._triton: {direct_imports}"
+    )

--- a/tokenspeed-kernel/test/thirdparty/test_kda_gate_precompute.py
+++ b/tokenspeed-kernel/test/thirdparty/test_kda_gate_precompute.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import pytest
 import torch
-import triton
+from tokenspeed_kernel._triton import triton
 from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
     _gate_tiling,
     _gate_tiling_dot,

--- a/tokenspeed-mla/pyproject.toml
+++ b/tokenspeed-mla/pyproject.toml
@@ -12,7 +12,7 @@ license = { file = "LICENSE" }
 dependencies = [
     "apache-tvm-ffi==0.1.13.post3",
     "nvidia-cutlass-dsl",
-    "tokenspeed-triton>=3.8.10.post20260721",
+    "tokenspeed-triton>=3.8.10.post20260906",
     "torch",
 ]
 


### PR DESCRIPTION
Move the vendor Triton and Proton floors to 3.8.10.post20260906 across the CUDA and ROCm requirements and the packages depending on them directly.

Changes coming with the bump:

* Route the last two kernel sources importing stock `triton` through `tokenspeed_kernel._triton`, with a test guarding against regressions.
* Add `_enforce_wave_uniform_i32` to state the wave-uniformity of `pid_n` that the compiler cannot prove, and apply it to the TDM scatter descriptor column offset in the gfx1250 mxfp4 MoE matmuls.
* Export `TRITON_LIBHIP_PATH` from the MI450 simulator launcher so Proton and the wheel's stock Triton share one HIP runtime.
* Widen the `.venv` ignore rule to `.venv*`, and note LLVM bisection.