### PR TITLE
perf(amd): Optimize GLM-5.3-Flash DSA decode on MI350X

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/attention.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/attention.py
@@ -159,6 +159,7 @@ def _dsa_dense_mfma_kv_kernel(
     FP8_INPUTS: gl.constexpr,
     NATIVE_FP8: gl.constexpr,
     NATIVE_E5M2: gl.constexpr,
+    COLUMN_PARALLEL: gl.constexpr,
     TRIM_EMPTY_TILES: gl.constexpr,
     NUM_KV_SPLITS: gl.constexpr,
 ):
@@ -171,6 +172,14 @@ def _dsa_dense_mfma_kv_kernel(
     ROPE_LOAD_VEC: gl.constexpr = 4 if NATIVE_FP8 else 2
     SHARED_INTERVAL: gl.constexpr = 1024 if NATIVE_FP8 else 512
     SHARED_PADDING: gl.constexpr = 32 if NATIVE_FP8 else 16
+    # The BF16 no-RoPE tile owns one MFMA row. Split its columns across the
+    # four waves, then restore the original score layout before softmax.
+    mfma_qk: gl.constexpr = gl.amd.cdna4.AMDMFMALayout(
+        version=4,
+        instr_shape=[16, 16, instr_k],
+        transposed=True,
+        warps_per_cta=([1, 4] if COLUMN_PARALLEL else [4, 1]),
+    )
     mfma_s: gl.constexpr = gl.amd.cdna4.AMDMFMALayout(
         version=4,
         instr_shape=[16, 16, instr_k],
@@ -181,7 +190,7 @@ def _dsa_dense_mfma_kv_kernel(
         version=4,
         instr_shape=[16, 16, instr_k],
         transposed=True,
-        warps_per_cta=[4, 1],
+        warps_per_cta=([1, 4] if COLUMN_PARALLEL else [4, 1]),
     )
 
     _qlora_tpw_k: gl.constexpr = min(64, D_V // INPUT_VEC)
@@ -249,22 +258,22 @@ def _dsa_dense_mfma_kv_kernel(
 
     dot_qlora_a: gl.constexpr = gl.DotOperandLayout(
         operand_index=0,
-        parent=mfma_s,
+        parent=mfma_qk,
         k_width=QK_K_WIDTH,
     )
     dot_qrope_a: gl.constexpr = gl.DotOperandLayout(
         operand_index=0,
-        parent=mfma_s,
+        parent=mfma_qk,
         k_width=QK_K_WIDTH,
     )
     dot_klora_b: gl.constexpr = gl.DotOperandLayout(
         operand_index=1,
-        parent=mfma_s,
+        parent=mfma_qk,
         k_width=QK_K_WIDTH,
     )
     dot_krope_b: gl.constexpr = gl.DotOperandLayout(
         operand_index=1,
-        parent=mfma_s,
+        parent=mfma_qk,
         k_width=QK_K_WIDTH,
     )
     dot_p_a: gl.constexpr = gl.DotOperandLayout(
@@ -569,10 +578,11 @@ def _dsa_dense_mfma_kv_kernel(
         if HAS_ROPE:
             k_rope_t_dot = smem_krope.index(cur_buf).load(dot_krope_b)
 
-        scores = gl.zeros([BLOCK_H, TILE_K], dtype=gl.float32, layout=mfma_s)
+        scores = gl.zeros([BLOCK_H, TILE_K], dtype=gl.float32, layout=mfma_qk)
         scores = gl.amd.cdna4.mfma(q_lora_dot, k_lora_t_dot, scores)
         if HAS_ROPE:
             scores = gl.amd.cdna4.mfma(q_rope_dot, k_rope_t_dot, scores)
+        scores = gl.convert_layout(scores, mfma_s)
         scores = scores * scale
 
         offs_h_mma = hg_offset + gl.arange(
@@ -613,10 +623,11 @@ def _dsa_dense_mfma_kv_kernel(
     if HAS_ROPE:
         k_rope_t_dot = smem_krope.index(cur_buf).load(dot_krope_b)
 
-    scores = gl.zeros([BLOCK_H, TILE_K], dtype=gl.float32, layout=mfma_s)
+    scores = gl.zeros([BLOCK_H, TILE_K], dtype=gl.float32, layout=mfma_qk)
     scores = gl.amd.cdna4.mfma(q_lora_dot, k_lora_t_dot, scores)
     if HAS_ROPE:
         scores = gl.amd.cdna4.mfma(q_rope_dot, k_rope_t_dot, scores)
+    scores = gl.convert_layout(scores, mfma_s)
     scores = scores * scale
 
     offs_h_mma = hg_offset + gl.arange(
@@ -1167,6 +1178,11 @@ def _run_dense_kv(
         NATIVE_FP8=(q.dtype == kv_cache.dtype and q.dtype in _FP8_DTYPES),
         NATIVE_E5M2=(
             q.dtype == torch.float8_e5m2 and kv_cache.dtype == torch.float8_e5m2
+        ),
+        COLUMN_PARALLEL=(
+            q.dtype == torch.bfloat16
+            and kv_cache.dtype == torch.bfloat16
+            and qk_rope_head_dim == 0
         ),
         TRIM_EMPTY_TILES=int(max_seqlen_k) < int(topk_slots.shape[1]),
         NUM_KV_SPLITS=num_kv_splits,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/attention.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/dsa/attention.py
@@ -1024,12 +1024,15 @@ def _select_num_kv_splits(
         return 1
     if not is_fp8:
         # This tuning comes from GLM-5.3-Flash. Split sufficiently large selected-KV
-        # rows across CTAs so the launch provides enough parallel work to fill the GPU.
+        # rows across CTAs so the launch provides enough parallel work to fill the
+        # GPU.
+        # Pooled selection can append up to three tail slots to the configured
+        # 2,048-token budget, so graph captures use widths from 2,048 through 2,051.
         if (
             int(qk_rope_head_dim) == 0
             and int(num_heads) == 16
-            and int(topk_width) == 2048
-            and work_tiles == 64
+            and 2048 <= int(topk_width) <= 2051
+            and work_tiles >= 64
         ):
             if int(num_tokens) == 16:
                 return 16

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/dsa_topk.py
@@ -229,14 +229,15 @@ def local_topk_to_global_slots(
     return global_slots, lens
 
 
-@triton.jit
+@triton.jit(
+    do_not_specialize=["total"],
+    do_not_specialize_on_alignment=["total"],
+)
 def _workspace_topk_to_global_slots_kernel(
     out_ptr,
     workspace_indices_ptr,
-    workspace_indices_stride,
     kv_workspace_slots_ptr,
     total,
-    topk: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -295,10 +296,8 @@ def workspace_topk_to_global_slots(
     _workspace_topk_to_global_slots_kernel[(triton.cdiv(total, block),)](
         out_view,
         workspace_indices,
-        workspace_indices.stride(0),
         kv_workspace_slots,
         total=total,
-        topk=workspace_indices.shape[1],
         BLOCK=block,
         num_warps=4,
         num_stages=1,

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
@@ -1650,18 +1650,39 @@ def test_dsa_native_fp8_split_schedule(
 
 
 @pytest.mark.parametrize(
-    ("tokens", "qk_rope_head_dim", "expected_splits"),
-    ((1, 0, 1), (16, 0, 16), (32, 0, 1), (64, 0, 4), (64, 64, 1)),
+    (
+        "tokens",
+        "topk_width",
+        "max_seqlen_k",
+        "qk_rope_head_dim",
+        "expected_splits",
+    ),
+    (
+        (1, 2048, 2047, 0, 1),
+        (16, 2048, 2047, 0, 16),
+        (32, 2048, 2047, 0, 1),
+        (64, 2048, 2047, 0, 4),
+        (16, 2051, 131072, 0, 16),
+        (64, 2049, 131072, 0, 4),
+        (64, 2051, 131072, 0, 4),
+        (64, 2051, 1961, 0, 1),
+        (64, 2051, 131072, 64, 1),
+        (64, 2052, 131072, 0, 1),
+    ),
 )
 def test_dsa_glm53_bf16_split_schedule(
-    tokens: int, qk_rope_head_dim: int, expected_splits: int
+    tokens: int,
+    topk_width: int,
+    max_seqlen_k: int,
+    qk_rope_head_dim: int,
+    expected_splits: int,
 ) -> None:
     assert (
         gfx950_dsa_backend._select_num_kv_splits(
             num_tokens=tokens,
             num_heads=16,
-            topk_width=2048,
-            max_seqlen_k=2047,
+            topk_width=topk_width,
+            max_seqlen_k=max_seqlen_k,
             is_fp8=False,
             qk_rope_head_dim=qk_rope_head_dim,
         )
@@ -1678,7 +1699,7 @@ def test_dsa_decode_glm53_flash_bf16_split_mfma(tokens: int) -> None:
     device = "cuda"
     num_heads = 16
     num_slots = 256
-    topk = 2048
+    topk = 2051
     kv_lora_rank = 512
     qk_nope_head_dim = 256
     generator = _generator(device, 1204 + tokens)
@@ -1707,7 +1728,7 @@ def test_dsa_decode_glm53_flash_bf16_split_mfma(tokens: int) -> None:
         sparse_kv_cache=None,
         topk_slots=topk_slots,
         topk_lens=topk_lens,
-        max_seqlen_k=2047,
+        max_seqlen_k=131072,
         qk_nope_head_dim=qk_nope_head_dim,
         kv_lora_rank=kv_lora_rank,
         qk_rope_head_dim=0,
@@ -1728,6 +1749,76 @@ def test_dsa_decode_glm53_flash_bf16_split_mfma(tokens: int) -> None:
     assert out.dtype == torch.bfloat16
     assert torch.isfinite(out).all()
     torch.testing.assert_close(out.float(), ref.float(), rtol=8e-2, atol=8e-2)
+
+
+@pytest.mark.skipif(
+    not is_cdna4(),
+    reason="the tested DSA kernel currently only supports gfx950",
+)
+def test_dsa_decode_glm53_flash_bf16_split_graph_tracks_live_lengths() -> None:
+    device = "cuda"
+    tokens = 16
+    num_heads = 16
+    num_slots = 512
+    topk = 2051
+    kv_lora_rank = 512
+    qk_nope_head_dim = 256
+    generator = _generator(device, 1220)
+    q = _randn_bf16(
+        (tokens, num_heads, kv_lora_rank), device=device, generator=generator
+    )
+    kv_cache = _randn_bf16(
+        (num_slots, kv_lora_rank), device=device, generator=generator
+    )
+    topk_slots = torch.full((tokens, topk), -1, device=device, dtype=torch.int32)
+    topk_lens = torch.empty(tokens, device=device, dtype=torch.int32)
+    out = torch.empty(
+        (tokens, num_heads, kv_lora_rank), device=device, dtype=torch.bfloat16
+    )
+    softmax_scale = 1.0 / math.sqrt(qk_nope_head_dim)
+
+    def invoke() -> None:
+        gluon_dsa_decode(
+            q=q,
+            kv_cache=kv_cache,
+            sparse_kv_cache=None,
+            topk_slots=topk_slots,
+            topk_lens=topk_lens,
+            max_seqlen_k=131072,
+            qk_nope_head_dim=qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=0,
+            softmax_scale=softmax_scale,
+            page_size=64,
+            q_len_per_req=4,
+            out=out,
+        )
+
+    topk_lens.fill_(13)
+    topk_slots[:, :13] = torch.arange(13, device=device, dtype=torch.int32)
+    invoke()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        invoke()
+
+    for visible in (13, 449):
+        topk_slots.fill_(-1)
+        topk_lens.fill_(visible)
+        selected = torch.arange(visible, device=device, dtype=torch.int32)
+        for row in range(tokens):
+            topk_slots[row, :visible] = torch.roll(selected, row)
+        graph.replay()
+        torch.cuda.synchronize()
+        ref = _dsa_reference(
+            q,
+            kv_cache,
+            torch.empty((num_slots, 0), dtype=q.dtype, device=device),
+            topk_slots,
+            topk_lens,
+            softmax_scale,
+        )
+        torch.testing.assert_close(out.float(), ref.float(), rtol=8e-2, atol=8e-2)
 
 
 @pytest.mark.skipif(

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_dsa_amd.py
@@ -1755,15 +1755,17 @@ def test_dsa_decode_glm53_flash_bf16_split_mfma(tokens: int) -> None:
     not is_cdna4(),
     reason="the tested DSA kernel currently only supports gfx950",
 )
-def test_dsa_decode_glm53_flash_bf16_split_graph_tracks_live_lengths() -> None:
+@pytest.mark.parametrize("tokens", (16, 64))
+def test_dsa_decode_glm53_flash_bf16_split_graph_tracks_live_lengths(
+    tokens: int,
+) -> None:
     device = "cuda"
-    tokens = 16
     num_heads = 16
-    num_slots = 512
+    num_slots = 2051
     topk = 2051
     kv_lora_rank = 512
     qk_nope_head_dim = 256
-    generator = _generator(device, 1220)
+    generator = _generator(device, 1220 + tokens)
     q = _randn_bf16(
         (tokens, num_heads, kv_lora_rank), device=device, generator=generator
     )
@@ -1772,12 +1774,15 @@ def test_dsa_decode_glm53_flash_bf16_split_graph_tracks_live_lengths() -> None:
     )
     topk_slots = torch.full((tokens, topk), -1, device=device, dtype=torch.int32)
     topk_lens = torch.empty(tokens, device=device, dtype=torch.int32)
-    out = torch.empty(
+    graph_out = torch.empty(
+        (tokens, num_heads, kv_lora_rank), device=device, dtype=torch.bfloat16
+    )
+    eager_out = torch.empty(
         (tokens, num_heads, kv_lora_rank), device=device, dtype=torch.bfloat16
     )
     softmax_scale = 1.0 / math.sqrt(qk_nope_head_dim)
 
-    def invoke() -> None:
+    def invoke(out: torch.Tensor) -> None:
         gluon_dsa_decode(
             q=q,
             kv_cache=kv_cache,
@@ -1796,13 +1801,13 @@ def test_dsa_decode_glm53_flash_bf16_split_graph_tracks_live_lengths() -> None:
 
     topk_lens.fill_(13)
     topk_slots[:, :13] = torch.arange(13, device=device, dtype=torch.int32)
-    invoke()
+    invoke(graph_out)
     torch.cuda.synchronize()
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        invoke()
+        invoke(graph_out)
 
-    for visible in (13, 449):
+    for visible in (13, 449, 526, 1961):
         topk_slots.fill_(-1)
         topk_lens.fill_(visible)
         selected = torch.arange(visible, device=device, dtype=torch.int32)
@@ -1810,6 +1815,10 @@ def test_dsa_decode_glm53_flash_bf16_split_graph_tracks_live_lengths() -> None:
             topk_slots[row, :visible] = torch.roll(selected, row)
         graph.replay()
         torch.cuda.synchronize()
+        replayed = graph_out.clone()
+        invoke(eager_out)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(replayed, eager_out, rtol=0.0, atol=0.0)
         ref = _dsa_reference(
             q,
             kv_cache,
@@ -1818,7 +1827,7 @@ def test_dsa_decode_glm53_flash_bf16_split_graph_tracks_live_lengths() -> None:
             topk_lens,
             softmax_scale,
         )
-        torch.testing.assert_close(out.float(), ref.float(), rtol=8e-2, atol=8e-2)
+        torch.testing.assert_close(replayed.float(), ref.float(), rtol=8e-2, atol=8e-2)
 
 
 @pytest.mark.skipif(

--- a/tokenspeed-kernel/test/ops/test_attention_dsa.py
+++ b/tokenspeed-kernel/test/ops/test_attention_dsa.py
@@ -304,6 +304,98 @@ def test_dsa_workspace_topk_to_global_slots(device: str) -> None:
     torch.testing.assert_close(slots.cpu(), expected.cpu())
 
 
+@pytest.mark.parametrize("total", [1, 255, 256, 257, 513])
+def test_dsa_workspace_conversion_tracks_runtime_total(device: str, total: int) -> None:
+    storage = torch.arange(total * 2, device=device, dtype=torch.int32).view(1, -1)
+    storage.remainder_(97)
+    workspace_indices = storage[:, ::2]
+    workspace_indices[:, ::11] = -1
+    output_storage = torch.empty((1, total * 2), device=device, dtype=torch.int32)
+    out = output_storage[:, ::2]
+    kv_workspace_slots = torch.arange(97, device=device, dtype=torch.int64) * 3 + 5
+    if total > 1:
+        assert not workspace_indices.is_contiguous()
+        assert not out.is_contiguous()
+
+    actual = dsa_workspace_topk_to_global_slots(
+        workspace_indices=workspace_indices,
+        kv_workspace_slots=kv_workspace_slots,
+        out=out,
+    )
+    safe_indices = workspace_indices.clamp_min(0).long()
+    expected = kv_workspace_slots[safe_indices].to(torch.int32)
+    expected.masked_fill_(workspace_indices < 0, -1)
+
+    assert actual.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(actual, expected)
+
+
+def test_dsa_workspace_conversion_empty_and_error_contracts() -> None:
+    workspace_indices = torch.empty((0, 3), dtype=torch.int32)
+    kv_workspace_slots = torch.empty(4, dtype=torch.int64)
+    out = torch.empty_like(workspace_indices)
+
+    actual = dsa_workspace_topk_to_global_slots(
+        workspace_indices=workspace_indices,
+        kv_workspace_slots=kv_workspace_slots,
+        out=out,
+    )
+
+    assert actual is out
+    with pytest.raises(TypeError, match="must be int32"):
+        dsa_workspace_topk_to_global_slots(
+            workspace_indices=workspace_indices.float(),
+            kv_workspace_slots=kv_workspace_slots,
+        )
+    with pytest.raises(ValueError, match=r"\[tokens, topk\]"):
+        dsa_workspace_topk_to_global_slots(
+            workspace_indices=torch.empty(0, dtype=torch.int32),
+            kv_workspace_slots=kv_workspace_slots,
+        )
+    with pytest.raises(ValueError, match="must be 1-D"):
+        dsa_workspace_topk_to_global_slots(
+            workspace_indices=workspace_indices,
+            kv_workspace_slots=kv_workspace_slots.view(2, 2),
+        )
+
+
+def test_dsa_workspace_conversion_graph_replay(device: str) -> None:
+    total = 257
+    workspace_indices = torch.arange(total, device=device, dtype=torch.int32).view(
+        1, total
+    )
+    workspace_indices.remainder_(97)
+    kv_workspace_slots = torch.arange(97, device=device, dtype=torch.int64) * 7 + 11
+    out = torch.empty_like(workspace_indices)
+
+    def run() -> torch.Tensor:
+        return dsa_workspace_topk_to_global_slots(
+            workspace_indices=workspace_indices,
+            kv_workspace_slots=kv_workspace_slots,
+            out=out,
+        )
+
+    run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+
+    workspace_indices.copy_(
+        torch.arange(total - 1, -1, -1, device=device, dtype=torch.int32).view(1, total)
+        % 97
+    )
+    workspace_indices[:, ::13] = -1
+    graph.replay()
+    torch.cuda.synchronize()
+
+    safe_indices = workspace_indices.clamp_min(0).long()
+    expected = kv_workspace_slots[safe_indices].to(torch.int32)
+    expected.masked_fill_(workspace_indices < 0, -1)
+    assert captured is out
+    torch.testing.assert_close(captured, expected)
+
+
 def _pack_sparse_kv(
     latent: torch.Tensor,
     rope: torch.Tensor,


### PR DESCRIPTION
## Summary

Optimize GLM-5.3-Flash BF16 dynamic sparse attention (DSA) for production
decode and verification graph shapes, while eliminating request-shape
recompilation in sparse-prompt slot conversion.

- Extend the GFX950 work-splitting schedule to the actual 2,048-2,051 selected
  slot widths used by the captured graph, retaining 16 splits for 16 rows and
  four splits for 64 rows.
- Distribute selected-value matrix columns across GPU waves instead of
  duplicating most matrix work along the row axis. This removes register spills
  while preserving masking, softmax, and reduction order.
- Keep the portable selected-slot conversion workspace size as a runtime bound
  so request-dependent sizes share one compiled kernel.

The first two changes are GFX950-specific kernel optimizations. The conversion
change is in the architecture-neutral Triton layer.

## ShareGPT performance

The three-commit DSA group was measured between adjacent historical operation
boundaries (measured against PR 3, https://github.com/lightseekorg/tokenspeed/pull/1432):

| Metric | PR 3 | This PR | Change |
|---|---:|---:|---:|
| Output throughput | 1,105.522 tok/s | 1,211.568 tok/s | +9.59% |
| Decode/user | 92.443 tok/s | 101.652 tok/s | +9.96% |
| Mean TPOT | 10.818 ms | 9.838 ms | 9.06% lower |
| Mean ITL | 35.406 ms | 31.867 ms | 10.00% lower |
| Mean TTFT | 504.999 ms | 480.003 ms | 4.95% lower |
| Mean end-to-end latency | 6,032.758 ms | 5,507.244 ms | 8.71% lower |

The selected-slot splitting change separately measured +0.97% output
throughput, +8.14% decode/user, 7.54% lower TPOT, and 7.42% lower ITL. The
column-distributed matrix change separately measured +2.06% output,
+3.58% decode/user, 3.46% lower TPOT, and 3.42% lower ITL. Those experiments
used different baselines and should not be added together. Output identity
changed at the grouped DSA boundary, so the +9.59% result includes a changed
speculative-decoding trajectory as well as faster kernels.

The workload used four MI350X GPUs, attention TP4, MoE TP4/EP1, MTP3 with
four-token verification, 16 concurrent requests, and 512 output tokens per
request. The primary operation-boundary measurements were collected over
`upstream/main` `b174a318`. The isolated DSA results used earlier source and
checkpoint stacks; their relative deltas are valid within each experiment, but
their absolute values are not cross-comparable. The current branch applies the
same executable feature changes to newer `upstream/main` `5af23865`, but that
resulting tree was not benchmarked.