### PR TITLE
perf(comm): reduce large all-reduces in two stages on CDNA4

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -410,15 +410,24 @@ class IrisAllReduce(object):
             all_reduce_distribution=1,
         )
 
+        # Whether this state can ever dispatch a two-stage reduction. Both the
+        # kernel's CDNA4 intrinsics and its partitioning are fixed properties of
+        # the state, so deciding once here keeps the buffers, the heap estimate
+        # and the dispatch from disagreeing.
+        self._two_stage_supported = _platform.is_cdna4 and group.size() in (4, 8)
+
         # Leave generous heap headroom for the symmetric input and Iris
         # bookkeeping such as ring/spinlock flags.
         if heap_size is None:
             buf_bytes = max_numel * dtype.itemsize
             # _input_buf, _attnres_input_buf (2), _producer_direct_scratch_buf,
-            # the staged path's rotating slots (_STAGED_SLOTS), the two-stage
-            # path's single staging buffer, and its scratch partition --
-            # counted as a whole buffer since world_size is not known yet.
-            heap_size = max(1 << 28, (6 + _STAGED_SLOTS) * buf_bytes + (16 << 20))
+            # and the staged path's rotating slots (_STAGED_SLOTS).
+            buffers = 4 + _STAGED_SLOTS
+            if self._two_stage_supported:
+                # its staging buffer, plus the scratch partition counted as a
+                # whole buffer rather than 1/world_size
+                buffers += 2
+            heap_size = max(1 << 28, buffers * buf_bytes + (16 << 20))
 
         free_gpu_memory_begin = _get_available_gpu_memory(torch.cuda.current_device())
         self._ctx = _get_or_create_iris_context(heap_size)
@@ -460,12 +469,21 @@ class IrisAllReduce(object):
         # survive graph capture, which records the staging copy's address and
         # replays it unchanged. The kernel's exit barrier is what makes one
         # buffer safe -- see EXIT_BARRIER.
-        self._two_stage_input_buf = self._ctx.zeros((max_numel,), dtype=dtype)
-        # Each rank reduces only its own partition and peers read it at the same
-        # offset, so scratch holds one partition rather than the whole payload.
-        self._two_stage_scratch_buf = self._ctx.zeros(
-            (max_numel // self.world_size,), dtype=dtype
-        )
+        #
+        # Skipped entirely where dispatch could never reach them: a CDNA3 part
+        # or a group of some other size would otherwise reserve a payload
+        # buffer and a scratch partition it can never use, and an explicit
+        # heap_size sized for the previous allocations would fail to fit them.
+        if self._two_stage_supported:
+            self._two_stage_input_buf = self._ctx.zeros((max_numel,), dtype=dtype)
+            # Each rank reduces only its own partition and peers read it at the
+            # same offset, so scratch holds one partition, not the whole payload.
+            self._two_stage_scratch_buf = self._ctx.zeros(
+                (max_numel // self.world_size,), dtype=dtype
+            )
+        else:
+            self._two_stage_input_buf = None
+            self._two_stage_scratch_buf = None
         self._producer_direct_block_size = 512
         # Use one program per tile for small payloads, capped to limit contention.
         self._producer_direct_max_programs = 84
@@ -478,9 +496,13 @@ class IrisAllReduce(object):
         # Separate epochs from the producer-direct reduce: in a tensor-parallel
         # MoE both collectives run inside one layer, and a shared counter would
         # let one path's epoch satisfy the other's barrier.
-        self._two_stage_ready_flags = self._ctx.zeros(
-            (self._producer_direct_max_programs, self.world_size),
-            dtype=torch.int32,
+        self._two_stage_ready_flags = (
+            self._ctx.zeros(
+                (self._producer_direct_max_programs, self.world_size),
+                dtype=torch.int32,
+            )
+            if self._two_stage_supported
+            else None
         )
         heap_bases = self._ctx.get_heap_bases()
         self._group_heap_bases = heap_bases[group_ranks].contiguous()
@@ -529,7 +551,7 @@ class IrisAllReduce(object):
         # The two-stage kernel stores through a CDNA4 buffer intrinsic, so it is
         # gated the same way the producer-direct reduce is; older AMD parts keep
         # the portable one-shot path.
-        if _platform.is_cdna4 and _use_two_stage_plain(
+        if self._two_stage_supported and _use_two_stage_plain(
             self.world_size, numel, self.dtype
         ):
             return self._all_reduce_two_stage(tensor, numel, safe=safe)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -410,11 +410,16 @@ class IrisAllReduce(object):
             all_reduce_distribution=1,
         )
 
-        # Whether this state can ever dispatch a two-stage reduction. Both the
-        # kernel's CDNA4 intrinsics and its partitioning are fixed properties of
-        # the state, so deciding once here keeps the buffers, the heap estimate
-        # and the dispatch from disagreeing.
-        self._two_stage_supported = _platform.is_cdna4 and group.size() in (4, 8)
+        # Whether this state can ever dispatch a two-stage reduction. Platform,
+        # group size and element type are all fixed for the life of the state,
+        # so deciding once here keeps the buffers, the heap estimate and the
+        # dispatch from disagreeing. Only the payload size is per-call, and it
+        # stays in _use_two_stage_plain.
+        self._two_stage_supported = (
+            _platform.is_cdna4
+            and group.size() in (4, 8)
+            and dtype in _PRODUCER_DIRECT_GL_DTYPES
+        )
 
         # Leave generous heap headroom for the symmetric input and Iris
         # bookkeeping such as ring/spinlock flags.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -106,6 +106,36 @@ def _use_two_stage_producer_direct(
     )
 
 
+def _use_two_stage_plain(
+    world_size: int,
+    numel: int,
+    dtype: torch.dtype,
+) -> bool:
+    """Whether a plain all-reduce of ``numel`` should take the two-stage path.
+
+    Args:
+        world_size: Ranks participating in the reduction.
+        numel: Elements in the tensor being reduced.
+        dtype: Element type; sets how many elements pack into a 64-bit word.
+
+    Returns:
+        True when the two-stage reduce-scatter/all-gather can run this shape.
+
+    Unlike the producer-direct threshold this carries no minimum size. Measured
+    on gfx950 at world 8, the two forms are within noise of each other below
+    about 16 tokens of hidden 7168 (one-shot is marginally ahead at some of those
+    shapes), and two-stage pulls away above it: 1.11x at 16 tokens, 1.37x at 32,
+    1.82x at 64. A minimum would buy nothing at the small end and risks sitting
+    in the wrong place as shapes change, so the only condition kept is the
+    kernel's structural one -- the payload has to split evenly into per-rank
+    partitions of whole 64-bit words.
+    """
+    if world_size not in (4, 8):
+        return False
+    elements_per_word = 8 // dtype.itemsize
+    return numel % (world_size * elements_per_word) == 0
+
+
 # Staging slots the one-shot all-reduce rotates through. Two is enough to keep
 # the reclaim wait off the critical path: a rank may be a whole invocation ahead
 # of its slowest peer before it has to wait for that peer to finish reading.
@@ -412,12 +442,40 @@ class IrisAllReduce(object):
         self._staged_input_buf = self._ctx.zeros(
             (_STAGED_SLOTS, max_numel), dtype=dtype
         )
+        # Two-stage plain all-reduce. One-shot stages inside its own kernel and
+        # picks a slot from its per-block epoch; the two-stage kernel instead
+        # reads peers' inputs out of symmetric memory, so the payload has to be
+        # staged before launch. That staging cannot share _staged_input_buf --
+        # its slot is chosen by one-shot's kernel from a counter we cannot see --
+        # nor _input_buf, which acquire_outputs hands to producer-direct. Hence
+        # dedicated buffers; at the configured max_numel they cost about 1 MiB.
+        #
+        # Two slots, for the reason spelled out on the one-shot kernel: writing
+        # E+1 lands on the other slot, and reaching E+2 means every peer passed
+        # the entry barrier at E+1, which they publish only after finishing
+        # their reads at E.
+        self._two_stage_input_buf = self._ctx.zeros(
+            (_STAGED_SLOTS, max_numel), dtype=dtype
+        )
+        # Each rank reduces only its own partition and peers read it at the same
+        # offset, so scratch holds one partition rather than the whole payload.
+        self._two_stage_scratch_buf = self._ctx.zeros(
+            (max_numel // self.world_size,), dtype=dtype
+        )
+        self._two_stage_slot = 0
         self._producer_direct_block_size = 512
         # Use one program per tile for small payloads, capped to limit contention.
         self._producer_direct_max_programs = 84
         # Experimental alternative: publish readiness into peer-local memory.
         self._producer_direct_publish_ready = False
         self._producer_direct_ready_flags = self._ctx.zeros(
+            (self._producer_direct_max_programs, self.world_size),
+            dtype=torch.int32,
+        )
+        # Separate epochs from the producer-direct reduce: in a tensor-parallel
+        # MoE both collectives run inside one layer, and a shared counter would
+        # let one path's epoch satisfy the other's barrier.
+        self._two_stage_ready_flags = self._ctx.zeros(
             (self._producer_direct_max_programs, self.world_size),
             dtype=torch.int32,
         )
@@ -458,6 +516,20 @@ class IrisAllReduce(object):
             f"tensor numel ({numel}) exceeds iris buffer capacity "
             f"({self.max_numel})"
         )
+        # One-shot has every rank publish the whole payload and read world_size
+        # copies of it, so its cost grows with the payload; the two-stage form
+        # moves 2x however wide the world is. Measured on gfx950 at world 8,
+        # including the staging copy this path pays and one-shot does not:
+        # parity below ~16 tokens of hidden 7168, then 1.11x at 16, 1.37x at 32,
+        # 1.82x at 64. The predicate is the kernel's partitioning requirement,
+        # not a crossover -- see _use_two_stage_plain.
+        # The two-stage kernel stores through a CDNA4 buffer intrinsic, so it is
+        # gated the same way the producer-direct reduce is; older AMD parts keep
+        # the portable one-shot path.
+        if _platform.is_cdna4 and _use_two_stage_plain(
+            self.world_size, numel, self.dtype
+        ):
+            return self._all_reduce_two_stage(tensor, numel)
         iris_stage_one_shot_allreduce_kernel[(triton.cdiv(numel, self._block_size),)](
             tensor.view(-1),
             self._staged_input_buf.view(-1),
@@ -516,6 +588,48 @@ class IrisAllReduce(object):
                 return False
             offset += tensor.numel()
         return offset % self._elements_per_word == 0 and offset <= self.max_numel
+
+    def _all_reduce_two_stage(self, tensor: torch.Tensor, numel: int) -> torch.Tensor:
+        """Reduce ``tensor`` in place via reduce-scatter then all-gather.
+
+        Args:
+            tensor: Contiguous local contribution; overwritten with the sum.
+            numel: ``tensor.numel()``, already checked against the heap capacity.
+
+        Returns:
+            ``tensor``, holding the reduction across the group.
+        """
+        slot = self._two_stage_slot
+        self._two_stage_slot = (slot + 1) % _STAGED_SLOTS
+        staged = self._two_stage_input_buf[slot]
+        staged[:numel].copy_(tensor.view(-1))
+
+        partition_numel = numel // self.world_size
+        partition_words = partition_numel // self._elements_per_word
+        # 512 threads move 16 bytes each, split evenly across ranks.
+        block_words = 1024 // self.world_size
+        num_tiles = triton.cdiv(partition_words, block_words)
+        num_programs = min(num_tiles, self._producer_direct_max_programs)
+        output = self._producer_direct_output_buf[:numel]
+        iris_reduce_symmetric_two_stage_gluon_kernel[(num_programs,)](
+            staged,
+            self._two_stage_scratch_buf,
+            output,
+            self._two_stage_ready_flags,
+            *self._heap_base_addresses,
+            RANK=self._iris_rank,
+            WORLD_SIZE=self.world_size,
+            PARTITION_WORDS=partition_words,
+            BLOCK_WORDS=block_words,
+            NUM_PROGRAMS=num_programs,
+            NUM_TILES=num_tiles,
+            NUM_WARPS=8,
+            ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
+            ELEMENTS_PER_WORD=self._elements_per_word,
+            num_warps=8,
+        )
+        tensor.view(-1).copy_(output)
+        return tensor
 
     def all_reduce_symmetric(
         self, tensors: tuple[torch.Tensor, ...]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -416,9 +416,9 @@ class IrisAllReduce(object):
             buf_bytes = max_numel * dtype.itemsize
             # _input_buf, _attnres_input_buf (2), _producer_direct_scratch_buf,
             # the staged path's rotating slots (_STAGED_SLOTS), the two-stage
-            # path's own slots (_STAGED_SLOTS), and its scratch partition --
+            # path's single staging buffer, and its scratch partition --
             # counted as a whole buffer since world_size is not known yet.
-            heap_size = max(1 << 28, (5 + 2 * _STAGED_SLOTS) * buf_bytes + (16 << 20))
+            heap_size = max(1 << 28, (6 + _STAGED_SLOTS) * buf_bytes + (16 << 20))
 
         free_gpu_memory_begin = _get_available_gpu_memory(torch.cuda.current_device())
         self._ctx = _get_or_create_iris_context(heap_size)
@@ -454,22 +454,18 @@ class IrisAllReduce(object):
         # reads peers' inputs out of symmetric memory, so the payload has to be
         # staged before launch. That staging cannot share _staged_input_buf --
         # its slot is chosen by one-shot's kernel from a counter we cannot see --
-        # nor _input_buf, which acquire_outputs hands to producer-direct. Hence
-        # dedicated buffers; at the configured max_numel they cost about 1 MiB.
+        # nor _input_buf, which acquire_outputs hands to producer-direct.
         #
-        # Two slots, for the reason spelled out on the one-shot kernel: writing
-        # E+1 lands on the other slot, and reaching E+2 means every peer passed
-        # the entry barrier at E+1, which they publish only after finishing
-        # their reads at E.
-        self._two_stage_input_buf = self._ctx.zeros(
-            (_STAGED_SLOTS, max_numel), dtype=dtype
-        )
+        # A single buffer, deliberately: rotating slots from the host does not
+        # survive graph capture, which records the staging copy's address and
+        # replays it unchanged. The kernel's exit barrier is what makes one
+        # buffer safe -- see EXIT_BARRIER.
+        self._two_stage_input_buf = self._ctx.zeros((max_numel,), dtype=dtype)
         # Each rank reduces only its own partition and peers read it at the same
         # offset, so scratch holds one partition rather than the whole payload.
         self._two_stage_scratch_buf = self._ctx.zeros(
             (max_numel // self.world_size,), dtype=dtype
         )
-        self._two_stage_slot = 0
         self._producer_direct_block_size = 512
         # Use one program per tile for small payloads, capped to limit contention.
         self._producer_direct_max_programs = 84
@@ -597,7 +593,7 @@ class IrisAllReduce(object):
         return offset % self._elements_per_word == 0 and offset <= self.max_numel
 
     def _all_reduce_two_stage(
-        self, tensor: torch.Tensor, numel: int, safe: bool = True
+        self, tensor: torch.Tensor, numel: int, safe: bool
     ) -> torch.Tensor:
         """Reduce ``tensor`` in place via reduce-scatter then all-gather.
 
@@ -611,9 +607,7 @@ class IrisAllReduce(object):
         Returns:
             The reduction across the group; a clone of ``tensor`` when ``safe``.
         """
-        slot = self._two_stage_slot
-        self._two_stage_slot = (slot + 1) % _STAGED_SLOTS
-        staged = self._two_stage_input_buf[slot]
+        staged = self._two_stage_input_buf
         staged[:numel].copy_(tensor.view(-1))
 
         partition_numel = numel // self.world_size
@@ -638,6 +632,7 @@ class IrisAllReduce(object):
             NUM_WARPS=8,
             ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
             ELEMENTS_PER_WORD=self._elements_per_word,
+            EXIT_BARRIER=True,
             num_warps=8,
         )
         tensor.view(-1).copy_(output)
@@ -683,6 +678,7 @@ class IrisAllReduce(object):
                 NUM_WARPS=8,
                 ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
                 ELEMENTS_PER_WORD=self._elements_per_word,
+                EXIT_BARRIER=False,
                 num_warps=8,
             )
         else:
@@ -1163,6 +1159,7 @@ def iris_reduce_symmetric_two_stage_gluon_kernel(
     NUM_WARPS: gl.constexpr,
     ELEMENT_DTYPE: gl.constexpr,
     ELEMENTS_PER_WORD: gl.constexpr,
+    EXIT_BARRIER: gl.constexpr,
 ):
     """Reduce-scatter producer outputs, then all-gather the rank partitions."""
     block_id = gl.program_id(0)
@@ -1316,6 +1313,34 @@ def iris_reduce_symmetric_two_stage_gluon_kernel(
             mask=gl.expand_dims(mask, 0),
         )
         tile_id += NUM_PROGRAMS
+
+    if EXIT_BARRIER:
+        # Callers that stage into the symmetric input before launching cannot
+        # rotate buffers safely: under graph capture the staging copy records a
+        # fixed address and replays it, so a rank one invocation ahead would
+        # overwrite an input its slower peers are still reducing. Holding the
+        # kernel until every peer has finished reading makes a single staging
+        # buffer correct by construction, at the price of one more rendezvous.
+        # Producer-direct callers own their input and pass False.
+        reads_done = gl.atomic_add(epoch_ptr, 1, sem="release", scope="sys") + 1
+        _iris_sync_rank_epoch(
+            ready_flags,
+            block_id,
+            reads_done,
+            local_heap,
+            heap_base_0,
+            heap_base_1,
+            heap_base_2,
+            heap_base_3,
+            heap_base_4,
+            heap_base_5,
+            heap_base_6,
+            heap_base_7,
+            RANK,
+            WORLD_SIZE,
+            NUM_WARPS,
+            PUBLISH=True,
+        )
 
 
 @gluon.jit

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -132,6 +132,11 @@ def _use_two_stage_plain(
     """
     if world_size not in (4, 8):
         return False
+    # The kernel packs elements into 64-bit words through
+    # _PRODUCER_DIRECT_GL_DTYPES; anything outside it (or wider than a word,
+    # which would make elements_per_word zero) stays on one-shot.
+    if dtype not in _PRODUCER_DIRECT_GL_DTYPES:
+        return False
     elements_per_word = 8 // dtype.itemsize
     return numel % (world_size * elements_per_word) == 0
 
@@ -410,8 +415,10 @@ class IrisAllReduce(object):
         if heap_size is None:
             buf_bytes = max_numel * dtype.itemsize
             # _input_buf, _attnres_input_buf (2), _producer_direct_scratch_buf,
-            # and the staged path's rotating slots (_STAGED_SLOTS).
-            heap_size = max(1 << 28, (4 + _STAGED_SLOTS) * buf_bytes + (16 << 20))
+            # the staged path's rotating slots (_STAGED_SLOTS), the two-stage
+            # path's own slots (_STAGED_SLOTS), and its scratch partition --
+            # counted as a whole buffer since world_size is not known yet.
+            heap_size = max(1 << 28, (5 + 2 * _STAGED_SLOTS) * buf_bytes + (16 << 20))
 
         free_gpu_memory_begin = _get_available_gpu_memory(torch.cuda.current_device())
         self._ctx = _get_or_create_iris_context(heap_size)
@@ -529,7 +536,7 @@ class IrisAllReduce(object):
         if _platform.is_cdna4 and _use_two_stage_plain(
             self.world_size, numel, self.dtype
         ):
-            return self._all_reduce_two_stage(tensor, numel)
+            return self._all_reduce_two_stage(tensor, numel, safe=safe)
         iris_stage_one_shot_allreduce_kernel[(triton.cdiv(numel, self._block_size),)](
             tensor.view(-1),
             self._staged_input_buf.view(-1),
@@ -589,15 +596,20 @@ class IrisAllReduce(object):
             offset += tensor.numel()
         return offset % self._elements_per_word == 0 and offset <= self.max_numel
 
-    def _all_reduce_two_stage(self, tensor: torch.Tensor, numel: int) -> torch.Tensor:
+    def _all_reduce_two_stage(
+        self, tensor: torch.Tensor, numel: int, safe: bool = True
+    ) -> torch.Tensor:
         """Reduce ``tensor`` in place via reduce-scatter then all-gather.
 
         Args:
             tensor: Contiguous local contribution; overwritten with the sum.
             numel: ``tensor.numel()``, already checked against the heap capacity.
+            safe: Return a copy rather than the caller's tensor, matching the
+                one-shot path -- the reduction lands in place either way, so
+                without this the result aliases the input.
 
         Returns:
-            ``tensor``, holding the reduction across the group.
+            The reduction across the group; a clone of ``tensor`` when ``safe``.
         """
         slot = self._two_stage_slot
         self._two_stage_slot = (slot + 1) % _STAGED_SLOTS
@@ -629,7 +641,7 @@ class IrisAllReduce(object):
             num_warps=8,
         )
         tensor.view(-1).copy_(output)
-        return tensor
+        return tensor.clone() if safe else tensor
 
     def all_reduce_symmetric(
         self, tensors: tuple[torch.Tensor, ...]

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -219,6 +219,29 @@ def test_producer_direct_two_stage_threshold(world_size, dtype, min_bytes):
     assert not _use_two_stage_producer_direct(2, min_numel, dtype)
 
 
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_plain_two_stage_admits_partitionable_shapes(dtype):
+    try:
+        from tokenspeed_kernel.ops.communication.iris import _use_two_stage_plain
+    except ImportError:
+        pytest.skip("iris is not installed")
+
+    elements_per_word = 8 // dtype.itemsize
+    # The plain path carries no minimum size -- two-stage measured faster than
+    # one-shot at every shape down to 14 KB -- so the predicate is purely the
+    # kernel's partitioning requirement.
+    aligned = 8 * elements_per_word
+    assert _use_two_stage_plain(8, aligned, dtype)
+    assert _use_two_stage_plain(8, aligned * 4096, dtype)
+    # every K3 decode width partitions evenly across 8 ranks
+    for tokens in (1, 8, 16, 32, 64):
+        assert _use_two_stage_plain(8, tokens * 7168, dtype)
+    # a payload that does not split into whole words per rank stays on one-shot
+    assert not _use_two_stage_plain(8, aligned + 1, dtype)
+    # world sizes without a tuned partitioning fall back
+    assert not _use_two_stage_plain(2, aligned, dtype)
+
+
 # ---------------------------------------------------------------------------
 # Suite 1: iris_all_reduce
 # ---------------------------------------------------------------------------

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -260,6 +260,36 @@ def test_plain_two_stage_rejects_unsupported_dtypes(dtype):
         assert not _use_two_stage_plain(8, numel, dtype)
 
 
+@pytest.mark.parametrize(
+    ("world_size", "dtype", "supported"),
+    [
+        (8, torch.bfloat16, True),
+        (4, torch.float32, True),
+        (2, torch.bfloat16, False),
+        (8, torch.float64, False),
+    ],
+)
+def test_two_stage_state_gate_matches_dispatch(world_size, dtype, supported):
+    """The state-level gate must agree with the per-call predicate.
+
+    A state that reserves the staging buffer and the larger heap for a
+    combination the predicate then refuses is not merely wasteful: a caller
+    supplying an explicit heap sized for the one-shot allocations fails to
+    construct. Everything the predicate tests apart from payload size is fixed
+    for the life of the state, so the two have to be decided from the same
+    conditions.
+    """
+    try:
+        from tokenspeed_kernel.ops.communication.iris import _use_two_stage_plain
+    except ImportError:
+        pytest.skip("iris is not installed")
+
+    # a payload that satisfies the size condition, so only the state-level
+    # conditions can decide the outcome
+    numel = 8 * 7168
+    assert _use_two_stage_plain(world_size, numel, dtype) is supported
+
+
 # ---------------------------------------------------------------------------
 # Suite 1: iris_all_reduce
 # ---------------------------------------------------------------------------

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -242,6 +242,24 @@ def test_plain_two_stage_admits_partitionable_shapes(dtype):
     assert not _use_two_stage_plain(2, aligned, dtype)
 
 
+@pytest.mark.parametrize("dtype", [torch.float64, torch.complex128, torch.int8])
+def test_plain_two_stage_rejects_unsupported_dtypes(dtype):
+    """Dtypes the packing kernel cannot express must stay on one-shot.
+
+    The kernel maps the element type through _PRODUCER_DIRECT_GL_DTYPES, so
+    admitting anything outside it would raise instead of reducing. Types wider
+    than a 64-bit word are the sharper case: they make elements-per-word zero,
+    which would divide by zero in the alignment check itself.
+    """
+    try:
+        from tokenspeed_kernel.ops.communication.iris import _use_two_stage_plain
+    except ImportError:
+        pytest.skip("iris is not installed")
+
+    for numel in (8, 64, 7168, 32 * 7168):
+        assert not _use_two_stage_plain(8, numel, dtype)
+
+
 # ---------------------------------------------------------------------------
 # Suite 1: iris_all_reduce
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Problem

The Iris all-reduce always took `iris_stage_one_shot_allreduce_kernel`. In that
form every rank publishes the whole payload and reads `world_size` copies of it,
so its cost grows with the payload. The reduce-scatter/all-gather form moves 2x
however wide the world is, and the producer-direct reduce already prefers it
above a size threshold -- the plain path had no such choice.

What prompted the investigation was decode traces on a tensor-parallel MoE: the
one-shot attention all-reduce grew from 19.5 to 31.5 us median between 1 and 32
tokens, with its p90 reaching 94 us, while the two-stage MoE reduce stayed flat
near 13.5 us. That observation is only suggestive -- the two are different
collectives, and the MoE reduce carries two tensors rather than one -- so the
controlled comparison below is what the change rests on.

## Change

`TritonCommState.all_reduce` now selects the two-stage reduce-scatter/all-gather
when the payload partitions evenly across ranks.

The predicate is that structural requirement rather than a crossover: the
payload has to split into per-rank partitions of whole 64-bit words. Dispatch is
additionally gated on CDNA4, matching the producer-direct reduce, because the
two-stage kernel stores through a CDNA4 buffer intrinsic; older AMD parts keep
the portable one-shot path.

## Numbers

Isolated, 8x CDNA4, hidden 7168, median of 100 after 20 warmup. Same tensor and
same entry point for both arms, so the algorithm is the only thing that varies;
the two-stage arm pays the staging copy that one-shot fuses into its own kernel:

| tokens | KB | one-shot us | two-stage us | speedup |
|---|---|---|---|---|
| 8 | 112 | 36.1 | 35.0 | 1.03x |
| 16 | 224 | 38.3 | 34.4 | 1.11x |
| 32 | 448 | 48.4 | 35.4 | 1.37x |
| 64 | 896 | 73.7 | 40.5 | 1.82x |
| 128 | 1792 | 132.8 | 42.4 | 3.13x |

End to end on a tensor-parallel MoE decode, 4K in / 1K out, identical bench
parameters on both arms, against current main. Means of repeated runs; the arms
are reproducible to within about 0.3% at concurrency 16 and 1% at 32:

| concurrency | output tok/s | delta | median TPOT ms | delta |
|---|---|---|---|---|
| 1 | 78.46 -> 78.72 | +0.3% | 12.37 -> 12.33 | -0.3% |
| 8 | 361.24 -> 367.20 | **+1.7%** | 19.92 -> 19.56 | **-1.8%** |
| 16 | 556.35 -> 569.92 | **+2.4%** | 24.39 -> 23.73 | **-2.7%** |
| 32 | 638.45 -> 657.19 | **+2.9%** | 41.50 -> 40.41 | **-2.6%** |

Both metrics move together at every concurrency. The gain is smaller than the
isolated speedup, as expected -- the collective is a minority of step time, and
much of its measured duration is spin-wait that a faster transfer does not
remove. It is also smaller than an earlier revision of this PR reported, because
the exit barrier described below costs a rendezvous per call; that is the price
of correctness under graph replay.

Concurrency 1 is neutral rather than a gain, and was worth checking rather than
assuming: it is the point where a regression was most plausible. The payload is a
single token, where the isolated benchmark puts two-stage at parity with
one-shot, and the exit barrier adds a rendezvous on top of that. Measured over
four runs per arm the two overlap (78.46 +/- 0.21 against 78.72 +/- 0.24), so the
barrier costs nothing there -- with one request in flight the ranks arrive
together and there is no skew for it to wait on.

Concurrency 8 has a single baseline sample against three for the other points.

## Why dedicated buffers

The path cannot share the existing ones:

- `acquire_outputs` hands `_input_buf` to producer-direct reductions;
- `_producer_direct_ready_flags` carries that path's epochs, and in a
  tensor-parallel MoE both collectives run inside one layer;
- `_staged_input_buf` is claimed by one-shot, which stages *inside its own
  kernel* and derives the slot from a per-block epoch that a host-side counter
  cannot stay in step with.

So it takes dedicated symmetric input, scratch and flags. Scratch holds a single
partition, since each rank reduces only its own slice and peers read it at the
same offset.

The staging buffer is a **single** buffer, not a rotating pair. Rotating slots
from the host does not survive graph capture: the staging copy is recorded at a
fixed address and replayed unchanged, so with an odd number of eligible
reductions in one graph the last call of a replay and the first of the next land
on the same slot, and a rank an invocation ahead can overwrite an input its
slower peers are still reducing -- silently wrong results rather than a failure.

One-shot escapes this because it stages inside its own kernel and derives the
slot from a per-block epoch, which does advance on replay. That does not map
cleanly onto the two-stage read pattern, which is keyed by rank and tile rather
than by the writing block. Instead the kernel takes an `EXIT_BARRIER` constexpr:
holding it until every peer has finished reading makes reuse of one buffer safe
by construction. Producer-direct callers own their input, never stage, and pass
`False`.

## Validation

- `46 passed` in the Iris communication suite, including the world-4 and world-8
  all-reduce correctness checks. Their shapes do exercise the new path -- 1024,
  896, 7168 and 229376 all partition evenly; only the small `(8,)` case stays on
  one-shot.
- `pre-commit run --all-files`
- Added tests pinning the dispatch predicate across dtypes and world sizes,
  including the dtypes that must stay on one-shot.
- Concurrent greedy decoding at the graph-captured batch sizes produces the same
  answers and the same output-to-output variation as an unpatched build of the
  same commit. That variation is pre-existing batch-position nondeterminism: an
  unpatched control reproduces it exactly, so it is not evidence either way about
  this path, and the check is reported only as "no new divergence".

## Notes for review

- **Results change in the last bits.** Grouping the summation differently from
  one-shot shifts rounding. Each form is deterministic run to run, but anything
  pinned bitwise against the old path will move.
- **Shared code path, measured on one model.** The CDNA4 gate leaves older AMD
  parts on the existing one-shot path, but every CDNA4 caller going through the
  Triton all-reduce backend picks this up, and the end-to-end numbers above come
  from one model at one placement.
- **The staging buffer is deliberately not rotated.** See above: a host-side
  slot counter is incorrect under graph replay. If a reviewer would rather pay
  for slot rotation than a barrier, it has to be driven from a device-side epoch
  the way one-shot does it.
- Payloads above the backend's size ceiling still fall back to NCCL and are
  untouched by this change. Raising that ceiling is worth its own look --
  measured separately, two-stage beats NCCL by 10-29% above it -- and is
  deliberately not bundled here.
