### PR TITLE
fix(runtime): preserve draft prefill KV write locations

### DIFF
--- a/docs/design/unified_path.md
+++ b/docs/design/unified_path.md
@@ -453,7 +453,10 @@ buffer; `fill_input_buffers` takes no table.
   write. A model path that writes multiple mode windows in one shot (the
   MLA draft's step-0 whole-batch write) concatenates the EXTEND span and the
   DECODE window — eager-only, MIXED rounds never run under a captured
-  graph. V4 composes the shared token-shaped resolve
+  graph. The router performs the same composition when a draft step-0
+  forward locally dispatches as DECODE while retaining the round's full K/V
+  rows; target MIXED decode halves and later draft steps keep their ordinary
+  decode-only windows. V4 composes the shared token-shaped resolve
   (`page_table.group_slot_mapping_from_raw`) over its own group tables; a
   degraded mapping fails closed to `-1` (skipped write), never to a raw
   fallback vector.

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/router.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/router.py
@@ -351,6 +351,22 @@ class CacheGroupRouter(AttentionBackend):
             )
         return self._extend_write_locations[gid]
 
+    def _forward_decode_write_locations(self, layer: PagedAttention) -> torch.Tensor:
+        """Include EXTEND rows when draft step 0 locally dispatches as DECODE."""
+        from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+
+        decode_locations = self.write_locations(layer, ForwardMode.DECODE)
+        if (
+            not self.is_draft
+            or self._decode_request_offset == 0
+            or self._extend_write_locations is None
+        ):
+            return decode_locations
+        extend_locations = self._extend_write_locations[layer.group_id]
+        if decode_locations.numel() == 0:
+            return extend_locations
+        return torch.cat((extend_locations, decode_locations))
+
     # ------------------------------------------------------------------
     # Metadata
     # ------------------------------------------------------------------
@@ -664,7 +680,11 @@ class CacheGroupRouter(AttentionBackend):
         # Under a prefill-graph replay the frozen forward_mode scalar is
         # always EXTEND, which is also the live mode.
         leaf = self._leaf_for(layer)
-        out_cache_loc = self.write_locations(layer, forward_mode)
+        out_cache_loc = (
+            self._forward_decode_write_locations(layer)
+            if forward_mode.is_decode()
+            else self.write_locations(layer, forward_mode)
+        )
         with self.record_pd_cache_step(forward_mode, save_kv_cache, record_kv_cache):
             if forward_mode.is_decode():
                 return leaf.forward_decode(
@@ -703,10 +723,8 @@ class CacheGroupRouter(AttentionBackend):
         **kwargs,
     ):
         """Composite hosts (hybrid GDN/KDA) dispatch decode directly."""
-        from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
-
         leaf = self._leaf_for(layer)
-        out_cache_loc = self.write_locations(layer, ForwardMode.DECODE)
+        out_cache_loc = self._forward_decode_write_locations(layer)
         return leaf.forward_decode(
             q,
             k,

--- a/test/runtime/test_cache_group_router.py
+++ b/test/runtime/test_cache_group_router.py
@@ -548,7 +548,7 @@ class CacheGroupRouterTest(unittest.TestCase):
             )
 
     def test_mixed_round_slices_decode_requests_after_the_extend_requests(self):
-        router, _ = self._router(spec=1)
+        router, leaves = self._router(spec=1)
         # Request 0 extends (prefix 4, 5 new tokens), request 1 decodes at
         # seq 4.
         seq_lens = torch.tensor([9, 4], dtype=torch.int32)
@@ -573,6 +573,138 @@ class CacheGroupRouterTest(unittest.TestCase):
         self.assertEqual(
             router.write_locations(_layer(FULL), ForwardMode.DECODE).tolist(), [39]
         )
+        router.forward(
+            torch.zeros(1),
+            torch.zeros(1),
+            torch.zeros(1),
+            _layer(FULL),
+            None,
+            ForwardMode.DECODE,
+            1,
+        )
+        self.assertEqual(leaves[FULL].calls[-1][2].tolist(), [39])
+
+    def test_draft_step_zero_local_decode_writes_the_full_extend_span(self):
+        router, leaves = self._router(is_draft=True, spec=1)
+        seq_lens = torch.tensor([9], dtype=torch.int32)
+        extend_seq_lens = torch.tensor([5], dtype=torch.int32)
+        extend_prefix_lens = torch.tensor([4], dtype=torch.int32)
+        router.init_forward_metadata(
+            1,
+            1,
+            torch.arange(1, dtype=torch.int32),
+            seq_lens,
+            ForwardMode.EXTEND,
+            block_tables=self._tables(1),
+            extend_seq_lens=extend_seq_lens,
+            extend_seq_lens_cpu=extend_seq_lens.clone(),
+            extend_prefix_lens=extend_prefix_lens,
+            extend_prefix_lens_cpu=extend_prefix_lens.clone(),
+            extend_with_prefix=True,
+        )
+        router.refresh_decode_metadata(
+            1,
+            1,
+            torch.arange(1, dtype=torch.int32),
+            seq_lens,
+            forward_mode=ForwardMode.DECODE,
+            block_tables=self._tables(1),
+            num_extends=1,
+        )
+        router.forward(
+            torch.zeros(1),
+            torch.zeros(5),
+            torch.zeros(5),
+            _layer(FULL),
+            None,
+            ForwardMode.DECODE,
+            1,
+        )
+        self.assertEqual(leaves[FULL].calls[-1][2].tolist(), [24, 25, 26, 27, 0])
+
+    def test_draft_step_zero_one_token_extend_ignores_q_k_shape_equality(self):
+        router, leaves = self._router(is_draft=True, spec=1)
+        seq_lens = torch.tensor([5], dtype=torch.int32)
+        one = torch.ones(1, dtype=torch.int32)
+        prefix = torch.tensor([4], dtype=torch.int32)
+        router.init_forward_metadata(
+            1,
+            1,
+            torch.arange(1, dtype=torch.int32),
+            seq_lens,
+            ForwardMode.EXTEND,
+            block_tables=self._tables(1),
+            extend_seq_lens=one,
+            extend_seq_lens_cpu=one.clone(),
+            extend_prefix_lens=prefix,
+            extend_prefix_lens_cpu=prefix.clone(),
+            extend_with_prefix=True,
+        )
+        router.refresh_decode_metadata(
+            1,
+            1,
+            torch.arange(1, dtype=torch.int32),
+            seq_lens,
+            forward_mode=ForwardMode.DECODE,
+            block_tables=self._tables(1),
+            num_extends=1,
+        )
+        q = torch.zeros(1)
+        router.forward_decode(q, q, q, _layer(FULL), None, 1)
+        self.assertEqual(leaves[FULL].calls[-1][2].tolist(), [24])
+
+    def test_draft_step_zero_mixed_decode_composes_both_windows(self):
+        router, leaves = self._router(is_draft=True, spec=1)
+        seq_lens = torch.tensor([9, 4], dtype=torch.int32)
+        extend_seq_lens = torch.tensor([5], dtype=torch.int32)
+        extend_prefix_lens = torch.tensor([4], dtype=torch.int32)
+        router.init_forward_metadata(
+            2,
+            1,
+            torch.arange(2, dtype=torch.int32),
+            seq_lens,
+            ForwardMode.MIXED,
+            block_tables=self._tables(),
+            extend_seq_lens=extend_seq_lens,
+            extend_seq_lens_cpu=extend_seq_lens.clone(),
+            extend_prefix_lens=extend_prefix_lens,
+            extend_prefix_lens_cpu=extend_prefix_lens.clone(),
+            extend_with_prefix=True,
+        )
+        router.refresh_decode_metadata(
+            2,
+            2,
+            torch.arange(2, dtype=torch.int32),
+            seq_lens,
+            forward_mode=ForwardMode.DECODE,
+            block_tables=self._tables(),
+            num_extends=1,
+        )
+        router.forward(
+            torch.zeros(2),
+            torch.zeros(6),
+            torch.zeros(6),
+            _layer(FULL),
+            None,
+            ForwardMode.DECODE,
+            2,
+        )
+        self.assertEqual(leaves[FULL].calls[-1][2].tolist(), [24, 25, 26, 27, 0, 39])
+
+        later = router.publish_draft_step_locations(
+            cache_start=torch.tensor([4, 0], dtype=torch.int32), num_tokens=1
+        )
+        router.forward(
+            torch.zeros(2),
+            torch.zeros(2),
+            torch.zeros(2),
+            _layer(FULL),
+            None,
+            ForwardMode.DECODE,
+            2,
+        )
+        self.assertEqual(leaves[FULL].calls[-1][2].data_ptr(), later.data_ptr())
+        self.assertEqual(later.tolist(), [24, 36])
 
     def test_capture_seeds_with_idle_rows_then_calls_leaf_capture_hooks(self):
         router, leaves = self._router()


### PR DESCRIPTION
## Summary
 Fix Qwen3.5-397B-A17B-NVFP4 MTP acceptance-rate regression on B200 TP8 CI.

## Root Cause
Draft step 0 (which is draft prefill step) locally dispatches attention as DECODE while retaining the full EXTEND K/V rows. The decode request offset incorrectly removed the EXTEND write locations, causing K/V rows to be truncated and skipped.

The missing draft KV writes changed subsequent draft candidates, causing the target model to reject more speculative tokens.

The fix composes the EXTEND span with the DECODE window for draft step 0 while preserving the existing behavior for target decode and later draft steps.

## Example
For a draft step-0 prefill with one request and 22 new tokens:

```text
Q shape:                (1, 2048)
K/V rows:               22
EXTEND write locations: 22
DECODE write locations: 0
```

Before the fix, the local DECODE dispatch selected the empty DECODE window. The TRT-LLM backend therefore truncated K/V from 22 rows to 0 and wrote nothing to the draft KV cache.

After the fix, draft step 0 selects all 22 EXTEND locations. For a MIXED batch, it selects the EXTEND locations 
followed by the DECODE locations, matching the K/V row order.
 
## Test Plan
- E2E correctness test passed.
- TP8 CI performance test passed.
- Average decoded tokens per iteration recovered from 3.27 to approximately 3.6.