### PR TITLE
[DO NOT MERGE] fix(pd): stop failing prefill rooms that are only queued on the decode

### DIFF
--- a/python/tokenspeed/runtime/pd/mooncake/prefill.py
+++ b/python/tokenspeed/runtime/pd/mooncake/prefill.py
@@ -23,7 +23,7 @@ import os
 import socket
 import threading
 import time
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Iterator
 from dataclasses import replace
 from itertools import chain, islice
@@ -120,6 +120,16 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             )
         self.start_transfer_thread(transfer_thread_pool_size, transfer_queue_size)
         self.bootstrap_time_out = envs.TOKENSPEED_DISAGGREGATION_BOOTSTRAP_TIMEOUT.get()
+        # Last time any decode made bootstrap progress with this prefill; the
+        # bootstrap deadline is measured from this as well as from arrival.
+        self.last_decode_progress = time.time()
+        # Rooms this prefill gave up on (room -> monotonic stamp), kept so a
+        # late pre-allocation for one of them is rejected instead of accepted.
+        self.failed_rooms: OrderedDict[int, float] = OrderedDict()
+        self.failed_room_ttl = max(
+            envs.TOKENSPEED_DISAGGREGATION_WAITING_TIMEOUT.get(), 0
+        )
+        self.failed_room_lock = threading.Lock()
         # Publish this manager only after every field used by its bootstrap and
         # transfer threads has been initialized.
         self.start_prefill_thread()
@@ -178,6 +188,42 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         with self.bootstrap_token_cond:
             self.prefill_metadata.pop(room, None)
             self.bootstrap_token_cond.notify_all()
+
+    def note_decode_progress(self) -> None:
+        """Record that a decode just made bootstrap progress with this prefill."""
+        self.last_decode_progress = time.time()
+
+    def _reap_failed_rooms(self) -> None:
+        """Drop expired tombstones; callers hold ``failed_room_lock``."""
+        if self.failed_room_ttl <= 0:
+            self.failed_rooms.clear()
+            return
+        now = time.monotonic()
+        while self.failed_rooms:
+            room, failed_at = next(iter(self.failed_rooms.items()))
+            if now - failed_at < self.failed_room_ttl:
+                return
+            del self.failed_rooms[room]
+
+    def _mark_room_failed(self, room: int) -> None:
+        """Tombstone one aborted room so a late pre-allocation is rejected."""
+        if self.failed_room_ttl <= 0:
+            return
+        with self.failed_room_lock:
+            # Re-insert at the tail so insertion order stays expiry order.
+            self.failed_rooms.pop(room, None)
+            self.failed_rooms[room] = time.monotonic()
+            self._reap_failed_rooms()
+
+    def _is_room_failed(self, room: int) -> bool:
+        """True when the room was failed, whether still tracked or tombstoned."""
+        if self.request_status.get(room) == TransferPoll.Failed:
+            return True
+        if self.failed_room_ttl <= 0:
+            return False
+        with self.failed_room_lock:
+            self._reap_failed_rooms()
+            return room in self.failed_rooms
 
     def _wait_prefill_metadata(
         self,
@@ -742,10 +788,14 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         status to every decode endpoint that already pre-allocated for this room
         (mirrors the in-transfer failure path), so the decode raises a FailedEvent and
         the client gets an error instead of hanging. A room whose decode has not
-        pre-allocated yet is only marked Failed locally (no endpoint to notify).
+        pre-allocated yet is only marked Failed locally (no endpoint to notify)
+        -- but the verdict is tombstoned, so if that decode does pre-allocate
+        later, ``_handle_bootstrap_message`` rejects the manifest and pushes
+        Failed to it then, rather than accepting a room that has no sender.
         """
         self.record_failure(room, reason)
         self.update_status(room, TransferPoll.Failed)
+        self._mark_room_failed(room)
         for req in list(self.transfer_infos.get(room, {}).values()):
             if not req.is_dummy:
                 try:
@@ -934,6 +984,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             self.rejected_decode_sessions.pop(session_id, None)
             with self.session_lock:
                 self._clear_failed_session(session_id)
+            self.note_decode_progress()
             logger.info(
                 "[Prefill bootstrap_thread] registered kv_args from decode session=%s",
                 session_id,
@@ -949,7 +1000,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
             registration = self.get_decode_registration(transfer_info)
             if transfer_info.is_dummy != registration.is_dummy:
                 raise ValueError("CachePD request kind disagrees with its registration")
-            if self.request_status.get(parsed_room) == TransferPoll.Failed:
+            if self._is_room_failed(parsed_room):
                 self.sync_status_to_decode_endpoint(
                     registration.endpoint,
                     registration.dst_port,
@@ -1022,7 +1073,7 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
         # A transfer worker can fail and remove the room after the precheck but
         # before this bootstrap-thread commit.  Do not let that interleaving
         # resurrect destination state for a sticky-Failed room.
-        if self.request_status.get(parsed_room) == TransferPoll.Failed:
+        if self._is_room_failed(parsed_room):
             self.transfer_infos.pop(parsed_room, None)
             self.sync_status_to_decode_endpoint(
                 registration.endpoint,
@@ -1032,6 +1083,8 @@ class MooncakeKVManagerPrefill(MooncakeKVManagerBase):
                 self._status_prefill_rank,
             )
             return
+        # The decode is draining its queue: hold off the deadline on waiting rooms.
+        self.note_decode_progress()
         complete = len(candidate_infos) == expected_fanout
         logger.info(
             "[Prefill bootstrap_thread] pre-alloc received: room=%d "

--- a/python/tokenspeed/runtime/pd/mooncake/sender.py
+++ b/python/tokenspeed/runtime/pd/mooncake/sender.py
@@ -128,16 +128,22 @@ class MooncakeKVSender:
             elif status == TransferPoll.Bootstrapping:
                 if self.init_time is not None:
                     now = time.time()
-                    elapsed = now - self.init_time
-                    if elapsed >= self.kv_mgr.bootstrap_time_out:
+                    waited = now - self.init_time
+                    # Measure from the later of arrival and the last decode progress: the
+                    # deadline catches a silent decode, not one still admitting its queue.
+                    idle = now - max(self.init_time, self.kv_mgr.last_decode_progress)
+                    if idle >= self.kv_mgr.bootstrap_time_out:
                         logger.warning_once(
                             "Some requests timed out when bootstrapping, "
-                            "which means prefill instances fail to receive the cache manifest from the decode instance of this request. "
+                            "which means prefill instances fail to receive the cache manifest from any decode instance for the whole timeout window. "
                             "If a greater mean TTFT is acceptable, you can 'export TOKENSPEED_DISAGGREGATION_BOOTSTRAP_TIMEOUT=600' (10 minutes) to relax the timeout condition. "
                         )
-                        self.kv_mgr.record_failure(
+                        # abort_room frees a decode that already pre-allocated and tombstones
+                        # the room so a late pre-allocation is rejected.
+                        self.kv_mgr.abort_room(
                             self.bootstrap_room,
-                            f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s in TransferPoll.Bootstrapping",
+                            f"Request {self.bootstrap_room} timed out after {waited:.1f}s in "
+                            f"TransferPoll.Bootstrapping ({idle:.1f}s with no decode bootstrap progress)",
                         )
                         self.conclude_state = TransferPoll.Failed
                         return TransferPoll.Failed

--- a/test/runtime/distributed/test_cache_pd_executors.py
+++ b/test/runtime/distributed/test_cache_pd_executors.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
+import time
+from collections import OrderedDict
 from contextlib import nullcontext
 from types import SimpleNamespace
 
@@ -300,6 +303,67 @@ class _OneChunkQueue:
         return chunk
 
 
+def _bootstrap_manager(*, failed_room_ttl: int = 300):
+    """A prefill manager carrying only the bootstrap-thread surface.
+
+    The real constructor needs a Mooncake engine and starts three threads, so
+    every manager test in this file builds the object directly and fills in
+    the fields the path under test reads.
+    """
+    from tokenspeed.runtime.pd.mooncake.prefill import MooncakeKVManagerPrefill
+
+    manager = object.__new__(MooncakeKVManagerPrefill)
+    manager.transfer_infos = {}
+    manager.request_status = {}
+    manager.failure_records = {}
+    manager.failure_lock = threading.Lock()
+    manager.failed_rooms = OrderedDict()
+    manager.failed_room_ttl = failed_room_ttl
+    manager.failed_room_lock = threading.Lock()
+    manager.last_decode_progress = time.time()
+    manager.bootstrap_time_out = 120
+    manager.decode_kv_args_table = {}
+    manager.rejected_decode_sessions = {}
+    manager.prefill_metadata = {}
+    manager.bootstrap_token_cond = threading.Condition()
+    manager.topology = _topology()
+    return manager
+
+
+def _pre_allocating_decode(manager) -> list[tuple]:
+    """Register one decode session on ``manager`` and capture its status pushes."""
+    manager.decode_kv_args_table = {
+        "session": _registration(
+            _layout(),
+            session="session",
+            endpoint="127.0.0.1",
+            pointer=0x1000,
+            expected_decode_ranks=(0,),
+        )
+    }
+    notifications: list[tuple] = []
+    manager.sync_status_to_decode_endpoint = (
+        lambda endpoint, port, room, status, rank: (
+            notifications.append((endpoint, port, room, status, rank))
+        )
+    )
+    return notifications
+
+
+def _waiting_sender(manager, *, waited: float):
+    from tokenspeed.runtime.pd.mooncake.sender import MooncakeKVSender
+
+    sender = object.__new__(MooncakeKVSender)
+    sender.kv_mgr = manager
+    sender.bootstrap_room = 9
+    sender.bootstrap_server_url = "127.0.0.1:9000"
+    sender.conclude_state = None
+    sender._layerwise_chunk_submitted = False
+    sender._layerwise_final_chunk_submitted = False
+    sender.init_time = time.time() - waited
+    return sender
+
+
 def test_decode_receiver_sends_static_registration_then_three_frame_request() -> None:
     from tokenspeed.runtime.pd.base.status import TransferPoll
     from tokenspeed.runtime.pd.mooncake.receiver import MooncakeKVReceiver
@@ -393,42 +457,132 @@ def test_failed_room_fanout_never_restores_state(
     fail_during_commit: bool,
 ) -> None:
     from tokenspeed.runtime.pd.base.status import TransferPoll
-    from tokenspeed.runtime.pd.mooncake.prefill import MooncakeKVManagerPrefill
 
-    layout = _layout()
-    registration = _registration(
-        layout,
-        session="session",
-        endpoint="127.0.0.1",
-        pointer=0x1000,
-        expected_decode_ranks=(0,),
-    )
-    manager = object.__new__(MooncakeKVManagerPrefill)
-    manager.decode_kv_args_table = {"session": registration}
-    manager.rejected_decode_sessions = {}
-    manager.transfer_infos = {}
+    manager = _bootstrap_manager()
+    notifications = _pre_allocating_decode(manager)
     manager.request_status = {
         9: (TransferPoll.WaitingForInput if fail_during_commit else TransferPoll.Failed)
     }
-    manager.topology = _topology()
     if fail_during_commit:
         manager._validate_cache_room_fanout = lambda _requests: (
             manager.request_status.__setitem__(9, TransferPoll.Failed)
         )
-    notifications = []
-    manager.sync_status_to_decode_endpoint = (
-        lambda endpoint, port, room, status, rank: (
-            notifications.append((endpoint, port, room, status, rank))
-        )
-    )
 
-    manager._handle_bootstrap_message(
-        [b"9", b"session", _destination_block_manifest().to_wire_bytes()]
-    )
+    manager._handle_bootstrap_message(_destination_transfer_frames())
 
     assert manager.transfer_infos == {}
     assert manager.request_status[9] == TransferPoll.Failed
     assert notifications == [("127.0.0.1", 9000, 9, TransferPoll.Failed, 0)]
+
+
+# --- The bootstrap deadline is a liveness check on the decode, not a deadline
+# on the decode's admission queue: both halves of a room are dispatched at
+# once, but the decode only pre-allocates one when its running window frees a
+# slot. Failing a room for that wait fails a request that is merely queued, and
+# the decode then holds a slot on a room this side has already dropped. ---
+
+
+def test_queued_room_survives_while_the_decode_keeps_pre_allocating() -> None:
+    from tokenspeed.runtime.pd.base.status import TransferPoll
+
+    aborts = []
+    manager = _bootstrap_manager()
+    manager.request_status = {9: TransferPoll.Bootstrapping}
+    manager.abort_room = lambda room, reason: aborts.append((room, reason))
+    # Waiting five times the deadline, but the decode committed a
+    # pre-allocation for some other room a moment ago.
+    sender = _waiting_sender(manager, waited=600.0)
+    manager.last_decode_progress = time.time() - 5.0
+
+    assert sender.poll() == TransferPoll.Bootstrapping
+    assert aborts == []
+
+    # The decode goes silent: a full timeout with no progress from any peer.
+    manager.last_decode_progress = time.time() - 600.0
+
+    assert sender.poll() == TransferPoll.Failed
+    assert len(aborts) == 1
+    assert aborts[0][0] == 9
+
+
+def test_bootstrap_timeout_aborts_the_room_and_frees_the_decode() -> None:
+    """A timed-out room must be concluded, not merely recorded.
+
+    ``record_failure`` alone leaves ``request_status`` untouched, so the room
+    never becomes sticky-Failed and any decode that already pre-allocated is
+    never told -- it waits out its own transfer timeout holding a slot.
+    """
+    from tokenspeed.runtime.pd.base.status import TransferPoll
+
+    manager = _bootstrap_manager()
+    notifications = _pre_allocating_decode(manager)
+    manager.request_status = {9: TransferPoll.Bootstrapping}
+    manager.transfer_infos = {9: {"session": _destination_transfer_info()}}
+    sender = _waiting_sender(manager, waited=600.0)
+    manager.last_decode_progress = time.time() - 600.0
+
+    assert sender.poll() == TransferPoll.Failed
+
+    assert manager.request_status[9] == TransferPoll.Failed
+    assert manager.transfer_infos == {}
+    assert notifications == [("127.0.0.1", 9000, 9, TransferPoll.Failed, 0)]
+    assert 9 in manager.failure_records
+
+
+def test_late_prealloc_for_a_dropped_room_is_rejected_not_bootstrapped() -> None:
+    """The decisive regression: a pre-allocation that arrives after the prefill
+    gave up must be refused. ``discard_room`` erases ``request_status``, so a
+    status-only guard reads ``None`` and the handler would accept the manifest,
+    mark a senderless room Bootstrapped, and leave the decode holding its slot
+    until its own waiting timeout.
+    """
+    from tokenspeed.runtime.pd.base.status import TransferPoll
+
+    manager = _bootstrap_manager()
+    notifications = _pre_allocating_decode(manager)
+    manager.request_status = {9: TransferPoll.Bootstrapping}
+
+    manager.abort_room(9, "timed out while bootstrapping")
+    # What DisaggPrefillExecutor._drop_request_state does on the FailedEvent.
+    manager.discard_room(9)
+    assert 9 not in manager.request_status
+
+    manager._handle_bootstrap_message(_destination_transfer_frames())
+
+    assert manager.transfer_infos == {}
+    assert manager.request_status.get(9) != TransferPoll.Bootstrapped
+    assert notifications == [("127.0.0.1", 9000, 9, TransferPoll.Failed, 0)]
+
+
+def test_committed_prealloc_stamps_decode_progress() -> None:
+    from tokenspeed.runtime.pd.base.status import TransferPoll
+
+    manager = _bootstrap_manager()
+    _pre_allocating_decode(manager)
+    manager.last_decode_progress = 0.0
+
+    manager._handle_bootstrap_message(_destination_transfer_frames())
+
+    assert manager.request_status[9] == TransferPoll.Bootstrapped
+    assert manager.last_decode_progress > 0.0
+
+
+def test_failed_room_tombstone_expires_with_its_ttl() -> None:
+    """The tombstone is bounded: it only has to outlive the window in which a
+    decode could still be waiting on this room."""
+    from tokenspeed.runtime.pd.base.status import TransferPoll
+
+    manager = _bootstrap_manager(failed_room_ttl=30)
+    _pre_allocating_decode(manager)
+    manager.request_status = {9: TransferPoll.Bootstrapping}
+
+    manager.abort_room(9, "timed out while bootstrapping")
+    manager.discard_room(9)
+    assert manager._is_room_failed(9)
+
+    manager.failed_rooms[9] = time.monotonic() - 31.0
+    assert not manager._is_room_failed(9)
+    assert manager.failed_rooms == OrderedDict()
 
 
 def test_cache_factory_exposes_only_typed_arena() -> None:


### PR DESCRIPTION
## Summary

Under prefill/decode disaggregation, a burst of requests larger than the decode's running window makes the prefill fail requests that are merely queued, and every such failure then pins a decode slot for the full waiting timeout. Observed behind SMG with one prefill and one decode worker on Qwen3.5-9B at `--max-num-seqs 4` and 32 concurrent requests: 14 of 64 requests failed, the eval took 1392 s instead of ~35 s, and the failures arrived in waves of exactly four per 300 s.

Mechanism, on `main`:

- The prefill's bootstrap deadline starts when the request arrives (`MooncakeKVSender.__init__`, `init_time = time.time()`) and trips at `bootstrap_time_out` (120 s). The only thing that clears `Bootstrapping` is the decode's manifest, which the decode sends only once its scheduler has admitted the prompt (`buildDecodeWorkerPlan` admits at most one remote prompt per round, and a pre-allocated room holds one of the `max_num_seqs // dp_size` req-pool slots through the transfer and the whole generation). With a window of 4, only four of the 32 rooms are ever visible to the prefill while the other 28 clocks run. The deadline therefore measures the decode's queue, which the prefill cannot see, instead of the decode's liveness.
- On timeout, `poll()` called only `record_failure`, which writes a dict entry and never marks the room `Failed`. `_drop_request_state` then pops `request_status`, so both sticky-Failed guards in the bootstrap handler read `None` and accept the late pre-allocation: the room is stored and logged `-> Bootstrapped` with no sender behind it. Nothing transfers, and the decode holds its slot until the 300 s waiting timeout. `abort_room`'s docstring already names the gap: a room whose decode has not pre-allocated is only marked Failed locally.

The guards and `abort_room` already exist here; they were never wired to the timeout path.

The change, no wire-format change:

- `sender.py`: the bootstrap deadline is measured from the later of the request's arrival and the decode's last observed progress, so it detects a dead peer rather than a busy queue.
- `prefill.py`: `note_decode_progress()` is stamped on session registration and on every committed pre-allocation; a timed-out room goes through `abort_room` instead of a bare `record_failure`, so a decode that did pre-allocate is released immediately; timed-out rooms get a bounded-TTL tombstone (`failed_rooms`, TTL = the waiting timeout) that both bootstrap guards consult through `_is_room_failed`, so a late manifest is rejected instead of resurrecting the room.

Reviewer notes: `last_decode_progress` is manager-wide, so with several decode workers a live one masks a dead one and an abandoned room can outlive its client while traffic flows; the complete cure is a decode-to-prefill room-abort message. `abort_room` now runs on the event-loop thread. Adding pre-allocation headroom in the decode req pool, beyond the running window, is a worthwhile follow-up but is a scheduler change and is not part of this fix.

## Test Plan

- Five regression tests added to `test/runtime/distributed/test_cache_pd_executors.py`: a room stays `Bootstrapping` past the deadline while a sibling room's pre-allocation shows the decode is alive; a dead decode still trips the deadline; a timed-out room is aborted rather than only recorded; a late pre-allocation for a timed-out room does not enter `transfer_infos`, does not reach `Bootstrapped`, and pushes `Failed`; the tombstone expires after its TTL. All five fail on `main` and pass with this change (verified locally through a scratch import harness because the module needs Triton at import; they need the GPU CI to run them for real).
- `pre-commit run --all-files` clean.
- End-to-end: the SMG PD lane that produced the failure (run 34173426995) versus the same lane with a 32-sequence window (run 34180087896: zero bootstrap or transfer failures, ~35 s per eval). A rerun of that lane at `--max-num-seqs 4` with this fix is the confirmation that the cascade is gone.
