### PR TITLE
perf(cache): reuse MLA prefill writes across row alignment

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -772,7 +772,10 @@ def _set_mla_kv_buffer_kernel(
         tl.extra.cuda.gdc_launch_dependents()
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["n_loc"],
+    do_not_specialize_on_alignment=["n_loc"],
+)
 def _set_mla_kv_buffer_per_loc_kernel(
     kv_buffer_ptr,
     cache_k_nope_ptr,


### PR DESCRIPTION
## Summary

Keep the multi-head latent-attention (MLA) cache-write row count dynamic in
both value and alignment. Aligned and unaligned prompt partitions now reuse a
compiled kernel for each real launch schedule and location-index width.

This leaves launch grids, two- and four-location schedules, tail masking,
memory accesses, and arithmetic unchanged. In the motivating workload it
reduced the relevant compiled variants from eight to four and eliminated the
eight compiler executions that previously appeared after benchmark timing had
started.

## ShareGPT performance

The single-commit boundary was measured against PR 2 (https://github.com/lightseekorg/tokenspeed/pull/1430):

| Metric | PR 2 | This PR | Change |
|---|---:|---:|---:|
| Output throughput | 1,103.155 tok/s | 1,107.569 tok/s | +0.40% |
| Decode/user | 92.197 tok/s | 92.546 tok/s | +0.38% |
| Mean TPOT | 10.846 ms | 10.805 ms | 0.38% lower |
| Mean ITL | 35.500 ms | 35.367 ms | 0.38% lower |
| Mean TTFT | 501.476 ms | 502.044 ms | 0.11% higher |
| Mean end-to-end latency | 6,042.897 ms | 6,023.536 ms | 0.32% lower |

A separate six-sample-per-state comparison across both startup orders measured
+0.31% output throughput, but decode/user and TPOT moved 0.34% and 0.33% in the
wrong direction, and startup-order drift was larger than the candidate delta.
The supported claim is removal of request-shape compilation with end-to-end
non-regression, not a proven steady-state throughput gain.

The ShareGPT workload used four MI350X GPUs, attention TP4, MoE TP4/EP1, MTP3
with four-token verification, 16 concurrent requests, and 512 output tokens
per request. These measurements were collected on `upstream/main` `b174a318`.
The current branch carries the same executable feature change on newer
`upstream/main` `5af23865`, but that resulting tree was not benchmarked.