### PR TITLE
fix: DFlash2 on Kimi-K3

### DIFF
--- a/python/tokenspeed/runtime/models/dflash2.py
+++ b/python/tokenspeed/runtime/models/dflash2.py
@@ -286,6 +286,7 @@ class DFlash2DecoderLayer(DFlashDecoderLayer):
                 attention.group_id = FULL_ATTENTION
                 # Storage remains in Kimi-K3's full-attention group. This field
                 # is only the compute visibility contract for the MLA backend.
+                # TODO: mla honours it but tokenspeed_mla ignores it.
                 attention.sliding_window_size = sliding_window
             self.comm_manager = CommManager(
                 mapping=mapping,
@@ -309,13 +310,10 @@ class DFlash2DecoderLayer(DFlashDecoderLayer):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
         ctx: ForwardContext,
-        out_cache_loc: torch.Tensor,
         residual: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if ctx.forward_mode.is_idle():
-            return super().forward(
-                positions, hidden_states, ctx, out_cache_loc, residual
-            )
+            return super().forward(positions, hidden_states, ctx, residual)
 
         if residual is None:
             residual = hidden_states
@@ -334,7 +332,6 @@ class DFlash2DecoderLayer(DFlashDecoderLayer):
             positions=positions,
             hidden_states=hidden_states,
             ctx=ctx,
-            out_cache_loc=out_cache_loc,
         )
         if self.comm_manager is not None:
             attention_kwargs["comm_manager"] = self.comm_manager
@@ -386,6 +383,10 @@ class DFlash2DraftModel(DFlashDraftModel):
     @property
     def _uses_mla(self) -> bool:
         return _dflash2_uses_mla(self.config)
+
+    @property
+    def attention_kind(self) -> str:
+        return "kimi_mla" if self._uses_mla else "qwen_mha"
 
     @torch.no_grad()
     def write_context_kv(
@@ -481,6 +482,18 @@ class DFlash2DraftModel(DFlashDraftModel):
             raise ValueError(
                 f"DFlash2 MLA checkpoint is missing {len(missing)} weights: {missing[:8]}"
             )
+        self.post_load_weights()
+
+    def post_load_weights(self) -> None:
+        """Precompute the absorbed decode factors from kv_b_proj.
+
+        Under ``--load-format dummy`` load_weights never runs, so the absorbed
+        decode kernel would dereference null w_kc/w_vc. DummyModelLoader calls
+        this hook, so populate them here. GQA checkpoints have no kv_b_proj to
+        absorb.
+        """
+        if not self._uses_mla:
+            return
         for layer in self.layers:
             self_attn = layer.self_attn
             self_attn.w_kc, self_attn.w_vc = _prepare_mla_kv_b_proj_weights(

--- a/test/runtime/test_dflash2.py
+++ b/test/runtime/test_dflash2.py
@@ -43,6 +43,7 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import FULL_ATTEN
 from tokenspeed.runtime.models import dflash as dflash_model
 from tokenspeed.runtime.models.dflash2 import (
     CandidateSelector,
+    DFlash2DecoderLayer,
     DFlash2DraftModel,
     DFlashGroupedConv,
     _dflash2_mla_rope,
@@ -296,3 +297,30 @@ def test_official_nodes_capture_and_replay_in_one_cuda_graph() -> None:
     expected = torch.empty_like(static_out)
     _walk_greedy_path(static_candidates, eager_scores, static_anchor, expected)
     torch.testing.assert_close(replayed, expected)
+
+
+@pytest.mark.parametrize(
+    ("attention_mode", "expected"),
+    (("mla", "kimi_mla"), ("gqa", "qwen_mha")),
+)
+def test_dflash2_publishes_the_attention_kind_the_drafter_slices_on(
+    attention_mode: str, expected: str
+) -> None:
+    """DFLASH publishes num_extends=0 only for kimi_mla."""
+    model = DFlash2DraftModel.__new__(DFlash2DraftModel)
+    model.config = SimpleNamespace(
+        architectures=["DFlash2DraftModel"],
+        dflash_config={"attention_mode": attention_mode},
+    )
+    assert model.attention_kind == expected
+
+
+def test_post_load_weights_is_a_no_op_for_gqa_checkpoints() -> None:
+    """A GQA draft holds a DFlashAttention with no kv_b_proj to absorb."""
+    model = DFlash2DraftModel.__new__(DFlash2DraftModel)
+    model.config = SimpleNamespace(
+        architectures=["DFlash2DraftModel"],
+        dflash_config={"attention_mode": "gqa"},
+    )
+    # .layers is deliberately absent: reaching the loop would raise here.
+    model.post_load_weights()


### PR DESCRIPTION
Fix DFlash2 failing to serve on Kimi-K3 in every configuration I tried: both MLA backends, both KV dtypes, several cudagraph capture sets, and `--enforce-eager`.

### What was wrong

- `DFlash2DecoderLayer.forward` took a required `out_cache_loc` that `DFlashDraftModel.forward` never passes, so the override could not be called at all. Both attention implementations already derive write locations from `ctx.attn_backend.write_locations()`, so the parameter is removed rather than defaulted.
- `DFlash2DraftModel` did not publish `attention_kind`, so DFLASH fell back to `"qwen_mha"` and set `num_extends = bs` instead of 0. Each MLA leaf then sliced away decode rows its own queries still needed: `tokenspeed_mla` went 32 to 28 rows and raised `Mismatched page_table.shape[0]`, `mla` went 32 to 0 rows and hit an illegal memory access.
- The absorbed MLA factors were computed at the end of `load_weights`, which `DummyModelLoader` never calls, so `--load-format dummy` left the decode kernel with null `w_kc`/`w_vc`. Moved to `post_load_weights()` and guarded for GQA checkpoints that have no `kv_b_proj`.

### Tested

- Kimi-K3 with `kimi-k3-dflash2` at 7 steps / 8 draft tokens on `--attention-backend mla`: reaches `engine ready` and serves, where it previously died in draft warmup.
- Same on `tokenspeed_mla`: also serves, and this patch touches no file that backend uses.
- Qwen3.8-27B with `Qwen3.8-27B-DFlash2` on `trtllm`: covers the GQA path through `post_load_weights`.
- Kimi-K3 with EAGLE-3.1 MLA at 3/4, real weights on TP16: accept length 3.032 / 2.490 against 2.972 / 2.490 before the patch, inside run to run noise.
- Reduced-layer Kimi-K3 under `--load-format dummy` on 4 GPUs: reproduces the original failure, serves after the fix.
- `test/runtime/test_dflash2.py` 17 passed, `pre-commit run --all-files` clean.

### Notes

`tokenspeed_mla` never reads `layer.sliding_window_size` while `mla`, `mha` and `trtllm` do, so `kimi-k3-dflash2` (4 sliding_attention layers at window 4096) will now run there with those layers unwindowed. This causes acceptance rate degredation, but will have a follow-up PR to fix it.
