### PR TITLE
perf(amd): Optimize GLM-5.3-Flash KPool decode and tail handling

### DIFF
--- a/python/tokenspeed/runtime/models/glm53_flash.py
+++ b/python/tokenspeed/runtime/models/glm53_flash.py
@@ -1178,15 +1178,18 @@ class Glm53FlashAttention(GlmMoeDsaAttention):
         topk: int,
     ) -> GlmDsaDecodeTopK:
         del topk
+        writes_full_workspace = decode_start == 0 and num_decode_tokens == num_tokens
         topk_indices = self._get_decode_topk_workspace(
             "_decode_topk_indices_buffer",
             num_tokens,
             self.index_topk + self.index_kpool - 1,
             indexer_output.query.device,
+            fill_value=None if writes_full_workspace else -1,
         )
         topk_lens = self._get_decode_topk_lens_workspace(
             num_tokens,
             indexer_output.query.device,
+            fill=not writes_full_workspace,
         )
         ctx.attn_backend.require_kpool_runtime().select_decode(
             query=indexer_output.query,

--- a/test/runtime/models/test_glm53_flash_models.py
+++ b/test/runtime/models/test_glm53_flash_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torch import nn
 
@@ -24,6 +25,7 @@ from tokenspeed.runtime.models.glm53_flash import (
     Glm53FlashAttention,
     Glm53FlashForCausalLM,
     Glm53FlashForConditionalGeneration,
+    Glm53FlashIndexerOutput,
     Glm53FlashKDA,
     Glm53FlashMoE,
 )
@@ -165,6 +167,78 @@ def test_kpool_decode_forwards_configured_context_bound(monkeypatch) -> None:
     assert captured["kwargs"]["kv_page_size"] == 64
     assert captured["kwargs"]["out"].shape == (4, 2051)
     assert captured["kwargs"]["lens_out"].shape == (4,)
+
+
+@pytest.mark.parametrize(
+    ("decode_start", "num_decode_tokens", "expected_fill_value", "expected_fill"),
+    [
+        pytest.param(0, 4, None, False, id="full-decode"),
+        pytest.param(1, 2, -1, True, id="mixed-prefill"),
+    ],
+)
+def test_glm53_flash_decode_topk_skips_only_overwritten_workspace_fills(
+    decode_start: int,
+    num_decode_tokens: int,
+    expected_fill_value: int | None,
+    expected_fill: bool,
+) -> None:
+    attention = Glm53FlashAttention.__new__(Glm53FlashAttention)
+    attention.index_topk = 12
+    attention.index_kpool = 4
+    attention.indexer = SimpleNamespace(weights_softmax_scale=0.25)
+    attention.attn_mqa = SimpleNamespace(layer_id=3)
+    captured = {}
+    topk_indices = torch.empty((4, 15), dtype=torch.int32)
+    topk_lens = torch.empty(4, dtype=torch.int32)
+
+    def get_indices(_name, _rows, _width, _device, *, fill_value=-1):
+        captured["fill_value"] = fill_value
+        return topk_indices
+
+    def get_lens(_rows, _device, *, fill=True):
+        captured["fill"] = fill
+        return topk_lens
+
+    def select_decode(**kwargs):
+        captured["out"] = kwargs["out"]
+        captured["lens_out"] = kwargs["lens_out"]
+
+    attention._get_decode_topk_workspace = get_indices
+    attention._get_decode_topk_lens_workspace = get_lens
+    ctx = SimpleNamespace(
+        attn_backend=SimpleNamespace(
+            require_kpool_runtime=lambda: SimpleNamespace(
+                select_decode=select_decode,
+            )
+        )
+    )
+    indexer_output = Glm53FlashIndexerOutput(
+        query=torch.zeros((4, 1, 128), dtype=torch.bfloat16),
+        key=torch.empty(0),
+        weights=torch.zeros((4, 1), dtype=torch.bfloat16),
+        gate=torch.empty(0),
+    )
+
+    result = attention._compute_decode_topk_indices_portable(
+        indexer_output=indexer_output,
+        ctx=ctx,
+        seq_lens=torch.tensor([8], dtype=torch.int32),
+        page_table=torch.zeros((1, 1), dtype=torch.int32),
+        q_len_per_req=1,
+        decode_start=decode_start,
+        num_tokens=4,
+        num_decode_tokens=num_decode_tokens,
+        topk=12,
+    )
+
+    assert captured["fill_value"] == expected_fill_value
+    assert captured["fill"] is expected_fill
+    assert captured["out"] is topk_indices
+    assert captured["lens_out"] is topk_lens
+    assert result.topk_indices is topk_indices
+    assert result.topk_lens is topk_lens
+
+
 def _build_model(monkeypatch) -> Glm53FlashForConditionalGeneration:
     monkeypatch.setattr(glm53_flash, "Glm53FlashForCausalLM", _FakeLanguageModel)
     return Glm53FlashForConditionalGeneration(

--- a/test/runtime/models/test_glm53_flash_models.py
+++ b/test/runtime/models/test_glm53_flash_models.py
@@ -13,6 +13,8 @@ from tokenspeed.runtime.configs.glm53_flash_config import (
     Glm53FlashVisionConfig,
 )
 from tokenspeed.runtime.distributed.mapping import Mapping
+from tokenspeed.runtime.layers.attention import kpool as kpool_runtime
+from tokenspeed.runtime.layers.attention.kpool import KPoolRuntime
 from tokenspeed.runtime.layers.dense.fp8 import Fp8LinearMethod
 from tokenspeed.runtime.layers.dense.unquant import UnquantizedLinearMethod
 from tokenspeed.runtime.layers.quantization.fp8 import Fp8Config
@@ -118,6 +120,51 @@ def _tiny_config() -> Glm53FlashConfig:
     )
 
 
+def test_kpool_decode_forwards_configured_context_bound(monkeypatch) -> None:
+    captured = {}
+
+    def fake_kpool_decode_topk(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return kwargs["out"], kwargs["lens_out"]
+
+    monkeypatch.setattr(kpool_runtime, "kpool_decode_topk", fake_kpool_decode_topk)
+    index_cache = torch.empty((4, 16, 132), dtype=torch.uint8)
+    ctx = SimpleNamespace(
+        attn_backend=SimpleNamespace(max_context_len=131072),
+        token_to_kv_pool=SimpleNamespace(
+            arena=SimpleNamespace(kv_page_size=64),
+            get_kpool_buffers=lambda _layer_id: (index_cache, None, None),
+        ),
+    )
+    query = torch.zeros((5, 2, 128), dtype=torch.bfloat16)
+    weights = torch.zeros((5, 2), dtype=torch.float32)
+    seq_lens = torch.tensor([1024, 2048], dtype=torch.int32)
+    page_table = torch.zeros((2, 4), dtype=torch.int32)
+    out = torch.empty((5, 2051), dtype=torch.int32)
+    lens_out = torch.empty(5, dtype=torch.int32)
+
+    KPoolRuntime(pool_size=4, index_topk=2048).select_decode(
+        query=query,
+        weights=weights,
+        softmax_scale=0.125,
+        ctx=ctx,
+        layer_id=3,
+        seq_lens=seq_lens,
+        page_table=page_table,
+        q_len_per_req=2,
+        decode_start=1,
+        num_decode_tokens=4,
+        out=out,
+        lens_out=lens_out,
+    )
+
+    assert captured["args"][0].shape == (4, 2, 128)
+    assert captured["kwargs"]["max_seq_len"] == 131072
+    assert captured["kwargs"]["page_size"] == 16
+    assert captured["kwargs"]["kv_page_size"] == 64
+    assert captured["kwargs"]["out"].shape == (4, 2051)
+    assert captured["kwargs"]["lens_out"].shape == (4,)
 def _build_model(monkeypatch) -> Glm53FlashForConditionalGeneration:
     monkeypatch.setattr(glm53_flash, "Glm53FlashForCausalLM", _FakeLanguageModel)
     return Glm53FlashForConditionalGeneration(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_cache.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_cache.py
@@ -223,7 +223,10 @@ def triton_kpool_prefill_write(
     )
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["num_tokens"],
+    do_not_specialize_on_alignment=["num_tokens"],
+)
 def _kpool_prefill_tail_write_kernel(
     k_ptr,
     gate_ptr,
@@ -239,7 +242,7 @@ def _kpool_prefill_tail_write_kernel(
     tail_k_stride_pool: tl.constexpr,
     tail_gate_stride_req: tl.constexpr,
     tail_gate_stride_pool: tl.constexpr,
-    NUM_TOKENS: tl.constexpr,
+    num_tokens,
     POOL_SIZE: tl.constexpr,
     TAIL_SIZE: tl.constexpr,
     TAIL_NUM_REQUESTS: tl.constexpr,
@@ -267,7 +270,7 @@ def _kpool_prefill_tail_write_kernel(
             valid_destination
             & (pool_offset < valid_count)
             & (source_row >= 0)
-            & (source_row < NUM_TOKENS)
+            & (source_row < num_tokens)
         )
         safe_source_row = tl.where(active, source_row, 0)
         destination_row = (destination_position + pool_offset) % TAIL_SIZE
@@ -394,7 +397,7 @@ def triton_kpool_prefill_tail_write(
         tail_k.stride(1),
         tail_gate.stride(0),
         tail_gate.stride(1),
-        NUM_TOKENS=k.shape[0],
+        num_tokens=k.shape[0],
         POOL_SIZE=pool_size,
         TAIL_SIZE=tail_k.shape[1],
         TAIL_NUM_REQUESTS=tail_k.shape[0],

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_expand.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_expand.py
@@ -26,7 +26,10 @@ import torch
 from tokenspeed_kernel._triton import tl, triton
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["block_table_stride", "block_table_cols"],
+    do_not_specialize_on_alignment=["block_table_stride", "block_table_cols"],
+)
 def _kpool_expand_slots_kernel(
     out,
     out_stride,
@@ -37,7 +40,7 @@ def _kpool_expand_slots_kernel(
     req_ids,
     block_table,
     block_table_stride,
-    block_table_cols: tl.constexpr,
+    block_table_cols,
     block_size: tl.constexpr,
     pool_size: tl.constexpr,
     group_topk: tl.constexpr,
@@ -156,6 +159,9 @@ def expand_kpool_to_flat_kv(
         raise ValueError(
             f"lens_out must be int32 {(num_tokens,)} on {pool_indices.device}"
         )
+
+    if num_tokens == 0:
+        return out, lens_out
 
     _kpool_expand_slots_kernel[(num_tokens,)](
         out,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_select.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_select.py
@@ -54,12 +54,15 @@ _TRAITS = {
 }
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["num_tokens"],
+    do_not_specialize_on_alignment=["num_tokens"],
+)
 def _kpool_decode_metadata_kernel(
     seq_lens,
     req_ids,
     causal_lens,
-    num_tokens: tl.constexpr,
+    num_tokens,
     q_len_per_req: tl.constexpr,
     BLOCK: tl.constexpr,
 ):

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_select.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/kpool_select.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel._triton import tl, triton
 from tokenspeed_kernel.ops.attention.cute_dsl.dsa_topk import (
     cute_dsl_decode_topk,
     has_cute_dsl_decode_topk,
@@ -51,6 +52,50 @@ _TRAITS = {
     "score_activation": frozenset({"relu", "none"}),
     "topk_layout": frozenset({"global_slots"}),
 }
+
+
+@triton.jit
+def _kpool_decode_metadata_kernel(
+    seq_lens,
+    req_ids,
+    causal_lens,
+    num_tokens: tl.constexpr,
+    q_len_per_req: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    token = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = token < num_tokens
+    req = token // q_len_per_req
+    q_offset = token - req * q_len_per_req
+    seq_len = tl.load(seq_lens + req, mask=mask, other=0).to(tl.int32)
+    causal_len = tl.maximum(
+        seq_len - (q_len_per_req - 1) + q_offset,
+        0,
+    )
+    tl.store(req_ids + token, req, mask=mask)
+    tl.store(causal_lens + token, causal_len, mask=mask)
+
+
+def _prepare_kpool_decode_metadata(
+    seq_lens: torch.Tensor,
+    num_tokens: int,
+    q_len_per_req: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build request ids and visible lengths in one device launch."""
+    req_ids = torch.empty(num_tokens, dtype=torch.int32, device=seq_lens.device)
+    causal_lens = torch.empty_like(req_ids)
+    block = min(triton.next_power_of_2(num_tokens), 1024)
+    _kpool_decode_metadata_kernel[(triton.cdiv(num_tokens, block),)](
+        seq_lens,
+        req_ids,
+        causal_lens,
+        num_tokens=num_tokens,
+        q_len_per_req=q_len_per_req,
+        BLOCK=block,
+        num_warps=1,
+        num_stages=1,
+    )
+    return req_ids, causal_lens
 
 
 def _empty_result(
@@ -83,14 +128,20 @@ def _select_pools_dense(
     use_cute_dsl_topk: bool,
 ) -> torch.Tensor:
     num_tokens = q.shape[0]
-    pool_indices = torch.empty(
-        (num_tokens, topk_pools), dtype=torch.int32, device=q.device
-    )
     if max_num_pools <= topk_pools:
-        return pool_indices
+        return torch.empty((num_tokens, topk_pools), dtype=torch.int32, device=q.device)
 
     row_bytes = max_num_pools * torch.float32.itemsize
     rows_per_tile = min(num_tokens, max(1, _MAX_DENSE_LOGITS_BYTES // row_bytes))
+    pool_indices = (
+        torch.empty(
+            (num_tokens, topk_pools),
+            dtype=torch.int32 if use_cute_dsl_topk else torch.int64,
+            device=q.device,
+        )
+        if use_cute_dsl_topk or rows_per_tile < num_tokens
+        else None
+    )
     logits_workspace = torch.empty(
         (rows_per_tile, max_num_pools), dtype=torch.float32, device=q.device
     )
@@ -118,6 +169,7 @@ def _select_pools_dense(
             length_masked_consumer=use_cute_dsl_topk,
         )
         if use_cute_dsl_topk:
+            assert pool_indices is not None
             cute_dsl_decode_topk(
                 logits,
                 pool_lens[start:end],
@@ -127,7 +179,10 @@ def _select_pools_dense(
             )
         else:
             selected = torch.topk(logits, k=topk_pools, dim=-1, sorted=False).indices
-            pool_indices[start:end].copy_(selected.to(torch.int32))
+            if pool_indices is None:
+                return selected
+            pool_indices[start:end].copy_(selected)
+    assert pool_indices is not None
     return pool_indices
 
 
@@ -207,18 +262,12 @@ def triton_dense_kpool_decode_topk(
         raise RuntimeError("KPool decode top-k requires CUDA tensors")
 
     device = q.device
-    seq_lens = seq_lens.to(device=device, dtype=torch.int32).contiguous()
-    token_ids = torch.arange(num_tokens, device=device, dtype=torch.int32)
-    req_ids = torch.div(token_ids, q_len_per_req, rounding_mode="floor")
-    # ROCm's int32 index-select path has a narrow crossover at 16 rows.
-    selected_seq_lens = (
-        seq_lens[req_ids]
-        if torch.version.hip is not None and num_tokens == 16
-        else seq_lens.index_select(0, req_ids)
+    seq_lens = seq_lens.to(device=device).contiguous()
+    req_ids, causal_lens = _prepare_kpool_decode_metadata(
+        seq_lens,
+        num_tokens,
+        q_len_per_req,
     )
-    causal_lens = (
-        selected_seq_lens - (q_len_per_req - 1) + token_ids % q_len_per_req
-    ).clamp_min_(0)
     use_cute = (
         has_cute_dsl_decode_topk()
         and topk_pools == _CUTE_DSL_TOPK_POOLS
@@ -239,7 +288,7 @@ def triton_dense_kpool_decode_topk(
     pool_indices = _select_pools_dense(
         q.contiguous(),
         pooled_k_cache,
-        weights.to(torch.float32).contiguous(),
+        weights.contiguous(),
         causal_lens,
         req_ids,
         index_block_table.to(device=device, dtype=torch.int32).contiguous(),

--- a/tokenspeed-kernel/test/ops/test_kpool_cache.py
+++ b/tokenspeed-kernel/test/ops/test_kpool_cache.py
@@ -352,6 +352,72 @@ def test_prefill_tail_write_masks_padded_and_invalid_rows() -> None:
     assert torch.equal(tail_gate[0], initial_gate[0])
 
 
+@pytest.mark.parametrize("num_tokens", [1, 7, 179, 206])
+def test_prefill_tail_write_tracks_runtime_source_bound(num_tokens: int) -> None:
+    generator = torch.Generator(device="cuda").manual_seed(32 + num_tokens)
+    keys = _random((num_tokens, _DIM), generator, 0.3)
+    gates = _random((num_tokens, _DIM), generator, 1.5)
+    tail_k = _random((5, 7, _DIM), generator, 1.0)
+    tail_gate = _random((5, 7, _DIM), generator, 1.0)
+    initial_k = tail_k.clone()
+    initial_gate = tail_gate.clone()
+    source_starts = torch.tensor(
+        [0, num_tokens - 1, num_tokens, max(num_tokens - 2, 0), -1],
+        device="cuda",
+    )
+    destination_slots = torch.arange(5, device="cuda")
+    destination_positions = torch.tensor([0, 6, 3, 4, 2], device="cuda")
+    valid_counts = torch.tensor([4, 4, 4, 3, 2], device="cuda")
+    expected = _reference_tail_write(
+        keys,
+        gates,
+        initial_k,
+        initial_gate,
+        source_starts,
+        destination_slots,
+        destination_positions,
+        valid_counts,
+    )
+
+    kpool_prefill_tail_write(
+        keys,
+        gates,
+        tail_k,
+        tail_gate,
+        source_starts,
+        destination_slots,
+        destination_positions,
+        valid_counts,
+        pool_size=_POOL,
+    )
+
+    assert torch.equal(tail_k, expected[0])
+    assert torch.equal(tail_gate, expected[1])
+
+
+def test_prefill_tail_write_empty_metadata_is_noop() -> None:
+    generator = torch.Generator(device="cuda").manual_seed(33)
+    keys = _random((8, _DIM), generator, 0.3)
+    gates = _random((8, _DIM), generator, 1.5)
+    tail_k = _random((2, 7, _DIM), generator, 1.0)
+    tail_gate = _random((2, 7, _DIM), generator, 1.0)
+    initial_k = tail_k.clone()
+    initial_gate = tail_gate.clone()
+    metadata = [torch.empty(0, dtype=torch.int32, device="cuda") for _ in range(4)]
+
+    kpool_prefill_tail_write(
+        keys,
+        gates,
+        tail_k,
+        tail_gate,
+        *metadata,
+        pool_size=_POOL,
+    )
+
+    assert torch.equal(tail_k, initial_k)
+    assert torch.equal(tail_gate, initial_gate)
+
+
 def test_prefill_tail_write_accepts_distinct_row_strides() -> None:
     generator = torch.Generator(device="cuda").manual_seed(30)
     keys = _random((12, _DIM + 8), generator, 0.3)[:, :_DIM]

--- a/tokenspeed-kernel/test/ops/test_kpool_select.py
+++ b/tokenspeed-kernel/test/ops/test_kpool_select.py
@@ -26,6 +26,9 @@ import pytest
 import torch
 from tokenspeed_kernel import kpool_decode_topk, kpool_prefill_topk
 from tokenspeed_kernel.ops.attention.triton.kpool_score import score_kpool_dense
+from tokenspeed_kernel.ops.attention.triton.kpool_select import (
+    _prepare_kpool_decode_metadata,
+)
 
 pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 
@@ -147,11 +150,13 @@ def _assert_selection(
         )
 
 
-def test_dense_scores_match_reference() -> None:
+@pytest.mark.parametrize("weight_dtype", [torch.float32, torch.bfloat16])
+def test_dense_scores_match_reference(weight_dtype: torch.dtype) -> None:
     q, cache, pooled_k, weights, seq_lens, index_table, _ = _setup(
         [2051, 4101], seed=47
     )
     req_ids = torch.arange(q.shape[0], dtype=torch.int32, device="cuda")
+    weights = weights.to(weight_dtype)
     pool_lens = seq_lens // _POOL
     max_num_pools = int(pool_lens.max())
     actual = score_kpool_dense(
@@ -180,6 +185,32 @@ def test_dense_scores_match_reference() -> None:
         ).sum(0)
 
     torch.testing.assert_close(actual, expected, rtol=0, atol=5e-7)
+
+
+@pytest.mark.parametrize("q_len_per_req", [1, 2, 4])
+@pytest.mark.parametrize("seq_dtype", [torch.int32, torch.int64])
+def test_decode_metadata_matches_torch_chain(
+    q_len_per_req: int,
+    seq_dtype: torch.dtype,
+) -> None:
+    seq_lens = torch.tensor([0, 2, 7], dtype=seq_dtype, device="cuda")
+    num_tokens = seq_lens.numel() * q_len_per_req
+    actual_req_ids, actual_causal_lens = _prepare_kpool_decode_metadata(
+        seq_lens,
+        num_tokens,
+        q_len_per_req,
+    )
+
+    token_ids = torch.arange(num_tokens, dtype=torch.int32, device="cuda")
+    expected_req_ids = token_ids // q_len_per_req
+    expected_causal_lens = (
+        seq_lens.to(torch.int32).index_select(0, expected_req_ids)
+        - (q_len_per_req - 1)
+        + token_ids % q_len_per_req
+    ).clamp_min(0)
+
+    assert torch.equal(actual_req_ids, expected_req_ids)
+    assert torch.equal(actual_causal_lens, expected_causal_lens)
 
 
 @pytest.mark.parametrize(

--- a/tokenspeed-kernel/test/ops/test_kpool_select.py
+++ b/tokenspeed-kernel/test/ops/test_kpool_select.py
@@ -268,6 +268,27 @@ def test_decode_metadata_matches_torch_chain(
     assert torch.equal(actual_causal_lens, expected_causal_lens)
 
 
+@pytest.mark.parametrize("num_reqs", [3, 13])
+def test_decode_metadata_cuda_graph_tracks_tail_batch_lengths(num_reqs: int) -> None:
+    seq_lens = torch.arange(num_reqs, dtype=torch.int32, device="cuda")
+
+    _prepare_kpool_decode_metadata(seq_lens, num_reqs, 1)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        req_ids, causal_lens = _prepare_kpool_decode_metadata(seq_lens, num_reqs, 1)
+
+    seq_lens.add_(17)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert torch.equal(
+        req_ids,
+        torch.arange(num_reqs, dtype=torch.int32, device="cuda"),
+    )
+    assert torch.equal(causal_lens, seq_lens)
+
+
 @pytest.mark.parametrize("table_cols", [1, 2, 5, 9, 16, 31])
 def test_expand_kpool_tracks_runtime_page_table_width(table_cols: int) -> None:
     pool_indices = torch.tensor(

--- a/tokenspeed-kernel/test/ops/test_kpool_select.py
+++ b/tokenspeed-kernel/test/ops/test_kpool_select.py
@@ -25,6 +25,9 @@ from __future__ import annotations
 import pytest
 import torch
 from tokenspeed_kernel import kpool_decode_topk, kpool_prefill_topk
+from tokenspeed_kernel.ops.attention.triton.kpool_expand import (
+    expand_kpool_to_flat_kv,
+)
 from tokenspeed_kernel.ops.attention.triton.kpool_score import score_kpool_dense
 from tokenspeed_kernel.ops.attention.triton.kpool_select import (
     _prepare_kpool_decode_metadata,
@@ -150,6 +153,58 @@ def _assert_selection(
         )
 
 
+def _reference_expand_kpool(
+    pool_indices: torch.Tensor,
+    causal_lens: torch.Tensor,
+    req_ids: torch.Tensor,
+    block_table: torch.Tensor,
+    *,
+    pool_size: int,
+    block_size: int,
+    append_tail: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, topk_pools = pool_indices.shape
+    width = topk_pools * pool_size + (pool_size - 1 if append_tail else 0)
+    slots = torch.full(
+        (num_tokens, width), -1, dtype=torch.int32, device=pool_indices.device
+    )
+    lens = torch.zeros(num_tokens, dtype=torch.int32, device=pool_indices.device)
+
+    for token in range(num_tokens):
+        seq_len = max(int(causal_lens[token]), 0)
+        num_pools = seq_len // pool_size
+        history_len = min(num_pools * pool_size, topk_pools * pool_size)
+        selected = (
+            list(range(num_pools))
+            if num_pools <= topk_pools
+            else pool_indices[token].tolist()
+        )
+        raw_slots = []
+        for pool in selected[:topk_pools]:
+            if len(raw_slots) >= history_len:
+                break
+            if 0 <= pool < num_pools:
+                raw_slots.extend(range(pool * pool_size, (pool + 1) * pool_size))
+            else:
+                raw_slots.extend([-1] * pool_size)
+        if append_tail:
+            raw_slots.extend(range(num_pools * pool_size, seq_len))
+
+        count = 0
+        req = int(req_ids[token])
+        for column, raw_slot in enumerate(raw_slots[:width]):
+            if not 0 <= raw_slot < seq_len:
+                continue
+            page_idx = raw_slot // block_size
+            if page_idx >= block_table.shape[1]:
+                continue
+            page = int(block_table[req, page_idx])
+            slots[token, column] = page * block_size + raw_slot % block_size
+            count += 1
+        lens[token] = count
+    return slots, lens
+
+
 @pytest.mark.parametrize("weight_dtype", [torch.float32, torch.bfloat16])
 def test_dense_scores_match_reference(weight_dtype: torch.dtype) -> None:
     q, cache, pooled_k, weights, seq_lens, index_table, _ = _setup(
@@ -211,6 +266,87 @@ def test_decode_metadata_matches_torch_chain(
 
     assert torch.equal(actual_req_ids, expected_req_ids)
     assert torch.equal(actual_causal_lens, expected_causal_lens)
+
+
+@pytest.mark.parametrize("table_cols", [1, 2, 5, 9, 16, 31])
+def test_expand_kpool_tracks_runtime_page_table_width(table_cols: int) -> None:
+    pool_indices = torch.tensor(
+        [[0, 1, 2], [0, -1, 5], [0, 2, 4], [0, 16, 32]],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    causal_lens = torch.tensor(
+        [0, 3, min(table_cols * _KV_PAGE, 17), table_cols * _KV_PAGE + 3],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    req_ids = torch.arange(4, dtype=torch.int32, device="cuda")
+    table_storage = torch.arange(
+        4 * (table_cols + 3), dtype=torch.int32, device="cuda"
+    ).view(4, table_cols + 3)
+    block_table = table_storage[:, :table_cols]
+    width = pool_indices.shape[1] * _POOL + _POOL - 1
+    out_storage = torch.empty((4, width + 2), dtype=torch.int32, device="cuda")
+    out = out_storage[:, :width]
+    lens_out = torch.empty(4, dtype=torch.int32, device="cuda")
+    assert not block_table.is_contiguous()
+    assert not out.is_contiguous()
+
+    expected = _reference_expand_kpool(
+        pool_indices,
+        causal_lens,
+        req_ids,
+        block_table,
+        pool_size=_POOL,
+        block_size=_KV_PAGE,
+        append_tail=True,
+    )
+    actual = expand_kpool_to_flat_kv(
+        pool_indices,
+        causal_lens,
+        req_ids,
+        block_table,
+        pool_size=_POOL,
+        kv_page_size=_KV_PAGE,
+        append_tail=True,
+        out=out,
+        lens_out=lens_out,
+    )
+
+    assert actual[0] is out
+    assert actual[1] is lens_out
+    assert torch.equal(actual[0], expected[0])
+    assert torch.equal(actual[1], expected[1])
+
+
+def test_expand_kpool_empty_input_and_invalid_table_contract() -> None:
+    pool_indices = torch.empty((0, 3), dtype=torch.int32, device="cuda")
+    causal_lens = torch.empty(0, dtype=torch.int32, device="cuda")
+    req_ids = torch.empty(0, dtype=torch.int32, device="cuda")
+    block_table = torch.empty((1, 2), dtype=torch.int32, device="cuda")
+
+    slots, lens = expand_kpool_to_flat_kv(
+        pool_indices,
+        causal_lens,
+        req_ids,
+        block_table,
+        pool_size=_POOL,
+        kv_page_size=_KV_PAGE,
+        append_tail=True,
+    )
+
+    assert slots.shape == (0, 15)
+    assert lens.shape == (0,)
+    with pytest.raises(ValueError, match="at least one page"):
+        expand_kpool_to_flat_kv(
+            pool_indices,
+            causal_lens,
+            req_ids,
+            block_table[:, :0],
+            pool_size=_POOL,
+            kv_page_size=_KV_PAGE,
+            append_tail=True,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Optimize GLM-5.3-Flash compressed-history selection (KPool) during decode and
make its prompt-tail metadata reusable across changing request shapes.

- Generate decode request mappings and visible lengths in one GPU launch.
- Skip selection-workspace initialization when every output row is overwritten.
- Consume BF16 selection weights directly and pass the one-tile top-k result
  directly into slot expansion.
- Keep prompt-tail row counts, page-table bounds, and live decode row counts as
  runtime values so tail requests reuse already compiled kernels.
- Preserve the existing masks, schedules, and power-of-two graph layouts, and
  handle an empty slot-expansion batch without a kernel launch.

The first commit adds coverage for the model context bound that is already
present on current `main`; it adds no new runtime behavior. The remaining four
commits implement the performance changes.

## ShareGPT performance

The five-commit PR boundary was measured as one group against its immediate
historical base:

| Metric | Base | This PR | Change |
|---|---:|---:|---:|
| Output throughput | 1,002.343 tok/s | 1,020.272 tok/s | +1.79% |
| Decode/user | 84.782 tok/s | 86.265 tok/s | +1.75% |
| Mean TPOT | 11.795 ms | 11.592 ms | 1.72% lower |
| Mean ITL | 37.263 ms | 36.622 ms | 1.72% lower |
| Mean TTFT | 502.901 ms | 501.905 ms | 0.20% lower |
| Mean end-to-end latency | 6,529.675 ms | 6,425.501 ms | 1.60% lower |

The fused decode-bookkeeping region also improved from 117.445 to 97.970 us
per layer under graph replay (-16.58%) and reduced the selected region from 26
to 15 GPU dispatches. The ShareGPT result above is attributable to this PR as a
five-commit group, not to any one commit.

The ShareGPT workload used four MI350X GPUs, attention TP4, MoE TP4/EP1, MTP3
with four-token verification, 16 concurrent requests, and 512 output tokens
per request. These measurements were collected on `upstream/main` `b174a318`.
The current branch carries the same executable feature changes on newer
`upstream/main` `5af23865`, but that resulting tree was not benchmarked.