### PR TITLE
docs: use Inkling docker tags tokenspeed:tml (drop missing :latest)

### DIFF
--- a/docs/recipes/models.md
+++ b/docs/recipes/models.md
@@ -14,9 +14,9 @@ Blog: https://lightseek.org/blog/tokenspeed-inkling.html
 ## Docker
 
 ### nvidia
-docker pull lightseekorg/tokenspeed:latest
+docker pull lightseekorg/tokenspeed:tml
 ### amd
-docker pull lightseekorg/tokenspeed-amd:latest
+docker pull lightseekorg/tokenspeed-amd:tml
 
 ## Launch command
 


### PR DESCRIPTION
## Summary
- Update Inkling recipe Docker pulls from nonexistent `:latest` tags to the published `:tml` tags for `lightseekorg/tokenspeed` and `lightseekorg/tokenspeed-amd`.
- Docker Hub currently serves `tml` (and a few other tags) for those images; `:latest` returns 404.

## Test plan
- [x] Confirm `https://hub.docker.com/v2/repositories/lightseekorg/tokenspeed/tags/latest` → 404
- [x] Confirm `.../tokenspeed/tags/tml` and `.../tokenspeed-amd/tags/tml` → 200
- [x] Diff is limited to the two `docker pull` lines in `docs/recipes/models.md`