### PR TITLE
test: add DeepSeek V4 Flash agentic benchmark

### DIFF
--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/agentic_bench.sh
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/agentic_bench.sh
@@ -116,7 +116,7 @@ for CONFIG in "${CONFIGS[@]}"; do
     fi
     echo "Warmup..."
     evalscope perf \
-        --model deepseek-v4-flash \
+        --model deepseek-ai/DeepSeek-V4-Flash-0731 \
         --url http://127.0.0.1:8000/v1/chat/completions \
         --api openai \
         --dataset swe_smith \
@@ -131,15 +131,15 @@ for CONFIG in "${CONFIGS[@]}"; do
 
     echo "Benchmark..."
     evalscope perf \
-        --model deepseek-v4-flash \
+        --model deepseek-ai/DeepSeek-V4-Flash-0731 \
         --url http://127.0.0.1:8000/v1/chat/completions \
         --api openai \
         --dataset swe_smith \
         --dataset-path agentic_dataset.json \
         --max-tokens 500 \
         --multi-turn \
-        --number 4 8 8 16 \
-        --parallel 1 2 4 8 \
+        --number 4 8 8 16 32 \
+        --parallel 1 2 4 8 16 \
         --extra-args '{"ignore_eos": true, "temperature": 0}' \
         --name $CONFIG \
         --outputs-dir $SWEEP_DIR \

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/agentic_bench.sh
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/agentic_bench.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+# Prepare dataset
+EVALSCOPE_COMMIT=acd09b44384d53174768bb1063f675420f76fae9
+pip install "evalscope[perf] @ git+https://github.com/modelscope/evalscope.git@${EVALSCOPE_COMMIT}"
+
+if [ ! -f agentic_dataset.json ]; then
+    (
+        BUILD_SCRIPT=$(mktemp)
+        trap 'rm -f "$BUILD_SCRIPT"' EXIT
+        wget \
+            https://raw.githubusercontent.com/modelscope/evalscope/${EVALSCOPE_COMMIT}/examples/perf/build_swe_smith_dataset.py \
+            -O "$BUILD_SCRIPT"
+        patch -s "$BUILD_SCRIPT" build_swe_smith_dataset.patch
+        PYTHONPATH=. python3 "$BUILD_SCRIPT" \
+            --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
+            --dataset-name SWE-bench/SWE-smith-trajectories \
+            --split tool \
+            --first-turn-length 50000 \
+            --subsequent-turn-length 800 \
+            --min-turns 10 \
+            --max-turns 15 \
+            --number 128 \
+            --output-path agentic_dataset.json \
+            --chars-per-token 3.0 \
+            --seed 42 \
+            --num-workers 1
+    )
+fi
+
+# Sweep configs
+CONFIGS=(
+    attn_tp4_moe_ep4
+)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVER_PID=
+SERVER_LOG=
+
+launch_server() {
+    local config=$1
+    SERVER_LOG=/tmp/tokenspeed_server_${config}.log
+    setsid ${SCRIPT_DIR}/configs/${config}.sh > "$SERVER_LOG" 2>&1 &
+    SERVER_PID=$!
+}
+
+wait_for_ready() {
+    local TIMEOUT=3600
+    local START=$SECONDS
+    until curl -sf -o /dev/null http://127.0.0.1:8000/readiness; do
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "Server died early. Last log lines:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if grep -qE "CUDA out of memory|OutOfMemory|RuntimeError|Killed" "$SERVER_LOG"; then
+            echo "Server hit a fatal error:" >&2
+            tail -100 "$SERVER_LOG" >&2
+            return 1
+        fi
+        if (( SECONDS - START > TIMEOUT )); then
+            echo "Timeout after ${TIMEOUT}s waiting for server" >&2
+            return 1
+        fi
+        sleep 5
+    done
+    echo "Server ready after $((SECONDS - START))s"
+}
+
+stop_server() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Stopping ts serve (pgid $SERVER_PID)..."
+        kill -TERM -"$SERVER_PID" 2>/dev/null || true
+        for _ in {1..20}; do
+            kill -0 "$SERVER_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -KILL -"$SERVER_PID" 2>/dev/null || true
+    fi
+    SERVER_PID=
+}
+
+wait_for_port_free() {
+    local port=${1:-8000}
+    local timeout=${2:-90}
+    local start=$SECONDS
+    while ! python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', $port)); s.close()" 2>/dev/null; do
+        if (( SECONDS - start > timeout )); then
+            echo "Port ${port} still in use after ${timeout}s" >&2
+            return 1
+        fi
+        sleep 1
+    done
+}
+
+trap stop_server EXIT  # safety net for Ctrl-C / errors
+
+# Preflight: bail out if port 8000 is already in use
+wait_for_port_free 8000
+
+SWEEP_TS=$(date +%Y%m%d_%H%M%S)
+SWEEP_DIR="${SCRIPT_DIR}/outputs/${SWEEP_TS}"
+echo "Sweep outputs: ${SWEEP_DIR}"
+
+for CONFIG in "${CONFIGS[@]}"; do
+    echo "=== Running $CONFIG ==="
+    launch_server "$CONFIG"
+
+    if ! wait_for_ready; then
+        stop_server
+        exit 1
+    fi
+    echo "Warmup..."
+    evalscope perf \
+        --model deepseek-v4-flash \
+        --url http://127.0.0.1:8000/v1/chat/completions \
+        --api openai \
+        --dataset swe_smith \
+        --dataset-path agentic_dataset.json \
+        --max-tokens 500 \
+        --multi-turn \
+        --number 2 \
+        --parallel 2 \
+        --extra-args '{"ignore_eos": true, "temperature": 0}' \
+        --dataset-offset 68 \
+        --outputs-dir /tmp/outputs
+
+    echo "Benchmark..."
+    evalscope perf \
+        --model deepseek-v4-flash \
+        --url http://127.0.0.1:8000/v1/chat/completions \
+        --api openai \
+        --dataset swe_smith \
+        --dataset-path agentic_dataset.json \
+        --max-tokens 500 \
+        --multi-turn \
+        --number 4 8 8 16 \
+        --parallel 1 2 4 8 \
+        --extra-args '{"ignore_eos": true, "temperature": 0}' \
+        --name $CONFIG \
+        --outputs-dir $SWEEP_DIR \
+        --no-timestamp
+
+    stop_server
+    wait_for_port_free 8000
+done

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/agentic_bench.sh
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/agentic_bench.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 # Prepare dataset
 EVALSCOPE_COMMIT=acd09b44384d53174768bb1063f675420f76fae9
 pip install "evalscope[perf] @ git+https://github.com/modelscope/evalscope.git@${EVALSCOPE_COMMIT}"
@@ -35,7 +38,6 @@ CONFIGS=(
     attn_tp4_moe_ep4
 )
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SERVER_PID=
 SERVER_LOG=
 
@@ -83,8 +85,8 @@ stop_server() {
 }
 
 wait_for_port_free() {
-    local port=${1:-8000}
-    local timeout=${2:-90}
+    local port=$1
+    local timeout=$2
     local start=$SECONDS
     while ! python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', $port)); s.close()" 2>/dev/null; do
         if (( SECONDS - start > timeout )); then
@@ -98,7 +100,7 @@ wait_for_port_free() {
 trap stop_server EXIT  # safety net for Ctrl-C / errors
 
 # Preflight: bail out if port 8000 is already in use
-wait_for_port_free 8000
+wait_for_port_free 8000 90
 
 SWEEP_TS=$(date +%Y%m%d_%H%M%S)
 SWEEP_DIR="${SCRIPT_DIR}/outputs/${SWEEP_TS}"
@@ -144,5 +146,5 @@ for CONFIG in "${CONFIGS[@]}"; do
         --no-timestamp
 
     stop_server
-    wait_for_port_free 8000
+    wait_for_port_free 8000 90
 done

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/build_swe_smith_dataset.patch
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/build_swe_smith_dataset.patch
@@ -1,6 +1,21 @@
 --- build_swe_smith_dataset.py
 +++ build_swe_smith_dataset.py
-@@ -340,2 +340,6 @@
+@@ -46 +46,0 @@
+-from evalscope.perf.plugin.datasets.utils import tokenize_chat_messages
+@@ -163 +162 @@
+-    """Count tokens for a list of chat messages using tokenize_chat_messages."""
++    """Count tokens for a list of chat messages using the chat template."""
+@@ -166 +165,8 @@
+-    return len(tokenize_chat_messages(tokenizer, messages))
++    return len(
++        tokenizer.apply_chat_template(
++            messages,
++            tools=None,
++            tokenize=True,
++            add_generation_prompt=True,
++        )
++    )
+@@ -340,2 +346,6 @@
 -    from modelscope import AutoTokenizer
 -    tokenizer = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=True)
 +    from deepseek_v4_tokenizer import load_tokenizer
@@ -9,23 +24,23 @@
 +        args.model_path,
 +        revision='7872f01b1d1fe23eabc4c98b48bffcef5a386062',
 +    )
-@@ -344,2 +348,4 @@
+@@ -344,2 +354,4 @@
 -    from modelscope import MsDataset
 -    dataset = MsDataset.load(args.dataset_name, split=args.split)
 +    from datasets import load_dataset
 +    dataset = load_dataset(
 +        args.dataset_name, split=args.split, revision='08e109b4a59eaeebf80e4675cd125d42e7ac99a4'
 +    )
-@@ -415 +421 @@
+@@ -415 +427 @@
 -    with multiprocessing.Pool(num_workers) as pool:
 +    if num_workers == 1:
-@@ -417 +423,2 @@
+@@ -417 +429,2 @@
 -            for conv in pool.imap(_build_one, work_items):
 +            for item in work_items:
 +                conv = _build_one(item)
-@@ -424 +430,0 @@
+@@ -424 +437,0 @@
 -                        pool.terminate()
-@@ -425,0 +432,12 @@
+@@ -425,0 +438,12 @@
 +    else:
 +        with multiprocessing.Pool(num_workers) as pool:
 +            with tqdm(total=args.number, desc='Building conversations') as pbar:

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/build_swe_smith_dataset.patch
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/build_swe_smith_dataset.patch
@@ -1,0 +1,40 @@
+--- build_swe_smith_dataset.py
++++ build_swe_smith_dataset.py
+@@ -340,2 +340,6 @@
+-    from modelscope import AutoTokenizer
+-    tokenizer = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=True)
++    from deepseek_v4_tokenizer import load_tokenizer
++
++    tokenizer = load_tokenizer(
++        args.model_path,
++        revision='7872f01b1d1fe23eabc4c98b48bffcef5a386062',
++    )
+@@ -344,2 +348,4 @@
+-    from modelscope import MsDataset
+-    dataset = MsDataset.load(args.dataset_name, split=args.split)
++    from datasets import load_dataset
++    dataset = load_dataset(
++        args.dataset_name, split=args.split, revision='08e109b4a59eaeebf80e4675cd125d42e7ac99a4'
++    )
+@@ -415 +421 @@
+-    with multiprocessing.Pool(num_workers) as pool:
++    if num_workers == 1:
+@@ -417 +423,2 @@
+-            for conv in pool.imap(_build_one, work_items):
++            for item in work_items:
++                conv = _build_one(item)
+@@ -424 +430,0 @@
+-                        pool.terminate()
+@@ -425,0 +432,12 @@
++    else:
++        with multiprocessing.Pool(num_workers) as pool:
++            with tqdm(total=args.number, desc='Building conversations') as pbar:
++                for conv in pool.imap(_build_one, work_items):
++                    if conv is None:
++                        skipped_build += 1
++                    else:
++                        conversations.append(conv)
++                        pbar.update(1)
++                        if len(conversations) >= args.number:
++                            pool.terminate()
++                            break

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/collect_outputs.py
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/collect_outputs.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Collect a sweep's per-config benchmark_summary.json files into one CSV."""
+
+import argparse
+import csv
+import json
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+COLUMNS = [
+    "config",
+    "Conc.",
+    "Latency (tps/user)",
+    "Throughput (tps/gpu)",
+    "Approx Cache Hit",
+    "Decoded Tok/Iter",
+]
+
+
+def num_gpus_from_config(config: str) -> int:
+    m = re.search(r"attn_(?:tp|dp)(\d+)", config)
+    if not m:
+        raise ValueError(f"Cannot infer GPU count from config name: {config}")
+    return int(m.group(1))
+
+
+def decoded_tok_per_iter(run_dir: Path) -> float:
+    """Iteration-weighted accept length: sum(completion-1) / sum(n_chunks-1).
+
+    The "Decoded Tok/Iter" in benchmark_summary.json is an unweighted
+    per-request mean; high-accept requests take fewer iterations, so that
+    mean overstates the aggregate and is inconsistent with TPOT/ITL.
+    """
+    db_path = run_dir / "benchmark_data.db"
+    if not db_path.is_file():
+        return -1.0
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = con.execute(
+            "SELECT completion_tokens, inter_token_latencies"
+            " FROM result WHERE success = 1"
+        ).fetchall()
+    finally:
+        con.close()
+    toks = iters = 0
+    for ctok, itl_json in rows:
+        n_gaps = len(json.loads(itl_json))  # == n_chunks - 1
+        if ctok and ctok > 1 and n_gaps > 0:
+            toks += ctok - 1
+            iters += n_gaps
+    return toks / iters if iters else -1.0
+
+
+def collect(sweep_dir: Path):
+    rows = []
+    for config_dir in sorted(p for p in sweep_dir.iterdir() if p.is_dir()):
+        config = config_dir.name
+        n_gpus = num_gpus_from_config(config)
+        for run_dir in sorted(config_dir.iterdir()):
+            summary_path = run_dir / "benchmark_summary.json"
+            if not summary_path.is_file():
+                continue
+            s = json.loads(summary_path.read_text())
+            tpot_ms = s["TPOT (ms)"]
+            decode_tps_user = 1000.0 / tpot_ms if tpot_ms else 0.0
+            tps_gpu = s["Total Throughput (tok/s)"] / n_gpus
+            rows.append(
+                {
+                    "config": config,
+                    "Conc.": s["Concurrency"],
+                    "Latency (tps/user)": round(decode_tps_user, 2),
+                    "Throughput (tps/gpu)": round(tps_gpu, 2),
+                    "Approx Cache Hit": round(s["KV Cache Hit Rate (%)"], 2),
+                    "Decoded Tok/Iter": round(decoded_tok_per_iter(run_dir), 4),
+                }
+            )
+    rows.sort(key=lambda r: (r["config"], r["Conc."]))
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("sweep_dir", type=Path, help="e.g. outputs/20260505_152734")
+    ap.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="CSV output path (default: stdout)",
+    )
+    args = ap.parse_args()
+
+    if not args.sweep_dir.is_dir():
+        sys.exit(f"Not a directory: {args.sweep_dir}")
+
+    rows = collect(args.sweep_dir)
+    out = args.output.open("w", newline="") if args.output else sys.stdout
+    try:
+        w = csv.DictWriter(out, fieldnames=COLUMNS)
+        w.writeheader()
+        w.writerows(rows)
+    finally:
+        if args.output:
+            out.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/configs/attn_tp4_moe_ep4.sh
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/configs/attn_tp4_moe_ep4.sh
@@ -2,17 +2,14 @@
 
 set -euo pipefail
 
+# Target verification and the DSpark draft use their validated MoE backends.
 exec ts serve \
     --model deepseek-ai/DeepSeek-V4-Flash-0731 \
-    --revision 7872f01b1d1fe23eabc4c98b48bffcef5a386062 \
-    --served-model-name deepseek-v4-flash \
     --trust-remote-code \
     --world-size 4 \
     --nprocs-per-node 4 \
     --nnodes 1 \
-    --pipeline-parallel-size 1 \
     --attn-tp-size 4 \
-    --data-parallel-size 1 \
     --dense-tp-size 4 \
     --moe-tp-size 1 \
     --ep-size 4 \
@@ -21,7 +18,7 @@ exec ts serve \
     --kv-cache-dtype fp8_e4m3 \
     --attention-use-fp4-indexer-cache \
     --max-model-len 96000 \
-    --max-num-seqs 8 \
+    --max-num-seqs 16 \
     --max-total-tokens 2560000 \
     --max-prefill-tokens 8192 \
     --chunked-prefill-size 8192 \
@@ -30,7 +27,7 @@ exec ts serve \
     --enable-prefix-caching \
     --speculative-config '{"method":"dspark","num_speculative_tokens":5}' \
     --speculative-eagle-topk 1 \
-    --max-cudagraph-capture-size 8 \
+    --max-cudagraph-capture-size 16 \
     --prefill-graph-max-tokens 8192 \
     --seed 0 \
     --enable-metrics \

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/configs/attn_tp4_moe_ep4.sh
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/configs/attn_tp4_moe_ep4.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+exec ts serve \
+    --model deepseek-ai/DeepSeek-V4-Flash-0731 \
+    --revision 7872f01b1d1fe23eabc4c98b48bffcef5a386062 \
+    --served-model-name deepseek-v4-flash \
+    --trust-remote-code \
+    --world-size 4 \
+    --nprocs-per-node 4 \
+    --nnodes 1 \
+    --pipeline-parallel-size 1 \
+    --attn-tp-size 4 \
+    --data-parallel-size 1 \
+    --dense-tp-size 4 \
+    --moe-tp-size 1 \
+    --ep-size 4 \
+    --moe-backend flashinfer_trtllm \
+    --draft-moe-backend mega_moe \
+    --kv-cache-dtype fp8_e4m3 \
+    --attention-use-fp4-indexer-cache \
+    --max-model-len 96000 \
+    --max-num-seqs 8 \
+    --max-total-tokens 2560000 \
+    --max-prefill-tokens 8192 \
+    --chunked-prefill-size 8192 \
+    --gpu-memory-utilization 0.90 \
+    --disable-kvstore \
+    --enable-prefix-caching \
+    --speculative-config '{"method":"dspark","num_speculative_tokens":5}' \
+    --speculative-eagle-topk 1 \
+    --max-cudagraph-capture-size 8 \
+    --prefill-graph-max-tokens 8192 \
+    --seed 0 \
+    --enable-metrics \
+    --enable-cache-report \
+    --host 127.0.0.1 \
+    --port 8000

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/configs/attn_tp4_moe_ep4.sh
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/configs/attn_tp4_moe_ep4.sh
@@ -7,8 +7,6 @@ exec ts serve \
     --model deepseek-ai/DeepSeek-V4-Flash-0731 \
     --trust-remote-code \
     --world-size 4 \
-    --nprocs-per-node 4 \
-    --nnodes 1 \
     --attn-tp-size 4 \
     --dense-tp-size 4 \
     --moe-tp-size 1 \

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/deepseek_v4_tokenizer.py
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/deepseek_v4_tokenizer.py
@@ -50,7 +50,7 @@ def load_tokenizer(model: str, revision: str):
     def apply_chat_template(
         self,
         messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None,
         **kwargs,
     ):
         thinking = kwargs.get("thinking", False) or kwargs.get("enable_thinking", False)

--- a/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/deepseek_v4_tokenizer.py
+++ b/test/agentic_benchmark/deepseek_v4_flash/tokenspeed/deepseek_v4_tokenizer.py
@@ -1,0 +1,93 @@
+# MIT License
+#
+# Copyright (c) 2026 TokenSpeed contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import importlib.util
+from types import MethodType
+from typing import Any
+
+from transformers import AutoTokenizer
+from transformers.utils.hub import cached_file
+
+
+def load_tokenizer(model: str, revision: str):
+    """Load a revision-pinned tokenizer with the checkpoint's V4 chat encoding."""
+    tokenizer = AutoTokenizer.from_pretrained(
+        model,
+        revision=revision,
+        trust_remote_code=True,
+        clean_up_tokenization_spaces=False,
+    )
+    encoding_path = cached_file(
+        model,
+        "encoding/encoding_dsv4.py",
+        revision=revision,
+    )
+    spec = importlib.util.spec_from_file_location("deepseek_v4_encoding", encoding_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load DeepSeek V4 encoding from {encoding_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs,
+    ):
+        thinking = kwargs.get("thinking", False) or kwargs.get("enable_thinking", False)
+        conversation = kwargs.get("conversation", messages).copy()
+        if tools:
+            conversation.insert(0, {"role": "system", "tools": tools})
+
+        reasoning_effort = kwargs.get("reasoning_effort")
+        if reasoning_effort not in ("max", "high"):
+            reasoning_effort = None
+
+        prompt = module.encode_messages(
+            conversation,
+            thinking_mode="thinking" if thinking else "chat",
+            drop_thinking=kwargs.get("drop_thinking", True),
+            reasoning_effort=reasoning_effort,
+        )
+        if not kwargs.get("tokenize", True):
+            return prompt
+
+        return_dict = kwargs.get("return_dict", False)
+        forwarded_keys = (
+            "truncation",
+            "max_length",
+            "padding",
+            "return_tensors",
+            "return_attention_mask",
+            "return_token_type_ids",
+            "return_special_tokens_mask",
+            "return_offsets_mapping",
+            "return_length",
+        )
+        forwarded = {key: kwargs[key] for key in forwarded_keys if key in kwargs}
+        encoding = self(prompt, add_special_tokens=False, **forwarded)
+        if return_dict:
+            return encoding
+        return encoding["input_ids"]
+
+    tokenizer.apply_chat_template = MethodType(apply_chat_template, tokenizer)
+    return tokenizer


### PR DESCRIPTION
## Summary

- add a SWE-Smith multi-turn agentic benchmark for DeepSeek V4 Flash
- add one manually checked four-GPU deployment config using Attention TP4, Dense TP4, and routed MoE TP1 x EP4
- collect per-user decode rate, per-GPU throughput, cache hit rate, and decoded tokens per iteration using the existing GLM5.2 benchmark format
- adapt dataset generation to the checkpoint-provided DeepSeek V4 chat encoding

## Validation

- `pre-commit run --all-files`
- shell syntax checks for the benchmark runner and deployment config
- Python compile checks for the tokenizer adapter and output collector
- dataset-builder patch dry run against the pinned EvalScope revision
- manual p1, p2, p4, and p8 end-to-end sweep with all requests completing successfully
