### PR TITLE
fix(qsa): preserve trtllm draft prefill metadata during decode refresh

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/paged/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/trtllm.py
@@ -276,7 +276,6 @@ class TRTLLMMHAAttnBackend(PagedAttentionBackend):
         num_extends: int = 0,
         for_graph_replay: bool = False,
     ) -> None:
-        del num_extends
         if self.block_decode_active:
             # DFLASH draft block: replicate the page table to each request's
             # block positions. Under replay the seq_lens are re-derived
@@ -293,9 +292,10 @@ class TRTLLMMHAAttnBackend(PagedAttentionBackend):
         self.seq_lens_buf[:bs].copy_(seq_lens[:bs])
         self.page_table_buf[:bs].copy_(page_table[:bs])
         self.forward_decode_metadata = self._decode_views(bs)
-        # Verify (and the draft's multi-token step 1) reads the prefill slot's
-        # clamped seqlens; refresh it whenever speculation is on.
-        if self.spec_num_tokens > 1:
+        # Pure verify (and the draft's multi-token step 1) reads the prefill
+        # slot. An extend/mixed draft refresh only seeds later decode steps and
+        # must preserve the ragged prefill metadata built immediately before it.
+        if self.spec_num_tokens > 1 and num_extends == 0:
             torch.clamp_min(
                 seq_lens[:bs],
                 self.spec_num_tokens,


### PR DESCRIPTION
## Summary
Draft setup initialized valid ragged prefill metadata, then decode refresh overwrote it with uniform speculative-verify metadata. Long prefill rows were left with invalid QSA request indices, causing ScatterGatherKernel out-of-bounds errors.
Error log
```
[ts] [2026-09-07 02:16:29,536  ATTN TP RANK 0] - INFO - Req: HEALTH_CHECK_1788718589.3496082 Finish! Accept_num_tokens_avg: 0 (generation_output_processor.py:425)
[ts] [2026-09-07 02:17:04] Generate request chatcmpl-mEQfndImGVRPwSoH66Q4xb3P-01a077f0-2f8a-7c73-826e-d9d5ec5f8f11 (stream=True)
[ts] [2026-09-07 02:17:04,653  ATTN TP RANK 0] - INFO - Prefill batch. #new-seq: 1, #new-token: 53, #cached-token: 0, #running-req: 1, #queue-req: 0 (batch_log.py:126)
[ts] /__w/pytorch/pytorch/aten/src/ATen/native/cuda/ScatterGatherKernel.cu:203: operator(): block: [0,0,0], thread: [32,0,0] Assertion `idx_dim >= 0 && idx_dim < index_size && "scatter gather kernel index out of bounds"` failed.
[ts] /__w/pytorch/pytorch/aten/src/ATen/native/cuda/ScatterGatherKernel.cu:203: operator(): block: [0,0,0], thread: [33,0,0] Assertion `idx_dim >= 0 && idx_dim < index_size && "scatter gather kernel index out of bounds"` failed.
[ts] /__w/pytorch/pytorch/aten/src/ATen/native/cuda/ScatterGatherKernel.cu:203: operator(): block: [0,0,0], thread: [34,0,0] Assertion `idx_dim >= 0 && idx_dim < index_size && "scatter gather kernel index out of bounds"` failed.
```

Fix: Use num_extends to preserve prefill metadata during extend/mixed draft refreshes, while continuing to refresh verify metadata for pure decode.

<!-- What changed and why? -->

## Test Plan
E2E test passed on TP4 Qwen3.8-Flash-Next-FP8 with MTP
<!-- How was this validated? -->