### PR TITLE
perf(gfx950): Optimize fused MXFP4 SwiGLU output layout

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/_layouts.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/_layouts.py
@@ -100,18 +100,52 @@ def _swiglu_split_layout(
     block_m: int, block_n_full: int, num_warps: int
 ) -> gl.constexpr:
     THREADS_PER_WARP = 64  # CDNA4 wavefront size.
-    # TODO: widening `size_per_thread` to `[1, 16]` would leave each half of
-    # the `gl.split` below with the 8 contiguous per-lane values that
-    # `quantize_gluon.scaled_downcast_layout()` requires, so the quantize
-    # tiles could drop their `convert_layout`.
-    # The same applies to the inline split layout in
-    # `prefill_stage1._apply_interleaved_gate_activation`.
     return gl.BlockedLayout(
         size_per_thread=[1, 8],
         threads_per_warp=[4, THREADS_PER_WARP // 4],
         warps_per_cta=[num_warps, 1],
         order=[1, 0],
     )
+
+
+@gluon.constexpr_function
+def _mxfp4_swiglu_split_layout(
+    block_m: int, block_n_full: int, num_warps: int
+) -> gl.constexpr:
+    # Match the post-split tile to scaled_downcast_layout(). The interleaved
+    # accumulator holds two adjacent values for each output, so its contiguous
+    # register extent is twice the downcast extent.
+    out_block_n = block_n_full // 2
+    out_per_thread = min(16, out_block_n)
+    lanes_n = max(1, min(8, out_block_n // out_per_thread))
+    lanes_m = 64 // lanes_n
+    warps_m = max(1, min(num_warps, block_m // lanes_m))
+    return gl.BlockedLayout(
+        size_per_thread=[1, 2 * out_per_thread],
+        threads_per_warp=[lanes_m, lanes_n],
+        warps_per_cta=[warps_m, num_warps // warps_m],
+        order=[1, 0],
+    )
+
+
+@gluon.jit
+def _swiglu_reduce_with_layout(
+    acc,
+    alpha: gl.constexpr,
+    limit: gl.constexpr,
+    beta: gl.constexpr,
+    OUT_BLOCK_N: gl.constexpr,
+    SPLIT_LAYOUT: gl.constexpr,
+):
+    BLOCK_M: gl.constexpr = acc.shape[0]
+    acc = gl.convert_layout(acc, SPLIT_LAYOUT)
+    reshaped = acc.reshape((BLOCK_M, OUT_BLOCK_N, 2))
+    gate, linear = gl.split(reshaped)
+    if limit > 0.0:
+        gate = gl.minimum(gate, limit)
+        linear = gl.clamp(linear, -limit, limit)
+    s = gate / (1.0 + gl.exp(-alpha * gate))
+    return s * (linear + beta)
 
 
 @gluon.jit
@@ -121,21 +155,29 @@ def _swiglu_reduce(
     limit: gl.constexpr,
     beta: gl.constexpr,
     OUT_BLOCK_N: gl.constexpr,
-    MMA: gl.constexpr,
 ):
-    BLOCK_M: gl.constexpr = acc.shape[0]
-    BLOCK_N_FULL: gl.constexpr = acc.shape[1]
     SPLIT_LAYOUT: gl.constexpr = _swiglu_split_layout(
-        BLOCK_M, BLOCK_N_FULL, gl.num_warps()
+        acc.shape[0], acc.shape[1], gl.num_warps()
     )
-    acc = gl.convert_layout(acc, SPLIT_LAYOUT)
-    reshaped = acc.reshape((BLOCK_M, OUT_BLOCK_N, 2))
-    gate, linear = gl.split(reshaped)
-    if limit > 0.0:
-        gate = gl.minimum(gate, limit)
-        linear = gl.clamp(linear, -limit, limit)
-    s = gate / (1.0 + gl.exp(-alpha * gate))
-    return s * (linear + beta)
+    return _swiglu_reduce_with_layout(
+        acc, alpha, limit, beta, OUT_BLOCK_N, SPLIT_LAYOUT
+    )
+
+
+@gluon.jit
+def _mxfp4_swiglu_reduce(
+    acc,
+    alpha: gl.constexpr,
+    limit: gl.constexpr,
+    beta: gl.constexpr,
+    OUT_BLOCK_N: gl.constexpr,
+):
+    SPLIT_LAYOUT: gl.constexpr = _mxfp4_swiglu_split_layout(
+        acc.shape[0], acc.shape[1], gl.num_warps()
+    )
+    return _swiglu_reduce_with_layout(
+        acc, alpha, limit, beta, OUT_BLOCK_N, SPLIT_LAYOUT
+    )
 
 
 @gluon.jit

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/medium_decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/medium_decode.py
@@ -466,7 +466,6 @@ def _medium_decode_body(
             SWIGLU_LIMIT,
             SWIGLU_BETA,
             OUT_BLOCK_N,
-            cfg.acc_layout,
         )
         out_inv_scale = 1.0 / gl.load(out_quant_scale_ptr).to(gl.float32)
         out = (out * out_inv_scale).to(Y.dtype.element_ty)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/pipelined_kernel.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/pipelined_kernel.py
@@ -27,6 +27,7 @@ from tokenspeed_kernel_amd._triton import gl, gluon
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.fused._layouts import (
     _group_m_swizzle,
     _load_layout,
+    _mxfp4_swiglu_reduce,
     _store_layout,
     _swiglu_reduce,
     _xcd_chiplet_swizzle,
@@ -54,7 +55,7 @@ from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.fused.pipelined_program import (
     _preshuffled_w_read_layout,
 )
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (
-    _mxfp4_quantize_tile,
+    _mxfp4_quantize_tile_in_layout,
     _mxfp4_store_cdna4_scale,
 )
 
@@ -1157,16 +1158,15 @@ def _pipelined_moe_tile_compute(
         acc = acc + bias[None, :].to(gl.float32)
 
     if DO_SWIGLU:
-        out = _swiglu_reduce(
-            acc,
-            SWIGLU_ALPHA,
-            SWIGLU_LIMIT,
-            SWIGLU_BETA,
-            OUT_BLOCK_N,
-            cfg.acc_layout,
-        )
         if HAS_MXFP4_QUANT_OUT:
-            packed, scale_byte = _mxfp4_quantize_tile(out)
+            out = _mxfp4_swiglu_reduce(
+                acc,
+                SWIGLU_ALPHA,
+                SWIGLU_LIMIT,
+                SWIGLU_BETA,
+                OUT_BLOCK_N,
+            )
+            packed, scale_byte = _mxfp4_quantize_tile_in_layout(out)
             packed = packed.reshape((BLOCK_M, OUT_BLOCK_N // 2))
             PACK_LAYOUT: gl.constexpr = packed.type.layout
             offs_pack_m = off_m + gl.arange(0, BLOCK_M, gl.SliceLayout(1, PACK_LAYOUT))
@@ -1226,6 +1226,13 @@ def _pipelined_moe_tile_compute(
                 K_SWIZZLE=8,
             )
             return
+        out = _swiglu_reduce(
+            acc,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+            SWIGLU_BETA,
+            OUT_BLOCK_N,
+        )
         if HAS_FP8_QUANT_OUT:
             scale = gl.load(out_quant_scale_ptr).to(gl.float32)
             inv_scale = 1.0 / scale

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/warp_decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/fused/warp_decode.py
@@ -522,7 +522,6 @@ def _warp_decode_stage1_coop_compute(
             SWIGLU_LIMIT,
             SWIGLU_BETA,
             OUT_BLOCK_N,
-            cfg.acc_layout,
         )
     out_inv_scale = 1.0 / gl.load(out_quant_scale_ptr).to(gl.float32)
     out = (out * out_inv_scale).to(Y.dtype.element_ty)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/quantize_gluon.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/mxfp4/quantize_gluon.py
@@ -28,9 +28,7 @@ Some constraints come with that:
 
 * The instruction needs 8 consecutive values along the scaled axis in one
   lane's consecutive registers, which an MFMA accumulator layout does not
-  provide. `scaled_downcast_layout()` names a layout that does; the tiles
-  convert into it, and a caller that owns its own tile layout should load
-  through the same helper so the conversion folds away.
+  provide. `scaled_downcast_layout()` names a layout that does.
 """
 
 from __future__ import annotations
@@ -46,9 +44,9 @@ def scaled_downcast_layout(block_m: int, block_n: int, num_warps: int) -> gl.con
     ``amdgpu.scaled_downcast_fp{4,8}`` requires every group of 8 consecutive
     values along the scaled axis to sit in one lane's consecutive registers and
     to share one E8M0 scale, so the tile must carry at least 8 -- here 16 --
-    values per lane along that axis. Callers that own their tile layout should
-    load through this so the conversion in :func:`_mxfp4_quantize_tile` and
-    :func:`_mxfp8_quantize_tile` folds away.
+    values per lane along that axis. Callers that own their tile layout can use
+    this layout with :func:`_mxfp4_quantize_tile_in_layout` to avoid a register
+    redistribution.
     """
     per_thread = min(16, block_n)
     lanes_n = max(1, min(8, block_n // per_thread))
@@ -63,22 +61,12 @@ def scaled_downcast_layout(block_m: int, block_n: int, num_warps: int) -> gl.con
 
 
 @gluon.jit
-def _mxfp4_quantize_tile(out):
-    """Quantize each contiguous 32-value group to packed E2M1 + UE8M0.
-
-    Returns the packed FP4 bytes (two values per byte along the last axis, so
-    half the input width) and one raw E8M0 scale byte per 32-value group.
-    """
-
-    BLOCK_M: gl.constexpr = out.shape[0]
-    OUT_BLOCK_N: gl.constexpr = out.shape[1]
+def _mxfp4_quantize_tile_impl(vals):
+    BLOCK_M: gl.constexpr = vals.shape[0]
+    OUT_BLOCK_N: gl.constexpr = vals.shape[1]
     Q_GROUPS: gl.constexpr = OUT_BLOCK_N // 32
     gl.static_assert(OUT_BLOCK_N % 32 == 0)
 
-    DOWNCAST_LAYOUT: gl.constexpr = scaled_downcast_layout(
-        BLOCK_M, OUT_BLOCK_N, gl.num_warps()
-    )
-    vals = gl.convert_layout(out.to(gl.bfloat16).to(gl.float32), DOWNCAST_LAYOUT)
     grouped = vals.reshape((BLOCK_M, Q_GROUPS, 32))
     amax = gl.max(gl.abs(grouped), axis=2, keep_dims=False)
     # Round amax up to a power of two, then back off two exponents so the
@@ -92,6 +80,25 @@ def _mxfp4_quantize_tile(out):
 
     packed = gl.amd.cdna4.scaled_downcast(vals, scale_byte, "e2m1", axis=1)
     return packed, scale_byte
+
+
+@gluon.jit
+def _mxfp4_quantize_tile_in_layout(out):
+    """Quantize an MXFP4 tile already satisfying the downcast layout contract."""
+
+    vals = out.to(gl.bfloat16).to(gl.float32)
+    return _mxfp4_quantize_tile_impl(vals)
+
+
+@gluon.jit
+def _mxfp4_quantize_tile(out):
+    """Relayout and quantize each contiguous 32-value group to MXFP4."""
+
+    DOWNCAST_LAYOUT: gl.constexpr = scaled_downcast_layout(
+        out.shape[0], out.shape[1], gl.num_warps()
+    )
+    vals = gl.convert_layout(out.to(gl.bfloat16).to(gl.float32), DOWNCAST_LAYOUT)
+    return _mxfp4_quantize_tile_impl(vals)
 
 
 @gluon.jit

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp_quantize_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_mxfp_quantize_gfx950.py
@@ -32,8 +32,14 @@ if not is_cdna4():
 
 import tokenspeed_kernel  # noqa: E402
 from tokenspeed_kernel_amd._triton import gl, gluon  # noqa: E402
+from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.fused._layouts import (  # noqa: E402
+    _mxfp4_swiglu_reduce,
+    _swiglu_reduce,
+    get_mfma_layout,
+)
 from tokenspeed_kernel_amd.ops.gfx950.moe.mxfp4.quantize_gluon import (  # noqa: E402
     _mxfp4_quantize_tile,
+    _mxfp4_quantize_tile_in_layout,
     _mxfp8_quantize_tile,
     quantize_mxfp8_sorted_routes,
     scaled_downcast_layout,
@@ -231,3 +237,119 @@ def test_quantize_tile_uses_hardware_scaled_downcast_gfx950(output_fp8: bool) ->
     amdgcn = compiled.asm["amdgcn"]
     suffix = "fp8" if output_fp8 else "fp4"
     assert f"v_cvt_scalef32_pk_{suffix}_f32" in amdgcn
+
+
+@gluon.jit
+def _swiglu_quantize_layout_probe_kernel(
+    x_ptr,
+    out_ptr,
+    scale_ptr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N_FULL: gl.constexpr,
+    OPTIMIZED: gl.constexpr,
+):
+    """Quantize a SwiGLU tile through the reference or optimized layout path."""
+
+    OUT_BLOCK_N: gl.constexpr = BLOCK_N_FULL // 2
+    acc_layout: gl.constexpr = get_mfma_layout(
+        gl.num_warps(),
+        True,
+        scale_preshuffle=False,
+        block_m=BLOCK_M,
+        w_via_vgpr=False,
+    )
+    rows = gl.arange(0, BLOCK_M, layout=gl.SliceLayout(1, acc_layout))
+    cols = gl.arange(0, BLOCK_N_FULL, layout=gl.SliceLayout(0, acc_layout))
+    acc = gl.load(x_ptr + rows[:, None] * BLOCK_N_FULL + cols[None, :]).to(gl.float32)
+    if OPTIMIZED:
+        activated = _mxfp4_swiglu_reduce(
+            acc,
+            1.0,
+            0.0,
+            0.0,
+            OUT_BLOCK_N,
+        )
+        quantized, scale_byte = _mxfp4_quantize_tile_in_layout(activated)
+    else:
+        activated = _swiglu_reduce(
+            acc,
+            1.0,
+            0.0,
+            0.0,
+            OUT_BLOCK_N,
+        )
+        quantized, scale_byte = _mxfp4_quantize_tile(activated)
+    quantized = quantized.reshape((BLOCK_M, OUT_BLOCK_N // 2))
+
+    out_layout: gl.constexpr = quantized.type.layout
+    out_rows = gl.arange(0, BLOCK_M, gl.SliceLayout(1, out_layout))
+    out_cols = gl.arange(0, OUT_BLOCK_N // 2, gl.SliceLayout(0, out_layout))
+    gl.store(
+        out_ptr + out_rows[:, None] * (OUT_BLOCK_N // 2) + out_cols[None, :],
+        quantized,
+    )
+
+    scale_layout: gl.constexpr = scale_byte.type.layout
+    scale_rows = gl.arange(0, BLOCK_M, gl.SliceLayout(1, scale_layout))
+    scale_cols = gl.arange(0, OUT_BLOCK_N // 32, gl.SliceLayout(0, scale_layout))
+    gl.store(
+        scale_ptr + scale_rows[:, None] * (OUT_BLOCK_N // 32) + scale_cols[None, :],
+        scale_byte,
+    )
+
+
+def _swiglu_quantize_layout_probe(
+    values: torch.Tensor,
+    *,
+    optimized: bool,
+    num_warps: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    block_m, block_n_full = values.shape
+    out_block_n = block_n_full // 2
+    out = torch.empty(
+        (block_m, out_block_n // 2),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    scales = torch.empty(
+        (block_m, out_block_n // 32),
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    _swiglu_quantize_layout_probe_kernel[(1,)](
+        values,
+        out,
+        scales,
+        BLOCK_M=block_m,
+        BLOCK_N_FULL=block_n_full,
+        OPTIMIZED=optimized,
+        num_warps=num_warps,
+    )
+    return out, scales
+
+
+@pytest.mark.parametrize("num_warps", [4, 8])
+def test_swiglu_quantize_layout_specialization_is_bit_exact_gfx950(
+    num_warps: int,
+) -> None:
+    generator = torch.Generator(device="cuda").manual_seed(161803)
+    values = torch.randn(
+        (64, 128),
+        dtype=torch.bfloat16,
+        device="cuda",
+        generator=generator,
+    )
+
+    expected, expected_scales = _swiglu_quantize_layout_probe(
+        values,
+        optimized=False,
+        num_warps=num_warps,
+    )
+    actual, actual_scales = _swiglu_quantize_layout_probe(
+        values,
+        optimized=True,
+        num_warps=num_warps,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+    torch.testing.assert_close(actual_scales, expected_scales, atol=0, rtol=0)


### PR DESCRIPTION
Give the regular and MXFP4-specialized SwiGLU paths explicit layout and quantization entry points. The specialized split places each output tile in the layout required by CDNA4 scaled_downcast, avoiding a redundant register redistribution before MXFP4 conversion. Non-quantized SwiGLU and SiTU retain the existing layout.

For fused stage-1 MXFP4-input/output MoE ` _pipelined_moe_kernel_scaled` kernel, MI350X/gfx950 benchmarks compare this commit with main at dad5c49d. One expert, input shape [M, 2880], BLOCK_M=64, BLOCK_K=256. Four warps and two pipeline stages. Numbers are median microseconds from 9 rounds, with 20 warmup replays, 50 timed replays, and 8 calls per CUDA graph:

| Schedule | M | origin/main | This commit | Improvement |
| --- | ---: | ---: | ---: | ---: |
| BN128, preshuffled | 128 | 9.151 us | 8.776 us | 4.10% |
| BN128, preshuffled | 512 | 21.128 us | 20.525 us | 2.85% |
| BN128, preshuffled | 2048 | 65.209 us | 63.603 us | 2.46% |
| BN256, non-preshuffled | 128 | 17.919 us | 17.455 us | 2.59% |
| BN256, non-preshuffled | 512 | 21.523 us | 21.193 us | 1.53% |
| BN256, non-preshuffled | 2048 | 61.261 us | 60.526 us | 1.20% |

ISA deltas:

| Schedule | M | Instructions | VGPR | SGPR | `ds_*` instr | `s_barrier` instr |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| BN128 | 128 | 1,155 -> 1,108 (-47) | 257 -> 257 | 96 -> 96 | 84 -> 76 | 13 -> 11 |
| BN128 | 512 | 1,169 -> 1,122 (-47) | 257 -> 257 | 96 -> 96 | 84 -> 76 | 13 -> 11 |
| BN128 | 2048 | 1,169 -> 1,122 (-47) | 257 -> 257 | 96 -> 96 | 84 -> 76 | 13 -> 11 |
| BN256 | 128 | 2,122 -> 2,098 (-24) | 268 -> 257 | 100 -> 100 | 144 -> 128 | 19 -> 11 |
| BN256 | 512 | 2,141 -> 2,119 (-22) | 268 -> 257 | 100 -> 100 | 144 -> 128 | 19 -> 11 |
| BN256 | 2048 | 2,141 -> 2,119 (-22) | 268 -> 257 | 100 -> 100 | 144 -> 128 | 19 -> 11 |

Add bit-exact coverage comparing the canonical and specialized paths for both 4- and 8-warp configurations.
