### PR TITLE
perf(amd): Tune GLM-5.3-Flash mHC verification kernels

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/mhc.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/mhc.py
@@ -155,6 +155,14 @@ def _mhc_pre_reduce_apply_kernel(
         gl.store(comb_mix + token * 16 + comb_offsets, comb, mask=active)
 
 
+def _mhc_pre_reduce_apply_block_h(
+    num_tokens: int, hidden_size: int, n_splits: int
+) -> int:
+    if (num_tokens, hidden_size, n_splits) == (64, 4096, 64):
+        return 1024
+    return 512
+
+
 def gluon_mhc_pre_reduce_apply_gfx950(
     gemm_out_mul: torch.Tensor,
     gemm_out_sqrsum: torch.Tensor,
@@ -191,7 +199,8 @@ def gluon_mhc_pre_reduce_apply_gfx950(
     if not 1 <= num_tokens <= 64:
         raise ValueError("GFX950 mHC specialization requires 1-64 tokens")
 
-    _mhc_pre_reduce_apply_kernel[(num_tokens, hidden_size // 512)](
+    block_h = _mhc_pre_reduce_apply_block_h(num_tokens, hidden_size, n_splits)
+    _mhc_pre_reduce_apply_kernel[(num_tokens, hidden_size // block_h)](
         gemm_out_mul,
         gemm_out_sqrsum,
         hc_scale,
@@ -206,6 +215,6 @@ def gluon_mhc_pre_reduce_apply_gfx950(
         HC_EPS=hc_eps,
         SINKHORN_ITERS=sinkhorn_iters,
         N_SPLITS=n_splits,
-        BLOCK_H=512,
+        BLOCK_H=block_h,
         num_warps=1,
     )

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/residual/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/residual/triton.py
@@ -710,6 +710,14 @@ def _mhc_prenorm_gemm_triton_kernel(
     )
 
 
+def _mhc_prenorm_gemm_launch_config(
+    num_tokens: int, k: int, n: int, n_splits: int
+) -> tuple[int, int, int, int, int]:
+    if (num_tokens, k, n, n_splits) == (64, 16384, 24, 64):
+        return 16, 16, 64, 2, 3
+    return 16, 32, 64, 4, 1
+
+
 def _mhc_prenorm_gemm_triton(
     x: torch.Tensor,
     fn: torch.Tensor,
@@ -719,10 +727,16 @@ def _mhc_prenorm_gemm_triton(
 ) -> None:
     num_tokens, k = x.shape
     n = fn.shape[0]
-    block_k = 64
+    block_m, block_n, block_k, num_warps, num_stages = _mhc_prenorm_gemm_launch_config(
+        num_tokens, k, n, n_splits
+    )
     split_k = triton.cdiv(triton.cdiv(k, n_splits), block_k) * block_k
     _mhc_prenorm_gemm_triton_kernel[
-        (n_splits, triton.cdiv(num_tokens, 16), triton.cdiv(n, 32))
+        (
+            n_splits,
+            triton.cdiv(num_tokens, block_m),
+            triton.cdiv(n, block_n),
+        )
     ](
         x,
         fn,
@@ -732,11 +746,11 @@ def _mhc_prenorm_gemm_triton(
         K=k,
         N=n,
         SPLIT_K=split_k,
-        BLOCK_M=16,
-        BLOCK_N=32,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
         BLOCK_K=block_k,
-        num_warps=4,
-        num_stages=1,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
 
 

--- a/tokenspeed-kernel/test/ops/test_mhc_gfx950.py
+++ b/tokenspeed-kernel/test/ops/test_mhc_gfx950.py
@@ -98,3 +98,46 @@ def test_gluon_mhc_pre_multitoken_matches_reference(
         torch.testing.assert_close(
             actual_tensor.float(), expected_tensor.float(), rtol=2e-2, atol=2e-2
         )
+
+
+def test_glm5_next_mhc_pre_graph_shape_replays_changed_input() -> None:
+    generator = torch.Generator(device="cuda").manual_seed(456)
+    residual = torch.randn(
+        64,
+        4,
+        4096,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    fn = (
+        torch.randn(
+            24,
+            4 * 4096,
+            device="cuda",
+            dtype=torch.float32,
+            generator=generator,
+        )
+        * 0.01
+    )
+    hc_scale = torch.tensor([0.7, 1.1, 0.5], device="cuda", dtype=torch.float32)
+    hc_base = (
+        torch.randn(24, device="cuda", dtype=torch.float32, generator=generator) * 0.01
+    )
+    args = (residual, fn, hc_scale, hc_base, 1e-6, 1e-6, 20)
+
+    tokenspeed_kernel.mhc_pre(*args, norm_weight=None, norm_eps=None)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_output = tokenspeed_kernel.mhc_pre(*args, norm_weight=None, norm_eps=None)
+
+    residual.copy_(torch.randn(residual.shape, device="cuda", dtype=residual.dtype))
+    expected = _reference(*args)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    for actual_tensor, expected_tensor in zip(graph_output, expected, strict=True):
+        torch.testing.assert_close(
+            actual_tensor.float(), expected_tensor.float(), rtol=2e-2, atol=2e-2
+        )


### PR DESCRIPTION
## Summary

Tune the multi-stream residual-mixing path (mHC) for the 64-row
GLM-5.3-Flash TP4 verification graph shape.

- Use a narrower output tile with two warps and three pipeline stages for the
  pre-normalization projection.
- Double the residual reduction's hidden-width block to 1,024 elements,
  halving the number of programs in that grid.
- Keep the previous schedules for other token counts, widths, projection
  sizes, and split decompositions.

Projection partials remain bit-exact. Normalization partials differ from the
prior schedule by at most 6.10e-5.

## ShareGPT performance

The two-commit residual-mixing group was measured against the MoE boundary (measured against PR 5, https://github.com/lightseekorg/tokenspeed/pull/1434):

| Metric | PR 5 | This PR | Change |
|---|---:|---:|---:|
| Output throughput | 1,226.596 tok/s | 1,306.447 tok/s | +6.51% |
| Decode/user | 103.361 tok/s | 102.164 tok/s | -1.16% |
| Mean TPOT | 9.675 ms | 9.788 ms | 1.17% higher |
| Mean ITL | 31.340 ms | 31.347 ms | 0.02% higher |
| Mean TTFT | 479.703 ms | 477.420 ms | 0.48% lower |
| Mean end-to-end latency | 5,420.548 ms | 5,479.205 ms | 1.08% higher |

The projection microbenchmark improved by 27.19% in eager execution and
20.53% under graph replay. The reduction kernel improved by 3.35% eagerly and
3.31% under replay. The end-to-end result must be read as a workload-throughput
gain with mixed latency, not a universal latency improvement: generated output
and the speculative-decoding trajectory changed at this boundary. An earlier
operation sweep reproduced a +6.04% output-throughput gain, but its latency
metrics moved in a different direction.

The workload used four MI350X GPUs, attention TP4, MoE TP4/EP1, MTP3 with
four-token verification, 16 concurrent requests, and 512 output tokens per
request. These measurements predate later test-only review amendments and the
final rebase. The executable kernel changes are unchanged on newer
`upstream/main` `5af23865`, but the current head was not rebenchmarked.