### PR TITLE
fix(qwen): prevent eager PLE index corruption after graph replay

### DIFF
--- a/docs/design/unified_path.md
+++ b/docs/design/unified_path.md
@@ -82,6 +82,13 @@ never captured (above-ladder decode, enforce-eager) builds its views lazily
 on first refresh — no new storage, one-time cost. Views must be
 pointer-stable: a captured graph holds their addresses forever.
 
+Helpers that memoize tensors created inside capture must not return those
+tensors to eager callers. Keeping a Python reference preserves the allocation,
+but an earlier graph sharing the same private pool can overwrite its contents
+on replay. PLE's uniform index bundles are reused during capture only; eager
+prefill and decode construct their indices through the same builder outside
+the capture pool.
+
 ### `for_graph_replay` is for graph-mechanics asymmetries only
 
 `for_graph_replay=True` means a graph is in play — live replay AND the base

--- a/python/tokenspeed/runtime/layers/qwen4_exp_ple.py
+++ b/python/tokenspeed/runtime/layers/qwen4_exp_ple.py
@@ -65,8 +65,9 @@ _IndexBundle = tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 # (bs, max_len) pair is fixed per bucket, so entries are bounded by the capture
 # set. Entries are never evicted: a replay reads the addresses its capture
 # recorded, so freeing one would let the allocator hand that memory to someone
-# else and feed a replay another tensor's bytes. Eager calls compute fresh
-# tensors instead of caching, so varied prefill lengths cannot grow this dict.
+# else and feed a replay another tensor's bytes. Other graphs sharing the
+# capture pool can overwrite their contents, so eager calls neither read nor
+# populate this cache. They compute fresh tensors instead.
 _UNIFORM_INDEX_CACHE: dict[tuple[int, int, torch.device], _IndexBundle] = {}
 
 
@@ -604,7 +605,10 @@ class Qwen4ExpPLELayer(nn.Module):
         max_len = max(lengths) if lengths else 0
         if bs and max_len > 0 and max_len * bs == total:
             key = (bs, max_len, device)
-            bundle = _UNIFORM_INDEX_CACHE.get(key)
+            capturing = (
+                device.type == "cuda" and torch.cuda.is_current_stream_capturing()
+            )
+            bundle = _UNIFORM_INDEX_CACHE.get(key) if capturing else None
             if bundle is None:
                 positions = torch.arange(total, device=device, dtype=torch.long)
                 req = positions // max_len
@@ -612,7 +616,7 @@ class Qwen4ExpPLELayer(nn.Module):
                 lengths_t = torch.full((bs,), max_len, device=device, dtype=torch.long)
                 starts = torch.arange(bs, device=device, dtype=torch.long) * max_len
                 bundle = (req, col, lengths_t, starts)
-                if device.type == "cuda" and torch.cuda.is_current_stream_capturing():
+                if capturing:
                     _UNIFORM_INDEX_CACHE[key] = bundle
             req, col, lengths_t, starts = bundle
         else:

--- a/test/ci/README.md
+++ b/test/ci/README.md
@@ -48,7 +48,7 @@ a score of at least 0.90.
 The Qwen3.8 Flash Next FP8 correctness task runs GSM8K on two GB200 GPUs with
 tensor parallelism 2 and three-step MTP. It keeps KVStore enabled and uses the
 bounded non-thinking chat template for CI stability. The task requires a score
-of at least 0.90.
+of at least 0.96.
 
 Each task expands into one matrix entry per runner label. Add a top-level
 `priority` to a task YAML to bias dispatch order. GitHub Actions starts matrix

--- a/test/ci/eval/qwen3.8-flash-next-fp8-evalscope-gsm8k.yaml
+++ b/test/ci/eval/qwen3.8-flash-next-fp8-evalscope-gsm8k.yaml
@@ -49,4 +49,4 @@ eval:
     --generation-config '{"do_sample":false,"temperature":0.0,"max_tokens":1024,"extra_body":{"chat_template_kwargs":{"enable_thinking":false}}}'
 report:
   github_step_summary: true
-score_threshold: 0.90
+score_threshold: 0.96

--- a/test/ci_system/test_eval_configs.py
+++ b/test/ci_system/test_eval_configs.py
@@ -168,7 +168,7 @@ def test_qwen38_flash_next_runs_gsm8k_with_kvstore_enabled():
     assert "--disable-kvstore" not in server_tokens
     assert flag_value(eval_tokens, "--model") == "Qwen/Qwen3.8-Flash-Next-FP8"
     assert flag_value(eval_tokens, "--datasets") == "gsm8k"
-    assert task["score_threshold"] == 0.90
+    assert task["score_threshold"] == 0.96
 
 
 def test_kimi_k3_amd_gates_use_eagle3():

--- a/test/runtime/test_qwen4_exp.py
+++ b/test/runtime/test_qwen4_exp.py
@@ -1937,6 +1937,47 @@ def test_ple_batch_indices_uniform_matches_general_path() -> None:
     assert torch.equal(fast[3], general[3][: len(lengths)])
 
 
+@_requires_cuda
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_ple_eager_indices_after_shared_pool_graph_replay(
+    monkeypatch: pytest.MonkeyPatch,
+    batch_size: int,
+) -> None:
+    monkeypatch.setattr(
+        "tokenspeed.runtime.layers.qwen4_exp_ple._UNIFORM_INDEX_CACHE", {}
+    )
+    device = torch.device("cuda")
+    pool = torch.cuda.graph_pool_handle()
+    overwrite = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(overwrite, pool=pool):
+        scratch = torch.full((4096,), 37, dtype=torch.long, device=device)
+    del scratch
+
+    capture = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(capture, pool=pool):
+        captured = Qwen4ExpPLELayer._batch_indices([1] * batch_size, device)
+        captured_output = tuple(value.clone() for value in captured[:4])
+
+    # An earlier graph can reuse these addresses for its transient tensors.
+    # Eager prefill must derive its indices without replaying the later graph.
+    overwrite.replay()
+    torch.cuda.synchronize()
+    eager = Qwen4ExpPLELayer._batch_indices([1] * batch_size, device)
+    expected = (
+        torch.arange(batch_size, dtype=torch.long),
+        torch.zeros(batch_size, dtype=torch.long),
+        torch.ones(batch_size, dtype=torch.long),
+        torch.arange(batch_size, dtype=torch.long),
+    )
+    for actual, reference in zip(eager[:4], expected, strict=True):
+        torch.testing.assert_close(actual.cpu(), reference, rtol=0, atol=0)
+
+    capture.replay()
+    torch.cuda.synchronize()
+    for actual, reference in zip(captured_output, expected, strict=True):
+        torch.testing.assert_close(actual.cpu(), reference, rtol=0, atol=0)
+
+
 @pytest.mark.parametrize("lengths", _PLE_LENGTH_CASES)
 def test_ple_token_contexts_matches_reference(lengths) -> None:
     ngram_size = 3


### PR DESCRIPTION
## Summary

Eager PLE calls could reuse uniform index tensors allocated during CUDA graph capture. Another graph sharing the private memory pool could overwrite those tensors on replay, leaving invalid request and column indices and causing illegal memory accesses in the n-gram kernel. Restrict both cache reads and writes to capture; eager calls construct fresh indices.

Add regression coverage with two graphs sharing a pool for batch sizes 1 and 4, checking eager indices after an overwrite and the subsequent graph replay. Document the tensor lifetime requirement.

Raise the Qwen3.8 Flash Next FP8 GSM8K CI threshold from 90% to 96%, with matching configuration assertions and documentation. The CI task uses TP2, three-step MTP, and KVStore.

## Test Plan

- `pre-commit run --all-files`: passed before commit and after rebase.
- `python -m pytest test/ci_system/test_eval_configs.py test/runtime/test_qwen4_exp.py::test_ple_eager_indices_after_shared_pool_graph_replay -q`: **8 passed** after rebase. Both new regression cases fail on the original implementation.
- Full `test/runtime/test_qwen4_exp.py` before rebase: **113 passed, 1 pre-existing failure** in `test_ple_gate_norm_fused_matches_unfused[dtype1-4-2048-257]`. The original implementation reproduces the same 153 BF16 tolerance mismatches; the tolerance is unchanged.
- Local end-to-end GSM8K before rebase, with the same PLE fix: **96.74% (1276/1319)** for `RadixArk/Qwen3.8-Flash-Next-NVFP4`, TP1, BF16 KV cache, CUDA graphs and Host L2 enabled. EvalScope 1.11.1, 4-shot, non-thinking, greedy decoding, `max_tokens=1024`, concurrency 16; **0 request errors**, with 22 responses reaching the token limit.
