### PR TITLE
Optimize KDA paged verification with split producers

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
@@ -42,18 +42,24 @@ from tokenspeed_kernel.ops.attention import (
     try_kda_fused_paged_decode,
     try_kda_fused_paged_verify,
 )
+from tokenspeed_kernel.ops.attention import (
+    kda_fused_paged_verify_uses_split_producers,
+    kda_verify_conv_update,
+)
 from tokenspeed_kernel.ops.attention.triton.capture_payload import (
     capture_replay_payload,
 )
 from tokenspeed_kernel.ops.attention.triton.verify_state_blocks import (
     commit_state_pages,
 )
+from tokenspeed_kernel.platform import pdl_enabled
 from typing_extensions import override
 
 from tokenspeed.runtime.layers.attention.backends.state.mamba import (
     MambaAttnBackend,
     logger,
 )
+from tokenspeed.runtime.utils.cuda_stream import StreamFork
 
 if TYPE_CHECKING:
     from tokenspeed.runtime.layers.attention.configs.base import (
@@ -110,6 +116,9 @@ class KdaAttnBackend(MambaAttnBackend):
         self._replay_active = False
         self._batched_replay_kernel = None
         self._replay_uses_raw_gate = False
+        self._verify_split_producers = False
+        self._verify_producer_stream: torch.cuda.Stream | None = None
+        self._verify_producer_forks: dict[int, StreamFork] = {}
         self._replay_payloads: tuple[torch.Tensor, ...] | None = None
         self._replay_weights: dict[int, tuple] = {}
         self._replay_descriptors = None
@@ -149,6 +158,14 @@ class KdaAttnBackend(MambaAttnBackend):
         self._replay_uses_raw_gate = self._replay_active and (
             kda_batched_replay_uses_raw_gate(self.dtype, **shape)
         )
+        self._verify_split_producers = self._replay_active and (
+            kda_fused_paged_verify_uses_split_producers(
+                self.dtype,
+                store_states=False,
+                recurrent_layout=self.kda_recurrent_layout,
+                **shape,
+            )
+        )
         if self._replay_active and self.speculative_num_draft_tokens > 1:
             rows = self.max_bs * self.speculative_num_draft_tokens
             layer_ids = tuple(self._state_layer_ids())
@@ -172,6 +189,14 @@ class KdaAttnBackend(MambaAttnBackend):
                     device=self.device,
                 )
                 first_conv, first_ssm = self._state_components(layer_ids[0])
+                if self._verify_split_producers and first_conv.is_cuda:
+                    self._verify_producer_stream = torch.cuda.Stream(
+                        device=first_conv.device, priority=-1
+                    )
+                    self._verify_producer_forks = {
+                        layer_id: StreamFork(self._verify_producer_stream)
+                        for layer_id in layer_ids
+                    }
                 hv, head_dim = first_ssm.shape[1:3]
                 for layer_id in layer_ids[1:]:
                     conv, ssm = self._state_components(layer_id)
@@ -458,6 +483,7 @@ class KdaAttnBackend(MambaAttnBackend):
             norm_eps,
             num_value_heads,
             head_v_dim,
+            enable_pdl=pdl_enabled(),
         ).view(1, -1, num_value_heads, head_v_dim)
 
     @override
@@ -520,6 +546,7 @@ class KdaAttnBackend(MambaAttnBackend):
                 norm_eps,
                 num_value_heads,
                 head_v_dim,
+                enable_pdl=pdl_enabled(),
             ).view(1, -1, num_value_heads, head_v_dim)
         return core_attn_out.squeeze(0)
 
@@ -557,6 +584,7 @@ class KdaAttnBackend(MambaAttnBackend):
             qkv, f_a, beta, gate = self._replay_payload(layer_id)
             rows = batch_size * draft_token_num
             replay_payload = {}
+            split_producers = {}
             if self._replay_uses_raw_gate:
                 # Fused verify writes QKV, raw-g, and beta directly into the
                 # persistent replay payload, avoiding a separate capture launch.
@@ -565,6 +593,30 @@ class KdaAttnBackend(MambaAttnBackend):
                     "replay_gate": gate[:rows],
                     "replay_beta": beta[:rows, : beta_raw.shape[-1]],
                 }
+            elif self._verify_split_producers:
+                fork = self._verify_producer_forks[layer_id]
+                with fork.scope(enable=True) as producer_fork:
+                    with producer_fork.branch():
+                        capture_replay_payload(
+                            (mixed_qkv[:rows], f_a_out[:rows], beta_raw[:rows]),
+                            (
+                                qkv[:rows, : mixed_qkv.shape[-1]],
+                                f_a[:rows, : f_a_out.shape[-1]],
+                                beta[:rows, : beta_raw.shape[-1]],
+                            ),
+                            rows,
+                        )
+                        g_raw = torch.nn.functional.linear(f_a_out[:rows], f_b_weight)
+                    conv_qkv = kda_verify_conv_update(
+                        mixed_qkv[:rows],
+                        conv_weights,
+                        conv_comp,
+                        state_in_blocks[:batch_size],
+                        num_heads=value_dim // attn_tp_size // head_v_dim,
+                        head_dim=head_v_dim,
+                        draft_token_num=draft_token_num,
+                    )
+                split_producers = {"g_raw": g_raw, "conv_qkv": conv_qkv}
             else:
                 capture_replay_payload(
                     (mixed_qkv[:rows], f_a_out[:rows], beta_raw[:rows]),
@@ -610,6 +662,7 @@ class KdaAttnBackend(MambaAttnBackend):
                 store_states=False,
                 recurrent_layout=self.kda_recurrent_layout,
                 **replay_payload,
+                **split_producers,
             )
             if fused_out is None:
                 raise RuntimeError(

--- a/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
@@ -30,6 +30,7 @@ import torch
 from tokenspeed_kernel.ops.activation.triton import rmsnorm_gated_sigmoid
 from tokenspeed_kernel.ops.attention import (
     kda_batched_replay_uses_raw_gate,
+    kda_fused_paged_verify_uses_split_producers,
     kda_paged_decode,
     kda_paged_prefill,
 )
@@ -38,13 +39,10 @@ from tokenspeed_kernel.ops.attention import (
 )
 from tokenspeed_kernel.ops.attention import (
     kda_replay_commit_supported,
+    kda_verify_conv_update,
     resolve_kda_batched_replay_commit,
     try_kda_fused_paged_decode,
     try_kda_fused_paged_verify,
-)
-from tokenspeed_kernel.ops.attention import (
-    kda_fused_paged_verify_uses_split_producers,
-    kda_verify_conv_update,
 )
 from tokenspeed_kernel.ops.attention.triton.capture_payload import (
     capture_replay_payload,
@@ -615,7 +613,16 @@ class KdaAttnBackend(MambaAttnBackend):
                         num_heads=value_dim // attn_tp_size // head_v_dim,
                         head_dim=head_v_dim,
                         draft_token_num=draft_token_num,
+                        recurrent_layout=self.kda_recurrent_layout,
                     )
+                # The graph capture pool owns captured allocations. In eager
+                # mode the producer tensors outlive this Python scope while
+                # verify runs on the main stream, so register that use with
+                # the caching allocator before launching its consumer.
+                if not torch.cuda.is_current_stream_capturing():
+                    consumer_stream = torch.cuda.current_stream()
+                    g_raw.record_stream(consumer_stream)
+                    conv_qkv.record_stream(consumer_stream)
                 split_producers = {"g_raw": g_raw, "conv_qkv": conv_qkv}
             else:
                 capture_replay_payload(

--- a/python/tokenspeed/runtime/models/glm53_flash.py
+++ b/python/tokenspeed/runtime/models/glm53_flash.py
@@ -39,6 +39,7 @@ import torch.nn.functional as F
 from tokenspeed_kernel import mhc_post, mhc_pre
 from tokenspeed_kernel.ops.activation.triton import rmsnorm_gated_sigmoid, silu_and_mul
 from tokenspeed_kernel.ops.transform import hadamard_transform
+from tokenspeed_kernel.platform import pdl_enabled
 from torch import nn
 
 from tokenspeed.runtime.configs.glm53_flash_config import (
@@ -770,6 +771,7 @@ class Glm53FlashKDA(nn.Module):
                 self.o_norm.variance_epsilon,
                 self.local_num_heads,
                 self.head_dim,
+                enable_pdl=pdl_enabled(),
             )
         return self.o_proj(core_output)[0]
 

--- a/python/tokenspeed/runtime/models/kimi_k3.py
+++ b/python/tokenspeed/runtime/models/kimi_k3.py
@@ -89,7 +89,7 @@ from tokenspeed_kernel.ops.moe.flashinfer.trtllm_mxfp4 import (
     situ_moe_unavailable_reason,
 )
 from tokenspeed_kernel.ops.tuning import load_packaged_flashinfer_tuning_cache
-from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.platform import current_platform, pdl_enabled
 from torch import nn
 
 from tokenspeed.runtime.configs.kimi_k3_config import KimiK3Config, KimiLinearConfig
@@ -1261,6 +1261,7 @@ class KimiLinearKDA(nn.Module):
                 self.o_norm.variance_epsilon,
                 hn,
                 hd,
+                enable_pdl=pdl_enabled(),
             )
         output, _ = self.o_proj(core_out)
         return output

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py
@@ -948,19 +948,26 @@ def _rmsnorm_gated_kernel(
     num_heads: tl.constexpr,
     head_dim: tl.constexpr,
     BLOCK_H: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     token = tl.program_id(0)
     offs_h = tl.arange(0, BLOCK_H)
     offs_d = tl.arange(0, head_dim)
     mask_h = offs_h < num_heads
     idx = token * num_heads * head_dim + offs_h[:, None] * head_dim + offs_d[None, :]
-    x = tl.load(x_ptr + idx, mask=mask_h[:, None], other=0.0).to(tl.float32)
-    var = tl.sum(x * x, axis=1) / head_dim
-    rsig = tl.math.rsqrt(var + eps)
     w = tl.load(weight_ptr + offs_d).to(tl.float32)
     gate_idx = token * gate_stride + offs_h[:, None] * head_dim + offs_d[None, :]
     g = tl.load(gate_ptr + gate_idx, mask=mask_h[:, None], other=0.0).to(tl.float32)
+    if ENABLE_PDL:
+        # Gate and norm weight are independent of the KDA primary. Delay only
+        # the attention-output read until every primary CTA has completed.
+        tl.extra.cuda.gdc_wait()
+    x = tl.load(x_ptr + idx, mask=mask_h[:, None], other=0.0).to(tl.float32)
+    var = tl.sum(x * x, axis=1) / head_dim
+    rsig = tl.math.rsqrt(var + eps)
     y = x * rsig[:, None] * w[None, :] * tl.sigmoid(g)
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
     tl.store(out_ptr + idx, y.to(out_ptr.dtype.element_ty), mask=mask_h[:, None])
 
 
@@ -971,6 +978,8 @@ def rmsnorm_gated_sigmoid(
     eps: float,
     num_heads: int,
     head_dim: int,
+    *,
+    enable_pdl: bool,
 ) -> torch.Tensor:
     """Per-head RMSNorm fused with a sigmoid output gate: ``rmsnorm(x)*w*sigmoid(g)``.
 
@@ -980,12 +989,15 @@ def rmsnorm_gated_sigmoid(
         weight: ``[head_dim]`` RMSNorm weight.
         eps: RMSNorm epsilon.
         num_heads / head_dim: per-head norm geometry.
+        enable_pdl: Whether to prefetch gate/weight before waiting for the
+            immediately preceding programmatic-launch primary.
 
     Returns:
         ``[num_tokens, num_heads*head_dim]`` tensor of ``x``'s dtype.
     """
     assert x.is_contiguous() and gate.shape == x.shape and gate.stride(-1) == 1
     out = torch.empty_like(x)
+    pdl_kwargs = {"launch_pdl": True} if enable_pdl else {}
     _rmsnorm_gated_kernel[(x.shape[0],)](
         x,
         gate,
@@ -996,7 +1008,9 @@ def rmsnorm_gated_sigmoid(
         num_heads=num_heads,
         head_dim=head_dim,
         BLOCK_H=triton.next_power_of_2(num_heads),
+        ENABLE_PDL=enable_pdl,
         num_warps=4,
+        **pdl_kwargs,
     )
     return out
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -5240,6 +5240,9 @@ def try_kda_fused_paged_verify(
     recurrent_layout = recurrent_layout or kda_recurrent_layout()
     if recurrent_layout not in ("k_major", "v_major"):
         raise ValueError(f"unsupported KDA recurrent layout {recurrent_layout!r}")
+    split_producers = g_raw is not None or conv_qkv is not None
+    if split_producers and (g_raw is None or conv_qkv is None):
+        raise ValueError("g_raw and conv_qkv must be provided together")
     signature = _attention_format_signature(
         q=mixed_qkv,
         k=mixed_qkv,
@@ -5256,6 +5259,7 @@ def try_kda_fused_paged_verify(
                 "recurrent_layout": recurrent_layout,
                 "num_heads": num_heads,
                 "head_dim": head_dim,
+                "split_producers": split_producers,
             },
             solution=solution,
             override=override,
@@ -5271,9 +5275,7 @@ def try_kda_fused_paged_verify(
                 "replay_beta": replay_beta,
             }
         )
-    if g_raw is not None or conv_qkv is not None:
-        if g_raw is None or conv_qkv is None:
-            raise ValueError("g_raw and conv_qkv must be provided together")
+    if split_producers:
         kwargs.update({"g_raw": g_raw, "conv_qkv": conv_qkv})
     return kernel(
         mixed_qkv=mixed_qkv,
@@ -5349,6 +5351,7 @@ def kda_verify_conv_update(
     num_heads: int,
     head_dim: int,
     draft_token_num: int,
+    recurrent_layout: str,
 ) -> torch.Tensor:
     """Materialize the convolution producer used by split KDA verification.
 
@@ -5360,19 +5363,31 @@ def kda_verify_conv_update(
         num_heads: Per-rank KDA head count.
         head_dim: KDA head width.
         draft_token_num: Verify positions per request.
+        recurrent_layout: Committed recurrent-state layout.
 
     Returns:
         Convolved and SiLU-activated QKV rows.
     """
-    from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
-        fused_kda_verify_conv_update,
+    signature = _attention_format_signature(
+        q=mixed_qkv,
+        k=mixed_qkv,
+        v=mixed_qkv,
     )
-
-    return fused_kda_verify_conv_update(
-        mixed_qkv,
-        conv_weights,
-        conv_states,
-        read_indices,
+    kernel = select_kernel(
+        "attention",
+        "kda_verify_conv_update",
+        signature,
+        traits={
+            "paged_state": True,
+            "split_producers": True,
+            "recurrent_layout": recurrent_layout,
+        },
+    )
+    return kernel(
+        mixed_qkv=mixed_qkv,
+        conv_weights=conv_weights,
+        conv_states=conv_states,
+        read_indices=read_indices,
         num_heads=num_heads,
         head_dim=head_dim,
         draft_token_num=draft_token_num,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -5224,6 +5224,8 @@ def try_kda_fused_paged_verify(
     replay_mixed_qkv: torch.Tensor | None = None,
     replay_gate: torch.Tensor | None = None,
     replay_beta: torch.Tensor | None = None,
+    g_raw: torch.Tensor | None = None,
+    conv_qkv: torch.Tensor | None = None,
 ) -> torch.Tensor | None:
     """Run a registered pre-convolution KDA target-verify fusion when available.
 
@@ -5262,11 +5264,17 @@ def try_kda_fused_paged_verify(
         return None
     kwargs = {}
     if replay_mixed_qkv is not None:
-        kwargs = {
-            "replay_mixed_qkv": replay_mixed_qkv,
-            "replay_gate": replay_gate,
-            "replay_beta": replay_beta,
-        }
+        kwargs.update(
+            {
+                "replay_mixed_qkv": replay_mixed_qkv,
+                "replay_gate": replay_gate,
+                "replay_beta": replay_beta,
+            }
+        )
+    if g_raw is not None or conv_qkv is not None:
+        if g_raw is None or conv_qkv is None:
+            raise ValueError("g_raw and conv_qkv must be provided together")
+        kwargs.update({"g_raw": g_raw, "conv_qkv": conv_qkv})
     return kernel(
         mixed_qkv=mixed_qkv,
         conv_weights=conv_weights,
@@ -5286,6 +5294,88 @@ def try_kda_fused_paged_verify(
         draft_token_num=draft_token_num,
         lower_bound=lower_bound,
         **kwargs,
+    )
+
+
+def kda_fused_paged_verify_uses_split_producers(
+    dtype: torch.dtype,
+    *,
+    store_states: bool,
+    recurrent_layout: str,
+    num_heads: int,
+    head_dim: int,
+) -> bool:
+    """Whether the selected verify implementation accepts split producers.
+
+    Args:
+        dtype: Activation dtype used to resolve the registered kernel.
+        store_states: Whether verify materializes per-position rollback state.
+        recurrent_layout: Committed recurrent-state layout.
+        num_heads: Per-rank KDA head count.
+        head_dim: KDA head width.
+
+    Returns:
+        True when the selected implementation accepts precomputed convolution
+        and gate tensors.
+    """
+    probe = torch.empty(0, dtype=dtype, device="meta")
+    signature = _attention_format_signature(q=probe, k=probe, v=probe)
+    traits = {
+        "paged_state": True,
+        "store_states": store_states,
+        "recurrent_layout": recurrent_layout,
+    }
+    traits["num_heads"] = num_heads
+    traits["head_dim"] = head_dim
+    try:
+        kernel = select_kernel(
+            "attention", "kda_fused_paged_verify", signature, traits=traits
+        )
+    except NoKernelFoundError:
+        return False
+    registered = KernelRegistry.get().get_by_name(kernel.name)
+    return bool(
+        registered is not None
+        and registered.traits.get("split_producers") == frozenset({True})
+    )
+
+
+def kda_verify_conv_update(
+    mixed_qkv: torch.Tensor,
+    conv_weights: torch.Tensor,
+    conv_states: torch.Tensor,
+    read_indices: torch.Tensor,
+    *,
+    num_heads: int,
+    head_dim: int,
+    draft_token_num: int,
+) -> torch.Tensor:
+    """Materialize the convolution producer used by split KDA verification.
+
+    Args:
+        mixed_qkv: Packed raw QKV projection rows.
+        conv_weights: Fused four-tap QKV convolution weights.
+        conv_states: Committed convolution-state pool.
+        read_indices: Committed page index for each request.
+        num_heads: Per-rank KDA head count.
+        head_dim: KDA head width.
+        draft_token_num: Verify positions per request.
+
+    Returns:
+        Convolved and SiLU-activated QKV rows.
+    """
+    from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
+        fused_kda_verify_conv_update,
+    )
+
+    return fused_kda_verify_conv_update(
+        mixed_qkv,
+        conv_weights,
+        conv_states,
+        read_indices,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        draft_token_num=draft_token_num,
     )
 
 
@@ -5737,6 +5827,8 @@ __all__ = [
     "kda_paged_decode",
     "try_kda_fused_paged_decode",
     "try_kda_fused_paged_verify",
+    "kda_fused_paged_verify_uses_split_producers",
+    "kda_verify_conv_update",
     "try_kda_replay_commit",
     "resolve_kda_batched_replay_commit",
     "kda_batched_replay_uses_raw_gate",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda_dispatch.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda_dispatch.py
@@ -15,7 +15,7 @@ from collections.abc import Callable
 
 import torch
 from tokenspeed_kernel.ops.attention import KdaPrefillResult
-from tokenspeed_kernel.platform import CapabilityRequirement
+from tokenspeed_kernel.platform import CapabilityRequirement, pdl_enabled
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import format_signatures
 
@@ -110,25 +110,27 @@ def _nvidia_fused_verify(
     lower_bound: float | None,
     store_states: bool,
     split_producers: bool = False,
+    g_raw: torch.Tensor | None = None,
+    conv_qkv: torch.Tensor | None = None,
 ) -> torch.Tensor:
     from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
         fused_kda_verify_conv_update,
         fused_recurrent_kda_verify_megafuse,
     )
 
-    conv_qkv = None
-    g_raw = None
     if split_producers:
-        conv_qkv = fused_kda_verify_conv_update(
-            mixed_qkv,
-            conv_weights,
-            conv_states,
-            read_indices,
-            num_heads=num_heads,
-            head_dim=head_dim,
-            draft_token_num=draft_token_num,
-        )
-        g_raw = torch.mm(f_a_out, f_b_weight.t())
+        if conv_qkv is None:
+            conv_qkv = fused_kda_verify_conv_update(
+                mixed_qkv,
+                conv_weights,
+                conv_states,
+                read_indices,
+                num_heads=num_heads,
+                head_dim=head_dim,
+                draft_token_num=draft_token_num,
+            )
+        if g_raw is None:
+            g_raw = torch.mm(f_a_out, f_b_weight.t())
 
     return fused_recurrent_kda_verify_megafuse(
         mixed_qkv,
@@ -152,6 +154,7 @@ def _nvidia_fused_verify(
         store_states=store_states,
         g_raw=g_raw,
         conv_qkv=conv_qkv,
+        enable_pdl=pdl_enabled(),
     ).view(1, -1, num_heads, head_dim)
 
 
@@ -166,6 +169,7 @@ def _nvidia_fused_verify(
     traits={
         "paged_state": frozenset({True}),
         "store_states": frozenset({True}),
+        "split_producers": frozenset({False}),
         "recurrent_layout": frozenset({"v_major"}),
     },
     tags={"nvidia", "paged_cache", "cuda_graph", "fusion", "speculative"},
@@ -210,6 +214,7 @@ def triton_nvidia_kda_fused_paged_verify(
         draft_token_num=draft_token_num,
         lower_bound=lower_bound,
         store_states=True,
+        split_producers=False,
     )
 
 
@@ -224,6 +229,7 @@ def triton_nvidia_kda_fused_paged_verify(
     traits={
         "paged_state": frozenset({True}),
         "store_states": frozenset({False}),
+        "split_producers": frozenset({False}),
         "recurrent_layout": frozenset({"v_major"}),
     },
     tags={"nvidia", "paged_cache", "cuda_graph", "fusion", "speculative"},
@@ -268,6 +274,7 @@ def triton_nvidia_kda_fused_paged_verify_no_store(
         draft_token_num=draft_token_num,
         lower_bound=lower_bound,
         store_states=False,
+        split_producers=False,
     )
 
 
@@ -284,6 +291,7 @@ def triton_nvidia_kda_fused_paged_verify_no_store(
     traits={
         "paged_state": frozenset({True}),
         "store_states": frozenset({False}),
+        "split_producers": frozenset({True}),
         "recurrent_layout": frozenset({"v_major"}),
     },
     tags={"nvidia", "paged_cache", "cuda_graph", "fusion", "speculative"},
@@ -307,6 +315,8 @@ def triton_nvidia_kda_fused_paged_verify_split(
     head_dim: int,
     draft_token_num: int,
     lower_bound: float | None,
+    g_raw: torch.Tensor | None = None,
+    conv_qkv: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run target verify with split convolution and gate producers."""
     return _nvidia_fused_verify(
@@ -329,6 +339,8 @@ def triton_nvidia_kda_fused_paged_verify_split(
         lower_bound=lower_bound,
         store_states=False,
         split_producers=True,
+        g_raw=g_raw,
+        conv_qkv=conv_qkv,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda_dispatch.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kda_dispatch.py
@@ -160,6 +160,47 @@ def _nvidia_fused_verify(
 
 @register_kernel(
     "attention",
+    "kda_verify_conv_update",
+    name="triton_nvidia_kda_verify_conv_update",
+    solution="triton",
+    capability=CapabilityRequirement(vendors=frozenset({"nvidia"})),
+    signatures=_DENSE_BF16_SIGNATURES,
+    priority=Priority.SPECIALIZED,
+    traits={
+        "paged_state": frozenset({True}),
+        "split_producers": frozenset({True}),
+        "recurrent_layout": frozenset({"v_major"}),
+    },
+    tags={"nvidia", "paged_cache", "cuda_graph", "fusion", "speculative"},
+)
+def triton_nvidia_kda_verify_conv_update(
+    mixed_qkv: torch.Tensor,
+    conv_weights: torch.Tensor,
+    conv_states: torch.Tensor,
+    read_indices: torch.Tensor,
+    *,
+    num_heads: int,
+    head_dim: int,
+    draft_token_num: int,
+) -> torch.Tensor:
+    """Materialize the NVIDIA split-verify convolution producer."""
+    from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
+        fused_kda_verify_conv_update,
+    )
+
+    return fused_kda_verify_conv_update(
+        mixed_qkv,
+        conv_weights,
+        conv_states,
+        read_indices,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        draft_token_num=draft_token_num,
+    )
+
+
+@register_kernel(
+    "attention",
     "kda_fused_paged_verify",
     name="triton_nvidia_kda_fused_paged_verify",
     solution="triton",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -732,6 +732,7 @@ def fused_recurrent_kda_verify_megafuse_fwd_kernel(
     HAS_PRECOMPUTED_CONV: tl.constexpr,
     STORE_STATES: tl.constexpr,
     USE_LOWER_BOUND: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
     """Run target verify, optionally storing each position's rollback state."""
     pid = tl.program_id(0)
@@ -807,6 +808,13 @@ def fused_recurrent_kda_verify_megafuse_fwd_kernel(
         b_bias = tl.load(dt_bias + i_hv * K + o_k, mask=mask_k, other=0.0).to(
             tl.float32
         )
+
+    if ENABLE_PDL:
+        # The state and weights above do not depend on the split producers.
+        # Fence before reading conv_qkv/g_raw, then release gated RMSNorm so
+        # it can prefetch its independent gate and weight during recurrence.
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
 
     for i_t in range(T):
         tok = bos + i_t
@@ -1102,6 +1110,7 @@ def fused_recurrent_kda_verify_megafuse(
     conv_qkv: torch.Tensor | None = None,
     num_warps: int | None = None,
     num_stages: int | None = None,
+    enable_pdl: bool,
 ) -> torch.Tensor:
     """Run target-verify recurrence with inline or precomputed producers.
 
@@ -1122,6 +1131,8 @@ def fused_recurrent_kda_verify_megafuse(
             128-wide heads and avoids wide V-major tiles when storing tapes.
         num_warps/num_stages: Optional launch overrides. Defaults route to
             1/3 for the fully split producer path and 4/2 otherwise.
+        enable_pdl: Whether this grid releases a programmatic-launch dependent
+            after its producer-independent prologue.
 
     Returns:
         o: ``[N*T, HV, V]`` attention output in ``qkv_raw``'s dtype.
@@ -1172,6 +1183,7 @@ def fused_recurrent_kda_verify_megafuse(
         raise ValueError(f"bv={bv} must be a positive power of two")
     BV = bv
     grid = (triton.cdiv(V, BV) * N * HV,)
+    pdl_kwargs = {"launch_pdl": True} if enable_pdl else {}
     fused_recurrent_kda_verify_megafuse_fwd_kernel[grid](
         qkv_raw=qkv_raw,
         conv_w=conv_w,
@@ -1213,8 +1225,10 @@ def fused_recurrent_kda_verify_megafuse(
         HAS_PRECOMPUTED_GATE=g_raw is not None,
         HAS_PRECOMPUTED_CONV=conv_qkv is not None,
         STORE_STATES=store_states,
+        ENABLE_PDL=enable_pdl,
         num_warps=num_warps,
         num_stages=num_stages,
+        **pdl_kwargs,
     )
     return out
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -1110,7 +1110,7 @@ def fused_recurrent_kda_verify_megafuse(
     conv_qkv: torch.Tensor | None = None,
     num_warps: int | None = None,
     num_stages: int | None = None,
-    enable_pdl: bool,
+    enable_pdl: bool = False,
 ) -> torch.Tensor:
     """Run target-verify recurrence with inline or precomputed producers.
 
@@ -1132,7 +1132,7 @@ def fused_recurrent_kda_verify_megafuse(
         num_warps/num_stages: Optional launch overrides. Defaults route to
             1/3 for the fully split producer path and 4/2 otherwise.
         enable_pdl: Whether this grid releases a programmatic-launch dependent
-            after its producer-independent prologue.
+            after its producer-independent prologue. Defaults to ``False``.
 
     Returns:
         o: ``[N*T, HV, V]`` attention output in ``qkv_raw``'s dtype.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -1110,7 +1110,7 @@ def fused_recurrent_kda_verify_megafuse(
     conv_qkv: torch.Tensor | None = None,
     num_warps: int | None = None,
     num_stages: int | None = None,
-    enable_pdl: bool = False,
+    enable_pdl: bool,
 ) -> torch.Tensor:
     """Run target-verify recurrence with inline or precomputed producers.
 
@@ -1132,7 +1132,7 @@ def fused_recurrent_kda_verify_megafuse(
         num_warps/num_stages: Optional launch overrides. Defaults route to
             1/3 for the fully split producer path and 4/2 otherwise.
         enable_pdl: Whether this grid releases a programmatic-launch dependent
-            after its producer-independent prologue. Defaults to ``False``.
+            after its producer-independent prologue.
 
     Returns:
         o: ``[N*T, HV, V]`` attention output in ``qkv_raw``'s dtype.

--- a/tokenspeed-kernel/test/ops/attention/test_kda_replay_commit.py
+++ b/tokenspeed-kernel/test/ops/attention/test_kda_replay_commit.py
@@ -746,6 +746,7 @@ def test_fused_verify_no_store_matches_store_and_leaves_tape_untouched():
         draft_token_num=t,
         lower_bound=LOWER_BOUND,
         store_states=True,
+        enable_pdl=False,
     ).view(1, -1, HV, V)
     torch.testing.assert_close(no_store, stored, atol=0.0, rtol=0.0)
     assert not torch.equal(conv_tape, conv_before)
@@ -783,6 +784,9 @@ def test_split_verify_wrapper_matches_fused_wrapper(n):
         triton_nvidia_kda_fused_paged_verify_no_store,
         triton_nvidia_kda_fused_paged_verify_split,
     )
+    from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
+        fused_kda_verify_conv_update,
+    )
 
     t = 3
     x = _window(n, t, seed=49 + n)
@@ -812,7 +816,69 @@ def test_split_verify_wrapper_matches_fused_wrapper(n):
     )
     fused = triton_nvidia_kda_fused_paged_verify_no_store(*args, **kwargs)
     split = triton_nvidia_kda_fused_paged_verify_split(*args, **kwargs)
+    conv_qkv = fused_kda_verify_conv_update(
+        x["qkv_raw"],
+        x["conv_w"],
+        x["conv_pool"],
+        x["read_indices"],
+        num_heads=HV,
+        head_dim=V,
+        draft_token_num=t,
+    )
+    g_raw = torch.mm(x["f_a"], x["w_fb"].t())
+    precomputed = triton_nvidia_kda_fused_paged_verify_split(
+        *args, **kwargs, g_raw=g_raw, conv_qkv=conv_qkv
+    )
     torch.testing.assert_close(split, fused, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(precomputed, split, atol=0.0, rtol=0.0)
+
+
+@pytest.mark.skipif(not current_platform().is_hopper_plus, reason="PDL requires SM90+")
+def test_verify_to_gated_norm_pdl_chain_matches_serial():
+    """The early verify trigger remains fenced before gated-norm reads."""
+    from tokenspeed_kernel.ops.activation.triton import rmsnorm_gated_sigmoid
+
+    n, t = 4, 4
+    x = _window(n, t, seed=57)
+    writes = torch.arange(n * t, device=DEV, dtype=torch.int32).view(n, t)
+    gate = torch.randn(n * t, P, device=DEV, dtype=torch.bfloat16)
+    weight = torch.randn(V, device=DEV, dtype=torch.bfloat16)
+
+    def run(enable_pdl: bool) -> torch.Tensor:
+        out = fused_recurrent_kda_verify_megafuse(
+            x["qkv_raw"],
+            x["conv_w"],
+            x["conv_pool"],
+            x["conv_pool"],
+            x["f_a"],
+            x["w_fb"],
+            x["beta"],
+            x["A_log"],
+            x["dt_bias"],
+            x["h_pool"],
+            x["h_pool"],
+            x["read_indices"],
+            writes,
+            num_heads=HV,
+            head_dim=V,
+            draft_token_num=t,
+            lower_bound=LOWER_BOUND,
+            store_states=False,
+            enable_pdl=enable_pdl,
+        )
+        return rmsnorm_gated_sigmoid(
+            out.reshape(-1, P),
+            gate,
+            weight,
+            1e-6,
+            HV,
+            V,
+            enable_pdl=enable_pdl,
+        )
+
+    serial = run(False)
+    pdl = run(True)
+    torch.testing.assert_close(pdl, serial, atol=0.0, rtol=0.0)
 
 
 def test_fused_verify_default_store_is_bit_identical_to_explicit_trait():
@@ -843,6 +909,7 @@ def test_fused_verify_default_store_is_bit_identical_to_explicit_trait():
                 head_dim=V,
                 draft_token_num=3,
                 lower_bound=LOWER_BOUND,
+                enable_pdl=False,
                 **kwargs,
             )
         )
@@ -884,6 +951,7 @@ def test_fused_verify_routed_bv_matches_bv32(n, t):
             lower_bound=LOWER_BOUND,
             store_states=False,
             bv=bv,
+            enable_pdl=False,
         )
         results.append(out)
     torch.testing.assert_close(results[0], results[1], atol=1e-5, rtol=8e-3)
@@ -921,6 +989,7 @@ def test_fused_verify_store_follows_permuted_write_rows():
                 draft_token_num=t,
                 lower_bound=LOWER_BOUND,
                 store_states=True,
+                enable_pdl=False,
             )
         )
         convs.append(conv)
@@ -955,4 +1024,5 @@ def test_fused_verify_rejects_non_power_of_two_bv():
             draft_token_num=3,
             lower_bound=LOWER_BOUND,
             bv=48,
+            enable_pdl=False,
         )

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -354,6 +354,7 @@ def test_kda_replay_is_registered_for_the_platform_layout() -> None:
             {
                 "paged_state": frozenset({True}),
                 "store_states": frozenset({True}),
+                "split_producers": frozenset({False}),
                 "recurrent_layout": frozenset({"v_major"}),
             },
         ),
@@ -370,6 +371,7 @@ def test_kda_replay_is_registered_for_the_platform_layout() -> None:
             {
                 "paged_state": frozenset({True}),
                 "store_states": frozenset({False}),
+                "split_producers": frozenset({False}),
                 "recurrent_layout": frozenset({"v_major"}),
             },
         ),
@@ -478,6 +480,7 @@ def test_kda_split_verify_registration_traits() -> None:
     assert spec.traits == {
         "paged_state": frozenset({True}),
         "store_states": frozenset({False}),
+        "split_producers": frozenset({True}),
         "recurrent_layout": frozenset({"v_major"}),
     }
 

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -1109,6 +1109,7 @@ def _run_megafuse(inp, *, fused: bool):
         NORM_EPS,
         heads,
         head_dim,
+        enable_pdl=False,
     ).view_as(out)
 
 

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -17,6 +17,7 @@ from tokenspeed_kernel.ops.attention import (
     kda_paged_prefill,
     kda_recurrent_layout,
     kda_replay_commit_supported,
+    kda_verify_conv_update,
     try_kda_fused_paged_decode,
     try_kda_fused_paged_verify,
     try_kda_replay_commit,
@@ -220,8 +221,77 @@ def test_kda_fused_verify_selects_all_layout_traits(
         "recurrent_layout": recurrent_layout,
         "num_heads": 1,
         "head_dim": 1,
+        "split_producers": False,
     }
     assert selected == expected
+
+
+def test_kda_fused_verify_selects_split_producer_kernel_when_inputs_are_given(
+    monkeypatch,
+) -> None:
+    selected = {}
+
+    def fake_select_kernel(*_args, **kwargs):
+        selected.update(kwargs["traits"])
+        return lambda **kernel_kwargs: kernel_kwargs["mixed_qkv"]
+
+    monkeypatch.setattr(attention_ops, "select_kernel", fake_select_kernel)
+    tensor = torch.empty(1, dtype=torch.bfloat16)
+    result = try_kda_fused_paged_verify(
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        state_pool=tensor,
+        state_scratch=tensor,
+        read_indices=tensor,
+        write_indices=tensor,
+        num_heads=1,
+        head_dim=1,
+        draft_token_num=1,
+        recurrent_layout="v_major",
+        store_states=False,
+        g_raw=tensor,
+        conv_qkv=tensor,
+    )
+    assert result is tensor
+    assert selected["split_producers"] is True
+
+
+def test_kda_verify_conv_update_resolves_registered_producer(monkeypatch) -> None:
+    selected = {}
+
+    def fake_select_kernel(*args, **kwargs):
+        selected["operator"] = args[1]
+        selected["traits"] = kwargs["traits"]
+        return lambda **kernel_kwargs: kernel_kwargs["mixed_qkv"]
+
+    monkeypatch.setattr(attention_ops, "select_kernel", fake_select_kernel)
+    tensor = torch.empty(1, dtype=torch.bfloat16)
+    result = kda_verify_conv_update(
+        tensor,
+        tensor,
+        tensor,
+        tensor,
+        num_heads=1,
+        head_dim=1,
+        draft_token_num=1,
+        recurrent_layout="v_major",
+    )
+    assert result is tensor
+    assert selected == {
+        "operator": "kda_verify_conv_update",
+        "traits": {
+            "paged_state": True,
+            "split_producers": True,
+            "recurrent_layout": "v_major",
+        },
+    }
 
 
 @pytest.mark.parametrize(
@@ -284,6 +354,14 @@ def test_kda_replay_is_registered_for_the_platform_layout() -> None:
             {
                 "paged_state": frozenset({True}),
                 "store_states": frozenset({True}),
+                "recurrent_layout": frozenset({"v_major"}),
+            },
+        ),
+        (
+            "triton_nvidia_kda_verify_conv_update",
+            {
+                "paged_state": frozenset({True}),
+                "split_producers": frozenset({True}),
                 "recurrent_layout": frozenset({"v_major"}),
             },
         ),


### PR DESCRIPTION
## Summary

- Split independent KDA verify producers onto separate CUDA streams and join before recurrent megafuse.
- Add a kernel capability gate so unsupported backends retain the existing inline-producer path.
- Add the PDL dependency chain from gate GEMM to verify megafuse and gated RMSNorm.
- Keep PDL disabled by default for the standalone recurrent KDA verify megafuse.

## Accuracy validation

Validated the optimized path using real Kimi-K3 weights on AIME 2026.

| Item | Configuration |
| --- | --- |
| Model | Kimi-K3 real checkpoint |
| Runtime dtype | BF16 |
| KV cache | FP8 E4M3 |
| Hardware | 8× NVIDIA GB300 GPUs across 2 nodes |
| Tensor parallelism | TP=8 |
| Pipeline parallelism | PP=1 |
| Expert parallelism | EP=1 |
| MoE backend | `flashinfer_trtllm` |
| KDA backend | `auto` |
| Maximum model length | 65,536 tokens |
| Maximum concurrent sequences | 16 |
| Chunked prefill / max prefill | 8,192 / 8,192 tokens |
| Speculative decoding | Disabled |
| Dataset | AIME 2026 |
| Samples | 30 |
| Sampling temperature | 1.0 |

| Model | Dataset | Metric | Samples | Result |
| --- | --- | --- | ---: | ---: |
| Kimi-K3 | AIME 2026 | Accuracy | 30 | 100% (30/30) |

The evaluation passed the configured `>= 0.9` threshold.

For reference, the end-to-end AIME run reported 1,993.6 ms average TTFT, 17.8 ms average TPOT, and 60.52 tok/s average throughput. This sampled evaluation validates correctness and reports an absolute serving result; it is not the paired performance comparison below.

## Performance

Paired same-node Nsight Systems measurement on a 20-layer Kimi-K3 configuration (TP8, batch size 4, EAGLE3 with 3 draft tokens, CUDA Graph; 30 replay iterations):

| Metric | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| KDA per-layer critical chain | 17.111 us | 12.627 us | -26.2% |
| Steady-state decode throughput (last 20 samples) | 1083.04 tok/s | 1101.09 tok/s | +1.7% |

These results are workload-specific and should not be extrapolated to every model or serving configuration.

## Validation

- KDA split-producer and PDL numerical-parity tests passed.
- Runtime and NVTX tests passed on both ranks.
- Each rank captured 30 CUDA Graph replays in the paired measurement.