### PR TITLE
fix(runtime): keep inline output IDs free of detokenizer context

### DIFF
--- a/python/tokenspeed/runtime/engine/output_processor.py
+++ b/python/tokenspeed/runtime/engine/output_processor.py
@@ -226,12 +226,12 @@ class OutputProcessor:
                     state.text += incremental_emit
                     if state.obj.stream:
                         state.logprobs_info = logprobs_info
-                        state.output_ids.extend(recv_obj.decode_ids[i])
+                        state.output_ids.extend(recv_obj.output_ids[i])
                         output_token_ids = state.output_ids[state.last_output_offset :]
                         state.last_output_offset = len(state.output_ids)
                     else:
                         state.logprobs_info.update(logprobs_info)
-                        state.output_ids.extend(recv_obj.decode_ids[i])
+                        state.output_ids.extend(recv_obj.output_ids[i])
                         output_token_ids = state.output_ids.copy()
 
                     out_dict = {

--- a/test/runtime/test_inline_detokenizer_receiver.py
+++ b/test/runtime/test_inline_detokenizer_receiver.py
@@ -171,6 +171,8 @@ def _batch_token_id_out(
         "generated_time": 0,
     }
     defaults.update(overrides)
+    if defaults["output_ids"] is None:
+        defaults["output_ids"] = [list(ids) for ids in decode_ids]
     return BatchTokenIDOut(
         rids=rids,
         finished_reasons=(
@@ -399,6 +401,26 @@ class TestOutputIdsShape(unittest.TestCase):
         self.assertEqual(out2["output_ids"], ids_b)
         # Cumulative state carries the full list.
         self.assertEqual(state.output_ids, ids_a + ids_b)
+
+    def test_prompt_tail_in_decode_ids_is_not_exposed_as_output_ids(self):
+        mgr = _StubTokenizerManager(self.tok, enable_inline_detokenizer=True)
+        state = _mk_state(stream=False, rid="r1")
+        _register(mgr, state)
+
+        prompt_tail = self.tok.encode("prompt context ")
+        generated = self.tok.encode("answer")
+        recv = _batch_token_id_out(
+            ["r1"],
+            decode_ids=[prompt_tail + generated],
+            read_offsets=[len(prompt_tail)],
+            output_ids=[generated],
+            finished_reasons=[{"type": "stop", "matched": None}],
+        )
+        mgr.output_processor.handle_batch_output(recv)
+
+        out = state.collector.take()
+        self.assertEqual(out["output_ids"], generated)
+        self.assertEqual(state.output_ids, generated)
 
     def test_non_stream_mode_emits_full_cumulative_output_ids(self):
         mgr = _StubTokenizerManager(self.tok, enable_inline_detokenizer=True)


### PR DESCRIPTION
## Summary

Fix inline detokenization returning prompt-context token IDs as generated output IDs, and add a regression test.

### Problem

`BatchTokenIDOut.decode_ids` supplies context for incremental text decoding. Its first frame can include a prompt suffix preceding the generated tokens. `BatchTokenIDOut.output_ids` contains the newly generated token IDs for that frame.

The inline branch currently appends `decode_ids` to request output state in both streaming and non-streaming modes. As a result, the returned text can look correct while `output_ids` incorrectly includes prompt context. A consumer reconstructing `prompt_ids + output_ids` then duplicates that context and no longer reproduces the sequence used during generation.

### Changes and rationale

- Accumulate `recv_obj.output_ids[i]` in both inline output branches, matching the existing `BatchStrOut` path.
- Keep `decode_ids` and read offsets exclusively for incremental text decoding; do not infer generation boundaries by trimming or re-encoding text.
- Populate generated IDs in the test fixture and add a case where `decode_ids` contains a prompt suffix but `output_ids` contains only the generated answer.

This preserves the existing output contract: streaming frames expose new IDs, while non-streaming responses expose cumulative IDs. It does not change model execution, logits, sampling, EOS handling, length limits, or collector coalescing behavior.

## Test Plan

- `pre-commit run --all-files`: passed on the upstream-based branch.
- Runtime Ruff checks (`F401,F841,F821,F823,F811,F541,UP035,UP006,UP007,UP045`): passed.
- `TestOutputIdsShape`: 3 tests passed with Python 3.11 and a cached Hugging Face tokenizer, covering streaming deltas, non-streaming accumulation, and exclusion of prompt-context IDs. The tested output-processing implementation is AST-identical and the test file is byte-identical to this PR; the tokenizer fixture was substituted for the default GPT-2 tokenizer in that validation environment.
- Full upstream CI and GPU integration tests have not been run locally.
