### PR TITLE
perf(amd): Optimize GLM-5.3-Flash MoE decode on MI350X

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/fp16/moe_align_device.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/fp16/moe_align_device.py
@@ -188,6 +188,7 @@ def _prepare_small_kernel(
     BLOCK_G: gl.constexpr,
     BLOCK_E: gl.constexpr,
     BLOCK_NB: gl.constexpr,
+    MAX_BLOCKS_PER_EXPERT: gl.constexpr,
     EM_MAX: gl.constexpr,
     INIT_TILE: gl.constexpr,
     EXPERT_START: gl.constexpr,
@@ -197,7 +198,6 @@ def _prepare_small_kernel(
     LG: gl.constexpr = gl.BlockedLayout([1], [64], [NW], [0])
     LE: gl.constexpr = gl.BlockedLayout([1], [64], [NW], [0])
     LI: gl.constexpr = gl.BlockedLayout([1], [64], [NW], [0])
-    LT: gl.constexpr = gl.BlockedLayout([1, 1], [1, 64], [NW, 1], [1, 0])
 
     for r0 in gl.static_range(0, EM_MAX, INIT_TILE):
         r = r0 + gl.arange(0, INIT_TILE, layout=LI)
@@ -226,6 +226,7 @@ def _prepare_small_kernel(
     padded = blocks_pe * block_m
     row_off = gl.associative_scan(padded, 0, _add) - padded
     blocks_incl = gl.associative_scan(blocks_pe, 0, _add)
+    block_start = blocks_incl - blocks_pe
     num_valid = gl.sum(padded, 0)
     num_blocks = gl.sum(blocks_pe, 0)
 
@@ -239,24 +240,23 @@ def _prepare_small_kernel(
     gl.store(num_blocks_ptr, num_blocks)
 
     for b0 in range(0, nb_max, BLOCK_NB):
-        bb = b0 + gl.arange(0, BLOCK_NB, layout=gl.SliceLayout(1, LT))
-        bi_row = gl.expand_dims(
-            gl.convert_layout(blocks_incl, gl.SliceLayout(0, LT)), 0
-        )
-        ve_row = gl.expand_dims(
-            gl.convert_layout(valid_e.to(gl.int32), gl.SliceLayout(0, LT)), 0
-        )
-        expert_b = gl.sum(
-            ((bi_row <= gl.expand_dims(bb, 1)) & (ve_row == 1)).to(gl.int32), axis=1
-        )
-        bb_l = b0 + gl.arange(0, BLOCK_NB, layout=LE)
-        expert_l = gl.convert_layout(expert_b, LE)
-        sei_val = gl.where(
-            bb_l < num_blocks,
-            expert_l,
+        block_ids = b0 + gl.arange(0, BLOCK_NB, layout=LE)
+        gl.store(
+            sei_ptr + block_ids,
             gl.full([BLOCK_NB], -1, gl.int32, layout=LE),
+            mask=block_ids < nb_max,
         )
-        gl.store(sei_ptr + bb_l, sei_val, mask=bb_l < nb_max)
+
+    # The sentinel fill is owned by one wave; synchronize before other waves
+    # overwrite live block ranges with expert IDs.
+    gl.barrier()
+
+    for block_offset in gl.static_range(0, MAX_BLOCKS_PER_EXPERT):
+        gl.store(
+            sei_ptr + block_start + block_offset,
+            e_ids,
+            mask=valid_e & (block_offset < blocks_pe),
+        )
 
 
 @gluon.jit
@@ -362,6 +362,10 @@ def moe_align_block_size_device(
             BLOCK_G=triton.next_power_of_2(N),
             BLOCK_E=BLOCK_E,
             BLOCK_NB=64,
+            # N is the flattened route count (token rows * top-k), not a GEMM dimension.
+            # block_m is routed rows per expert block; this matches the worst
+            # case, where all routes hit one expert.
+            MAX_BLOCKS_PER_EXPERT=triton.cdiv(N, block_m),
             EM_MAX=EM_max,
             INIT_TILE=triton.next_power_of_2(min(1024, EM_max)),
             EXPERT_START=expert_start,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/fp16/stage2_kernel.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/fp16/stage2_kernel.py
@@ -265,6 +265,13 @@ def gluon_bf16_moe_reduce_kernel(
     gl.store(out_ptrs, acc.to(out_ptr.type.element_ty), mask=mask)
 
 
+def _select_reduce_schedule(num_tokens: int) -> tuple[int, int]:
+    """Select the top-k reduction tile for graph decode or the general path."""
+    if num_tokens <= 64:
+        return 16, 128
+    return 64, 256
+
+
 def invoke_stage2(
     inter_states: torch.Tensor,  # (num_tokens*topk, I) bf16
     w2: torch.Tensor,  # (E, D, I)            bf16
@@ -378,8 +385,7 @@ def invoke_stage2(
         num_warps=num_warps,
     )
 
-    R_BLOCK_M = 64
-    R_BLOCK_N = 256
+    R_BLOCK_M, R_BLOCK_N = _select_reduce_schedule(num_tokens)
     rgrid = (triton.cdiv(num_tokens, R_BLOCK_M) * triton.cdiv(D, R_BLOCK_N),)
     gluon_bf16_moe_reduce_kernel[rgrid](
         partials,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/routing.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/routing.py
@@ -169,7 +169,10 @@ def _route_u32_bits_to_f32(bits, element_ty: gl.constexpr):
         return bits.to(gl.uint16).to(element_ty, bitcast=True).to(gl.float32)
 
 
-@gluon.jit
+@gluon.jit(
+    do_not_specialize=("M",),
+    do_not_specialize_on_alignment=("M",),
+)
 def _sigmoid_bias_topk_route_gluon_kernel(
     logits_ptr,  # (M, E)
     bias_ptr,  # (E)
@@ -182,7 +185,7 @@ def _sigmoid_bias_topk_route_gluon_kernel(
     stride_tik,
     stride_twm,
     stride_twk,
-    M: gl.constexpr,
+    M,
     E: gl.constexpr,
     TOPK: gl.constexpr,
     MP: gl.constexpr,
@@ -371,7 +374,7 @@ def _launch_sigmoid_bias_topk_route_gluon(
         topk_ids.stride(1),
         topk_weights.stride(0),
         topk_weights.stride(1),
-        M=M,
+        M,
         E=E,
         TOPK=topk,
         MP=_next_pow2(M),

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_bf16_moe_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_bf16_moe_gfx950.py
@@ -121,6 +121,196 @@ def test_small_route_device_alignment_contract() -> None:
     )
 
 
+def _assert_production_alignment_contract(
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    outputs: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    *,
+    num_experts: int,
+    block_m: int,
+    expert_start: int,
+) -> None:
+    sorted_ids, sorted_experts, sorted_weights, num_valid = outputs
+    num_tokens, top_k = topk_ids.shape
+    local_ids = topk_ids.reshape(-1) - expert_start
+    local_mask = (local_ids >= 0) & (local_ids < num_experts)
+    counts = torch.bincount(
+        local_ids[local_mask].to(torch.int64), minlength=num_experts
+    )
+    blocks_per_expert = (counts + block_m - 1) // block_m
+    expected_experts = torch.arange(
+        num_experts, device="cuda", dtype=torch.int32
+    ).repeat_interleave(blocks_per_expert)
+    valid_rows = int((blocks_per_expert.sum() * block_m).item())
+
+    assert int(num_valid.item()) == valid_rows
+    torch.testing.assert_close(
+        sorted_experts[: expected_experts.numel()], expected_experts, rtol=0, atol=0
+    )
+    assert torch.all(sorted_experts[expected_experts.numel() :] == -1)
+
+    row_experts = expected_experts.repeat_interleave(block_m)
+    packed = sorted_ids[:valid_rows]
+    weights = sorted_weights[:valid_rows]
+    routed = packed != num_tokens
+    tokens = packed[routed] & 0xFFFFFF
+    slots = packed[routed] >> 24
+    actual_flat_slots = torch.sort(tokens * top_k + slots).values
+    expected_flat_slots = (
+        torch.nonzero(local_mask, as_tuple=False).flatten().to(torch.int32)
+    )
+    torch.testing.assert_close(actual_flat_slots, expected_flat_slots, rtol=0, atol=0)
+    torch.testing.assert_close(
+        topk_ids[tokens, slots] - expert_start,
+        row_experts[routed],
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        weights[routed], topk_weights[tokens, slots], rtol=0, atol=0
+    )
+    assert torch.all(packed[~routed] == num_tokens)
+    assert torch.all(weights[~routed] == 0)
+    assert torch.all(sorted_ids[valid_rows:] == num_tokens)
+    assert torch.all(sorted_weights[valid_rows:] == 0)
+
+
+@pytest.mark.parametrize("routing", ["concentrated", "distributed", "filtered"])
+def test_small_route_production_alignment_contract(routing: str) -> None:
+    """Production-sized concentrated, distributed, and EP routes stay exact."""
+    num_tokens, num_experts, top_k, block_m = 64, 288, 8, 16
+    flat_slots = torch.arange(num_tokens * top_k, device="cuda", dtype=torch.int32)
+    if routing == "concentrated":
+        expert_start = 0
+        topk_ids = torch.zeros_like(flat_slots)
+    elif routing == "distributed":
+        expert_start = 0
+        topk_ids = (flat_slots * 37).remainder(num_experts)
+    else:
+        expert_start = 100
+        route_pattern = torch.tensor(
+            [99, 100, 101, 200, 387, 388, 42, 999],
+            device="cuda",
+            dtype=torch.int32,
+        )
+        topk_ids = route_pattern.repeat(num_tokens)
+    topk_ids = topk_ids.reshape(num_tokens, top_k)
+    topk_weights = (flat_slots.float() + 0.25).reshape(num_tokens, top_k)
+    outputs = moe_align_block_size_device(
+        topk_ids,
+        topk_weights,
+        num_experts,
+        block_m,
+        expert_start=expert_start,
+    )
+    torch.cuda.synchronize()
+    _assert_production_alignment_contract(
+        topk_ids,
+        topk_weights,
+        outputs,
+        num_experts=num_experts,
+        block_m=block_m,
+        expert_start=expert_start,
+    )
+
+
+@pytest.mark.parametrize("case", ["no_local_routes", "maximum_small_route"])
+def test_small_route_boundary_alignment_contract(case: str) -> None:
+    """The direct-fill bound handles empty routing and its 1,024-route edge."""
+    num_experts, top_k, block_m = 288, 8, 16
+    if case == "no_local_routes":
+        num_tokens = 1
+        expert_start = 100
+        topk_ids = torch.full(
+            (num_tokens, top_k),
+            expert_start - 1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+    else:
+        num_tokens = 128
+        expert_start = 0
+        topk_ids = torch.full(
+            (num_tokens, top_k),
+            num_experts - 1,
+            dtype=torch.int32,
+            device="cuda",
+        )
+    topk_weights = torch.arange(
+        num_tokens * top_k, dtype=torch.float32, device="cuda"
+    ).reshape(num_tokens, top_k)
+
+    outputs = moe_align_block_size_device(
+        topk_ids,
+        topk_weights,
+        num_experts,
+        block_m,
+        expert_start=expert_start,
+    )
+    torch.cuda.synchronize()
+    _assert_production_alignment_contract(
+        topk_ids,
+        topk_weights,
+        outputs,
+        num_experts=num_experts,
+        block_m=block_m,
+        expert_start=expert_start,
+    )
+
+
+def test_small_route_production_alignment_graph_replay() -> None:
+    """Graph replay preserves cross-wave block-table initialization ordering."""
+    num_tokens, num_experts, top_k, block_m = 64, 288, 8, 16
+    flat_slots = torch.arange(num_tokens * top_k, device="cuda", dtype=torch.int32)
+    topk_ids = ((flat_slots.remainder(3) + 1) * 64).reshape(num_tokens, top_k)
+    topk_weights = (flat_slots.float() + 0.25).reshape(num_tokens, top_k)
+
+    moe_align_block_size_device(
+        topk_ids,
+        topk_weights,
+        num_experts,
+        block_m,
+        expert_start=0,
+    )
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        outputs = moe_align_block_size_device(
+            topk_ids,
+            topk_weights,
+            num_experts,
+            block_m,
+            expert_start=0,
+        )
+    for _ in range(32):
+        graph.replay()
+    torch.cuda.synchronize()
+    _assert_production_alignment_contract(
+        topk_ids,
+        topk_weights,
+        outputs,
+        num_experts=num_experts,
+        block_m=block_m,
+        expert_start=0,
+    )
+    first_experts = outputs[1].clone()
+
+    topk_ids.copy_((((flat_slots + 1).remainder(3) + 1) * 64 + 1).reshape_as(topk_ids))
+    topk_weights.copy_(torch.flip(topk_weights, dims=(0, 1)))
+    for _ in range(32):
+        graph.replay()
+    torch.cuda.synchronize()
+    _assert_production_alignment_contract(
+        topk_ids,
+        topk_weights,
+        outputs,
+        num_experts=num_experts,
+        block_m=block_m,
+        expert_start=0,
+    )
+    assert not torch.equal(outputs[1], first_experts)
+
+
 @pytest.mark.parametrize("num_tokens", [1, 8, 32, 64, 256])
 def test_fp16_weight_moe_matches_fp32_reference(num_tokens):
     """End-to-end output matches the fp32 oracle (auto decode/prefill path)."""

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_routing_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp4_routing_gfx950.py
@@ -291,6 +291,40 @@ def test_sigmoid_bias_topk_route_gluon_matches_bf16_e384(
     torch.testing.assert_close(actual_weights, expected_weights, atol=0, rtol=0)
 
 
+@pytest.mark.parametrize("num_tokens", [1, 2, 3, 4, 5, 8, 9, 13, 16])
+def test_sigmoid_bias_topk_route_gluon_matches_v9_shapes(
+    num_tokens: int,
+) -> None:
+    generator = torch.Generator(device="cuda").manual_seed(4900 + num_tokens)
+    logits = torch.randn(
+        (num_tokens, 288),
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    correction_bias = (
+        torch.randn(288, device="cuda", dtype=torch.float32, generator=generator) * 0.01
+    )
+    expected_weights, expected_ids = _route_reference(
+        logits,
+        correction_bias,
+        routed_scaling_factor=2.827,
+        normalize_topk_weights=True,
+    )
+
+    actual_ids, actual_weights = invoke_sigmoid_bias_topk_route_gluon(
+        logits,
+        correction_bias,
+        8,
+        routed_scaling_factor=2.827,
+        normalize_topk_weights=True,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(actual_ids, expected_ids, atol=0, rtol=0)
+    torch.testing.assert_close(actual_weights, expected_weights, atol=0, rtol=0)
+
+
 @pytest.mark.parametrize("dtype", _ROUTE_DTYPES)
 def test_sigmoid_bias_topk_route_gluon_handles_strided_inputs(
     dtype: torch.dtype,
@@ -471,6 +505,63 @@ def test_sigmoid_bias_topk_route_gluon_graph_replay_uses_updated_inputs(
         logits,
         correction_bias,
         routed_scaling_factor=2.0,
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(graph_ids, expected_ids, atol=0, rtol=0)
+    torch.testing.assert_close(graph_weights, expected_weights, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("num_tokens", [3, 13])
+def test_sigmoid_bias_topk_route_gluon_v9_graph_replay_uses_updated_inputs(
+    num_tokens: int,
+) -> None:
+    generator = torch.Generator(device="cuda").manual_seed(5700 + num_tokens)
+    logits = torch.randn(
+        (num_tokens, 288),
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    correction_bias = (
+        torch.randn(288, device="cuda", dtype=torch.float32, generator=generator) * 0.01
+    )
+    invoke_sigmoid_bias_topk_route_gluon(
+        logits,
+        correction_bias,
+        8,
+        routed_scaling_factor=2.827,
+        normalize_topk_weights=True,
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_ids, graph_weights = invoke_sigmoid_bias_topk_route_gluon(
+            logits,
+            correction_bias,
+            8,
+            routed_scaling_factor=2.827,
+            normalize_topk_weights=True,
+        )
+
+    replacement_logits = torch.randn(
+        logits.shape,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    replacement_bias = (
+        torch.randn(288, device="cuda", dtype=torch.float32, generator=generator) * 0.01
+    )
+    logits.copy_(replacement_logits)
+    correction_bias.copy_(replacement_bias)
+    expected_weights, expected_ids = _route_reference(
+        logits,
+        correction_bias,
+        routed_scaling_factor=2.827,
+        normalize_topk_weights=True,
     )
     graph.replay()
     torch.cuda.synchronize()


### PR DESCRIPTION
## Summary

Optimize the GFX950 BF16 mixture-of-experts (MoE) path for GLM-5.3-Flash
decode and four-token verification shapes.

- Use a smaller final expert-reduction tile for graph shapes through 64 rows
  while retaining the existing schedule for larger workloads.
- Build expert block ranges directly for small routing workloads instead of
  scanning every expert for every output block.
- Keep the live row count dynamic so sigmoid-routing kernels are reused across
  request counts within the same padded graph shape.

The changes preserve route offsets, the existing unordered atomic-scatter
contract, packed route IDs and routing weights, the sequential FP32 reduction
order, and BF16 output arithmetic.

## ShareGPT performance

The three-commit MoE group was measured against the DSA boundary (measured against PR 4, https://github.com/lightseekorg/tokenspeed/pull/1433):

| Metric | PR 4 | This PR | Change |
|---|---:|---:|---:|
| Output throughput | 1,211.568 tok/s | 1,226.596 tok/s | +1.24% |
| Decode/user | 101.652 tok/s | 103.361 tok/s | +1.68% |
| Mean TPOT | 9.838 ms | 9.675 ms | 1.65% lower |
| Mean ITL | 31.867 ms | 31.340 ms | 1.65% lower |
| Mean TTFT | 480.003 ms | 479.703 ms | 0.06% lower |
| Mean end-to-end latency | 5,507.244 ms | 5,420.548 ms | 1.57% lower |

The smaller reduction tile improved its full stage-two chain by 2.65% at 16
rows and 4.63% at 64 rows. Direct expert-block construction reduced its
42-call graph region by 59.40%. Routing-kernel variants across rows 1-16 fell
from 11 to five. The table is the accepted PR-level performance result; the
individual measurements should not be added together.

The workload used four MI350X GPUs, attention TP4, MoE TP4/EP1, MTP3 with
four-token verification, 16 concurrent requests, and 512 output tokens per
request. The primary operation-boundary measurements were collected over
`upstream/main` `b174a318`. The isolated MoE results used earlier source and
checkpoint stacks; their relative deltas are valid within each experiment, but
their absolute values are not cross-comparable. The current branch applies the
same executable feature changes to newer `upstream/main` `5af23865`, but that
resulting tree was not benchmarked.