### PR TITLE
perf(gfx950): load compact e8m0 scales in the SiTU decode GEMVs

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/README.md
@@ -29,7 +29,7 @@ accumulation because each rank owns only a sparse subset of the routed experts.
 | `__init__.py` | Package exports: the stage invokers, the top-k route entries, the prefill weight aliases, and the scale gather. |
 | `prefill_stage1.py` / `prefill_stage2.py` | Block-ragged MXFP4/MXFP8-activation, MXFP4-weight prefill GEMMs (gdot128-preshuffled weights). |
 | `decode_stage1.py` / `decode_stage2.py` | A4W4 direct-MFMA decode kernels plus their invokers: stage 1 fuses SwiGLU, stage 2 fuses the routed-weight top-k combine. |
-| `decode_common.py` | Direct CDNA4 MFMA primitives shared by both decode stages: tile addressing, MXFP4 operand loads, `mfma_scaled`. |
+| `decode_common.py` | Direct CDNA4 MFMA primitives shared by both decode stages: tile addressing, MXFP4 operand loads, `mfma_scaled`, and the compact scaled-upcast scale tile `situ_decode.py` reuses. |
 | `routing.py` | Fused dense top-k route kernels (softmax, sigmoid-bias, and a prefill variant); output is top-k only, **not** ragged metadata (contrast `fused/routing.py`). |
 | `moe_sorting.py` | Block-aligned expert sort feeding the package prefill stages. |
 | `situ_decode.py` / `situ_grouped.py` | A16W4 in-situ expert-parallel paths: route-direct warp decode reads linear or gdot128 weights, while the contiguous-EP grouped GEMM reads linear weights. |

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/decode_common.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/decode_common.py
@@ -25,12 +25,14 @@ Tile addressing, MXFP4 operand loads, and the scaled-MFMA op used by both
 production decode stages (``decode_stage1.py`` / ``decode_stage2.py``). They
 assume the intermediate rows are in (token, topk-slot) order, so no ragged
 metadata / scatter indices are consumed. ``situ_decode.py`` reuses the CDNA4
-scale-offset helper for its in-situ dequantization path.
+scale-offset helper and the compact scaled-upcast scale tile for its in-situ
+dequantization path.
 """
 
 from __future__ import annotations
 
 from tokenspeed_kernel_amd._triton import gl, gluon
+from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.scale_layout import MXFP4_BLOCK
 
 
 @gluon.jit
@@ -80,6 +82,63 @@ def _cdna4_swizzled_mxfp4_scale_offset(
         + n_mix.to(gl.int64)
     )
     return scale_expert_off + k_lin * stride_slin + n_block.to(gl.int64) * stride_snb
+
+
+# One v_cvt_scalef32_pk_bf16_fp4 converts eight packed FP4 values under a
+# single scale, so a lane must cover whole groups of that size.
+_SCALED_UPCAST_GROUP = 8
+
+
+@gluon.constexpr_function
+def _compact_mxfp4_scale_tile(expanded_layout, axis):
+    """Return the compact e8m0 scale tile for a CDNA4 scaled-upcast result.
+
+    ``gl.amd.cdna4.scaled_upcast`` takes a scale tensor whose extent along the
+    scaled axis merely has to divide the result's, so a lane can hold one scale
+    per ``v_cvt_scalef32_pk_bf16_fp4`` group instead of one per upcast element.
+    The op infers that operand's layout from the result's by folding away the
+    register bases the division makes redundant, which for a blocked result
+    layout is the same layout with a smaller ``size_per_thread`` on ``axis``.
+
+    A lane that already covers a whole 32-element MXFP4 block keeps one scale
+    per block, so the tile is exactly the block scales the tile needs. A lane
+    covering fewer elements keeps one scale per lane instead, and the lanes
+    within a block re-read its byte; that is still one load and one register
+    per lane rather than one per upcast element.
+
+    Args:
+        expanded_layout: ``gl.BlockedLayout`` of the scaled-upcast result tile.
+        axis: Scaled axis of the upcast, as passed to ``scaled_upcast``.
+
+    Returns:
+        A ``(layout, group)`` pair: the layout the compact scale tile must be
+        loaded in, and the number of result elements each of its entries
+        covers, so the caller can address one scale byte per ``group``
+        elements.
+
+    Raises:
+        ValueError: If a lane does not cover whole scaled-upcast groups along
+            ``axis``, which leaves a group without a single scale to apply.
+    """
+    per_lane = expanded_layout.size_per_thread[axis]
+    if per_lane % _SCALED_UPCAST_GROUP:
+        raise ValueError(
+            "scaled upcast needs every lane to cover whole "
+            f"{_SCALED_UPCAST_GROUP}-element groups along axis {axis}, but "
+            f"each lane covers {per_lane} elements"
+        )
+    group = min(per_lane, MXFP4_BLOCK)
+    size_per_thread = list(expanded_layout.size_per_thread)
+    size_per_thread[axis] = per_lane // group
+    return (
+        gl.BlockedLayout(
+            size_per_thread,
+            expanded_layout.threads_per_warp,
+            expanded_layout.warps_per_cta,
+            expanded_layout.order,
+        ),
+        group,
+    )
 
 
 @gluon.constexpr_function

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/situ_decode.py
@@ -25,11 +25,15 @@ CDNA4-swizzles their ``(E, K / 32, N)`` scales.  Decode can consume those
 existing buffers directly: one wave reduces K for a small output-column block,
 without sorting routes or padding each one to a 64-row grouped GEMM. gfx950's
 native scaled upcast expands each E2M1/UE8M0 tile directly to exact BF16 weight
-values, avoiding scalar nibble and exponent decoding in both GEMVs.
+values, avoiding scalar nibble and exponent decoding in both GEMVs. Its scale
+operand stays compact--one e8m0 byte per 32-value block.
 
 Kimi K3's 1792-byte packed hidden dimension uses a masked 1024-byte W13 tile.
 The 14.3% padded tail is cheaper than five additional loop iterations on
-gfx950; masked values and scales are zero-filled before the reduction.
+gfx950; masked values and scales are zero-filled before the reduction. The
+compact scale tile matters most here: an expanded tile carries a distinct tail
+predicate per weight, which keeps the redundant per-weight scale loads from
+being merged, while a compact one masks whole blocks.
 
 Stage 1 writes one BF16 activated row per local route. Stage 2 visits the original
 top-k slots, skips remote EP ids (``-1``), preserves the per-route BF16 W2
@@ -42,6 +46,7 @@ import torch
 from tokenspeed_kernel_amd._triton import gl, gluon, triton
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.decode_common import (
     _cdna4_swizzled_mxfp4_scale_offset,
+    _compact_mxfp4_scale_tile,
     _gluon_dot_preshuffled_w_offset,
 )
 
@@ -218,8 +223,14 @@ def _stage1_a16w4_situ_warp_gemv(
     )
     expanded_n_layout: gl.constexpr = gl.SliceLayout(1, expanded_layout)
     expanded_k_layout: gl.constexpr = gl.SliceLayout(0, expanded_layout)
+    scale_tile: gl.constexpr = _compact_mxfp4_scale_tile(expanded_layout, 1)
+    scale_layout: gl.constexpr = scale_tile[0]
+    SCALE_GROUP: gl.constexpr = scale_tile[1]
+    scale_n_layout: gl.constexpr = gl.SliceLayout(1, scale_layout)
+    scale_k_layout: gl.constexpr = gl.SliceLayout(0, scale_layout)
     offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=n_layout)
     expanded_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=expanded_n_layout)
+    scale_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=scale_n_layout)
 
     packed_k = hidden_dim // 2
     x_row = token.to(gl.int64) * stride_xm
@@ -228,28 +239,35 @@ def _stage1_a16w4_situ_warp_gemv(
     if LINEAR_WEIGHTS and not W13_INTERLEAVED:
         gate_col = offs_n
         up_col = intermediate_dim + offs_n
-        expanded_gate_col = expanded_offs_n
-        expanded_up_col = intermediate_dim + expanded_offs_n
+        scale_gate_col = scale_offs_n
+        scale_up_col = intermediate_dim + scale_offs_n
     else:
         # Triton's SiTU preprocessor and the optional linear interleaved layout
         # store adjacent gate/up output columns.
         gate_col = 2 * offs_n
         up_col = gate_col + 1
-        expanded_gate_col = 2 * expanded_offs_n
-        expanded_up_col = expanded_gate_col + 1
+        scale_gate_col = 2 * scale_offs_n
+        scale_up_col = scale_gate_col + 1
     gate_acc = gl.zeros([BLOCK_N], gl.float32, expanded_n_layout)
     up_acc = gl.zeros([BLOCK_N], gl.float32, expanded_n_layout)
 
     for kb0 in range(0, packed_k, BLOCK_KB):
         offs_kb = kb0 + gl.arange(0, BLOCK_KB, layout=k_layout)
         expanded_k = 2 * kb0 + gl.arange(0, 2 * BLOCK_KB, layout=expanded_k_layout)
+        scale_k = 2 * kb0 + SCALE_GROUP * gl.arange(
+            0, (2 * BLOCK_KB) // SCALE_GROUP, layout=scale_k_layout
+        )
         if MASK_K_TAIL:
             packed_k_valid = offs_kb < packed_k
             expanded_k_valid = expanded_k < hidden_dim
+            scale_k_valid = scale_k < hidden_dim
         else:
             packed_k_valid = gl.full([BLOCK_KB], True, gl.int1, layout=k_layout)
             expanded_k_valid = gl.full(
                 [2 * BLOCK_KB], True, gl.int1, layout=expanded_k_layout
+            )
+            scale_k_valid = gl.full(
+                [(2 * BLOCK_KB) // SCALE_GROUP], True, gl.int1, layout=scale_k_layout
             )
         x = gl.amd.cdna4.buffer_load(
             ptr=x_ptr,
@@ -270,26 +288,26 @@ def _stage1_a16w4_situ_warp_gemv(
         if LINEAR_WEIGHTS:
             gate_scale_offsets = (
                 scale_expert
-                + expanded_gate_col[:, None].to(gl.int64) * stride_slin
-                + (expanded_k[None, :] // 32).to(gl.int64) * stride_snb
+                + scale_gate_col[:, None].to(gl.int64) * stride_slin
+                + (scale_k[None, :] // 32).to(gl.int64) * stride_snb
             )
             up_scale_offsets = (
                 scale_expert
-                + expanded_up_col[:, None].to(gl.int64) * stride_slin
-                + (expanded_k[None, :] // 32).to(gl.int64) * stride_snb
+                + scale_up_col[:, None].to(gl.int64) * stride_slin
+                + (scale_k[None, :] // 32).to(gl.int64) * stride_snb
             )
         else:
             gate_scale_offsets = _cdna4_swizzled_mxfp4_scale_offset(
                 scale_expert,
-                expanded_gate_col[:, None],
-                expanded_k[None, :] // 32,
+                scale_gate_col[:, None],
+                scale_k[None, :] // 32,
                 stride_slin,
                 stride_snb,
             )
             up_scale_offsets = _cdna4_swizzled_mxfp4_scale_offset(
                 scale_expert,
-                expanded_up_col[:, None],
-                expanded_k[None, :] // 32,
+                scale_up_col[:, None],
+                scale_k[None, :] // 32,
                 stride_slin,
                 stride_snb,
             )
@@ -310,7 +328,7 @@ def _stage1_a16w4_situ_warp_gemv(
             gl.amd.cdna4.buffer_load(
                 ptr=w13_scale_ptr,
                 offsets=gate_scale_offsets.to(gl.int32),
-                mask=expanded_k_valid[None, :],
+                mask=scale_k_valid[None, :],
                 other=0,
             ),
             gl.bfloat16,
@@ -321,7 +339,7 @@ def _stage1_a16w4_situ_warp_gemv(
             gl.amd.cdna4.buffer_load(
                 ptr=w13_scale_ptr,
                 offsets=up_scale_offsets.to(gl.int32),
-                mask=expanded_k_valid[None, :],
+                mask=scale_k_valid[None, :],
                 other=0,
             ),
             gl.bfloat16,
@@ -418,8 +436,13 @@ def _stage1_a16w4_situ_gdot_gemv(
     packed_k_layout: gl.constexpr = gl.SliceLayout(0, packed_layout)
     expanded_n_layout: gl.constexpr = gl.SliceLayout(1, expanded_layout)
     expanded_k_layout: gl.constexpr = gl.SliceLayout(0, expanded_layout)
+    scale_tile: gl.constexpr = _compact_mxfp4_scale_tile(expanded_layout, 1)
+    scale_layout: gl.constexpr = scale_tile[0]
+    SCALE_GROUP: gl.constexpr = scale_tile[1]
+    scale_n_layout: gl.constexpr = gl.SliceLayout(1, scale_layout)
+    scale_k_layout: gl.constexpr = gl.SliceLayout(0, scale_layout)
     offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=packed_n_layout)
-    expanded_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=expanded_n_layout)
+    scale_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=scale_n_layout)
 
     packed_k = hidden_dim // 2
     x_row = token.to(gl.int64) * stride_xm
@@ -430,8 +453,12 @@ def _stage1_a16w4_situ_gdot_gemv(
     for kb0 in range(0, packed_k, BLOCK_KB):
         offs_kb = kb0 + gl.arange(0, BLOCK_KB, layout=packed_k_layout)
         expanded_k = 2 * kb0 + gl.arange(0, 2 * BLOCK_KB, layout=expanded_k_layout)
+        scale_k = 2 * kb0 + SCALE_GROUP * gl.arange(
+            0, (2 * BLOCK_KB) // SCALE_GROUP, layout=scale_k_layout
+        )
         packed_k_valid = offs_kb < packed_k
         expanded_k_valid = expanded_k < hidden_dim
+        scale_k_valid = scale_k < hidden_dim
         x = gl.amd.cdna4.buffer_load(
             ptr=x_ptr,
             offsets=(x_row + expanded_k * stride_xk).to(gl.int32),
@@ -453,12 +480,12 @@ def _stage1_a16w4_situ_gdot_gemv(
             ptr=w13_scale_ptr,
             offsets=_cdna4_swizzled_mxfp4_scale_offset(
                 scale_expert,
-                expanded_offs_n[:, None],
-                expanded_k[None, :] // 32,
+                scale_offs_n[:, None],
+                scale_k[None, :] // 32,
                 stride_slin,
                 stride_snb,
             ).to(gl.int32),
-            mask=expanded_k_valid[None, :],
+            mask=scale_k_valid[None, :],
             other=0,
         )
         weight = gl.amd.cdna4.scaled_upcast(
@@ -624,8 +651,14 @@ def _stage2_a16w4_warp_gemv_combine(
     )
     expanded_n_layout: gl.constexpr = gl.SliceLayout(1, expanded_layout)
     expanded_k_layout: gl.constexpr = gl.SliceLayout(0, expanded_layout)
+    scale_tile: gl.constexpr = _compact_mxfp4_scale_tile(expanded_layout, 1)
+    scale_layout: gl.constexpr = scale_tile[0]
+    SCALE_GROUP: gl.constexpr = scale_tile[1]
+    scale_n_layout: gl.constexpr = gl.SliceLayout(1, scale_layout)
+    scale_k_layout: gl.constexpr = gl.SliceLayout(0, scale_layout)
     offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=n_layout)
     expanded_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=expanded_n_layout)
+    scale_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=scale_n_layout)
     packed_k = intermediate_dim // 2
     acc = gl.zeros([BLOCK_N], gl.float32, expanded_n_layout)
 
@@ -652,13 +685,23 @@ def _stage2_a16w4_warp_gemv_combine(
                 expanded_k = 2 * kb0 + gl.arange(
                     0, 2 * BLOCK_KB, layout=expanded_k_layout
                 )
+                scale_k = 2 * kb0 + SCALE_GROUP * gl.arange(
+                    0, (2 * BLOCK_KB) // SCALE_GROUP, layout=scale_k_layout
+                )
                 if MASK_K_TAIL:
                     packed_k_valid = offs_kb < packed_k
                     expanded_k_valid = expanded_k < intermediate_dim
+                    scale_k_valid = scale_k < intermediate_dim
                 else:
                     packed_k_valid = gl.full([BLOCK_KB], True, gl.int1, layout=k_layout)
                     expanded_k_valid = gl.full(
                         [2 * BLOCK_KB], True, gl.int1, layout=expanded_k_layout
+                    )
+                    scale_k_valid = gl.full(
+                        [(2 * BLOCK_KB) // SCALE_GROUP],
+                        True,
+                        gl.int1,
+                        layout=scale_k_layout,
                     )
                 inter = gl.amd.cdna4.buffer_load(
                     ptr=inter_ptr,
@@ -674,14 +717,14 @@ def _stage2_a16w4_warp_gemv_combine(
                 if LINEAR_WEIGHTS:
                     scale_offsets = (
                         scale_expert
-                        + expanded_offs_n[:, None].to(gl.int64) * stride_slin
-                        + (expanded_k[None, :] // 32).to(gl.int64) * stride_snb
+                        + scale_offs_n[:, None].to(gl.int64) * stride_slin
+                        + (scale_k[None, :] // 32).to(gl.int64) * stride_snb
                     )
                 else:
                     scale_offsets = _cdna4_swizzled_mxfp4_scale_offset(
                         scale_expert,
-                        expanded_offs_n[:, None],
-                        expanded_k[None, :] // 32,
+                        scale_offs_n[:, None],
+                        scale_k[None, :] // 32,
                         stride_slin,
                         stride_snb,
                     )
@@ -696,7 +739,7 @@ def _stage2_a16w4_warp_gemv_combine(
                     gl.amd.cdna4.buffer_load(
                         ptr=w2_scale_ptr,
                         offsets=scale_offsets.to(gl.int32),
-                        mask=expanded_k_valid[None, :],
+                        mask=scale_k_valid[None, :],
                         other=0,
                     ),
                     gl.bfloat16,
@@ -767,8 +810,14 @@ def _stage2_a16w4_gdot_gemv_combine(
     packed_k_layout: gl.constexpr = gl.SliceLayout(0, packed_layout)
     expanded_n_layout: gl.constexpr = gl.SliceLayout(1, expanded_layout)
     expanded_k_layout: gl.constexpr = gl.SliceLayout(0, expanded_layout)
+    scale_tile: gl.constexpr = _compact_mxfp4_scale_tile(expanded_layout, 1)
+    scale_layout: gl.constexpr = scale_tile[0]
+    SCALE_GROUP: gl.constexpr = scale_tile[1]
+    scale_n_layout: gl.constexpr = gl.SliceLayout(1, scale_layout)
+    scale_k_layout: gl.constexpr = gl.SliceLayout(0, scale_layout)
     offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=packed_n_layout)
     expanded_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=expanded_n_layout)
+    scale_offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=scale_n_layout)
     packed_k = intermediate_dim // 2
     acc = gl.zeros([BLOCK_N], gl.float32, expanded_n_layout)
 
@@ -792,8 +841,12 @@ def _stage2_a16w4_gdot_gemv_combine(
                 expanded_k = 2 * kb0 + gl.arange(
                     0, 2 * BLOCK_KB, layout=expanded_k_layout
                 )
+                scale_k = 2 * kb0 + SCALE_GROUP * gl.arange(
+                    0, (2 * BLOCK_KB) // SCALE_GROUP, layout=scale_k_layout
+                )
                 packed_k_valid = offs_kb < packed_k
                 expanded_k_valid = expanded_k < intermediate_dim
+                scale_k_valid = scale_k < intermediate_dim
                 inter = gl.amd.cdna4.buffer_load(
                     ptr=inter_ptr,
                     offsets=(inter_row + expanded_k * stride_ipk).to(gl.int32),
@@ -815,12 +868,12 @@ def _stage2_a16w4_gdot_gemv_combine(
                     ptr=w2_scale_ptr,
                     offsets=_cdna4_swizzled_mxfp4_scale_offset(
                         scale_expert,
-                        expanded_offs_n[:, None],
-                        expanded_k[None, :] // 32,
+                        scale_offs_n[:, None],
+                        scale_k[None, :] // 32,
                         stride_slin,
                         stride_snb,
                     ).to(gl.int32),
-                    mask=expanded_k_valid[None, :],
+                    mask=scale_k_valid[None, :],
                     other=0,
                 )
                 weight = gl.amd.cdna4.scaled_upcast(

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_situ_gfx950.py
@@ -35,11 +35,42 @@ if not is_cdna4():
 
 import tokenspeed_kernel  # noqa: E402
 from tokenspeed_kernel.selection import kernel_override  # noqa: E402
+from tokenspeed_kernel_amd._triton import gl  # noqa: E402
+from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.decode_common import (  # noqa: E402
+    _compact_mxfp4_scale_tile,
+)
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (  # noqa: E402
     quantize_mxfp8_sorted_routes,
 )
 
 _A8W4_EP_APPLY = "gluon_mxfp4_a8w4_situ_ep_precomputed_moe_apply"
+
+
+@pytest.mark.parametrize(
+    "per_lane, scales_per_lane, group",
+    [(64, 2, 32), (32, 1, 32), (16, 1, 16), (8, 1, 8)],
+    ids=["two_blocks", "one_block", "half_block", "quarter_block"],
+)
+def test_compact_scale_tile_holds_one_scale_per_upcast_group(
+    per_lane: int, scales_per_lane: int, group: int
+) -> None:
+    # A lane spanning a whole 32-value MXFP4 block keeps that block's single
+    # scale; a lane spanning less keeps one scale and re-reads the block byte.
+    expanded = gl.BlockedLayout([2, per_lane], [1, 64], [4, 1], [1, 0])
+    layout, elements_per_scale = _compact_mxfp4_scale_tile(expanded, 1)
+    assert elements_per_scale == group
+    assert layout.size_per_thread == [2, scales_per_lane]
+    assert layout.threads_per_warp == expanded.threads_per_warp
+    assert layout.warps_per_cta == expanded.warps_per_cta
+    assert layout.order == expanded.order
+
+
+def test_compact_scale_tile_rejects_partial_upcast_groups() -> None:
+    # Under eight values per lane a v_cvt_scalef32_pk_bf16_fp4 group would span
+    # two scales, so the K tile may not shrink that far.
+    expanded = gl.BlockedLayout([2, 4], [1, 64], [4, 1], [1, 0])
+    with pytest.raises(ValueError, match="whole 8-element groups"):
+        _compact_mxfp4_scale_tile(expanded, 1)
 
 
 def _a8w4_ep_plan(intermediate_size: int) -> dict:


### PR DESCRIPTION
Triton's CDNA4 `scaled_upcast` now accepts a scale operand whose extent along the scaled axis only has to divide the result's, so a lane can hold one scale per `v_cvt_scalef32_pk_bf16_fp4` group instead of one per weight value. Derive that tile from the upcast result's layout and address one e8m0 byte per 32-value block.

### Expanded vs compact scale

An MXFP4 weight carries one e8m0 scale per 32 values, so the expanded scale tile had every lane load the *same* byte 32 times over. Those copies cost nothing as long as the compiler can see they are one load and fold them into one, which is what happens on a K tile that is fully in bounds.

Kimi K3's W13 K dimension is 1792 packed bytes against a 1024-byte tile, so the second tile hangs off the end of the weight and every load in it is predicated -- each element carries a "still inside K?" bit that turns the load off past the boundary. The expanded tile computes that bit per weight value, so the 32 copies of one scale byte reach the backend as 32 loads that share an address but differ in their predicate, and nothing can be folded away. The compact tile holds one entry per 32-value block, and a block is either wholly inside K or wholly outside it because K is always a multiple of 32, so one predicate covers the whole block and there are no copies left to fold. The masked tile now pays an unmasked tile's scale cost.

### Static gfx950 ISA status

Kimi K3 EP8 (hidden 3584, intermediate 3072):

| kernel | instrs | VMEM | of which scale | VGPR | SGPR |
| --- | --- | --- | --- | --- | --- |
| stage-1 W13 warp GEMV | 903 -> 883 | 20 -> 16 | 8 -> 4 | 147 -> 146 | 37 -> 34 |
| stage-1 W13, hidden 4096 (exact tiles) | 806 | 4 | 4 | 143 | 34 |
| stage-2 W2 warp combine | 1137 | 32 | 8 | 39 | 54 |
| stage-1 / stage-2 gdot GEMV | 353 / 250 | 4 / 4 | 1 / 1 | 42 / 42 | 34 / 37 |

Rows without an arrow are byte-identical before and after: their tiles are exact, so the duplicate loads already folded.

A lane must still cover whole 8-value upcast groups, so the helper rejects a K tile below 256 packed bytes; that tile already failed to compile.