### PR TITLE
perf(amd): Optimize GLM-5.3-Flash recurrent verification

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
@@ -101,6 +101,7 @@ class KdaAttnBackend(MambaAttnBackend):
     """
 
     _verify_reads_committed_recurrent_state = True
+    _verify_packed_qkv_views = True
 
     def __init__(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
@@ -100,6 +100,8 @@ class KdaAttnBackend(MambaAttnBackend):
     the conv, the gate GEMV and the recurrence into a single launch.
     """
 
+    _verify_reads_committed_recurrent_state = True
+
     def __init__(
         self,
         config: AttnConfig,
@@ -745,8 +747,10 @@ class KdaAttnBackend(MambaAttnBackend):
         )
 
         beta_b = beta_raw.view(batch_size, draft_token_num, num_value_heads)
-        initial_pool = ssm_scratch
-        initial_rows = output_indices[:batch_size, 0] - 1
+        # The recurrence has independent read and write pools: committed pages
+        # provide the initial state while every speculative checkpoint lands in scratch.
+        initial_pool = ssm_comp
+        initial_rows = state_in_blocks[:batch_size]
         write_rows = output_indices[:batch_size]
         state_out = ssm_scratch
 

--- a/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
@@ -319,6 +319,7 @@ class MambaAttnBackend(AttentionBackend):
     # The hybrid wrapper unions the sub-backends' declarations, so a Kimi-K3
     # contract (history + state) is covered once both consumers exist.
     cache_consumer_families = frozenset({"state"})
+    _verify_reads_committed_recurrent_state: bool = False
 
     def __init__(self, config: AttnConfig, spec: SoftmaxAttnConfig):
         super().__init__(config, spec)
@@ -684,7 +685,7 @@ class MambaAttnBackend(AttentionBackend):
             src_row_strides=tables["conv_comp_stride"],
             dst_row_strides=tables["conv_scratch_stride"],
         )
-        if not self.replay_ssm:
+        if not self.replay_ssm and not self._verify_reads_committed_recurrent_state:
             copy_state_rows(
                 tables["ssm_comp"],
                 tables["ssm_scratch"],

--- a/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
@@ -707,16 +707,27 @@ class MambaAttnBackend(AttentionBackend):
         grid = cache.get((bs, draft_token_num))
         if grid is not None:
             return grid
-        stride = draft_token_num + 1
-        base = (
-            torch.arange(bs, dtype=torch.int32, device=self.device) * stride
-        ).unsqueeze(1)
+        base = self._verify_scratch_base_rows(bs, draft_token_num).unsqueeze(1)
         steps = torch.arange(
             1, draft_token_num + 1, dtype=torch.int32, device=self.device
         ).unsqueeze(0)
         grid = base + steps
         cache[(bs, draft_token_num)] = grid
         return grid
+
+    def _verify_scratch_base_rows(self, bs: int, draft_token_num: int) -> torch.Tensor:
+        """Graph-stable scratch initialization row for each request."""
+        cache = getattr(self, "_verify_base_cache", None)
+        if cache is None:
+            cache = self._verify_base_cache = {}
+        key = (bs, draft_token_num)
+        rows = cache.get(key)
+        if rows is None:
+            rows = torch.arange(bs, dtype=torch.int32, device=self.device) * (
+                draft_token_num + 1
+            )
+            cache[key] = rows
+        return rows
 
     def commit_verified_state(self, accepted_length: torch.Tensor) -> None:
         """Commit the accepted draft prefix into each group's state slab."""
@@ -1633,7 +1644,7 @@ class MambaAttnBackend(AttentionBackend):
             if layer_id == self._state_layer_ids()[0]:
                 self._seed_verify_scratch_batched(batch_size, draft_token_num)
             conv_states = conv_scratch
-            conv_read = output_indices[:batch_size, 0] - 1
+            conv_read = self._verify_scratch_base_rows(batch_size, draft_token_num)
             conv_out = output_indices[:batch_size]
             # shouldn't use contiguous here, because causal_conv1d_update
             # support input non-contiguous

--- a/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
@@ -79,6 +79,31 @@ if TYPE_CHECKING:
 _STATE_GROUP_ID = LINEAR_ATTENTION
 
 
+def _packed_qkv_views(
+    mixed_qkv: torch.Tensor,
+    *,
+    num_q_heads: int,
+    num_k_heads: int,
+    num_v_heads: int,
+    head_q: int,
+    head_k: int,
+    head_v: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Expose packed Q/K/V rows without changing storage or materializing copies."""
+    seq_len = mixed_qkv.shape[0]
+    widths = (
+        num_q_heads * head_q,
+        num_k_heads * head_k,
+        num_v_heads * head_v,
+    )
+    query, key, value = mixed_qkv.split(widths, dim=-1)
+    return (
+        query.view(1, seq_len, num_q_heads, head_q),
+        key.view(1, seq_len, num_k_heads, head_k),
+        value.view(1, seq_len, num_v_heads, head_v),
+    )
+
+
 @dataclass(frozen=True)
 class _StateBlockIndexPlan:
     checkpoint_granularity: int
@@ -320,6 +345,7 @@ class MambaAttnBackend(AttentionBackend):
     # contract (history + state) is covered once both consumers exist.
     cache_consumer_families = frozenset({"state"})
     _verify_reads_committed_recurrent_state: bool = False
+    _verify_packed_qkv_views: bool = False
 
     def __init__(self, config: AttnConfig, spec: SoftmaxAttnConfig):
         super().__init__(config, spec)
@@ -1716,16 +1742,30 @@ class MambaAttnBackend(AttentionBackend):
                 b.view(seq_len, -1),
             )
 
-        query, key, value = fused_qkv_split_gdn_prefill(
-            mixed_qkv,
-            num_q_heads=num_heads,
-            num_k_heads=num_heads,
-            num_v_heads=num_value_heads,
-            head_q=head_k_dim,
-            head_k=head_k_dim,
-            head_v=head_v_dim,
-            replay=replay_inputs,
-        )
+        # KDA can consume zero-copy strided views. When recurrent-state replay is
+        # enabled, the existing split kernel must remain because it also saves the
+        # persistent inputs needed to reconstruct accepted state later.
+        if is_target_verify and self._verify_packed_qkv_views and replay_inputs is None:
+            query, key, value = _packed_qkv_views(
+                mixed_qkv,
+                num_q_heads=num_heads,
+                num_k_heads=num_heads,
+                num_v_heads=num_value_heads,
+                head_q=head_k_dim,
+                head_k=head_k_dim,
+                head_v=head_v_dim,
+            )
+        else:
+            query, key, value = fused_qkv_split_gdn_prefill(
+                mixed_qkv,
+                num_q_heads=num_heads,
+                num_k_heads=num_heads,
+                num_v_heads=num_value_heads,
+                head_q=head_k_dim,
+                head_k=head_k_dim,
+                head_v=head_v_dim,
+                replay=replay_inputs,
+            )
 
         if is_target_verify:
             core_attn_out = self._verify_scan(

--- a/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
+++ b/python/tokenspeed/runtime/layers/attention/linear/causal_conv1d.py
@@ -46,7 +46,6 @@ def _causal_conv1d_fwd_kernel(  # continuous batching
     token_chunk_offset_ptr,
     o_ptr,  # (dim, seqlen) - actually pointing to x_ptr
     # Matrix dimensions
-    batch: tl.int32,  # actually padded_batch
     dim: tl.constexpr,
     seqlen: tl.int32,  # cu_seqlen
     num_cache_lines: tl.constexpr,
@@ -578,7 +577,6 @@ def causal_conv1d_fn(
         token_chunk_offset_ptr,
         out,
         # Matrix dimensions
-        padded_batch,
         dim,
         cu_seqlen,
         num_cache_lines,

--- a/test/runtime/test_causal_conv1d_graph_replay.py
+++ b/test/runtime/test_causal_conv1d_graph_replay.py
@@ -1,0 +1,137 @@
+"""Graph-replay coverage for the continuous-batch prefill convolution."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ci_system.ci_register import register_cuda_ci
+
+from tokenspeed.runtime.layers.attention.linear.causal_conv1d import (
+    _causal_conv1d_fwd_kernel,
+)
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
+
+_TIMED_LENGTHS = [46, 526, 20]
+
+
+def _reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    lengths: list[int],
+) -> torch.Tensor:
+    width = weight.shape[1]
+    out = torch.empty_like(x)
+    start = 0
+    for length in lengths:
+        sequence = x[:, start : start + length].float()
+        padded = F.pad(sequence, (width - 1, 0))
+        acc = sum(
+            padded[:, offset : offset + length] * weight[:, offset, None].float()
+            for offset in range(width)
+        )
+        out[:, start : start + length] = F.silu(acc).to(x.dtype)
+        start += length
+    return out[:, :start]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device")
+def test_v9_timed_partition_replays_changed_inputs() -> None:
+    torch.manual_seed(29)
+    device = torch.device("cuda")
+    dim = 32
+    width = 4
+    total_tokens = sum(_TIMED_LENGTHS)
+    x = torch.randn(
+        total_tokens,
+        dim,
+        dtype=torch.bfloat16,
+        device=device,
+    ).transpose(0, 1)
+    weight = torch.randn(dim, width, dtype=torch.bfloat16, device=device)
+    conv_states = torch.zeros(3, dim, width - 1, dtype=x.dtype, device=device)
+    cache_indices = torch.arange(3, dtype=torch.int32, device=device)
+    has_initial_state = torch.zeros(3, dtype=torch.bool, device=device)
+    query_start_loc = torch.tensor(
+        [0, *torch.tensor(_TIMED_LENGTHS).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=device,
+    )
+    batch_rows: list[int] = []
+    chunk_offsets: list[int] = []
+    for row, length in enumerate(_TIMED_LENGTHS):
+        for chunk in range((length + 7) // 8):
+            batch_rows.append(row)
+            chunk_offsets.append(chunk)
+    batch_ptr = torch.tensor(batch_rows, dtype=torch.int32, device=device)
+    token_chunk_offset = torch.tensor(
+        chunk_offsets,
+        dtype=torch.int32,
+        device=device,
+    )
+    out = torch.empty_like(x)
+
+    def launch() -> None:
+        _causal_conv1d_fwd_kernel[(len(batch_rows), 1)](
+            x,
+            weight,
+            None,
+            conv_states,
+            cache_indices,
+            has_initial_state,
+            query_start_loc,
+            batch_ptr,
+            token_chunk_offset,
+            out,
+            dim,
+            total_tokens,
+            conv_states.shape[0],
+            0,
+            x.stride(0),
+            x.stride(1),
+            weight.stride(0),
+            weight.stride(1),
+            conv_states.stride(0),
+            conv_states.stride(1),
+            conv_states.stride(2),
+            0,
+            out.stride(0),
+            out.stride(1),
+            -1,
+            HAS_BIAS=False,
+            KERNEL_WIDTH=width,
+            SILU_ACTIVATION=True,
+            HAS_INITIAL_STATES=True,
+            HAS_CACHE=True,
+            IS_CONTINUOUS_BATCHING=True,
+            USE_PAD_SLOT=True,
+            NP2_STATELEN=4,
+            BLOCK_M=8,
+            BLOCK_N=256,
+            num_stages=2,
+        )
+
+    launch()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+
+    x.copy_(torch.randn_like(x))
+    conv_states.zero_()
+    out.zero_()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        out,
+        _reference(x, weight, _TIMED_LENGTHS),
+        atol=2e-2,
+        rtol=2e-2,
+    )

--- a/test/runtime/test_gdn_state_paging.py
+++ b/test/runtime/test_gdn_state_paging.py
@@ -479,6 +479,18 @@ class VerifyMetadataTest(unittest.TestCase):
             560,
         )
 
+    def test_target_verify_reuses_graph_stable_scratch_base_rows(self):
+        rows = self.backend._verify_scratch_base_rows(3, 4)
+        grid = self.backend._verify_scratch_grid(3, 4)
+
+        self.assertIs(rows, self.backend._verify_scratch_base_rows(3, 4))
+        self.assertEqual(rows.dtype, self.torch.int32)
+        self.assertEqual(rows.tolist(), [0, 5, 10])
+        self.assertEqual(
+            grid.tolist(),
+            [[1, 2, 3, 4], [6, 7, 8, 9], [11, 12, 13, 14]],
+        )
+
 
 class GDNStatePagingGPUTest(unittest.TestCase):
     """MambaAttnBackend state paging vs the

--- a/test/runtime/test_kimi_k3_kda.py
+++ b/test/runtime/test_kimi_k3_kda.py
@@ -270,6 +270,47 @@ def test_set_kv_pool_binds_contract_state_groups(monkeypatch) -> None:
     }
 
 
+def test_kda_verify_seed_omits_only_the_recurrent_state(monkeypatch) -> None:
+    """KDA reads committed recurrence directly while GDN keeps full seeding."""
+    from tokenspeed_kernel.ops.kvcache import triton as kvcache_triton
+
+    contract = _stub_contract(prefix_granularity=4, usable_pages=8)
+    pool = _StubContractPool(
+        contract,
+        "cpu",
+        conv_dim=3 * 4 * 128,
+        width=4,
+        num_heads=4,
+        head_dim=128,
+    )
+    state_pages = {
+        group_id: torch.tensor([1, 2], dtype=torch.int32) for group_id in _STATE_GROUPS
+    }
+    calls = []
+
+    def record_copy(*_args, **kwargs):
+        calls.append(kwargs["row_bytes"])
+
+    monkeypatch.setattr(kvcache_triton, "copy_state_rows", record_copy)
+
+    kda = _backend("cpu", contract_pool=pool, spec_tokens=4)
+    kda._replay_active = False
+    kda.preallocate_verify_workspace(2, 4)
+    kda.forward_metadata = SimpleNamespace(state_in_blocks_by_group=state_pages)
+    kda._seed_verify_scratch_batched(2, 4)
+    conv_bytes = pool.get_component(0, "conv_state")[0].nbytes
+    state_bytes = pool.get_component(0, "recurrent_state")[0].nbytes
+    assert calls == [conv_bytes]
+
+    calls.clear()
+    gdn = mamba.MambaAttnBackend(*_backend_config("cpu", spec_tokens=4))
+    gdn.set_kv_pool(pool)
+    gdn.preallocate_verify_workspace(2, 4)
+    gdn.forward_metadata = SimpleNamespace(state_in_blocks_by_group=state_pages)
+    gdn._seed_verify_scratch_batched(2, 4)
+    assert calls == [conv_bytes, state_bytes]
+
+
 # ---------------------------------------------------------------------------
 # Per-group dual-index metadata
 # ---------------------------------------------------------------------------

--- a/test/runtime/test_kimi_k3_kda_eager_commit.py
+++ b/test/runtime/test_kimi_k3_kda_eager_commit.py
@@ -17,6 +17,7 @@ from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.state.kda import KdaAttnBackend
 from tokenspeed.runtime.layers.attention.backends.state.mamba import (
     MambaAttnBackend,
+    _packed_qkv_views,
 )
 from tokenspeed.runtime.layers.attention.registry import _prepare_verify_workspace
 
@@ -29,9 +30,16 @@ DEV = "cuda"
 
 
 class _Harness:
-    def __init__(self, *, eager_replay: bool, seed: int = 0):
+    def __init__(
+        self,
+        *,
+        eager_replay: bool,
+        seed: int = 0,
+        max_bs: int = 8,
+        usable_pages: int = 24,
+    ):
         torch.manual_seed(seed)
-        self.pool = _make_kimi_pool(DEV, usable_pages=24)
+        self.pool = _make_kimi_pool(DEV, usable_pages=usable_pages)
         self.contract = self.pool.arena.runtime_contract
         spec = SimpleNamespace(
             num_attention_heads=H,
@@ -44,7 +52,7 @@ class _Harness:
             dtype=torch.bfloat16,
             is_draft=False,
             speculative_num_draft_tokens=T,
-            max_bs=8,
+            max_bs=max_bs,
             components=(spec,),
             # Stub component(): this backend construction never queries components.
             component=lambda cls: None,
@@ -165,6 +173,35 @@ def _assert_committed_pages_equal(left, right, pages):
             )
 
 
+def test_packed_qkv_views_keep_projection_storage_and_stride():
+    rows, row_width, production_steps = 64, 6416, 4
+    packed_width = 3 * 16 * D
+    projection = torch.randn(rows, row_width, dtype=torch.bfloat16, device=DEV)
+    packed = projection[:, :packed_width]
+
+    query, key, value = _packed_qkv_views(
+        packed,
+        num_q_heads=16,
+        num_k_heads=16,
+        num_v_heads=16,
+        head_q=D,
+        head_k=D,
+        head_v=D,
+    )
+
+    storage_ptr = projection.untyped_storage().data_ptr()
+    for tensor in (query, key, value):
+        assert tensor.untyped_storage().data_ptr() == storage_ptr
+        assert tensor.stride()[1:] == (row_width, D, 1)
+        recurrent_view = tensor.view(16, production_steps, 16, D)
+        assert recurrent_view.stride() == (
+            production_steps * row_width,
+            row_width,
+            D,
+            1,
+        )
+
+
 def test_direct_committed_read_matches_seeded_verify_and_commit_bitwise():
     """The fallback may skip only the recurrent-state seed copy."""
     direct = _Harness(eager_replay=False, seed=73)
@@ -258,6 +295,101 @@ def test_direct_committed_read_matches_seeded_verify_and_commit_bitwise():
                 direct.pool.get_component(layer_id, component),
                 seeded.pool.get_component(layer_id, component),
             )
+
+
+def test_packed_qkv_views_match_materialized_split_across_commits():
+    """Packed views preserve verifier outputs and committed state over rounds."""
+    rpis = [0, 1]
+    viewed = _Harness(
+        eager_replay=False,
+        seed=89,
+        max_bs=len(rpis),
+        usable_pages=8,
+    )
+    materialized = _Harness(
+        eager_replay=False,
+        seed=89,
+        max_bs=len(rpis),
+        usable_pages=8,
+    )
+    for harness in (viewed, materialized):
+        harness.backend._verify = MethodType(MambaAttnBackend._verify, harness.backend)
+    materialized.backend._verify_packed_qkv_views = False
+
+    # One layer per state group covers routing without recompiling all layers.
+    for harness in (viewed, materialized):
+        harness.layer_ids = [
+            next(
+                layer_id
+                for layer_id in harness.layer_ids
+                if harness.pool.state_group_by_layer[layer_id] == group_id
+            )
+            for group_id in _STATE_GROUPS
+        ]
+
+    pages = {
+        group_id: [
+            2 + group_index * len(rpis) + request_index
+            for request_index in range(len(rpis))
+        ]
+        for group_index, group_id in enumerate(_STATE_GROUPS)
+    }
+    all_pages = [page for group_pages in pages.values() for page in group_pages]
+    assert len(all_pages) == len(set(all_pages))
+    page_ids = torch.tensor(all_pages, dtype=torch.int64, device=DEV)
+    generator = torch.Generator(device=DEV).manual_seed(93)
+    for viewed_layer, materialized_layer in zip(
+        viewed.layer_ids, materialized.layer_ids, strict=True
+    ):
+        group_id = viewed.pool.state_group_by_layer[viewed_layer]
+        assert group_id == materialized.pool.state_group_by_layer[materialized_layer]
+        for component in ("conv_state", "recurrent_state"):
+            viewed_state = viewed.pool.get_component(viewed_layer, component)
+            viewed_state[page_ids] = torch.randn(
+                (len(page_ids), *viewed_state.shape[1:]),
+                dtype=viewed_state.dtype,
+                device=DEV,
+                generator=generator,
+            )
+            materialized.pool.get_component(materialized_layer, component).copy_(
+                viewed_state
+            )
+
+    seq_lens = [8 + T] * len(rpis)
+    accepts = ([0, T], [2, 1], [T, 0], [1, 2])
+    for round_index, accepted in enumerate(accepts):
+        for harness in (viewed, materialized):
+            harness.prepare_metadata(rpis, pages, seq_lens)
+        inputs = viewed.inputs(len(rpis), 97 + round_index)
+        viewed_out = viewed.forward(inputs, len(rpis))
+        materialized_out = materialized.forward(inputs, len(rpis))
+        torch.cuda.synchronize()
+
+        write_rows = viewed.backend.forward_metadata.mamba_output_indices.long()
+        for viewed_layer, actual, expected in zip(
+            viewed.layer_ids, viewed_out, materialized_out, strict=True
+        ):
+            assert torch.equal(actual, expected), f"layer {viewed_layer}"
+            viewed_conv, viewed_state = viewed.backend._verify_scratch[viewed_layer]
+            materialized_conv, materialized_state = (
+                materialized.backend._verify_scratch[viewed_layer]
+            )
+            assert torch.equal(viewed_conv[write_rows], materialized_conv[write_rows])
+            assert torch.equal(viewed_state[write_rows], materialized_state[write_rows])
+
+        accepted_tensor = torch.tensor(accepted, dtype=torch.int32, device=DEV)
+        viewed.backend.commit_verified_state(accepted_tensor)
+        materialized.backend.commit_verified_state(accepted_tensor)
+        torch.cuda.synchronize()
+        for viewed_layer in viewed.layer_ids:
+            for component in ("conv_state", "recurrent_state"):
+                assert torch.equal(
+                    viewed.pool.get_component(viewed_layer, component),
+                    materialized.pool.get_component(viewed_layer, component),
+                )
+        seq_lens = [
+            length + count for length, count in zip(seq_lens, accepted, strict=True)
+        ]
 
 
 def test_eager_replay_matches_scratch_over_multiple_rounds_and_layers():

--- a/test/runtime/test_kimi_k3_kda_eager_commit.py
+++ b/test/runtime/test_kimi_k3_kda_eager_commit.py
@@ -11,7 +11,7 @@ from test.runtime.conftest import KIMI_STATE_GROUPS as _STATE_GROUPS
 from test.runtime.conftest import block_tables_for as _tables_for
 from test.runtime.conftest import kimi_recipe as _kimi_recipe
 from test.runtime.conftest import make_kimi_pool as _make_kimi_pool
-from types import SimpleNamespace  # noqa: E402
+from types import MethodType, SimpleNamespace  # noqa: E402
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.state.kda import KdaAttnBackend
@@ -162,6 +162,101 @@ def _assert_committed_pages_equal(left, right, pages):
                 right.pool.get_component(layer_id, "recurrent_state")[page],
                 atol=1e-5,
                 rtol=1e-3,
+            )
+
+
+def test_direct_committed_read_matches_seeded_verify_and_commit_bitwise():
+    """The fallback may skip only the recurrent-state seed copy."""
+    direct = _Harness(eager_replay=False, seed=73)
+    seeded = _Harness(eager_replay=False, seed=73)
+    for harness in (direct, seeded):
+        harness.backend._verify = MethodType(MambaAttnBackend._verify, harness.backend)
+    seeded.backend._verify_reads_committed_recurrent_state = False
+
+    def seeded_verify_scan(
+        self,
+        query,
+        key,
+        value,
+        ssm_comp,
+        ssm_scratch,
+        state_in_blocks,
+        output_indices,
+        **kwargs,
+    ):
+        del ssm_comp, state_in_blocks
+        return KdaAttnBackend._verify_scan(
+            self,
+            query,
+            key,
+            value,
+            ssm_scratch,
+            ssm_scratch,
+            output_indices[: kwargs["batch_size"], 0] - 1,
+            output_indices,
+            **kwargs,
+        )
+
+    seeded.backend._verify_scan = MethodType(seeded_verify_scan, seeded.backend)
+    rpis = [0, 1, 2]
+    pages = {
+        group_id: [2 + group * len(rpis) + i for i in range(len(rpis))]
+        for group, group_id in enumerate(_STATE_GROUPS)
+    }
+    generator = torch.Generator(device=DEV).manual_seed(79)
+    for direct_layer, seeded_layer in zip(direct.layer_ids, seeded.layer_ids):
+        direct_group = direct.pool.state_group_by_layer[direct_layer]
+        seeded_group = seeded.pool.state_group_by_layer[seeded_layer]
+        assert direct_group == seeded_group
+        page_ids = torch.tensor(pages[direct_group], dtype=torch.int64, device=DEV)
+        for component in ("conv_state", "recurrent_state"):
+            direct_pool = direct.pool.get_component(direct_layer, component)
+            seeded_pool = seeded.pool.get_component(seeded_layer, component)
+            values = torch.randn(
+                (len(page_ids), *direct_pool.shape[1:]),
+                dtype=direct_pool.dtype,
+                device=DEV,
+                generator=generator,
+            )
+            direct_pool[page_ids] = values
+            seeded_pool[page_ids] = values
+
+    committed_before = {
+        (layer_id, component): direct.pool.get_component(layer_id, component).clone()
+        for layer_id in direct.layer_ids
+        for component in ("conv_state", "recurrent_state")
+    }
+
+    seq_lens = [8 + T] * len(rpis)
+    for harness in (direct, seeded):
+        harness.prepare_metadata(rpis, pages, seq_lens)
+    inputs = direct.inputs(len(rpis), 83)
+    direct_out = direct.forward(inputs, len(rpis))
+    seeded_out = seeded.forward(inputs, len(rpis))
+    torch.cuda.synchronize()
+
+    write_rows = direct.backend.forward_metadata.mamba_output_indices.long()
+    for layer_id, actual, expected in zip(direct.layer_ids, direct_out, seeded_out):
+        assert torch.equal(actual, expected)
+        direct_conv, direct_state = direct.backend._verify_scratch[layer_id]
+        seeded_conv, seeded_state = seeded.backend._verify_scratch[layer_id]
+        assert torch.equal(direct_conv[write_rows], seeded_conv[write_rows])
+        assert torch.equal(direct_state[write_rows], seeded_state[write_rows])
+        for component in ("conv_state", "recurrent_state"):
+            assert torch.equal(
+                direct.pool.get_component(layer_id, component),
+                committed_before[(layer_id, component)],
+            )
+
+    accepted = torch.tensor([1, T, 2], dtype=torch.int32, device=DEV)
+    direct.backend.commit_verified_state(accepted)
+    seeded.backend.commit_verified_state(accepted)
+    torch.cuda.synchronize()
+    for layer_id in direct.layer_ids:
+        for component in ("conv_state", "recurrent_state"):
+            assert torch.equal(
+                direct.pool.get_component(layer_id, component),
+                seeded.pool.get_component(layer_id, component),
             )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/triton/fla_kda_recurrent.py
@@ -394,6 +394,29 @@ def fused_recurrent_kda_mtp_fwd_kernel(
         p_beta += stride_beta_tok
 
 
+def _kda_mtp_launch_config(
+    batch_size: int,
+    draft_tokens: int,
+    num_heads: int,
+    num_value_heads: int,
+    key_dim: int,
+    value_dim: int,
+    recurrent_layout: str,
+) -> tuple[int, int]:
+    """Choose the measured GLM-5.3-Flash target-verify launch schedule."""
+    if (
+        batch_size,
+        draft_tokens,
+        num_heads,
+        num_value_heads,
+        key_dim,
+        value_dim,
+        recurrent_layout,
+    ) == (16, 4, 16, 16, 128, 128, "v_major"):
+        return 2, 3
+    return 4, 2
+
+
 def fused_recurrent_kda_mtp(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -443,6 +466,15 @@ def fused_recurrent_kda_mtp(
     for t, d in ((q, K), (k, K), (v, V), (g, K)):
         assert t.stride(-1) == 1 and t.stride(-2) == d, "inner dims must be dense"
     out = torch.empty(B, T, HV, V, dtype=v.dtype, device=v.device)
+    num_warps, num_stages = _kda_mtp_launch_config(
+        B,
+        T,
+        H,
+        HV,
+        K,
+        V,
+        recurrent_layout,
+    )
     grid = (triton.cdiv(V, 32) * B * HV,)
     fused_recurrent_kda_mtp_fwd_kernel[grid](
         q=q,
@@ -480,8 +512,8 @@ def fused_recurrent_kda_mtp(
         APPLY_BETA_SIGMOID=use_beta_sigmoid_in_kernel,
         HAS_DT_BIAS=dt_bias is not None,
         USE_LOWER_BOUND=lower_bound is not None,
-        num_warps=4,
-        num_stages=2,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return out
 

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -299,6 +299,125 @@ def test_glm53_flash_mtp_graph_shape_matches_baseline_and_replays() -> None:
     )
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_mtp_direct_committed_read_matches_seeded_scratch_and_replays() -> None:
+    """Separate read/write pools replace the recurrent-state seed exactly."""
+    from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
+        fused_recurrent_kda_mtp,
+    )
+
+    torch.manual_seed(91)
+    device = "cuda"
+    batch, steps, heads, dim = 3, 4, 4, 128
+    pages = 7
+    row_elements = heads * dim * dim
+    page_stride = row_elements + 37
+    committed_storage = torch.randn(
+        pages * page_stride, dtype=torch.float32, device=device
+    )
+    committed = torch.as_strided(
+        committed_storage,
+        size=(pages, heads, dim, dim),
+        stride=(page_stride, dim * dim, dim, 1),
+    )
+    q = torch.randn(batch, steps, heads, dim, dtype=torch.bfloat16, device=device)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    gate = torch.randn_like(q)
+    beta = torch.randn(batch, steps, heads, dtype=torch.bfloat16, device=device)
+    a_log = torch.randn(heads, dtype=torch.float32, device=device)
+    dt_bias = torch.randn(heads, dim, dtype=torch.float32, device=device)
+    read_indices = torch.tensor([-1, 4, 1], dtype=torch.int32, device=device)
+    scratch_rows = batch * (steps + 1)
+    bases = torch.arange(batch, dtype=torch.int32, device=device) * (steps + 1)
+    write_indices = bases[:, None] + torch.arange(
+        1, steps + 1, dtype=torch.int32, device=device
+    )
+
+    def run(
+        state_pool: torch.Tensor,
+        initial_rows: torch.Tensor,
+        state_out: torch.Tensor,
+    ) -> torch.Tensor:
+        return fused_recurrent_kda_mtp(
+            q,
+            k,
+            v,
+            gate,
+            beta,
+            a_log,
+            dt_bias,
+            state_pool,
+            initial_rows,
+            write_indices,
+            h_pool_out=state_out,
+            lower_bound=-5.0,
+            recurrent_layout="v_major",
+        )
+
+    def seeded_oracle(indices: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        scratch = torch.full(
+            (scratch_rows, heads, dim, dim),
+            13.0,
+            dtype=torch.float32,
+            device=device,
+        )
+        scratch[bases.long()] = 0
+        valid = indices >= 0
+        scratch[bases[valid].long()] = committed[indices[valid].long()]
+        return run(scratch, bases, scratch), scratch
+
+    expected_out, expected_scratch = seeded_oracle(read_indices)
+    direct_scratch = torch.full_like(expected_scratch, -17.0)
+    committed_before = committed_storage.clone()
+    actual_out = run(committed, read_indices, direct_scratch)
+    torch.cuda.synchronize()
+
+    assert torch.equal(actual_out, expected_out)
+    assert torch.equal(
+        direct_scratch[write_indices.long()],
+        expected_scratch[write_indices.long()],
+    )
+    assert torch.equal(committed_storage, committed_before)
+    assert committed.data_ptr() != direct_scratch.data_ptr()
+
+    accepted = torch.tensor([1, 4, 2], dtype=torch.int64, device=device)
+    destinations = torch.tensor([2, 3, 5], dtype=torch.int64, device=device)
+    expected_committed = committed.clone()
+    actual_committed = committed.clone()
+    rows = bases.long() + accepted
+    expected_committed[destinations] = expected_scratch[rows]
+    actual_committed[destinations] = direct_scratch[rows]
+    assert torch.equal(actual_committed, expected_committed)
+
+    stable_indices = torch.tensor([1, -1, 4], dtype=torch.int32, device=device)
+    graph_scratch = torch.empty_like(direct_scratch)
+    run(committed, stable_indices, graph_scratch)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out = run(committed, stable_indices, graph_scratch)
+    graph.replay()
+    torch.cuda.synchronize()
+    first_graph_out = graph_out.clone()
+
+    stable_indices.copy_(torch.tensor([-1, 3, 5], dtype=torch.int32, device=device))
+    committed[3].copy_(torch.randn_like(committed[3]))
+    committed[5].copy_(torch.randn_like(committed[5]))
+    changed_committed = committed_storage.clone()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    replay_expected_out, replay_expected_scratch = seeded_oracle(stable_indices)
+    assert not torch.equal(graph_out, first_graph_out)
+    assert torch.equal(graph_out, replay_expected_out)
+    assert torch.equal(
+        graph_scratch[write_indices.long()],
+        replay_expected_scratch[write_indices.long()],
+    )
+    assert torch.equal(committed_storage, changed_committed)
+
+
 @pytest.mark.parametrize(
     "recurrent_layout,store_states",
     [

--- a/tokenspeed-kernel/test/ops/test_kda_recurrent.py
+++ b/tokenspeed-kernel/test/ops/test_kda_recurrent.py
@@ -174,6 +174,131 @@ def test_kda_verify_split_launch_requires_both_hoists_and_honors_overrides() -> 
     ) == (32, 8, 5)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_glm53_flash_mtp_graph_shape_matches_baseline_and_replays() -> None:
+    """The tuned TP4 graph shape preserves the established kernel output."""
+    from tokenspeed_kernel._triton import triton
+    from tokenspeed_kernel.thirdparty.triton.fla_kda_recurrent import (
+        fused_recurrent_kda_mtp,
+        fused_recurrent_kda_mtp_fwd_kernel,
+    )
+
+    torch.manual_seed(16)
+    dev = "cuda"
+    batch, steps, heads, key_dim, value_dim = 16, 4, 16, 128, 128
+    q = torch.randn(batch, steps, heads, key_dim, dtype=torch.bfloat16, device=dev)
+    k = torch.randn_like(q)
+    v = torch.randn(batch, steps, heads, value_dim, dtype=torch.bfloat16, device=dev)
+    g = torch.randn_like(q)
+    beta = torch.randn(batch, steps, heads, dtype=torch.bfloat16, device=dev)
+    a_log = torch.randn(heads, dtype=torch.float32, device=dev)
+    dt_bias = torch.randn(heads, key_dim, dtype=torch.float32, device=dev)
+    read_indices = torch.arange(batch, dtype=torch.int32, device=dev)
+    write_indices = batch + torch.arange(
+        batch * steps, dtype=torch.int32, device=dev
+    ).view(batch, steps)
+    pages = batch * (steps + 1)
+    initial = torch.randn(
+        batch,
+        heads,
+        value_dim,
+        key_dim,
+        dtype=torch.float32,
+        device=dev,
+    )
+
+    reference_pool = torch.zeros(
+        pages,
+        heads,
+        value_dim,
+        key_dim,
+        dtype=torch.float32,
+        device=dev,
+    )
+    reference_pool[:batch].copy_(initial)
+    reference_output = torch.empty_like(v)
+    grid = triton.cdiv(value_dim, 32) * batch * heads
+    fused_recurrent_kda_mtp_fwd_kernel[(grid,)](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        A_log=a_log,
+        dt_bias=dt_bias,
+        o=reference_output,
+        h_pool=reference_pool,
+        h_pool_out=reference_pool,
+        read_indices=read_indices,
+        write_indices=write_indices.reshape(-1),
+        lower_bound=-5.0,
+        stride_q_tok=q.stride(1),
+        stride_k_tok=k.stride(1),
+        stride_v_tok=v.stride(1),
+        stride_g_tok=g.stride(1),
+        stride_beta_tok=beta.stride(1),
+        scale=key_dim**-0.5,
+        N=batch,
+        T=steps,
+        H=heads,
+        HV=heads,
+        K=key_dim,
+        V=value_dim,
+        BK=key_dim,
+        BV=32,
+        stride_state_page=reference_pool.stride(0),
+        stride_state_out_page=reference_pool.stride(0),
+        V_MAJOR=True,
+        USE_QK_L2NORM_IN_KERNEL=True,
+        USE_GATE_IN_KERNEL=True,
+        APPLY_BETA_SIGMOID=True,
+        HAS_DT_BIAS=True,
+        USE_LOWER_BOUND=True,
+        num_warps=4,
+        num_stages=2,
+    )
+
+    tuned_pool = torch.zeros_like(reference_pool)
+    tuned_pool[:batch].copy_(initial)
+
+    def run_tuned() -> torch.Tensor:
+        return fused_recurrent_kda_mtp(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            a_log,
+            dt_bias,
+            tuned_pool,
+            read_indices,
+            write_indices,
+            lower_bound=-5.0,
+            recurrent_layout="v_major",
+        )
+
+    tuned_output = run_tuned()
+    torch.testing.assert_close(
+        tuned_output.float(), reference_output.float(), atol=1e-4, rtol=1e-4
+    )
+    torch.testing.assert_close(
+        tuned_pool[batch:], reference_pool[batch:], atol=1e-4, rtol=1e-4
+    )
+
+    run_tuned()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = run_tuned()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(graph_output, tuned_output, atol=0, rtol=0)
+    torch.testing.assert_close(
+        tuned_pool[batch:], reference_pool[batch:], atol=1e-4, rtol=1e-4
+    )
+
+
 @pytest.mark.parametrize(
     "recurrent_layout,store_states",
     [


### PR DESCRIPTION
## Summary

Optimize the recurrent-attention path used by GLM-5.3-Flash speculative-token
verification, building on the KPool branch below it.

- Use the measured two-warp, three-stage recurrent schedule for the exact TP4,
  batch-16, four-token verification shape while preserving the existing
  schedule for other shapes.
- Read initial recurrent state directly from committed cache pages and keep
  speculative checkpoint writes in scratch storage, removing the full state
  seed copy without changing accepted-state commits.
- Reuse graph-stable scratch base rows, removing 34 small integer launches from
  the 34-layer verification graph.
- Expose packed query, key, and value output as zero-copy views when safe;
  retain materialization when replay must preserve inputs for accepted-state
  reconstruction and on other model paths.
- Remove an unused padded-batch argument from prompt convolution so warmup and
  tail partitions reuse one compiled kernel.

The direct committed-state path applies to the portable recurrent verifier.
The related recurrent architecture retains full seeding, and NVIDIA's fused
verifier path is unchanged.

## ShareGPT performance

The five-commit recurrent-attention group was measured against PR 1 (https://github.com/lightseekorg/tokenspeed/pull/1429):

| Metric | PR 1 | This PR | Change |
|---|---:|---:|---:|
| Output throughput | 1,020.272 tok/s | 1,103.155 tok/s | +8.12% |
| Decode/user | 86.265 tok/s | 92.197 tok/s | +6.88% |
| Mean TPOT | 11.592 ms | 10.846 ms | 6.43% lower |
| Mean ITL | 36.622 ms | 35.500 ms | 3.06% lower |
| Mean TTFT | 501.905 ms | 501.476 ms | 0.09% lower |
| Mean end-to-end latency | 6,425.501 ms | 6,042.897 ms | 5.95% lower |

Supporting graph-replay measurements showed a 12.10% faster recurrent launch,
a 22.93% faster 34-layer verifier region from direct state reads, a 4.02%
improvement from cached scratch rows, and a 12.24% reduction for the verifier
producer-plus-recurrence graph from zero-copy packed views. These isolated
percentages overlap and should not be added together; the table is the
PR-level result.

The ShareGPT workload used four MI350X GPUs, attention TP4, MoE TP4/EP1, MTP3
with four-token verification, 16 concurrent requests, and 512 output tokens
per request. These measurements were collected on `upstream/main` `b174a318`.
The current branch carries the same executable feature changes on newer
`upstream/main` `5af23865`, but that resulting tree was not benchmarked.