### PR TITLE
refactor(cache): pin ordinary store sources until the ACK; stream-order only the retraction snapshot

### DIFF
--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -224,14 +224,23 @@ blocks, the transfer boundary validates the loaded block count and returns
 before mapping Host pointers or touching the accelerator runtime. Flagged
 loads still publish readiness for empty consumers.
 
-Writeback uploads block metadata asynchronously on the caller stream. An
-event recorded after both metadata copies protects the pinned CPU staging
-tables: before refilling them, the next submission waits only if that event
-is incomplete. This does not wait for the payload transfer or publish a
-writeback ACK. Device metadata reuse stays ordered after the previous payload
-by caller-stream FIFO; the forward-to-cache and cache-to-page-reuse fences
-remain unchanged. Even a partially submitted metadata upload records its
-retirement event before propagating a staging failure.
+Writeback runs on the executor's write stream, ordered after the caller's
+stream (which the caller has already ordered behind the forwards that wrote
+the pages). Each op says how the scheduler guards its Device sources
+(`source_pinned`, see `scheduler.md` §2). A pinned op's sources stay cached
+and unevictable until the ACK, so its copy overlaps whatever the round does
+next and nobody waits on it. An unpinned op's sources may be re-granted in the
+same plan, so it is launched first and the caller's stream waits on its
+completion event before the plan's page zeroing is enqueued — the zeroing,
+load-backs, forwards and RDMA triggers behind it inherit the fence. The two
+kinds use separate staging lanes: each lane uploads block metadata
+asynchronously and records an event after both metadata copies to protect its
+pinned CPU staging tables — before refilling them, the next submission on
+that lane waits only if that event is incomplete. This does not wait for the
+payload transfer or publish a writeback ACK. Device metadata reuse stays
+ordered after the previous payload by write-stream FIFO. Even a partially
+submitted metadata upload records its retirement event before propagating a
+staging failure.
 
 Ready flags are valid only for a full-geometry H2D transfer. Consumers first
 wait for the current generation's flag initialization event, then its layer
@@ -390,7 +399,11 @@ Its responsibilities:
   Host. At finish or retraction, all eligible Device-resident non-state pages
   and only the newest Device-resident checkpoint per state group are queued
   before request ownership is released. Ordinary sliding-window entries
-  always stream when published.
+  always stream when published. The queue is drained by
+  `TierTransferManager::StartPendingStores(guard)`: every store but a
+  retraction's snapshot pins its Device sources until the ACK; the snapshot
+  store is stream-ordered instead, because its sources are re-granted in the
+  same round (`scheduler.md` §2).
 * **Reclamation and lifecycle.** `ReclaimExpired`, `Free`,
   `ClearDeviceCache`/`ClearCache`, and `NumNewlyReleasableLcmBlocks` for
   ranking retraction (preemption) victims.

--- a/docs/design/event-loop.md
+++ b/docs/design/event-loop.md
@@ -262,11 +262,14 @@ For orientation, one iteration of `event_loop`:
 4. **One `DeviceHandle.execute(plan, planned)` call per round**, in an order
    that is itself a correctness contract for same-round page reuse:
    host-cache write-backs first (a retraction's snapshot copy must read the
-   reused pages' old bytes), then page zeroing (the new owner's
+   reused pages' old bytes, so its op is stream-ordered and fences the
+   forward thread's stream on its completion here; an ordinary store's
+   sources are pinned by the scheduler until the ACK, so its copy rides the
+   write stream and fences nothing), then page zeroing (the new owner's
    sanitization), then load-backs (they target zeroed pages), then the
    plan's remote streams to the transfer peer (a D-node remote prefill
    waits on the zeroing fence inside its submission, which the FIFO orders
-   after the write-backs), then the plan's batch to the model. `planned` is
+   after the write-back fence), then the plan's batch to the model. `planned` is
    None on idle and empty rounds; the plan's own work (hygiene, the remote
    streams) still runs. Then commit from the queue head down to the
    effective depth and poll PD transfer events.

--- a/docs/design/scheduler.md
+++ b/docs/design/scheduler.md
@@ -165,21 +165,40 @@ required a cross-round capacity barrier. Two edges of the loop:
   order (§3) tries the blocker before any other claim.
 
 **The victim's pages are released — and grantable — immediately**, even though
-its L2 snapshot has not been copied yet. The runtime enqueues the D2H snapshot
-copy on the **forward thread's stream** ahead of everything else the plan does
-to those pages — the same stream carries the zeroing, fences the forwards, and
-gates a granted remote prefill's RDMA trigger (see `DeviceHandle.execute` and
-`event-loop.md`) — so the copy reads the old bytes whatever the scheduler does
-with the pages. Store tickets consequently pin only their Host destinations;
-the ack's one job is publishing the Host entry.
+its L2 snapshot has not been copied yet. The snapshot store is issued with
+`StoreSourceGuard::kStreamOrdered`: its ticket pins only the Host destination,
+and the runtime fences the **forward thread's stream** on the D2H copy's
+completion ahead of everything else the plan does to those pages — that
+stream carries the zeroing, fences the forwards, and gates a granted remote
+prefill's RDMA trigger (see `DeviceHandle.execute` and `event-loop.md`) — so
+the copy reads the old bytes whatever the scheduler does with the pages. This
+is the one store that pays for its ordering on the forward's critical path,
+and it has to: the pages are gone in the same round.
+
+**Every other store pins its Device sources until the ack.** Boundary
+publications of a live request and the finish-time flush are issued with
+`StoreSourceGuard::kPinnedUntilAck`: the ticket holds a `CacheBlockRef` on
+each source, so the block stays cached and unevictable — the admission planner
+cannot take it, `ClearDeviceCache` refuses, `NumNewlyReleasableLcmBlocks` does
+not count it — until `CompleteWriteBack` publishes the Host entry and drops the
+pin. Nothing else needs to know the copy is in flight, so the runtime copies
+on its own stream and no forward waits. A cached block is never written again
+by its owner (prefix reuse already depends on that), so the pin alone makes
+the copy race-free. Both guards are one path — `StartPendingStores(guard)` —
+and the op carries `source_pinned` to the runtime, which branches on the guard
+and never on the reason.
 
 **Per-victim quiescence, not global.** A request whose own forward is still
 out must not be retracted — its result would land on pages it no longer owns —
 and one whose pages a PD transfer still pins must not be either. Both are
 checked on the chosen victim; if it is not quiescent, retraction waits for it
-rather than sacrificing a worse-ranked request. The one remaining global gate
-is an in-flight load-back: it is writing pages its readmission owns, and the
-victim policy cannot see that write. In-flight *stores* gate nothing anymore.
+rather than sacrificing a worse-ranked request. Two global gates remain. An
+in-flight load-back: it is writing pages its readmission owns, and the victim
+policy cannot see that write. And an in-flight *pinned* store: it holds Device
+capacity the ack returns by itself, so retracting anyone for that capacity
+would be the thrash of §4 — the blocked admission retries against the
+released pins next round instead. Stream-ordered stores hold nothing and gate
+nothing.
 
 The forward-out check is a count on `fsm::ForwardState`, incremented when a
 forward is scheduled and cleared when its result lands. It lives on the base
@@ -372,13 +391,18 @@ no victim and nothing could free that page.
   prefill.
 - Retraction fires only when no prefill progressed and an admission failed
   (2). The chosen victim must be quiescent — no forward of its own in flight,
-  no PD pin on its pages — and an in-flight load-back defers all retraction;
-  in-flight stores defer nothing.
+  no PD pin on its pages — and an in-flight load-back or an in-flight pinned
+  store defers all retraction; stream-ordered stores defer nothing.
 - Freed capacity is granted to the request it was freed for in the same plan
   build whenever the round's grammar admits the grant (2); the write-back →
   zero → load → forward order on the forward thread's stream is what makes
   the immediate release safe, and changing `DeviceHandle.execute`'s ordering
   breaks it.
+- A store either pins its Device sources until the ack or is stream-ordered;
+  never neither (2). Only `retractVictim` issues a stream-ordered store — its
+  sources are granted away in the same round — and only such an op may be
+  fenced ahead of the plan's page reuse by the runtime. A new store site
+  chooses its guard explicitly (`StartPendingStores` has no default).
 - Only computed tokens are published as a prefix — `retractVictim` reads the
   window of an incomplete prefill rather than its whole token count.
 - At most one readmission is in progress per role, by phase construction; a

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -80,6 +80,21 @@ class _Ack(NamedTuple):
     op_ids: list[int]
 
 
+class _WriteLane:
+    """Staging for one kind of write-back submission.
+
+    Each lane owns its transfer workspace and the event guarding that
+    workspace's pinned metadata staging, so the two lanes a round may submit
+    (stream-ordered, then pinned) never wait on each other's staging.
+    """
+
+    __slots__ = ("workspace", "metadata_done")
+
+    def __init__(self) -> None:
+        self.workspace = HostTransferWorkspace()
+        self.metadata_done = None
+
+
 def _num_host_lcm_blocks(
     *,
     host_lcm_block_bytes: int,
@@ -163,14 +178,18 @@ class L2CacheExecutor:
             tracker = LayerwiseLoadTracker(len(layout.consumers))
             pool.register_layerwise_load_tracker(tracker)
             self._load_trackers.append((tracker, len(layout.consumers)))
-        # Write-backs run on the CALLER's current stream -- the forward
-        # thread's default stream, the same one that carries the plan's page
-        # zeroing and fences its forwards. That single-stream FIFO is the
-        # correctness story for retraction: the D2H snapshot copy reads the
-        # victim's pages after the victim's last forward wrote them and
-        # before anything later in the plan (zeroing, the granted request's
-        # work) can touch them. Loads keep their own stream: their consumers
-        # are fenced per layer by the tracker events.
+        # Write-backs run on their own stream, ordered after the caller's
+        # current stream -- the forward thread's default stream, which the
+        # caller has already ordered behind the forwards that wrote the
+        # pages. What differs per op is who waits on the copy: a
+        # stream-ordered op (a retraction's snapshot, whose sources this very
+        # plan may re-grant) fences the caller's stream on its completion, so
+        # the plan's zeroing, load-backs and forwards stay behind it; a pinned
+        # op (an ordinary publication, whose sources the scheduler holds until
+        # the ACK) fences nothing and never holds up the round. Loads keep
+        # their own stream: their consumers are fenced per layer by the
+        # tracker events.
+        self.write_stream = _new_cache_stream(None)
         self.load_stream = _new_cache_stream(_load_stream_priority())
         device = self.layout.buffers[0].device
         fields_by_id = {}
@@ -235,12 +254,12 @@ class L2CacheExecutor:
             num_device_buffers=len(self.layout.buffers),
         )
         if io_backend == "kernel" and device.type != "npu":
-            # Both the caller stream (D2H) and load stream (H2D) consume this
+            # Both the write stream (D2H) and load stream (H2D) consume this
             # immutable table, so publish it synchronously once at init.
             geometry = geometry.bind(device, non_blocking=False)
         self._transfer_geometry = geometry
-        self._write_workspace = HostTransferWorkspace()
-        self._write_metadata_done = None
+        self._ordered_write_lane = _WriteLane()
+        self._pinned_write_lane = _WriteLane()
         # A tracker waits for an event set's previous final-layer event before
         # reusing its index. Aligning workspaces to those indices keeps each
         # load's pinned and Device block-ID tables immutable until all
@@ -266,26 +285,38 @@ class L2CacheExecutor:
         self._load_poisoned = False
 
     def submit_write_backs(self, plan) -> None:
-        """Enqueue the plan's D2H snapshot copies on the current stream.
+        """Enqueue the plan's D2H copies on the write stream.
 
-        Must run BEFORE the plan's page zeroing: the scheduler may have
-        granted a snapshot's source pages to another request in the same
-        plan, and only the stream order keeps the copy reading the old bytes.
+        Must run BEFORE the plan's page zeroing, on the caller's stream
+        already ordered behind the forwards that wrote the pages. The
+        scheduler marks each op ``source_pinned``: a pinned op's sources stay
+        cached and unevictable until the ACK, so its copy rides the write
+        stream and nobody waits on it; an unpinned op's sources may already
+        be granted to another request in this very plan, so it goes first and
+        the caller's stream waits on its completion -- the plan's zeroing,
+        load-backs and forwards are ordered behind that wait.
         """
-        op_ids: list[int] = []
-        transfers: list[tuple[int, int, int]] = []
+        ordered_op_ids: list[int] = []
+        ordered_transfers: list[tuple[int, int, int]] = []
+        pinned_op_ids: list[int] = []
+        pinned_transfers: list[tuple[int, int, int]] = []
         for operation in plan.cache:
             if isinstance(operation, Cache.WriteBackOp):
-                self._append_transfers(
-                    operation.op_ids,
-                    operation.group_ids,
-                    operation.src_pages,
-                    operation.dst_pages,
-                    collected_op_ids=op_ids,
-                    transfers=transfers,
-                    source_is_device=True,
+                self._append_write_backs(
+                    operation,
+                    ordered_op_ids=ordered_op_ids,
+                    ordered_transfers=ordered_transfers,
+                    pinned_op_ids=pinned_op_ids,
+                    pinned_transfers=pinned_transfers,
                 )
-        self._start_writing(op_ids, transfers)
+        fence = self._start_writing(
+            ordered_op_ids, ordered_transfers, lane=self._ordered_write_lane
+        )
+        if fence is not None:
+            device_module.current_stream().wait_event(fence)
+        self._start_writing(
+            pinned_op_ids, pinned_transfers, lane=self._pinned_write_lane
+        )
 
     def submit_load_backs(self, plan) -> None:
         """Launch the plan's H2D loads; runs after the plan's page zeroing."""
@@ -305,6 +336,35 @@ class L2CacheExecutor:
         load_index = self._start_loading(op_ids, transfers)
         for tracker, _ in self._load_trackers:
             tracker.set_consumers(load_index if load_index is not None else -1)
+
+    @classmethod
+    def _append_write_backs(
+        cls,
+        operation,
+        *,
+        ordered_op_ids: list[int],
+        ordered_transfers: list[tuple[int, int, int]],
+        pinned_op_ids: list[int],
+        pinned_transfers: list[tuple[int, int, int]],
+    ) -> None:
+        source_pinned = operation.source_pinned
+        if len(source_pinned) != len(operation.op_ids):
+            raise ValueError("ragged cache operation batch")
+        for index, pinned in enumerate(source_pinned):
+            op_ids, transfers = (
+                (pinned_op_ids, pinned_transfers)
+                if pinned
+                else (ordered_op_ids, ordered_transfers)
+            )
+            cls._append_transfers(
+                operation.op_ids[index : index + 1],
+                operation.group_ids[index : index + 1],
+                operation.src_pages[index : index + 1],
+                operation.dst_pages[index : index + 1],
+                collected_op_ids=op_ids,
+                transfers=transfers,
+                source_is_device=True,
+            )
 
     @staticmethod
     def _append_transfers(
@@ -337,56 +397,64 @@ class L2CacheExecutor:
         self,
         op_ids: Sequence[int],
         transfers: Sequence[tuple[int, int, int]],
-    ) -> None:
+        *,
+        lane: _WriteLane,
+    ):
+        """Launch one D2H batch on the write stream; return its completion event.
+
+        Returns None when nothing was launched (no ops, or ops with no
+        transfers, which are acknowledged at the next poll).
+        """
         if not op_ids:
-            return
+            return None
         op_ids = _ordered_unique(op_ids)
         if not transfers:
             with self._ack_lock:
                 self._ready_write_op_ids.extend(op_ids)
-            return
+            return None
         if self.attn_tp_rank == 0:
             logger.info(
-                "[L2] writeback started: operations=%d blocks=%d",
+                "[L2] writeback started: operations=%d blocks=%d pinned=%s",
                 len(op_ids),
                 len(transfers),
+                lane is self._pinned_write_lane,
             )
-        # On the caller's (forward thread's default) stream: the scheduler
-        # releases -- and may re-grant -- the source pages the moment it
-        # emits this op, and the single-stream FIFO is what keeps the copy
-        # ahead of the pages' next writer.
-        stream = device_module.current_stream()
+        # The caller's stream is already ordered behind the forwards that
+        # wrote the source pages; inheriting it here is what lets the copy
+        # read the final bytes.
+        stream = self.write_stream
+        stream.wait_stream(device_module.current_stream())
         # CPU writes are not ordered by stream FIFO. Retire the previous
         # metadata upload before refilling its pinned source, not at submit.
-        if self._write_metadata_done is not None:
-            if not self._write_metadata_done.query():
-                self._write_metadata_done.synchronize()
-        num_blocks, _ = self._write_workspace.load_block_transfers(
+        if lane.metadata_done is not None:
+            if not lane.metadata_done.query():
+                lane.metadata_done.synchronize()
+        num_blocks, _ = lane.workspace.load_block_transfers(
             transfers, geometry=self._transfer_geometry
         )
-        mode = self._write_workspace.prepare_backend(
+        mode = lane.workspace.prepare_backend(
             self.layout.buffers,
             self.host_storage.host_buffer,
             backend=self.transfer_backend,
         )
         if mode.uses_device_tables:
-            if self._write_metadata_done is None:
-                self._write_metadata_done = device_module.Event()
+            if lane.metadata_done is None:
+                lane.metadata_done = device_module.Event()
             try:
-                self._write_workspace.commit_block_transfers(
+                lane.workspace.commit_block_transfers(
                     num_blocks, self.layout.buffers[0].device, non_blocking=True
                 )
             finally:
                 # Also protect a partially submitted upload if staging fails.
                 # This event excludes the payload transfer; Device table reuse
-                # and source-page reuse remain ordered by the caller stream.
-                self._write_metadata_done.record(stream)
+                # remains ordered by the write stream's FIFO.
+                lane.metadata_done.record(stream)
         transfer_cache_blocks(
             "d2h",
             self.layout.buffers,
             self.host_storage.host_buffer,
             self._transfer_geometry,
-            self._write_workspace,
+            lane.workspace,
             stream,
             num_blocks=num_blocks,
             geometry_offset=0,
@@ -399,6 +467,7 @@ class L2CacheExecutor:
         finish.record(stream)
         with self._ack_lock:
             self._write_acks.append(_Ack(finish, op_ids))
+        return finish
 
     def _start_loading(
         self,
@@ -601,9 +670,10 @@ class L2CacheExecutor:
         return event
 
     def shutdown(self) -> None:
-        # Write-backs ride the default stream (shared per device, so this
-        # thread's handle reaches them); only loads have their own stream.
+        # The caller's stream carries the fences the transfers were ordered
+        # behind; the write and load streams carry the transfers themselves.
         torch.cuda.current_stream().synchronize()
+        self.write_stream.synchronize()
         self.load_stream.synchronize()
 
     def reset(self) -> None:

--- a/python/tokenspeed/runtime/execution/device.py
+++ b/python/tokenspeed/runtime/execution/device.py
@@ -270,11 +270,15 @@ class DeviceHandle:
 
         The whole plan on the FIFO -- one thread, explicitly ordered streams -- in an order
         that IS the correctness argument for same-round page reuse:
-        retraction write-backs first (they must read the reused pages' old
-        bytes), then page zeroing (the new owner's sanitization), then
-        load-backs (they target zeroed pages), the transfer peer's remote
-        streams, and finally the ``ForwardBatch``. The loop hands the round
-        over and does not branch on it.
+        write-backs first (a stream-ordered one -- a retraction's snapshot,
+        whose sources this plan may re-grant -- fences the caller's stream
+        on its completion so it reads the reused pages' old bytes; a pinned
+        one -- an ordinary publication, whose sources the scheduler holds
+        until the ACK -- rides the write stream and fences nothing), then
+        page zeroing (the new owner's sanitization), then load-backs (they
+        target zeroed pages), the transfer peer's remote streams, and finally
+        the ``ForwardBatch``. The loop hands the round over and does not
+        branch on it.
 
         Args:
             execution_plan: The round's plan, a per-round value copy out of
@@ -304,8 +308,9 @@ class DeviceHandle:
         executor = self._executor
         l2 = self._l2 if execution_plan.cache else None
         if l2 is not None:
-            # Ahead of the zeroing: a retraction's snapshot sources may be
-            # this very plan's pages_to_zero.
+            # Ahead of the zeroing: a stream-ordered store's sources may be
+            # this very plan's pages_to_zero, and its fence lands on the
+            # caller's stream here, before the zeroing is enqueued.
             def _write_backs():
                 executor.order_cache_operations()
                 l2.submit_write_backs(execution_plan)
@@ -453,10 +458,10 @@ class DeviceHandle:
         pages, so it must follow them and the zeroing fence (Mooncake and
         GPUDirect writes are not ordered by the zeroing stream, so the
         destination pages must be published from sanitized memory). The same
-        fence covers a retraction write-back reading pages this admission was
-        granted: the zero event is recorded on the forward thread's stream
-        AFTER the write-back copies, so waiting on it waits on them too. One
-        ordered
+        fence covers a retraction's stream-ordered write-back reading pages
+        this admission was granted: the zero event is recorded on the forward
+        thread's stream AFTER that stream waited on the write-back's
+        completion, so waiting on it waits on the copy too. One ordered
         unit, so one submission — asynchronous like every other: completion
         arrives through the transfer events, and a submission failure
         surfaces from the settle at the next round's execute.

--- a/test/runtime/test_device_handle.py
+++ b/test/runtime/test_device_handle.py
@@ -131,6 +131,7 @@ def _handle(trace, **kwargs):
         SimpleNamespace(
             forward_thread=_ForwardThread(trace),
             execute_forward_op=lambda *a, **k: trace.append("forward"),
+            order_cache_operations=lambda: trace.append("order"),
             write_remote_spec_candidate_ids=lambda idx, ids: trace.append(
                 ("candidates", idx, list(ids))
             ),
@@ -232,15 +233,17 @@ def test_an_aborted_request_still_lands_its_candidates_but_is_not_armed():
 
 
 # ----------------------------------------------------------------------
-# L2 cache plans: write-backs launch AHEAD of the zeroing (they must read
-# the reused pages' old bytes), load-backs behind it.
+# L2 cache plans: write-backs launch AHEAD of the zeroing (a stream-ordered
+# one must read the reused pages' old bytes, and fences the caller's stream
+# before the zeroing is enqueued), load-backs behind it.
 # ----------------------------------------------------------------------
 
 
 def test_one_plan_orders_write_backs_zeroing_then_load_backs():
     """The FIFO carries the correctness order for same-round page reuse: the
-    retraction snapshot copies read the reused pages before the new owner's
-    zeroing wipes them, and the load-backs target zeroed pages."""
+    write-backs are submitted behind the forward fence and ahead of the new
+    owner's zeroing (a stream-ordered snapshot copy lands its fence there),
+    and the load-backs target zeroed pages."""
     trace: list = []
     plan = _plan(pages_to_zero=[3, 4], cache=["op"])
     handle = _handle(
@@ -259,6 +262,7 @@ def test_one_plan_orders_write_backs_zeroing_then_load_backs():
 
     assert trace == [
         "submit",
+        "order",
         ("write_backs", ["op"]),
         "submit",
         ("zero", (3, 4)),
@@ -268,6 +272,27 @@ def test_one_plan_orders_write_backs_zeroing_then_load_backs():
     # Polling never touches the FIFO — the round head must not wait on it.
     assert handle.poll_cache_results() == ["done"]
     assert trace[-1] != "submit"
+
+
+def test_zeroing_without_cache_ops_still_orders_behind_the_forwards():
+    """With no L2 work this round the zeroing closure itself must place the
+    forward fence: nothing else on the FIFO would."""
+    trace: list = []
+    handle = _handle(
+        trace,
+        l2_cache_executor=SimpleNamespace(
+            submit_write_backs=lambda p: trace.append(("write_backs", p.cache)),
+            submit_load_backs=lambda p: trace.append(("load_backs", p.cache)),
+            poll_results=lambda: [],
+        ),
+    )
+    handle._executor.zero_cache_pages = lambda pages: trace.append(
+        ("zero", tuple(pages))
+    )
+
+    handle.execute(_plan(pages_to_zero=[3]), None)
+
+    assert trace == ["submit", "order", ("zero", (3,))]
 
 
 def test_a_plan_with_no_device_work_submits_nothing():

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -321,10 +321,8 @@ class GroupAwareWireTest(unittest.TestCase):
         self.assertEqual(op_ids, [7])
         self.assertEqual(transfers, [(0, 5, 9), (1, 5, 9)])
 
-    def test_writeback_reuses_static_geometry_on_the_caller_stream(self):
-        executor_module = self._executor_module()
+    def _make_write_executor(self, executor_module):
         L2CacheExecutor = executor_module.L2CacheExecutor
-
         executor = L2CacheExecutor.__new__(L2CacheExecutor)
         executor._ack_lock = threading.Lock()
         executor.attn_tp_rank = 0
@@ -334,24 +332,34 @@ class GroupAwareWireTest(unittest.TestCase):
         executor.host_storage = SimpleNamespace(host_buffer="host")
         executor.transfer_backend = "auto"
         executor._write_acks = []
-        executor._write_workspace = Mock()
-        executor._write_metadata_done = None
-        executor._write_workspace.load_block_transfers.return_value = (1, (0, 1))
-        executor._write_workspace.prepare_backend.return_value = SimpleNamespace(
-            uses_device_tables=True,
-        )
+        executor.write_stream = Mock(name="write_stream")
+        for lane_name in ("_ordered_write_lane", "_pinned_write_lane"):
+            lane = SimpleNamespace(workspace=Mock(), metadata_done=None)
+            lane.workspace.load_block_transfers.return_value = (1, (0, 1))
+            lane.workspace.prepare_backend.return_value = SimpleNamespace(
+                uses_device_tables=True,
+            )
+            setattr(executor, lane_name, lane)
         executor._transfer_geometry = SimpleNamespace(
             device_rows=object(),
             layer_slices=((0, 2), (2, 1)),
             num_field_rows=3,
         )
-        stream = object()
+        return executor, device
+
+    def test_writeback_rides_the_write_stream_ordered_after_the_caller(self):
+        executor_module = self._executor_module()
+        executor, device = self._make_write_executor(executor_module)
+        lane = executor._pinned_write_lane
+        caller_stream = object()
         finish = Mock()
         metadata_done = Mock()
 
         with (
             patch.object(
-                executor_module.device_module, "current_stream", return_value=stream
+                executor_module.device_module,
+                "current_stream",
+                return_value=caller_stream,
             ),
             patch.object(
                 executor_module.device_module,
@@ -360,15 +368,18 @@ class GroupAwareWireTest(unittest.TestCase):
             ),
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
         ):
-            executor._start_writing([7], [(0, 5, 9)])
+            fence = executor._start_writing([7], [(0, 5, 9)], lane=lane)
 
-        # On the CALLER's current stream: the copy must read the source pages
-        # before anything later in the plan (zeroing, the granted request's
-        # writes) can touch them, and the single-stream FIFO is that fence.
-        executor._write_workspace.load_block_transfers.assert_called_once_with(
+        # On the write stream, ordered after the caller's stream (which the
+        # caller ordered behind the forwards that wrote the pages). The
+        # completion event is handed back so a stream-ordered submission can
+        # fence the caller on it; a pinned one simply drops it.
+        self.assertIs(fence, finish)
+        executor.write_stream.wait_stream.assert_called_once_with(caller_stream)
+        lane.workspace.load_block_transfers.assert_called_once_with(
             [(0, 5, 9)], geometry=executor._transfer_geometry
         )
-        executor._write_workspace.commit_block_transfers.assert_called_once_with(
+        lane.workspace.commit_block_transfers.assert_called_once_with(
             1, device, non_blocking=True
         )
         transfer.assert_called_once_with(
@@ -376,8 +387,8 @@ class GroupAwareWireTest(unittest.TestCase):
             executor.layout.buffers,
             executor.host_storage.host_buffer,
             executor._transfer_geometry,
-            executor._write_workspace,
-            stream,
+            lane.workspace,
+            executor.write_stream,
             num_blocks=1,
             geometry_offset=0,
             num_geometry_rows=3,
@@ -385,9 +396,10 @@ class GroupAwareWireTest(unittest.TestCase):
             grid_cap=None,
             layer_ready_flags=None,
         )
-        finish.record.assert_called_once_with(stream)
-        metadata_done.record.assert_called_once_with(stream)
+        finish.record.assert_called_once_with(executor.write_stream)
+        metadata_done.record.assert_called_once_with(executor.write_stream)
         metadata_done.synchronize.assert_not_called()
+        self.assertIsNone(executor._ordered_write_lane.metadata_done)
 
         # Refill must wait for metadata, but must never wait for payload ACK.
         for ready in (False, True):
@@ -396,18 +408,14 @@ class GroupAwareWireTest(unittest.TestCase):
                 metadata_done.query.return_value = ready
                 order = Mock()
                 order.attach_mock(metadata_done.synchronize, "retire")
-                order.attach_mock(
-                    executor._write_workspace.load_block_transfers, "refill"
-                )
-                order.attach_mock(
-                    executor._write_workspace.commit_block_transfers, "upload"
-                )
+                order.attach_mock(lane.workspace.load_block_transfers, "refill")
+                order.attach_mock(lane.workspace.commit_block_transfers, "upload")
                 order.attach_mock(metadata_done.record, "record")
                 with (
                     patch.object(
                         executor_module.device_module,
                         "current_stream",
-                        return_value=stream,
+                        return_value=caller_stream,
                     ),
                     patch.object(
                         executor_module.device_module, "Event", return_value=finish
@@ -415,7 +423,7 @@ class GroupAwareWireTest(unittest.TestCase):
                     patch.object(executor_module, "transfer_cache_blocks") as transfer,
                 ):
                     order.attach_mock(transfer, "payload")
-                    executor._start_writing([8], [(0, 6, 10)])
+                    executor._start_writing([8], [(0, 6, 10)], lane=lane)
                 names = [call[0] for call in order.mock_calls]
                 self.assertEqual(
                     names,
@@ -423,6 +431,116 @@ class GroupAwareWireTest(unittest.TestCase):
                     + ["refill", "upload", "record", "payload"],
                 )
                 finish.synchronize.assert_not_called()
+
+    def test_submit_write_backs_fences_only_stream_ordered_ops(self):
+        executor_module = self._executor_module()
+        executor, _ = self._make_write_executor(executor_module)
+        caller_stream = Mock(name="caller_stream")
+        ordered_finish = Mock(name="ordered_finish")
+        pinned_finish = Mock(name="pinned_finish")
+        events = iter(
+            [
+                Mock(name="ordered_meta"),
+                ordered_finish,
+                Mock(name="pinned_meta"),
+                pinned_finish,
+            ]
+        )
+
+        class WriteBackOp:
+            def __init__(self):
+                self.op_ids = [11, 12, 13]
+                self.group_ids = [[0], [0], [0]]
+                self.src_pages = [[1], [2], [3]]
+                self.dst_pages = [[5], [6], [7]]
+                self.source_pinned = [True, False, True]
+
+        with (
+            patch.object(
+                executor_module.Cache, "WriteBackOp", WriteBackOp, create=True
+            ),
+            patch.object(
+                executor_module.device_module,
+                "current_stream",
+                return_value=caller_stream,
+            ),
+            patch.object(
+                executor_module.device_module,
+                "Event",
+                side_effect=lambda: next(events),
+            ),
+            patch.object(executor_module, "transfer_cache_blocks") as transfer,
+        ):
+            executor.submit_write_backs(SimpleNamespace(cache=[WriteBackOp()]))
+
+        # The stream-ordered op (12) launches first and the caller's stream
+        # waits on ITS completion only; the pinned ops (11, 13) follow on the
+        # write stream and fence nothing -- the scheduler holds their sources.
+        ordered_lane = executor._ordered_write_lane
+        pinned_lane = executor._pinned_write_lane
+        ordered_lane.workspace.load_block_transfers.assert_called_once_with(
+            [(0, 2, 6)], geometry=executor._transfer_geometry
+        )
+        pinned_lane.workspace.load_block_transfers.assert_called_once_with(
+            [(0, 1, 5), (0, 3, 7)], geometry=executor._transfer_geometry
+        )
+        self.assertEqual(
+            [call.args[4] for call in transfer.call_args_list],
+            [ordered_lane.workspace, pinned_lane.workspace],
+        )
+        caller_stream.wait_event.assert_called_once_with(ordered_finish)
+        self.assertEqual(
+            [(ack.finish_event, ack.op_ids) for ack in executor._write_acks],
+            [(ordered_finish, [12]), (pinned_finish, [11, 13])],
+        )
+
+    def test_submit_write_backs_without_stream_ordered_ops_fences_nothing(self):
+        executor_module = self._executor_module()
+        executor, _ = self._make_write_executor(executor_module)
+        caller_stream = Mock(name="caller_stream")
+
+        class WriteBackOp:
+            def __init__(self):
+                self.op_ids = [11]
+                self.group_ids = [[0]]
+                self.src_pages = [[1]]
+                self.dst_pages = [[5]]
+                self.source_pinned = [True]
+
+        with (
+            patch.object(
+                executor_module.Cache, "WriteBackOp", WriteBackOp, create=True
+            ),
+            patch.object(
+                executor_module.device_module,
+                "current_stream",
+                return_value=caller_stream,
+            ),
+            patch.object(executor_module.device_module, "Event", side_effect=Mock),
+            patch.object(executor_module, "transfer_cache_blocks"),
+        ):
+            executor.submit_write_backs(SimpleNamespace(cache=[WriteBackOp()]))
+
+        caller_stream.wait_event.assert_not_called()
+        executor._ordered_write_lane.workspace.load_block_transfers.assert_not_called()
+
+    def test_submit_write_backs_rejects_ragged_guard_vector(self):
+        executor_module = self._executor_module()
+        executor, _ = self._make_write_executor(executor_module)
+
+        class WriteBackOp:
+            def __init__(self):
+                self.op_ids = [11, 12]
+                self.group_ids = [[0], [0]]
+                self.src_pages = [[1], [2]]
+                self.dst_pages = [[5], [6]]
+                self.source_pinned = [True]
+
+        with patch.object(
+            executor_module.Cache, "WriteBackOp", WriteBackOp, create=True
+        ):
+            with self.assertRaises(ValueError):
+                executor.submit_write_backs(SimpleNamespace(cache=[WriteBackOp()]))
 
     def test_loadback_logs_non_empty_batch(self):
         executor_module, executor, _, geometry, workspace = self._make_load_executor(
@@ -1010,8 +1128,9 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         executor._start_writing(  # pylint: disable=protected-access
             [7],
             [(0, 1, 1), (0, 4, 4), (1, 3, 3)],
+            lane=executor._pinned_write_lane,  # pylint: disable=protected-access
         )
-        torch.cuda.current_stream().synchronize()
+        executor.write_stream.synchronize()
         write_results = executor.poll_results()
         self.assertEqual([int(event.op_id) for event in write_results], [7])
 
@@ -1052,10 +1171,17 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         executor, pool, _ = self._make_executor(layout, io_backend="kernel")
         for generation in range(3):
             # Reuse one Device source, but preserve each batch in its own Host
-            # block. No caller synchronization between write submissions.
+            # block. No caller synchronization between write submissions; the
+            # write stream inherits the caller's order, so each copy reads the
+            # fill that preceded it.
             for block in range(1, 4):
                 device[16:20].fill_(generation * 16 + block)
-                executor._start_writing([block], [(0, 1, block)])
+                executor._start_writing(
+                    [block], [(0, 1, block)], lane=executor._pinned_write_lane
+                )
+            # The load below has no scheduler ACK to wait for, so order it
+            # behind the copies the way a stream-ordered submission would.
+            torch.cuda.current_stream().wait_stream(executor.write_stream)
             device.fill_(0xEE)
             load_index = executor._start_loading(
                 [9], [(0, block, block) for block in range(1, 4)]
@@ -1090,7 +1216,9 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         device[16:20].fill_(0x11)
         device[56:60].fill_(0x12)
         torch.cuda.synchronize()
-        executor._start_writing([7], [(0, 1, 1)])  # pylint: disable=protected-access
+        executor._start_writing(  # pylint: disable=protected-access
+            [7], [(0, 1, 1)], lane=executor._pinned_write_lane
+        )
         torch.cuda.synchronize()
         self.assertEqual([int(event.op_id) for event in executor.poll_results()], [7])
 

--- a/tokenspeed-scheduler/bindings/python_module.cpp
+++ b/tokenspeed-scheduler/bindings/python_module.cpp
@@ -266,7 +266,8 @@ NB_MODULE(tokenspeed_scheduler_ext, m) {
         .def_ro("op_ids", &tokenspeed::WriteBackBatch::op_ids)
         .def_ro("group_ids", &tokenspeed::WriteBackBatch::group_ids)
         .def_ro("src_pages", &tokenspeed::WriteBackBatch::src_pages)
-        .def_ro("dst_pages", &tokenspeed::WriteBackBatch::dst_pages);
+        .def_ro("dst_pages", &tokenspeed::WriteBackBatch::dst_pages)
+        .def_ro("source_pinned", &tokenspeed::WriteBackBatch::source_pinned);
 
     auto collect_forward = [](const tokenspeed::ExecutionPlan& plan) -> nb::list {
         nb::list result;

--- a/tokenspeed-scheduler/csrc/cache/tier/transfer.h
+++ b/tokenspeed-scheduler/csrc/cache/tier/transfer.h
@@ -53,9 +53,24 @@ struct CacheTransferHash {
     }
 };
 
+// How a store's Device source is protected while its D2H copy is in flight.
+enum class StoreSourceGuard : std::uint8_t {
+    // The scheduler pins the Device block until the runtime acknowledges the
+    // copy: it stays cached and unevictable, so the runtime may copy it on
+    // any stream, off the forward's critical path. Ordinary publication.
+    kPinnedUntilAck,
+    // The Device block is released -- and may be re-granted -- the moment the
+    // store issues; the runtime must order the copy on the forward thread's
+    // stream ahead of the plan's page reuse. A retraction's snapshot: the
+    // victim's pages are granted away in the same round.
+    kStreamOrdered,
+};
+
 struct WriteBackOperation {
     std::uint32_t op_id{0};
     std::vector<CacheTransfer> transfers;  // DEVICE→HOST.
+    // False is the safe reading: the runtime orders the copy ahead of reuse.
+    bool source_pinned{false};
 };
 
 struct WriteBackBatch {
@@ -63,6 +78,10 @@ struct WriteBackBatch {
     std::vector<std::vector<std::uint32_t>> group_ids;
     std::vector<std::vector<std::int32_t>> src_pages;
     std::vector<std::vector<std::int32_t>> dst_pages;
+    // Per op: whether the scheduler holds the Device sources until the ACK
+    // (see StoreSourceGuard). The runtime must order an unpinned op's copy
+    // ahead of the plan's page zeroing; a pinned op may ride any stream.
+    std::vector<bool> source_pinned;
 
     explicit WriteBackBatch(const std::vector<WriteBackOperation>& ops) {
         std::unordered_set<CacheTransfer, CacheTransferHash> seen;
@@ -82,6 +101,7 @@ struct WriteBackBatch {
             group_ids.push_back(std::move(operation_groups));
             src_pages.push_back(std::move(operation_sources));
             dst_pages.push_back(std::move(operation_destinations));
+            source_pinned.push_back(op.source_pinned);
         }
     }
 };

--- a/tokenspeed-scheduler/csrc/cache/tier/transfer_manager.cpp
+++ b/tokenspeed-scheduler/csrc/cache/tier/transfer_manager.cpp
@@ -20,13 +20,14 @@
 
 #include "cache/tier/transfer_manager.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "utils.h"
 
 namespace tokenspeed {
 
-std::optional<WriteBackOperation> TierTransferManager::StartPendingStores() {
+std::optional<WriteBackOperation> TierTransferManager::StartPendingStores(StoreSourceGuard guard) {
     std::vector<CacheKey> keys;
     std::vector<CacheBlockRef> device_block_refs;
     std::vector<std::uint32_t> group_ids;
@@ -37,7 +38,7 @@ std::optional<WriteBackOperation> TierTransferManager::StartPendingStores() {
             continue;
         }
 
-        const CacheBlockRef device_block_ref = coordinator_.AcquireDeviceCachedBlock(candidate.key);
+        CacheBlockRef device_block_ref = coordinator_.AcquireDeviceCachedBlock(candidate.key);
         if (!device_block_ref) {
             continue;
         }
@@ -54,6 +55,7 @@ std::optional<WriteBackOperation> TierTransferManager::StartPendingStores() {
     CacheCoordinator::HostAllocationBatch host_allocation = coordinator_.AcquireHostBlocks(group_ids);
     _assert(host_allocation.blocks.size() == keys.size(), "Host allocation result must stay aligned");
 
+    const bool pin_source = guard == StoreSourceGuard::kPinnedUntilAck;
     std::vector<CacheTransfer> transfers;
     std::vector<StoreTicket> tickets;
     transfers.reserve(host_allocation.stats.allocated);
@@ -63,16 +65,18 @@ std::optional<WriteBackOperation> TierTransferManager::StartPendingStores() {
         if (!host_block_ref) {
             continue;
         }
-        // The source page id is resolved here and not pinned: the forward
-        // thread's stream orders the copy ahead of any later reuse.
         const GroupAllocator& manager = coordinator_.Allocator(static_cast<std::int32_t>(group_ids[i]));
         transfers.push_back(CacheTransfer{
             .group_id = group_ids[i],
             .source_page = manager.ResolveCacheBlockId(device_block_refs[i]->Location()),
             .destination_page = manager.ResolveCacheBlockId(host_block_ref->Location()),
         });
+        // A stream-ordered store resolves the source page id and lets the
+        // reference go: the forward thread's stream orders the copy ahead of
+        // any later reuse. A pinned store keeps it until the ACK.
         tickets.push_back(StoreTicket{
             std::move(keys[i]),
+            pin_source ? std::move(device_block_refs[i]) : CacheBlockRef{},
             std::move(host_block_ref),
         });
     }
@@ -84,9 +88,18 @@ std::optional<WriteBackOperation> TierTransferManager::StartPendingStores() {
     for (const StoreTicket& ticket : tickets) {
         store_keys_.insert(ticket.key);
     }
-    const bool inserted = write_backs_.emplace(op_id, std::move(tickets)).second;
+    const bool inserted = write_backs_.emplace(op_id, InFlightWriteBack{guard, std::move(tickets)}).second;
     _assert(inserted, "duplicate store op id");
-    return WriteBackOperation{op_id, std::move(transfers)};
+    return WriteBackOperation{
+        .op_id = op_id,
+        .transfers = std::move(transfers),
+        .source_pinned = pin_source,
+    };
+}
+
+bool TierTransferManager::HasPinnedStoresInFlight() const {
+    return std::ranges::any_of(
+        write_backs_, [](const auto& entry) { return entry.second.guard == StoreSourceGuard::kPinnedUntilAck; });
 }
 
 LoadBackOperation TierTransferManager::StartPrefixLoad(std::vector<BlockTransfer> block_transfers) {
@@ -113,11 +126,13 @@ void TierTransferManager::CompleteWriteBack(std::uint32_t op_id) {
     if (it == write_backs_.end()) {
         return;
     }
-    std::vector<StoreTicket> stores = std::move(it->second);
+    std::vector<StoreTicket> stores = std::move(it->second.tickets);
     write_backs_.erase(it);
     for (const StoreTicket& ticket : stores) {
         store_keys_.erase(ticket.key);
     }
+    // Publishing the Host entry also drops the tickets' Device pins (if any)
+    // when `stores` goes out of scope: the source is evictable again.
     for (StoreTicket& ticket : stores) {
         coordinator_.CacheHostBlock(ticket.host_block_ref, ticket.key);
     }

--- a/tokenspeed-scheduler/csrc/cache/tier/transfer_manager.h
+++ b/tokenspeed-scheduler/csrc/cache/tier/transfer_manager.h
@@ -39,24 +39,40 @@ class TierTransferManager {
 public:
     explicit TierTransferManager(CacheCoordinator& coordinator) : coordinator_{coordinator} {}
 
-    std::optional<WriteBackOperation> StartPendingStores();
+    // Drains the coordinator's pending store candidates into one write-back
+    // op. `guard` says how the Device sources are protected while the copy is
+    // in flight (see StoreSourceGuard): every candidate drained by this call
+    // gets the same guard, so a retraction's kStreamOrdered drain also covers
+    // ordinary candidates queued earlier in the round -- a superset that is
+    // always safe, only slower.
+    std::optional<WriteBackOperation> StartPendingStores(StoreSourceGuard guard);
     LoadBackOperation StartPrefixLoad(std::vector<BlockTransfer> block_transfers);
 
     void CompleteWriteBack(std::uint32_t op_id);
     void CompleteLoadBack(std::uint32_t op_id);
 
     bool HasLoadBacksInFlight() const { return !load_backs_.empty(); }
+    // Pinned stores hold Device capacity that returns by itself at the ACK;
+    // the scheduler defers retraction while any is in flight rather than
+    // sacrificing a request for capacity that is about to free.
+    bool HasPinnedStoresInFlight() const;
     bool HasAnyInFlight() const { return !write_backs_.empty() || !load_backs_.empty(); }
 
 private:
-    // A store ticket pins only its Host destination. The Device source may
-    // be reused (even freed and re-granted) the moment the store is issued:
-    // the runtime enqueues the D2H copy on the forward thread's stream ahead
-    // of any subsequent write to those pages, so the snapshot reads the old
-    // bytes. The ACK's one job is publishing the Host entry (CacheHostBlock).
+    // A store ticket always pins its Host destination; the ACK's one job is
+    // publishing that entry (CacheHostBlock). Whether it also pins the Device
+    // source is the op's StoreSourceGuard: kPinnedUntilAck keeps the source
+    // cached and unevictable until the ACK, kStreamOrdered leaves it empty
+    // and relies on the runtime ordering the copy ahead of any reuse.
     struct StoreTicket {
         CacheKey key;
+        CacheBlockRef device_block_ref;
         CacheBlockRef host_block_ref;
+    };
+
+    struct InFlightWriteBack {
+        StoreSourceGuard guard;
+        std::vector<StoreTicket> tickets;
     };
 
     std::uint32_t nextOpId() { return next_op_id_++; }
@@ -64,7 +80,7 @@ private:
     std::vector<CacheTransfer> resolveTransfers(std::span<const BlockTransfer> block_transfers) const;
 
     CacheCoordinator& coordinator_;
-    std::unordered_map<std::uint32_t, std::vector<StoreTicket>> write_backs_;
+    std::unordered_map<std::uint32_t, InFlightWriteBack> write_backs_;
     std::unordered_set<CacheKey, CacheKeyHash> store_keys_;
     // Each transfer pins both tiers until the runtime acknowledges the copy.
     std::unordered_map<std::uint32_t, std::vector<BlockTransfer>> load_backs_;

--- a/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/operations/forward.cpp
@@ -704,7 +704,10 @@ void Scheduler::retractVictim(Request& victim, std::vector<WriteBackOperation>& 
         }
         coordinator_.QueueCachedBlocksForStore(cache_progress.prefix_hashes);
         coordinator_.QueueLatestSnapshotBlocksForStore(cache_progress.prefix_hashes);
-        if (auto write_back = tier_transfers_.StartPendingStores()) {
+        // The victim's pages are granted away in this very round, so the
+        // ticket cannot pin them: the runtime orders the copy on the forward
+        // thread's stream ahead of the plan's page reuse instead.
+        if (auto write_back = tier_transfers_.StartPendingStores(StoreSourceGuard::kStreamOrdered)) {
             write_back_operations.push_back(std::move(*write_back));
         }
     }
@@ -732,7 +735,9 @@ void Scheduler::retractVictim(Request& victim, std::vector<WriteBackOperation>& 
 // A readmission's failed admission never reaches here (its phase records no
 // blocker): when the readmission needs a victim, the two simply do not fit
 // together, and swapping them is pure thrash -- it waits for a completion
-// instead.
+// instead. Likewise while an ordinary (pinned) store is in flight: its
+// Device pages come back at the ACK without anyone giving way, so retracting
+// for capacity they hold would be the same thrash.
 //
 // A grant that cannot join its round (a local prefill grant beside an
 // already-built decode batch, where the role's grammar keeps them apart)
@@ -747,7 +752,10 @@ void Scheduler::maybeRetractForCapacity(AdmissionFeedback& feedback, PlanBuild& 
     }
     // A load-back mid-flight is writing pages its readmission owns; the
     // victim policy cannot see that write, so no retraction until it lands.
-    if (tier_transfers_.HasLoadBacksInFlight()) {
+    // A pinned store mid-flight holds pages the ACK is about to release; the
+    // blocked admission retries against them next round before anyone is
+    // sacrificed. (Stream-ordered stores hold nothing and gate nothing.)
+    if (tier_transfers_.HasLoadBacksInFlight() || tier_transfers_.HasPinnedStoresInFlight()) {
         return;
     }
 

--- a/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/outside_event_handler.cpp
@@ -121,7 +121,9 @@ std::optional<WriteBackOperation> Scheduler::publishCompletedPages(Request& requ
     }
     coordinator_.QueueCachedBlocksForStore(progress.prefix_hashes);
     coordinator_.QueueLatestSnapshotBlocksForStore(progress.prefix_hashes);
-    return tier_transfers_.StartPendingStores();
+    // The request's pages are released right after this (FinishEvent); the
+    // pinned ticket keeps them cached and unevictable until the copy ACKs.
+    return tier_transfers_.StartPendingStores(StoreSourceGuard::kPinnedUntilAck);
 }
 
 void Scheduler::handleEvent(const forward::UpdateReserveNumTokens& event) {

--- a/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
+++ b/tokenspeed-scheduler/csrc/scheduler/scheduler.cpp
@@ -447,7 +447,10 @@ ExecutionPlan Scheduler::NextExecutionPlan() {
     plan.With(ForwardBatch{std::move(forward_operations)});
 
     if (config_.StreamsDeviceCacheToHost()) {
-        if (auto store = tier_transfers_.StartPendingStores()) {
+        // Boundary publications of live requests: their owners hold the pages,
+        // and the ticket pins them until the ACK, so the copy stays off the
+        // forward's critical path.
+        if (auto store = tier_transfers_.StartPendingStores(StoreSourceGuard::kPinnedUntilAck)) {
             write_back_operations.push_back(std::move(*store));
         }
     }

--- a/tokenspeed-scheduler/python/tests/test_cache_binding.py
+++ b/tokenspeed-scheduler/python/tests/test_cache_binding.py
@@ -46,6 +46,12 @@ def test_removed_storage_cache_api_is_not_exported():
     assert not hasattr(ts.Scheduler, "get_request_paged_cache_page_ids")
 
 
+def test_write_back_op_carries_the_source_guard():
+    # The runtime branches on how the scheduler guards the Device sources
+    # (pinned until the ACK, or released and stream-ordered), never on why.
+    assert hasattr(Cache.WriteBackOp, "source_pinned")
+
+
 def test_cache_event_fields_are_bound():
     write_back = Cache.WriteBackDoneEvent()
     write_back.op_id = 7

--- a/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
@@ -27,6 +27,7 @@ TEST(CacheOperationTest, WriteBackDeduplicatesTransfersAcrossBatch) {
     WriteBackOperation duplicate;
     duplicate.op_id = 8;
     duplicate.transfers = {CacheTransfer{0, 2, 22}, CacheTransfer{0, 3, 33}};
+    duplicate.source_pinned = true;
 
     WriteBackBatch batch({op, duplicate});
 
@@ -36,6 +37,8 @@ TEST(CacheOperationTest, WriteBackDeduplicatesTransfersAcrossBatch) {
     EXPECT_EQ(batch.dst_pages[0], std::vector<std::int32_t>({11, 22}));
     EXPECT_EQ(batch.src_pages[1], std::vector<std::int32_t>({3}));
     EXPECT_EQ(batch.dst_pages[1], std::vector<std::int32_t>({33}));
+    EXPECT_EQ(batch.source_pinned, std::vector<bool>({false, true}))
+        << "the guard travels per op; an unset op reads as stream-ordered";
 }
 
 TEST(CacheOperationTest, SamePagesInDifferentGroupsAreDistinctTransfers) {
@@ -141,7 +144,7 @@ TEST(CacheOperationTest, DeviceRequestLimitDoesNotDependOnHostCapacity) {
     EXPECT_EQ(small_host.MaxSingleRequestTokens(), large_host.MaxSingleRequestTokens());
 }
 
-TEST(CacheOperationTest, RetractionStoreIsBestEffortAndUsesOrdinaryTransferPins) {
+TEST(CacheOperationTest, StreamOrderedStorePinsNoDeviceSource) {
     BlockPool device_pool{2};
     BlockPool host_pool{1};
     const std::array specs{CacheGroupSpec{
@@ -161,8 +164,10 @@ TEST(CacheOperationTest, RetractionStoreIsBestEffortAndUsesOrdinaryTransferPins)
     coordinator.CacheFullBlocks(tables, hashes, admission->access_epoch);
 
     coordinator.QueueCachedBlocksForStore(hashes);
-    auto write_back = transfers.StartPendingStores();
+    auto write_back = transfers.StartPendingStores(StoreSourceGuard::kStreamOrdered);
     ASSERT_TRUE(write_back);
+    EXPECT_FALSE(write_back->source_pinned);
+    EXPECT_FALSE(transfers.HasPinnedStoresInFlight());
     coordinator.Free(tables);
     // The ticket pins no Device source: the runtime orders the D2H copy on
     // the forward thread's stream ahead of any reuse, so the cache stays clearable.
@@ -170,6 +175,46 @@ TEST(CacheOperationTest, RetractionStoreIsBestEffortAndUsesOrdinaryTransferPins)
 
     transfers.CompleteWriteBack(write_back->op_id);
     EXPECT_TRUE(coordinator.ContainsHostCachedBlock(CacheKey{.group_id = 0, .content_hash = "h0"}));
+}
+
+TEST(CacheOperationTest, PinnedStoreHoldsDeviceSourceUntilAck) {
+    BlockPool device_pool{1};
+    BlockPool host_pool{1};
+    const std::array specs{CacheGroupSpec{
+        .kind = AttnKind::kFull,
+        .cache_blocks_per_lcm_block = 1,
+        .block_granularity = 2,
+    }};
+    CacheCoordinator coordinator = MakeCoordinator(specs, /*prefix_granularity=*/2, device_pool, &host_pool,
+                                                   /*stream_device_cache_to_host=*/false);
+    TierTransferManager transfers{coordinator};
+
+    std::vector<BlockTable> tables(1);
+    std::vector<GroupDemand> demands{{.table = &tables[0], .num_tokens = 2}};
+    auto admission = coordinator.Admit(coordinator.ProbePrefix({}), demands);
+    ASSERT_TRUE(admission);
+    const std::array<std::string, 1> hashes{"h0"};
+    coordinator.CacheFullBlocks(tables, hashes, admission->access_epoch);
+
+    coordinator.QueueCachedBlocksForStore(hashes);
+    auto write_back = transfers.StartPendingStores(StoreSourceGuard::kPinnedUntilAck);
+    ASSERT_TRUE(write_back);
+    EXPECT_TRUE(write_back->source_pinned);
+    EXPECT_TRUE(transfers.HasPinnedStoresInFlight());
+    coordinator.Free(tables);
+    // The owner is gone, but the ticket still holds the Device source: it is
+    // neither evictable nor clearable until the runtime acknowledges the copy.
+    EXPECT_FALSE(coordinator.ClearDeviceCache());
+    std::vector<BlockTable> newcomer(1);
+    std::vector<GroupDemand> newcomer_demands{{.table = &newcomer[0], .num_tokens = 2}};
+    EXPECT_FALSE(coordinator.Admit(coordinator.ProbePrefix({}), newcomer_demands))
+        << "the only Device block is pinned by the in-flight store";
+
+    transfers.CompleteWriteBack(write_back->op_id);
+    EXPECT_FALSE(transfers.HasPinnedStoresInFlight());
+    EXPECT_TRUE(coordinator.ContainsHostCachedBlock(CacheKey{.group_id = 0, .content_hash = "h0"}));
+    EXPECT_TRUE(coordinator.Admit(coordinator.ProbePrefix({}), newcomer_demands))
+        << "the ACK released the pin; the block is evictable again";
 }
 
 TEST(CacheOperationTest, HostDestinationCannotBeReusedBeforeWriteBackAck) {
@@ -194,7 +239,7 @@ TEST(CacheOperationTest, HostDestinationCannotBeReusedBeforeWriteBackAck) {
     cache_device(first_key);
     const std::array first_hashes{first_key.content_hash};
     coordinator.QueueCachedBlocksForStore(first_hashes);
-    auto first = transfers.StartPendingStores();
+    auto first = transfers.StartPendingStores(StoreSourceGuard::kPinnedUntilAck);
     ASSERT_TRUE(first);
     ASSERT_EQ(first->transfers.size(), 1u);
     const std::int32_t destination = first->transfers.front().destination_page;
@@ -203,11 +248,11 @@ TEST(CacheOperationTest, HostDestinationCannotBeReusedBeforeWriteBackAck) {
     cache_device(second_key);
     const std::array second_hashes{second_key.content_hash};
     coordinator.QueueCachedBlocksForStore(second_hashes);
-    EXPECT_FALSE(transfers.StartPendingStores());
+    EXPECT_FALSE(transfers.StartPendingStores(StoreSourceGuard::kPinnedUntilAck));
 
     transfers.CompleteWriteBack(first->op_id);
     coordinator.QueueCachedBlocksForStore(second_hashes);
-    auto second = transfers.StartPendingStores();
+    auto second = transfers.StartPendingStores(StoreSourceGuard::kPinnedUntilAck);
     ASSERT_TRUE(second);
     ASSERT_EQ(second->transfers.size(), 1u);
     EXPECT_EQ(second->transfers.front().destination_page, destination);
@@ -236,7 +281,7 @@ TEST(CacheOperationTest, RetractionStoreSkipsWhenHostHasNoPlacement) {
     coordinator.CacheFullBlocks(tables, hashes, admission->access_epoch);
 
     coordinator.QueueCachedBlocksForStore(hashes);
-    EXPECT_FALSE(transfers.StartPendingStores());
+    EXPECT_FALSE(transfers.StartPendingStores(StoreSourceGuard::kPinnedUntilAck));
     coordinator.Free(tables);
     EXPECT_TRUE(coordinator.ClearDeviceCache());
 }
@@ -286,7 +331,7 @@ TEST(CacheOperationTest, PendingStoresUseBatchHostAllocation) {
     const std::array group_zero_hashes{group_zero_first.content_hash, group_zero_second.content_hash};
     coordinator.QueueCachedBlocksForStore(group_zero_hashes);
 
-    auto write_back = transfers.StartPendingStores();
+    auto write_back = transfers.StartPendingStores(StoreSourceGuard::kPinnedUntilAck);
 
     ASSERT_TRUE(write_back);
     ASSERT_EQ(write_back->transfers.size(), 2u);

--- a/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_scenarios.cpp
@@ -1315,11 +1315,13 @@ TEST_F(PrefillSlideAdmissionSuite, LongPromptAdmittedOnlyBecausePrefillSlides) {
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
 }
 
-TEST_F(PrefillSlideAdmissionSuite, InFlightStoreDoesNotDeferAdmission) {
+TEST_F(PrefillSlideAdmissionSuite, InFlightStorePinsItsSourcesUntilAck) {
     // Sink ON over the LongPromptAdmittedOnlyBecausePrefillSlides math: device
     // 13 -> 12 usable, c1+c2 charge 8, c3 needs 6 = free 4 + slide credit 2.
-    // A store ticket pins no device source (the forward thread's stream orders the
-    // copy before any reuse), so c3 admits WHILE op1 is still in flight.
+    // An ordinary store ticket pins its device sources until the ACK, so the
+    // slid SWA pages op1 is copying are not evictable yet: c3 waits one round
+    // for the ACK -- and waits, rather than retracting anyone (least of all
+    // itself) for capacity that the ACK is about to return.
     config_.disable_l2_cache = false;
     config_.host_allocator.total_pages = 13;
     scheduler_ = std::make_unique<Scheduler>(config_);
@@ -1339,19 +1341,28 @@ TEST_F(PrefillSlideAdmissionSuite, InFlightStoreDoesNotDeferAdmission) {
     const auto op1 = std::get<WriteBackBatch>(wb1.front());
     ASSERT_EQ(op1.op_ids.size(), 1u);
     EXPECT_EQ(op1.src_pages.at(0).size(), 4u) << "the first completed Full+SWA pages stream together";
+    EXPECT_EQ(op1.source_pinned, std::vector<bool>{true}) << "an ordinary publication pins its sources";
     ASSERT_EQ(scheduler_->PoolFreeBlocks(), 4);
 
-    ExecutionPlan c3 = PlanOnce();  // slide credit 2: admitted with op1 in flight; emits op2
+    ExecutionPlan stalled = PlanOnce();  // slide credit 2 is pinned by op1: c3 cannot admit yet
+    const ForwardBatch* stalled_forward = FindForwardBatch(stalled);
+    ASSERT_TRUE(stalled_forward == nullptr || stalled_forward->request_ids.empty())
+        << "an in-flight pinned store holds the slid pages until the ACK";
+    EXPECT_TRUE(ExtractCacheOpsOfKind<WriteBackBatch>(stalled).empty())
+        << "a retraction would have emitted a snapshot store; the pinned store defers retraction instead";
+    EXPECT_EQ(scheduler_->WaitingSize(), 0u) << "the prefill keeps its place; nothing was retracted";
+    EXPECT_EQ(scheduler_->PrefillSize(), 1u);
+
+    SendWriteBackDone(op1.op_ids.at(0));
+    EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 4);
+
+    ExecutionPlan c3 = PlanOnce();  // the ACK released the pins: slide credit 2 -> admitted; emits op2
     ASSERT_NE(FindForwardBatch(c3), nullptr);
-    ASSERT_EQ(FindForwardBatch(c3)->request_ids.size(), 1u)
-        << "an in-flight store must not defer admission: its sources are not pinned";
+    ASSERT_EQ(FindForwardBatch(c3)->request_ids.size(), 1u) << "the ACK returns the slid pages; c3 admits";
     auto wb2 = ExtractCacheOpsOfKind<WriteBackBatch>(c3);
     ASSERT_EQ(wb2.size(), 1u);
     const auto op2 = std::get<WriteBackBatch>(wb2.front());
     EXPECT_EQ(scheduler_->PoolFreeBlocks(), 0);
-
-    SendWriteBackDone(op1.op_ids.at(0));
-    EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 4);
 
     SendForwardDone("r1", {99});
     ExecutionPlan decode = PlanOnce();  // last prefill pages stream on PrefillDone
@@ -1361,17 +1372,16 @@ TEST_F(PrefillSlideAdmissionSuite, InFlightStoreDoesNotDeferAdmission) {
     auto wb3 = ExtractCacheOpsOfKind<WriteBackBatch>(decode);
     ASSERT_EQ(wb3.size(), 1u);
     const auto op3 = std::get<WriteBackBatch>(wb3.front());
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), 2)
-        << "the finalize slide's pages return at once: store tickets hold no device pins";
 
     SendForwardDone("r1", {100});
     SendFinish("r1");
-    PlanOnce();  // reap: no device pins, the pool balances immediately
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
+    PlanOnce();
+    EXPECT_LT(scheduler_->PoolFreeBlocks(), free_at_start)
+        << "op2/op3 still pin their sources: the pool does not balance before their ACKs";
     SendWriteBackDone(op2.op_ids.at(0));
     SendWriteBackDone(op3.op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 12);
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
+    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "the ACKs return every pinned source";
 }
 
 // Pool 17 -> 16 usable: swa at full prompt length would need 10+10+2 = 22
@@ -3942,7 +3952,9 @@ TEST_F(DecodeCachingSuite, PoolBalanceAcrossDecodeCaching) {
 // ---------------------------------------------------------------------------
 // M15 streaming L2 sink: pages registered by a planning round batch into ONE
 // D2H write-back; WriteBackDone commits the host index and unpins the source
-// blocks. Byte movement itself is Phase D.
+// blocks (an ordinary store pins its Device sources until the ACK; only a
+// retraction's snapshot store leaves them to the runtime's stream order).
+// Byte movement itself is Phase D.
 // ---------------------------------------------------------------------------
 class StreamingSinkSuite : public SchedulerTestSuite {
 protected:
@@ -4001,19 +4013,20 @@ TEST_F(StreamingSinkSuite, RegisteredPagesEmitWriteBackAndIndexOnDone) {
     ASSERT_EQ(stream_wb->op_ids.size(), 1u);
     EXPECT_EQ(stream_wb->src_pages.at(0).size(), 6u);
     EXPECT_EQ(stream_wb->dst_pages.at(0).size(), 6u);
+    EXPECT_EQ(stream_wb->source_pinned, std::vector<bool>{true}) << "an ordinary publication pins its sources";
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 0) << "nothing indexed until WriteBackDone";
     EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 0);
 
     ExecutionPlan finish = FinishAndReap("r1");
     EXPECT_FALSE(FindWriteBack(finish).has_value()) << "already-streamed prefill pages must not rewrite at finish";
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start)
-        << "sources are not pinned: the forward thread's stream orders the copy before any reuse";
+    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start - 6)
+        << "the six sources stay pinned until the ACK: the finished request's other pages return, these do not";
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 0);
 
     SendWriteBackDone(stream_wb->op_ids.at(0));
     PlanOnce();
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
+    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "the ACK returns the pinned sources";
 }
 
 TEST_F(StreamingSinkSuite, DuplicateRegistrationsAreDroppedAtDrain) {
@@ -4044,7 +4057,7 @@ TEST_F(StreamingSinkSuite, HostPoolExhaustionSkipsSilently) {
     auto stream_wb1 = FindWriteBack(finalize1);
     ASSERT_TRUE(stream_wb1.has_value());
     EXPECT_FALSE(FindWriteBack(FinishAndReap("r1")).has_value());
-    ASSERT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
+    ASSERT_EQ(scheduler_->PoolFreeBlocks(), free_at_start - 6) << "r1's six sources stay pinned in flight";
     ASSERT_EQ(scheduler_->HostPoolFreeBlocks(), 0) << "r1 holds all 6 host pages in flight";
 
     ExecutionPlan finalize2 = RunToFinalize(MakeRequestSpec("r2", /*num_pages=*/4, /*start=*/501));
@@ -4053,7 +4066,8 @@ TEST_F(StreamingSinkSuite, HostPoolExhaustionSkipsSilently) {
     ExecutionPlan finish2 = FinishAndReap("r2");
     EXPECT_FALSE(FindWriteBack(finish2).has_value())
         << "finish-created candidates must also skip a fully-consumed host pool";
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
+    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start - 6)
+        << "dropped candidates pin nothing; only r1's in-flight sources are held";
 
     SendWriteBackDone(stream_wb1->op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
@@ -4102,13 +4116,13 @@ TEST_F(StreamingSinkSuite, SameRoundDuplicateKeysDedupeAtDrain) {
 
     EXPECT_FALSE(FindWriteBack(FinishAndReap("r1")).has_value());
     EXPECT_FALSE(FindWriteBack(FinishAndReap("r2")).has_value()) << "same-round duplicates must be dropped";
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start)
-        << "no source pins: the forward thread's stream orders the copies before any reuse";
+    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start - 6)
+        << "one pinned source per emitted key; the dropped duplicates pin nothing";
 
     SendWriteBackDone(stream_wb->op_ids.at(0));
     EXPECT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     EXPECT_EQ(scheduler_->HostPoolFreeBlocks(), 6) << "the six cached host pages remain occupied";
-    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start);
+    EXPECT_EQ(scheduler_->PoolFreeBlocks(), free_at_start) << "the ACK returns the pinned sources";
 }
 
 TEST_F(StreamingSinkSuite, MidDrainPoolFillEmitsPartialOp) {
@@ -4142,7 +4156,7 @@ TEST_F(StreamingSinkSuite, DuplicateWriteBackDoneIsIgnored) {
     SendWriteBackDone(stream_wb->op_ids.at(0));
     ASSERT_EQ(scheduler_->HostPoolCachedBlocks(), 6);
     const std::int32_t free_after_ack = scheduler_->PoolFreeBlocks();
-    EXPECT_EQ(free_after_ack, free_after_reap) << "the ack publishes host entries; no device pins to return";
+    EXPECT_EQ(free_after_ack, free_after_reap + 6) << "the ack publishes host entries and returns the six pins";
 
     // A replayed ack must be a no-op (the ledger already retired the op).
     SendWriteBackDone(stream_wb->op_ids.at(0));

--- a/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_outside_event_handler.cpp
@@ -485,6 +485,8 @@ TEST_F(DecodeRetractionL2TestSuite, RetractionLetsBlockedAdmissionRun) {
     ASSERT_EQ(write_back_ops.size(), 1u);
     const auto& write_back = std::get<WriteBackBatch>(write_back_ops.front());
     ASSERT_EQ(write_back.op_ids.size(), 1u);
+    EXPECT_EQ(write_back.source_pinned, std::vector<bool>{false})
+        << "the victim's pages are granted away this round; the runtime must order the copy ahead of reuse";
 
     // The retraction round grants the freed capacity to the blocked request
     // in the same plan: its remote admission rides plan.remote_prefill.


### PR DESCRIPTION
## Why

Every host-cache store travelled the same way: the ticket pinned only its Host destination, the Device source was released the moment the op issued, and the runtime kept the copy safe by enqueuing every D2H on the forward thread's stream ahead of the plan's page zeroing (#1239). That ordering is exactly what a retraction needs — the victim's pages are granted away in the same round — but it had two costs for the *ordinary* stores (boundary publications, the finish-time flush):

- every write-back sat on the forward's critical path: `execute_forward_op` waits on the caller's stream, so the next forward waited for the whole D2H batch to copy;
- the scheduler was blind to which Device blocks a copy was still reading — correctness lived entirely in `DeviceHandle.execute`'s enqueue order.

## What

One path, one explicit parameter. `TierTransferManager::StartPendingStores(guard)` takes a `StoreSourceGuard`:

- **`kPinnedUntilAck`** — boundary publications (`NextExecutionPlan`) and the finish-time flush (`publishCompletedPages`). The ticket holds a `CacheBlockRef` on each Device source, so the block stays cached and unevictable (admission planner, `ClearDeviceCache`, `NumNewlyReleasableLcmBlocks` all see the pin) until `CompleteWriteBack` publishes the Host entry and drops it. The runtime copies on its own write stream; no forward waits.
- **`kStreamOrdered`** — `retractVictim` only. The ticket pins no Device source; the op is flagged so the runtime fences the forward thread's stream on the copy's completion before the plan's zeroing, exactly as before.

The wire op carries `source_pinned` per entry (`WriteBackBatch::source_pinned`, bound as `Cache.WriteBackOp.source_pinned`). `L2CacheExecutor.submit_write_backs` partitions on it: stream-ordered ops launch first and the caller's stream `wait_event`s their completion; pinned ops follow with no fence. Each kind has its own staging lane (`_WriteLane`) so the two submissions a round may make never wait on each other's metadata upload. The runtime branches on the guard, never on the reason (the old `is_retract` stays unexported).

**A pinned store in flight defers retraction**, like an in-flight load-back. The capacity it holds returns by itself at the ACK, so retracting anyone for it — including a chunked prefill retracting *itself* while its own boundary store copies — is pure thrash; the blocked admission retries against the released pins next round.

## Behaviour change to be aware of

Pages an ordinary store is copying are no longer grantable until the ACK (typically the next round). The `PrefillSlideAdmissionSuite` slide-credit scenario shows the visible effect: chunk 3 waits one round for chunk 2's store ACK instead of admitting immediately, and nothing is retracted while it waits.

## Tests

- C++ (`tokenspeed_scheduler_tests`, 460/460): new `PinnedStoreHoldsDeviceSourceUntilAck` / `StreamOrderedStorePinsNoDeviceSource`; `StreamingSinkSuite` and `PrefillSlideAdmissionSuite` updated to the pin semantics (pool balances only after the ACK; the stalled round emits no snapshot store and retracts nobody); `RetractionLetsBlockedAdmissionRun` asserts `source_pinned == {false}`; `WriteBackBatch` carries the flag per op.
- Python: write-stream launch ordered after the caller, partition-and-fence (`caller_stream.wait_event` only on the stream-ordered op), no fence without stream-ordered ops, ragged guard vector rejected, binding exposes `source_pinned`; the CUDA round-trip / metadata-reuse / merged-draft integration tests pass on an H20.
- `test_device_handle.py::test_one_plan_orders_write_backs_zeroing_then_load_backs` was already failing on `main` (its fake executor predated `order_cache_operations`); fixed here and extended to assert the fence order, plus a case for zeroing without cache ops.
- `pre-commit run --all-files` clean; CI ruff selections clean.
- **Not run:** an end-to-end `--enable-kvstore` serving run with retraction. The dev box's GPUs are occupied and are not used for regressions.

## Docs

`docs/design/scheduler.md` §2/§5, `cache-concepts.md` (writeback paragraph and the two-tier bullet) and `event-loop.md` (anatomy step 4) record the new invariant: a store either pins its sources until the ACK or is stream-ordered, never neither, and only `retractVictim` issues a stream-ordered one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
