### PR TITLE
perf(amd): Tune GFX950 TP4 Iris decode all-reduce

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -94,10 +94,32 @@ _PRODUCER_DIRECT_GL_DTYPES = {
 
 
 @dataclass(frozen=True)
+class _StagedAllReduceKernelTuning:
+    world_size: int
+    dtype: torch.dtype
+    numel: int
+    block_size: int
+    num_subgroups: int
+
+    def __post_init__(self) -> None:
+        if (
+            self.world_size <= 1
+            or self.numel <= 0
+            or self.block_size <= 0
+            or self.num_subgroups <= 0
+        ):
+            raise ValueError("invalid staged Iris kernel tuning")
+
+    def num_programs(self) -> int:
+        return triton.cdiv(self.numel, self.block_size)
+
+
+@dataclass(frozen=True)
 class _StagedAllReduceKernelConfig:
     block_size: int
     num_subgroups: int
     input_slots: int
+    cdna4_tunings: tuple[_StagedAllReduceKernelTuning, ...]
 
     def __post_init__(self) -> None:
         if self.block_size <= 0 or self.num_subgroups <= 0 or self.input_slots < 2:
@@ -105,6 +127,24 @@ class _StagedAllReduceKernelConfig:
 
     def max_programs(self, max_numel: int) -> int:
         return triton.cdiv(max_numel, self.block_size)
+
+    def tuning(
+        self,
+        numel: int,
+        world_size: int,
+        dtype: torch.dtype,
+        is_cdna4: bool,
+    ) -> _StagedAllReduceKernelTuning | None:
+        if not is_cdna4:
+            return None
+        for tuning in self.cdna4_tunings:
+            if (
+                tuning.world_size == world_size
+                and tuning.dtype == dtype
+                and tuning.numel == numel
+            ):
+                return tuning
+        return None
 
 
 @dataclass(frozen=True)
@@ -265,6 +305,16 @@ IRIS_ALL_REDUCE_KERNEL_CONFIG = IrisAllReduceKernelConfig(
         block_size=2048,
         num_subgroups=4,
         input_slots=2,
+        # This CDNA4 TP4 tuning came from GLM-5.3-Flash decode.
+        cdna4_tunings=(
+            _StagedAllReduceKernelTuning(
+                world_size=4,
+                dtype=torch.bfloat16,
+                numel=16 * 4096,
+                block_size=512,
+                num_subgroups=1,
+            ),
+        ),
     ),
     producer_direct=_ProducerDirectAllReduceKernelConfig(
         supported_world_sizes=(2, 4, 8),
@@ -376,6 +426,27 @@ def _use_two_stage_plain(
         total_numel=numel,
         elements_per_word=elements_per_word,
     )
+
+
+def _select_staged_all_reduce_path(
+    numel: int,
+    world_size: int,
+    dtype: torch.dtype,
+    two_stage_supported: bool,
+) -> tuple[_StagedAllReduceKernelTuning | None, bool]:
+    """Resolve the tuned one-shot override and two-stage dispatch together."""
+    tuning = IRIS_ALL_REDUCE_KERNEL_CONFIG.staged.tuning(
+        numel=numel,
+        world_size=world_size,
+        dtype=dtype,
+        is_cdna4=_platform.is_cdna4,
+    )
+    use_two_stage = (
+        tuning is None
+        and two_stage_supported
+        and _use_two_stage_plain(world_size, numel, dtype)
+    )
+    return tuning, use_two_stage
 
 
 def _get_available_gpu_memory(gpu_id: int, empty_cache: bool = True) -> float:
@@ -688,6 +759,14 @@ class IrisAllReduce(object):
         self._staged_max_programs = staged_config.max_programs(
             max_numel=staged_max_numel
         )
+        self._staged_tunings = tuple(
+            tuning
+            for tuning in staged_config.cdna4_tunings
+            if _platform.is_cdna4
+            and tuning.world_size == self.world_size
+            and tuning.dtype == dtype
+            and tuning.numel <= staged_max_numel
+        )
 
         # Whether this state can ever dispatch a two-stage reduction. Platform,
         # group size and element type are all fixed for the life of the state,
@@ -714,12 +793,15 @@ class IrisAllReduce(object):
                 producer_direct_max_numel
                 + self._producer_direct_scratch_numel
                 + staged_config.input_slots * staged_max_numel
+                + staged_config.input_slots
+                * sum(tuning.numel for tuning in self._staged_tunings)
                 + 2 * attnres_max_numel
                 + (staged_max_numel if self._staged_two_stage_supported else 0)
                 + self._staged_two_stage_scratch_numel
             )
             flag_numel = self.world_size * (
                 self._staged_max_programs
+                + sum(tuning.num_programs() for tuning in self._staged_tunings)
                 + 2 * attnres_max_rows
                 + (
                     self._producer_direct_max_programs
@@ -793,6 +875,17 @@ class IrisAllReduce(object):
             if staged_max_numel
             else None
         )
+        # Different block geometries cannot share per-block epochs or rotating
+        # slots because their block IDs cover overlapping element ranges.
+        self._staged_tuning_workspaces = {
+            tuning: (
+                self._ctx.zeros((staged_config.input_slots, tuning.numel), dtype=dtype),
+                self._ctx.zeros(
+                    (tuning.num_programs(), self.world_size), dtype=torch.int32
+                ),
+            )
+            for tuning in self._staged_tunings
+        }
         # Two-stage plain all-reduce. One-shot stages inside its own kernel and
         # picks a slot from its per-block epoch; the two-stage kernel instead
         # reads peers' inputs out of symmetric memory, so the payload has to be
@@ -880,6 +973,13 @@ class IrisAllReduce(object):
             f"tensor numel ({numel}) exceeds iris buffer capacity "
             f"({self.staged_max_numel})"
         )
+        kernel_config = self._kernel_config.staged
+        tuning, use_two_stage = _select_staged_all_reduce_path(
+            numel=numel,
+            world_size=self.world_size,
+            dtype=self.dtype,
+            two_stage_supported=self._staged_two_stage_supported,
+        )
         # One-shot has every rank publish the whole payload and read world_size
         # copies of it, so its cost grows with the payload; the two-stage form
         # moves 2x however wide the world is. Measured on gfx950 at world 8,
@@ -890,25 +990,35 @@ class IrisAllReduce(object):
         # The two-stage kernel stores through a CDNA4 buffer intrinsic, so it is
         # gated the same way the producer-direct reduce is; older AMD parts keep
         # the portable one-shot path.
-        if self._staged_two_stage_supported and _use_two_stage_plain(
-            self.world_size, numel, self.dtype
-        ):
+        # Keep an explicitly tuned one-shot shape on that path. On TP4 gfx950,
+        # one-shot remains faster for 16x4096 while two-stage wins at 64x4096.
+        if use_two_stage:
             return self._all_reduce_two_stage(tensor, numel, safe=safe)
-        kernel_config = self._kernel_config.staged
-        block_size = kernel_config.block_size
+        if tuning is None:
+            block_size = kernel_config.block_size
+            num_subgroups = kernel_config.num_subgroups
+            input_buf = self._staged_input_buf
+            ready_flags = self._ready_flags
+            slot_stride = self.staged_max_numel
+        else:
+            block_size = tuning.block_size
+            num_subgroups = tuning.num_subgroups
+            input_buf, ready_flags = self._staged_tuning_workspaces[tuning]
+            slot_stride = tuning.numel
+        assert input_buf is not None and ready_flags is not None
         iris_stage_one_shot_allreduce_kernel[(triton.cdiv(numel, block_size),)](
             tensor.view(-1),
-            self._staged_input_buf.view(-1),
+            input_buf.view(-1),
             tensor.view(-1),
-            self._ready_flags,
+            ready_flags,
             self._group_heap_bases,
             numel,
             RANK=self._iris_rank,
             WORLD_SIZE=self.world_size,
             BLOCK_SIZE=block_size,
-            SLOT_STRIDE=self.staged_max_numel,
+            SLOT_STRIDE=slot_stride,
             NUM_SLOTS=kernel_config.input_slots,
-            num_warps=kernel_config.num_subgroups,
+            num_warps=num_subgroups,
         )
 
         return tensor.clone() if safe else tensor

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -272,6 +272,34 @@ def test_producer_direct_two_stage_threshold(world_size, dtype, min_bytes):
     assert not _use_two_stage_producer_direct(2, min_numel, dtype)
 
 
+@pytest.mark.parametrize(
+    ("numel", "expected_path", "expected_schedule"),
+    [
+        (16 * 4096, "one_shot", (512, 1)),
+        (64 * 4096, "two_stage", None),
+    ],
+)
+def test_tp4_decode_staged_path_only_keeps_small_one_shot_shape(
+    monkeypatch,
+    numel,
+    expected_path,
+    expected_schedule,
+):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
+
+    monkeypatch.setattr(iris_ops, "_platform", SimpleNamespace(is_cdna4=True))
+
+    tuning, use_two_stage = iris_ops._select_staged_all_reduce_path(
+        numel,
+        4,
+        torch.bfloat16,
+        two_stage_supported=True,
+    )
+    assert ("two_stage" if use_two_stage else "one_shot") == expected_path
+    schedule = None if tuning is None else (tuning.block_size, tuning.num_subgroups)
+    assert schedule == expected_schedule
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
 def test_plain_two_stage_admits_partitionable_shapes(dtype):
     try:
@@ -379,6 +407,10 @@ def _ar_shape_cases() -> List[Tuple[int, ...]]:
     ]
 
 
+def _ar_graph_shape_cases() -> List[Tuple[int, ...]]:
+    return [(16, 4096), (64, 4096)]
+
+
 def _ar_output_shape_cases() -> List[Tuple[Tuple[int, ...], ...]]:
     """Producer-direct collections spanning one, two, and three outputs."""
     return [
@@ -426,7 +458,8 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
         attnres_config = kernel_config.kimi_k3_attnres
         output_shape_cases = _ar_output_shape_cases()
         staged_max_numel = max(
-            int(torch.tensor(shape).prod()) for shape in _ar_shape_cases()
+            max(int(torch.tensor(shape).prod()) for shape in _ar_shape_cases()),
+            max(int(torch.tensor(shape).prod()) for shape in _ar_graph_shape_cases()),
         )
         producer_direct_max_numel = max(
             sum(int(torch.tensor(shape).prod()) for shape in shapes)
@@ -477,6 +510,26 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             kernel_config.staged.input_slots,
             staged_max_numel,
         )
+        assert state._ready_flags.shape == (
+            kernel_config.staged.max_programs(staged_max_numel),
+            world_size,
+        )
+        if world_size == 4 and current_platform().is_cdna4:
+            tuning = kernel_config.staged.tuning(
+                numel=16 * 4096,
+                world_size=world_size,
+                dtype=torch.bfloat16,
+                is_cdna4=True,
+            )
+            assert tuning is not None
+            tuned_input, tuned_ready = state._staged_tuning_workspaces[tuning]
+            assert tuned_input.shape == (
+                kernel_config.staged.input_slots,
+                tuning.numel,
+            )
+            assert tuned_ready.shape == (tuning.num_programs(), world_size)
+            assert tuned_input.data_ptr() != state._staged_input_buf.data_ptr()
+            assert tuned_ready.data_ptr() != state._ready_flags.data_ptr()
         if state._staged_two_stage_supported:
             assert state._staged_two_stage_input_buf.numel() == staged_max_numel
             assert (
@@ -507,6 +560,22 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             )
         for shape in _ar_shape_cases():
             _check_all_reduce(state, rank, world_size, shape, device)
+        if world_size == 4:
+            for shape in _ar_graph_shape_cases():
+                _check_all_reduce_graph_replay(
+                    state,
+                    rank,
+                    world_size,
+                    shape,
+                    device,
+                )
+            if current_platform().is_cdna4:
+                _check_mixed_geometry_graph_replay(
+                    state,
+                    rank,
+                    world_size,
+                    device,
+                )
         for shapes in output_shape_cases:
             _check_all_reduce_symmetric_outputs(
                 state,
@@ -591,6 +660,92 @@ def _check_all_reduce(state, rank: int, world_size: int, shape, device) -> None:
         result.shape == expected.shape
     ), f"shape mismatch: {result.shape} vs {expected.shape}"
     torch.testing.assert_close(result, expected, atol=0, rtol=0)
+
+
+def _check_all_reduce_graph_replay(
+    state,
+    rank: int,
+    world_size: int,
+    shape,
+    device,
+) -> None:
+    from tokenspeed_kernel.ops.communication.iris import iris_all_reduce
+
+    local = torch.full(shape, rank + 1, dtype=torch.bfloat16, device=device)
+    result = iris_all_reduce(state, local, safe=False)
+    expected_value = world_size * (world_size + 1) // 2
+    torch.testing.assert_close(
+        result,
+        torch.full_like(result, expected_value),
+        atol=0,
+        rtol=0,
+    )
+
+    local.fill_(rank + 1)
+    torch.cuda.synchronize()
+    dist.barrier()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_result = iris_all_reduce(state, local, safe=False)
+
+    for replay_index in range(1, 5):
+        scale = replay_index + 1
+        local.fill_(scale * (rank + 1))
+        torch.cuda.synchronize()
+        dist.barrier()
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            graph_result,
+            torch.full_like(graph_result, scale * expected_value),
+            atol=0,
+            rtol=0,
+        )
+
+
+def _check_mixed_geometry_graph_replay(
+    state,
+    rank: int,
+    world_size: int,
+    device,
+) -> None:
+    from tokenspeed_kernel.ops.communication.iris import iris_all_reduce
+
+    shapes = ((16, 4096), (65535,))
+    inputs = [
+        torch.empty(shape, dtype=torch.bfloat16, device=device) for shape in shapes
+    ]
+    graphs = []
+    for local in inputs:
+        local.fill_(rank + 1)
+        torch.cuda.synchronize()
+        dist.barrier()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            iris_all_reduce(state, local, safe=False)
+        graphs.append(graph)
+
+    expected_rank_sum = world_size * (world_size + 1) // 2
+    snapshots = [[torch.empty_like(local) for _ in range(8)] for local in inputs]
+    for replay_index in range(8):
+        scale = replay_index + 1
+        for local, graph, outputs in zip(inputs, graphs, snapshots, strict=True):
+            local.fill_(scale * (rank + 1))
+            if rank == 0:
+                torch.cuda._sleep(1_000_000)
+            graph.replay()
+            outputs[replay_index].copy_(local)
+
+    torch.cuda.synchronize()
+    for outputs in snapshots:
+        for replay_index, output in enumerate(outputs):
+            expected = (replay_index + 1) * expected_rank_sum
+            torch.testing.assert_close(
+                output,
+                torch.full_like(output, expected),
+                atol=0,
+                rtol=0,
+            )
 
 
 def _check_all_reduce_symmetric_outputs(


### PR DESCRIPTION
## Summary

Tune the four-GPU Iris all-reduce used by the GLM-5.3-Flash decode and
verification graphs on GFX950.

- For four-rank BF16 payloads with 65,536 or 262,144 elements, corresponding
  to the measured `[16, 4096]` and `[64, 4096]` shapes, replace the
  2,048-element, four-warp tile with a 512-element, one-warp tile.
- Create more workgroups so the reduction is distributed more evenly across
  the GPU for the two measured graph shapes.
- Increase readiness-metadata capacity to give every smaller workgroup its own
  synchronization row.
- Retain the existing schedule for other platforms, rank counts, data types,
  and payload sizes.

## ShareGPT performance

The cumulative operation boundary measured this commit against the
residual-mixing branch (compared against PR 6, https://github.com/lightseekorg/tokenspeed/pull/1435):

| Metric | PR 6 | This PR | Change |
|---|---:|---:|---:|
| Output throughput | 1,306.447 tok/s | 1,311.749 tok/s | +0.41% |
| Decode/user | 102.164 tok/s | 102.764 tok/s | +0.59% |
| Mean TPOT | 9.788 ms | 9.731 ms | 0.58% lower |
| Mean ITL | 31.347 ms | 31.164 ms | 0.58% lower |
| Mean TTFT | 477.420 ms | 480.602 ms | 0.67% higher |
| Mean end-to-end latency | 5,479.205 ms | 5,453.223 ms | 0.47% lower |

Because that cumulative movement is below 1%, the primary causal evidence is
a separate ShareGPT comparison across both startup orders, with six measured
invocations per state: output throughput improved from 1,024.97 to 1,041.21
tok/s (+1.58%), decode/user from 82.48 to 85.23 tok/s (+3.33%), TPOT from
12.124 to 11.734 ms (3.22% lower), and ITL from 34.021 to 33.673 ms (1.02%
lower). Both startup orders improved those decode metrics. TTFT was noisy and
its median was 2.69% higher, so no first-token-latency improvement is claimed.
This isolated A/B used an earlier local checkpoint and segmented prompt replay,
unlike the public-checkpoint, eager-prompt operation campaign. Relative changes
are valid within each experiment, but absolute values are not cross-comparable.

At the kernel level, simultaneous four-GPU graph replay improved the
slowest-rank time from 33.22 to 28.92 us (-12.9%) for `[16, 4096]` and from
40.16 to 38.02 us (-5.3%) for `[64, 4096]`.

The workload used four MI350X GPUs, attention TP4, MoE TP4/EP1, MTP3 with
four-token verification, 16 concurrent requests, and 512 output tokens per
request. The primary operation-boundary measurements were collected over
`upstream/main` `b174a318`; the earlier-checkpoint protocols for the isolated
and retained-stack results are described above. The current branch applies the
same executable feature change to newer `upstream/main` `5af23865`, but that
resulting tree was not benchmarked.