### PR TITLE
fix(l2): metadata uploads on the write stream; cache ops name their producer stream

### DIFF
--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -234,7 +234,10 @@ and unevictable until the ACK, so its copy overlaps whatever the round does
 next and nobody waits on it. An unpinned op's sources may be re-granted in the
 same plan, so it is launched first and the caller's stream waits on its
 completion event before the plan's page zeroing is enqueued — the zeroing,
-load-backs, forwards and RDMA triggers behind it inherit the fence. The two
+load-backs, forwards and RDMA triggers behind it inherit the fence (the
+forward by waiting on the default stream in its prologue; that wait is
+one-way, the zeroing's and the writeback's own waits are what order the
+default and write streams behind the forwards). The two
 kinds use separate staging lanes: each lane uploads block metadata
 asynchronously and records an event after both metadata copies to protect its
 pinned CPU staging tables — before refilling them, the next submission on

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -224,9 +224,11 @@ blocks, the transfer boundary validates the loaded block count and returns
 before mapping Host pointers or touching the accelerator runtime. Flagged
 loads still publish readiness for empty consumers.
 
-Writeback runs on the executor's write stream, ordered after the caller's
-stream (which the caller has already ordered behind the forwards that wrote
-the pages). Each op says how the scheduler guards its Device sources
+Writeback runs on the executor's write stream, ordered after the producer
+stream the caller names -- the model executor's execution stream, where the
+forwards wrote the pages. (Page zeroing likewise orders itself behind that
+stream inside `zero_cache_pages`; there is no caller-side fence to remember.)
+Each op says how the scheduler guards its Device sources
 (`source_pinned`, see `scheduler.md` §2). A pinned op's sources stay cached
 and unevictable until the ACK, so its copy overlaps whatever the round does
 next and nobody waits on it. An unpinned op's sources may be re-granted in the

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -178,10 +178,9 @@ class L2CacheExecutor:
             tracker = LayerwiseLoadTracker(len(layout.consumers))
             pool.register_layerwise_load_tracker(tracker)
             self._load_trackers.append((tracker, len(layout.consumers)))
-        # Write-backs run on their own stream, ordered after the caller's
-        # current stream -- the forward thread's default stream, which the
-        # caller has already ordered behind the forwards that wrote the
-        # pages. What differs per op is who waits on the copy: a
+        # Write-backs run on their own stream, ordered after the producer
+        # stream the caller names per submission -- the one the forwards wrote
+        # the pages on. What differs per op is who waits on the copy: a
         # stream-ordered op (a retraction's snapshot, whose sources this very
         # plan may re-grant) fences the caller's stream on its completion, so
         # the plan's zeroing, load-backs and forwards stay behind it; a pinned
@@ -284,17 +283,24 @@ class L2CacheExecutor:
         self._ready_load_op_ids: list[int] = []
         self._load_poisoned = False
 
-    def submit_write_backs(self, plan) -> None:
+    def submit_write_backs(self, plan, *, producer_stream) -> None:
         """Enqueue the plan's D2H copies on the write stream.
 
-        Must run BEFORE the plan's page zeroing, on the caller's stream
-        already ordered behind the forwards that wrote the pages. The
-        scheduler marks each op ``source_pinned``: a pinned op's sources stay
-        cached and unevictable until the ACK, so its copy rides the write
-        stream and nobody waits on it; an unpinned op's sources may already
-        be granted to another request in this very plan, so it goes first and
-        the caller's stream waits on its completion -- the plan's zeroing,
-        load-backs and forwards are ordered behind that wait.
+        Must run BEFORE the plan's page zeroing. Every copy is ordered behind
+        ``producer_stream`` -- the stream the forwards wrote the source pages
+        on -- so it reads their final bytes. The scheduler marks each op
+        ``source_pinned``: a pinned op's sources stay cached and unevictable
+        until the ACK, so its copy rides the write stream and nobody waits on
+        it; an unpinned op's sources may already be granted to another request
+        in this very plan, so it goes first and the caller's stream waits on
+        its completion -- the plan's zeroing, load-backs and forwards are
+        ordered behind that wait.
+
+        Args:
+            plan: The round's ExecutionPlan; its ``Cache.WriteBackOp``
+                entries are read here.
+            producer_stream: The stream whose completed work every copy must
+                observe -- the model executor's execution stream.
         """
         ordered_op_ids: list[int] = []
         ordered_transfers: list[tuple[int, int, int]] = []
@@ -310,12 +316,18 @@ class L2CacheExecutor:
                     pinned_transfers=pinned_transfers,
                 )
         fence = self._start_writing(
-            ordered_op_ids, ordered_transfers, lane=self._ordered_write_lane
+            ordered_op_ids,
+            ordered_transfers,
+            lane=self._ordered_write_lane,
+            producer_stream=producer_stream,
         )
         if fence is not None:
             device_module.current_stream().wait_event(fence)
         self._start_writing(
-            pinned_op_ids, pinned_transfers, lane=self._pinned_write_lane
+            pinned_op_ids,
+            pinned_transfers,
+            lane=self._pinned_write_lane,
+            producer_stream=producer_stream,
         )
 
     def submit_load_backs(self, plan) -> None:
@@ -399,6 +411,7 @@ class L2CacheExecutor:
         transfers: Sequence[tuple[int, int, int]],
         *,
         lane: _WriteLane,
+        producer_stream,
     ):
         """Launch one D2H batch on the write stream; return its completion event.
 
@@ -419,11 +432,10 @@ class L2CacheExecutor:
                 len(transfers),
                 lane is self._pinned_write_lane,
             )
-        # The caller's stream is already ordered behind the forwards that
-        # wrote the source pages; inheriting it here is what lets the copy
-        # read the final bytes.
+        # Behind the forwards that wrote the source pages: that is what lets
+        # the copy read their final bytes.
         stream = self.write_stream
-        stream.wait_stream(device_module.current_stream())
+        stream.wait_stream(producer_stream)
         # CPU writes are not ordered by stream FIFO. Retire the previous
         # metadata upload before refilling its pinned source, not at submit.
         if lane.metadata_done is not None:

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -432,23 +432,28 @@ class L2CacheExecutor:
         num_blocks, _ = lane.workspace.load_block_transfers(
             transfers, geometry=self._transfer_geometry
         )
-        mode = lane.workspace.prepare_backend(
-            self.layout.buffers,
-            self.host_storage.host_buffer,
-            backend=self.transfer_backend,
-        )
-        if mode.uses_device_tables:
-            if lane.metadata_done is None:
-                lane.metadata_done = device_module.Event()
-            try:
-                lane.workspace.commit_block_transfers(
-                    num_blocks, self.layout.buffers[0].device, non_blocking=True
-                )
-            finally:
-                # Also protect a partially submitted upload if staging fails.
-                # This event excludes the payload transfer; Device table reuse
-                # remains ordered by the write stream's FIFO.
-                lane.metadata_done.record(stream)
+        # Address-table allocation and the metadata H2D must be enqueued on
+        # the write stream itself: the payload kernel below reads those tables
+        # from that stream, and a copy issued on the caller's stream would sit
+        # behind the wait recorded above with nothing ordering it first.
+        with device_module.stream(stream):
+            mode = lane.workspace.prepare_backend(
+                self.layout.buffers,
+                self.host_storage.host_buffer,
+                backend=self.transfer_backend,
+            )
+            if mode.uses_device_tables:
+                if lane.metadata_done is None:
+                    lane.metadata_done = device_module.Event()
+                try:
+                    lane.workspace.commit_block_transfers(
+                        num_blocks, self.layout.buffers[0].device, non_blocking=True
+                    )
+                finally:
+                    # Also protect a partially submitted upload if staging
+                    # fails. This event excludes the payload transfer; Device
+                    # table reuse remains ordered by the write stream's FIFO.
+                    lane.metadata_done.record(stream)
         transfer_cache_blocks(
             "d2h",
             self.layout.buffers,

--- a/python/tokenspeed/runtime/execution/device.py
+++ b/python/tokenspeed/runtime/execution/device.py
@@ -310,20 +310,22 @@ class DeviceHandle:
         if l2 is not None:
             # Ahead of the zeroing: a stream-ordered store's sources may be
             # this very plan's pages_to_zero, and its fence lands on the
-            # caller's stream here, before the zeroing is enqueued.
-            def _write_backs():
-                executor.order_cache_operations()
-                l2.submit_write_backs(execution_plan)
-
-            self._l2_submissions.append(self._thread.submit(_write_backs))
+            # forward thread's stream here, before the zeroing is enqueued.
+            # The copies themselves order behind the execution stream, where
+            # the forwards wrote the pages.
+            self._l2_submissions.append(
+                self._thread.submit(
+                    lambda: l2.submit_write_backs(
+                        execution_plan, producer_stream=executor.execution_stream
+                    )
+                )
+            )
         pages = execution_plan.pages_to_zero
-
-        def _zero_pages():
-            if l2 is None:
-                executor.order_cache_operations()
-            return executor.zero_cache_pages(pages)
-
-        zero_future = self._thread.submit(_zero_pages) if pages else None
+        zero_future = (
+            self._thread.submit(lambda: executor.zero_cache_pages(pages))
+            if pages
+            else None
+        )
         if l2 is not None:
             self._l2_submissions.append(
                 self._thread.submit(lambda: l2.submit_load_backs(execution_plan))

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -495,6 +495,12 @@ class ModelExecutor:
         )
 
         self.device_module = torch.get_device_module(self.device)
+        # Two streams, named once. `default_stream` is the forward thread's
+        # own: everything the data plane enqueues outside an explicit stream
+        # context -- page zeroing, the cache ops' fences and start events,
+        # the forward prologue's handshake -- lands here. `execution_stream`
+        # carries the model launches and the runtime-state writes.
+        self.default_stream = self.device_module.default_stream(self.device)
         self.execution_stream = self.device_module.Stream()
         # The data plane: every CUDA-touching operation after startup is
         # submitted here and runs in FIFO order on one thread. The event loop
@@ -1080,19 +1086,19 @@ class ModelExecutor:
                     spec_step_idx=step_idx,
                 )
 
-    def order_cache_operations(self) -> None:
-        """Order caller-stream cache work after previously submitted forwards.
-
-        Called on the forward thread before D2H or page reuse. This inserts
-        a GPU dependency, not a host synchronization; the forward prologue's
-        wait is too late to protect cache operations submitted before it.
-        """
-        self.device_module.current_stream().wait_stream(self.execution_stream)
-
     def zero_cache_pages(self, pages):
-        """Clear newly owned pages and return a CUDA completion event when needed."""
+        """Clear newly owned pages and return a CUDA completion event when needed.
+
+        Runs on ``default_stream``, ordered behind the forwards in flight on
+        ``execution_stream``: the pages' previous owner may still be writing
+        them. The plan's later work on the default stream (the load-backs'
+        start event, the remote prefill's fence) inherits the order; the next
+        forward's prologue waits on the default stream and so runs after the
+        zeroing.
+        """
         if not pages:
             return None
+        self.default_stream.wait_stream(self.execution_stream)
 
         def sanitize(pool, pool_pages) -> bool:
             zero_new_blocks = getattr(pool, "zero_new_blocks", None)
@@ -1149,7 +1155,7 @@ class ModelExecutor:
         if torch.device(self.device).type not in {"cuda", "npu"}:
             return None
         done = self.device_module.Event()
-        done.record(self.device_module.current_stream(self.device))
+        done.record(self.default_stream)
         return done
 
     @nvtx_range("reset_valid_cache_length", color="orange")
@@ -1188,7 +1194,7 @@ class ModelExecutor:
 
     def _write_valid_cache_lengths(self, pool_indices, lengths) -> None:
         """Publish per-row valid cache lengths on the execution stream."""
-        self.execution_stream.wait_stream(self.device_module.current_stream())
+        self.execution_stream.wait_stream(self.default_stream)
         with self.device_module.stream(self.execution_stream):
             rows = torch.tensor(
                 pool_indices,
@@ -1233,8 +1239,8 @@ class ModelExecutor:
             # Wait for previous iteration's runtime state updates
             # (future_input_map, valid_cache_lengths) on execution_stream to
             # complete before reading them.
-            self.device_module.current_stream().wait_stream(self.execution_stream)
-            self.execution_stream.wait_stream(self.device_module.current_stream())
+            self.default_stream.wait_stream(self.execution_stream)
+            self.execution_stream.wait_stream(self.default_stream)
         with self.device_module.stream(self.execution_stream):
             bs = len(forward_op.request_ids)
             # Outside the graph: in-graph sites only OR into the flag buffer.

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -497,9 +497,11 @@ class ModelExecutor:
         self.device_module = torch.get_device_module(self.device)
         # Two streams, named once. `default_stream` is the forward thread's
         # own: everything the data plane enqueues outside an explicit stream
-        # context -- page zeroing, the cache ops' fences and start events,
-        # the forward prologue's handshake -- lands here. `execution_stream`
-        # carries the model launches and the runtime-state writes.
+        # context -- page zeroing, the cache ops' fences and start events --
+        # lands here. `execution_stream` carries the model launches and the
+        # runtime-state writes. Dependencies between them are placed by the
+        # consumer: each forward waits on the default stream in its prologue;
+        # zeroing and write-back wait on the execution stream themselves.
         self.default_stream = self.device_module.default_stream(self.device)
         self.execution_stream = self.device_module.Stream()
         # The data plane: every CUDA-touching operation after startup is
@@ -1236,10 +1238,10 @@ class ModelExecutor:
         graph_padded_bs = 0
 
         with nvtx_range("pre_fill_setup", color="orange"):
-            # Wait for previous iteration's runtime state updates
-            # (future_input_map, valid_cache_lengths) on execution_stream to
-            # complete before reading them.
-            self.default_stream.wait_stream(self.execution_stream)
+            # Behind the default-stream work the plan enqueued ahead of this
+            # forward: the page zeroing, the retraction write-back's fence,
+            # the multimodal features. The runtime-state reads below need no
+            # cross-stream wait -- their writers ran on execution_stream too.
             self.execution_stream.wait_stream(self.default_stream)
         with self.device_module.stream(self.execution_stream):
             bs = len(forward_op.request_ids)

--- a/test/runtime/test_device_handle.py
+++ b/test/runtime/test_device_handle.py
@@ -131,7 +131,7 @@ def _handle(trace, **kwargs):
         SimpleNamespace(
             forward_thread=_ForwardThread(trace),
             execute_forward_op=lambda *a, **k: trace.append("forward"),
-            order_cache_operations=lambda: trace.append("order"),
+            execution_stream="execution-stream",
             write_remote_spec_candidate_ids=lambda idx, ids: trace.append(
                 ("candidates", idx, list(ids))
             ),
@@ -241,15 +241,18 @@ def test_an_aborted_request_still_lands_its_candidates_but_is_not_armed():
 
 def test_one_plan_orders_write_backs_zeroing_then_load_backs():
     """The FIFO carries the correctness order for same-round page reuse: the
-    write-backs are submitted behind the forward fence and ahead of the new
-    owner's zeroing (a stream-ordered snapshot copy lands its fence there),
-    and the load-backs target zeroed pages."""
+    write-backs are submitted ahead of the new owner's zeroing (a
+    stream-ordered snapshot copy lands its fence there), and the load-backs
+    target zeroed pages. The copies are told which stream wrote the pages;
+    the zeroing orders itself behind that stream."""
     trace: list = []
     plan = _plan(pages_to_zero=[3, 4], cache=["op"])
     handle = _handle(
         trace,
         l2_cache_executor=SimpleNamespace(
-            submit_write_backs=lambda p: trace.append(("write_backs", p.cache)),
+            submit_write_backs=lambda p, *, producer_stream: trace.append(
+                ("write_backs", p.cache, producer_stream)
+            ),
             submit_load_backs=lambda p: trace.append(("load_backs", p.cache)),
             poll_results=lambda: ["done"],
         ),
@@ -262,8 +265,7 @@ def test_one_plan_orders_write_backs_zeroing_then_load_backs():
 
     assert trace == [
         "submit",
-        "order",
-        ("write_backs", ["op"]),
+        ("write_backs", ["op"], "execution-stream"),
         "submit",
         ("zero", (3, 4)),
         "submit",
@@ -272,27 +274,6 @@ def test_one_plan_orders_write_backs_zeroing_then_load_backs():
     # Polling never touches the FIFO — the round head must not wait on it.
     assert handle.poll_cache_results() == ["done"]
     assert trace[-1] != "submit"
-
-
-def test_zeroing_without_cache_ops_still_orders_behind_the_forwards():
-    """With no L2 work this round the zeroing closure itself must place the
-    forward fence: nothing else on the FIFO would."""
-    trace: list = []
-    handle = _handle(
-        trace,
-        l2_cache_executor=SimpleNamespace(
-            submit_write_backs=lambda p: trace.append(("write_backs", p.cache)),
-            submit_load_backs=lambda p: trace.append(("load_backs", p.cache)),
-            poll_results=lambda: [],
-        ),
-    )
-    handle._executor.zero_cache_pages = lambda pages: trace.append(
-        ("zero", tuple(pages))
-    )
-
-    handle.execute(_plan(pages_to_zero=[3]), None)
-
-    assert trace == ["submit", "order", ("zero", (3,))]
 
 
 def test_a_plan_with_no_device_work_submits_nothing():
@@ -309,7 +290,7 @@ def test_a_failed_cache_submission_surfaces_at_the_next_poll():
     would leave its ops counted in flight forever."""
     trace: list = []
 
-    def exploding(plan):
+    def exploding(plan, *, producer_stream):
         raise ValueError("bad cache op")
 
     handle = _handle(

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -361,6 +361,7 @@ class GroupAwareWireTest(unittest.TestCase):
                 "current_stream",
                 return_value=caller_stream,
             ),
+            patch.object(executor_module.device_module, "stream") as stream_ctx,
             patch.object(
                 executor_module.device_module,
                 "Event",
@@ -376,6 +377,11 @@ class GroupAwareWireTest(unittest.TestCase):
         # fence the caller on it; a pinned one simply drops it.
         self.assertIs(fence, finish)
         executor.write_stream.wait_stream.assert_called_once_with(caller_stream)
+        # The address tables and the metadata H2D are enqueued on the write
+        # stream too: the payload kernel reads them from that stream, and a
+        # copy left on the caller's stream would land behind the wait above
+        # with nothing ordering it ahead of the kernel.
+        stream_ctx.assert_called_once_with(executor.write_stream)
         lane.workspace.load_block_transfers.assert_called_once_with(
             [(0, 5, 9)], geometry=executor._transfer_geometry
         )
@@ -401,7 +407,9 @@ class GroupAwareWireTest(unittest.TestCase):
         metadata_done.synchronize.assert_not_called()
         self.assertIsNone(executor._ordered_write_lane.metadata_done)
 
-        # Refill must wait for metadata, but must never wait for payload ACK.
+        # Refill must wait for metadata, but must never wait for payload ACK;
+        # the upload and its retirement event sit inside the write-stream
+        # context, the payload launch names the stream explicitly.
         for ready in (False, True):
             with self.subTest(metadata_ready=ready):
                 metadata_done.reset_mock()
@@ -417,18 +425,28 @@ class GroupAwareWireTest(unittest.TestCase):
                         "current_stream",
                         return_value=caller_stream,
                     ),
+                    patch.object(executor_module.device_module, "stream") as stream_ctx,
                     patch.object(
                         executor_module.device_module, "Event", return_value=finish
                     ),
                     patch.object(executor_module, "transfer_cache_blocks") as transfer,
                 ):
+                    order.attach_mock(stream_ctx, "stream")
                     order.attach_mock(transfer, "payload")
                     executor._start_writing([8], [(0, 6, 10)], lane=lane)
                 names = [call[0] for call in order.mock_calls]
                 self.assertEqual(
                     names,
                     ([] if ready else ["retire"])
-                    + ["refill", "upload", "record", "payload"],
+                    + [
+                        "refill",
+                        "stream",
+                        "stream().__enter__",
+                        "upload",
+                        "record",
+                        "stream().__exit__",
+                        "payload",
+                    ],
                 )
                 finish.synchronize.assert_not_called()
 
@@ -463,6 +481,9 @@ class GroupAwareWireTest(unittest.TestCase):
                 executor_module.device_module,
                 "current_stream",
                 return_value=caller_stream,
+            ),
+            patch.object(
+                executor_module.device_module, "stream", return_value=nullcontext()
             ),
             patch.object(
                 executor_module.device_module,
@@ -515,6 +536,9 @@ class GroupAwareWireTest(unittest.TestCase):
                 executor_module.device_module,
                 "current_stream",
                 return_value=caller_stream,
+            ),
+            patch.object(
+                executor_module.device_module, "stream", return_value=nullcontext()
             ),
             patch.object(executor_module.device_module, "Event", side_effect=Mock),
             patch.object(executor_module, "transfer_cache_blocks"),

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -9,7 +9,7 @@ import unittest
 from contextlib import nullcontext
 from importlib import import_module, util
 from types import ModuleType, SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
@@ -352,6 +352,7 @@ class GroupAwareWireTest(unittest.TestCase):
         executor, device = self._make_write_executor(executor_module)
         lane = executor._pinned_write_lane
         caller_stream = object()
+        producer_stream = object()
         finish = Mock()
         metadata_done = Mock()
 
@@ -369,14 +370,17 @@ class GroupAwareWireTest(unittest.TestCase):
             ),
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
         ):
-            fence = executor._start_writing([7], [(0, 5, 9)], lane=lane)
+            fence = executor._start_writing(
+                [7], [(0, 5, 9)], lane=lane, producer_stream=producer_stream
+            )
 
-        # On the write stream, ordered after the caller's stream (which the
-        # caller ordered behind the forwards that wrote the pages). The
-        # completion event is handed back so a stream-ordered submission can
-        # fence the caller on it; a pinned one simply drops it.
+        # On the write stream, ordered after the producer stream the caller
+        # named (the forwards that wrote the pages) -- not after whatever
+        # stream happens to be current. The completion event is handed back
+        # so a stream-ordered submission can fence the caller on it; a pinned
+        # one simply drops it.
         self.assertIs(fence, finish)
-        executor.write_stream.wait_stream.assert_called_once_with(caller_stream)
+        executor.write_stream.wait_stream.assert_called_once_with(producer_stream)
         # The address tables and the metadata H2D are enqueued on the write
         # stream too: the payload kernel reads them from that stream, and a
         # copy left on the caller's stream would land behind the wait above
@@ -433,7 +437,9 @@ class GroupAwareWireTest(unittest.TestCase):
                 ):
                     order.attach_mock(stream_ctx, "stream")
                     order.attach_mock(transfer, "payload")
-                    executor._start_writing([8], [(0, 6, 10)], lane=lane)
+                    executor._start_writing(
+                        [8], [(0, 6, 10)], lane=lane, producer_stream=producer_stream
+                    )
                 names = [call[0] for call in order.mock_calls]
                 self.assertEqual(
                     names,
@@ -454,6 +460,7 @@ class GroupAwareWireTest(unittest.TestCase):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
         caller_stream = Mock(name="caller_stream")
+        producer = object()
         ordered_finish = Mock(name="ordered_finish")
         pinned_finish = Mock(name="pinned_finish")
         events = iter(
@@ -492,7 +499,9 @@ class GroupAwareWireTest(unittest.TestCase):
             ),
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
         ):
-            executor.submit_write_backs(SimpleNamespace(cache=[WriteBackOp()]))
+            executor.submit_write_backs(
+                SimpleNamespace(cache=[WriteBackOp()]), producer_stream=producer
+            )
 
         # The stream-ordered op (12) launches first and the caller's stream
         # waits on ITS completion only; the pinned ops (11, 13) follow on the
@@ -514,11 +523,17 @@ class GroupAwareWireTest(unittest.TestCase):
             [(ack.finish_event, ack.op_ids) for ack in executor._write_acks],
             [(ordered_finish, [12]), (pinned_finish, [11, 13])],
         )
+        self.assertEqual(
+            executor.write_stream.wait_stream.call_args_list,
+            [call(producer), call(producer)],
+            "both launches order behind the producer stream the caller named",
+        )
 
     def test_submit_write_backs_without_stream_ordered_ops_fences_nothing(self):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
         caller_stream = Mock(name="caller_stream")
+        producer = object()
 
         class WriteBackOp:
             def __init__(self):
@@ -543,7 +558,9 @@ class GroupAwareWireTest(unittest.TestCase):
             patch.object(executor_module.device_module, "Event", side_effect=Mock),
             patch.object(executor_module, "transfer_cache_blocks"),
         ):
-            executor.submit_write_backs(SimpleNamespace(cache=[WriteBackOp()]))
+            executor.submit_write_backs(
+                SimpleNamespace(cache=[WriteBackOp()]), producer_stream=producer
+            )
 
         caller_stream.wait_event.assert_not_called()
         executor._ordered_write_lane.workspace.load_block_transfers.assert_not_called()
@@ -551,6 +568,7 @@ class GroupAwareWireTest(unittest.TestCase):
     def test_submit_write_backs_rejects_ragged_guard_vector(self):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
+        producer = object()
 
         class WriteBackOp:
             def __init__(self):
@@ -564,7 +582,9 @@ class GroupAwareWireTest(unittest.TestCase):
             executor_module.Cache, "WriteBackOp", WriteBackOp, create=True
         ):
             with self.assertRaises(ValueError):
-                executor.submit_write_backs(SimpleNamespace(cache=[WriteBackOp()]))
+                executor.submit_write_backs(
+                    SimpleNamespace(cache=[WriteBackOp()]), producer_stream=producer
+                )
 
     def test_loadback_logs_non_empty_batch(self):
         executor_module, executor, _, geometry, workspace = self._make_load_executor(
@@ -1153,6 +1173,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
             [7],
             [(0, 1, 1), (0, 4, 4), (1, 3, 3)],
             lane=executor._pinned_write_lane,  # pylint: disable=protected-access
+            producer_stream=torch.cuda.current_stream(),
         )
         executor.write_stream.synchronize()
         write_results = executor.poll_results()
@@ -1194,14 +1215,21 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         )
         executor, pool, _ = self._make_executor(layout, io_backend="kernel")
         for generation in range(3):
-            # Reuse one Device source, but preserve each batch in its own Host
-            # block. No caller synchronization between write submissions; the
-            # write stream inherits the caller's order, so each copy reads the
-            # fill that preceded it.
+            # Three back-to-back submissions, each with its own Device source
+            # and Host block, with no caller synchronization between them: if
+            # a later batch's block table overwrote an earlier one's before its
+            # payload ran, the wrong pair would be copied. The sources are
+            # distinct on purpose -- a pinned store's source is never rewritten
+            # while its copy is in flight, so the test must not rewrite one
+            # either.
             for block in range(1, 4):
-                device[16:20].fill_(generation * 16 + block)
+                offset = 8 + block * 8
+                device[offset : offset + 4].fill_(generation * 16 + block)
                 executor._start_writing(
-                    [block], [(0, 1, block)], lane=executor._pinned_write_lane
+                    [block],
+                    [(0, block, block)],
+                    lane=executor._pinned_write_lane,
+                    producer_stream=torch.cuda.current_stream(),
                 )
             # The load below has no scheduler ACK to wait for, so order it
             # behind the copies the way a stream-ordered submission would.
@@ -1241,7 +1269,10 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         device[56:60].fill_(0x12)
         torch.cuda.synchronize()
         executor._start_writing(  # pylint: disable=protected-access
-            [7], [(0, 1, 1)], lane=executor._pinned_write_lane
+            [7],
+            [(0, 1, 1)],
+            lane=executor._pinned_write_lane,
+            producer_stream=torch.cuda.current_stream(),
         )
         torch.cuda.synchronize()
         self.assertEqual([int(event.op_id) for event in executor.poll_results()], [7])

--- a/test/runtime/test_model_executor_cache_state.py
+++ b/test/runtime/test_model_executor_cache_state.py
@@ -43,6 +43,7 @@ def test_mixed_batch_resets_only_prefill_lengths(monkeypatch):
     executor = ModelExecutor.__new__(ModelExecutor)
     executor.device = "cpu"
     executor.device_module = torch.cuda
+    executor.default_stream = object()
     executor.execution_stream = _ExecutionStream()
     executor.runtime_states = _RuntimeStates()
 
@@ -59,7 +60,6 @@ def test_mixed_batch_resets_only_prefill_lengths(monkeypatch):
         return torch_tensor(*args, **kwargs)
 
     monkeypatch.setattr(torch, "tensor", tensor_without_pinning)
-    monkeypatch.setattr(torch.cuda, "current_stream", lambda: object())
     monkeypatch.setattr(torch.cuda, "stream", lambda _: nullcontext())
 
     executor._reset_valid_cache_length(forward_op)
@@ -76,6 +76,7 @@ def test_remote_prefill_seeds_the_complete_prompt_length(monkeypatch):
     executor = ModelExecutor.__new__(ModelExecutor)
     executor.device = "cpu"
     executor.device_module = torch.cuda
+    executor.default_stream = object()
     executor.execution_stream = _ExecutionStream()
     executor.runtime_states = _RuntimeStates()
 
@@ -93,7 +94,6 @@ def test_remote_prefill_seeds_the_complete_prompt_length(monkeypatch):
         return torch_tensor(*args, **kwargs)
 
     monkeypatch.setattr(torch, "tensor", tensor_without_pinning)
-    monkeypatch.setattr(torch.cuda, "current_stream", lambda: object())
     monkeypatch.setattr(torch.cuda, "stream", lambda _: nullcontext())
 
     executor.reset_remote_prefill_cache_lengths(forward_op)

--- a/test/runtime/test_page_zeroing_contract.py
+++ b/test/runtime/test_page_zeroing_contract.py
@@ -19,21 +19,57 @@ from ci_system.ci_register import register_cuda_ci  # noqa: E402
 register_cuda_ci(est_time=15, suite="runtime-1gpu")
 
 
+class _DefaultStream:
+    """Records the streams it was asked to wait on, in call order."""
+
+    def __init__(self, trace):
+        self._trace = trace
+
+    def wait_stream(self, stream):
+        self._trace.append(("wait", stream))
+
+
 class ZeroCachePagesContractTest(unittest.TestCase):
     @staticmethod
-    def _call(pool, page_ids, draft_pool=None):
-        from tokenspeed.runtime.execution.model_executor import ModelExecutor
-
-        fake = types.SimpleNamespace(
+    def _fake(pool, draft_pool, trace):
+        return types.SimpleNamespace(
             token_to_kv_pool=pool,
             draft_token_to_kv_pool=draft_pool,
             device="cpu",
+            default_stream=_DefaultStream(trace),
+            execution_stream="execution-stream",
         )
+
+    @classmethod
+    def _call(cls, pool, page_ids, draft_pool=None):
+        from tokenspeed.runtime.execution.model_executor import ModelExecutor
+
+        fake = cls._fake(pool, draft_pool, trace=[])
         return ModelExecutor.zero_cache_pages(fake, page_ids)
 
     def test_empty_page_list_is_a_noop(self):
-        pool = types.SimpleNamespace()
-        self.assertIsNone(self._call(pool, []))
+        from tokenspeed.runtime.execution.model_executor import ModelExecutor
+
+        trace = []
+        fake = self._fake(types.SimpleNamespace(), None, trace)
+        self.assertIsNone(ModelExecutor.zero_cache_pages(fake, []))
+        self.assertEqual(trace, [], "an empty list places no fence either")
+
+    def test_zeroing_orders_itself_behind_the_execution_stream(self):
+        # The pages' previous owner may still be writing them from a forward
+        # in flight on the execution stream: the default stream waits on it
+        # before the pool touches a byte, and the function places that wait
+        # itself rather than relying on a caller-side fence.
+        from tokenspeed.runtime.execution.model_executor import ModelExecutor
+
+        trace = []
+        pool = types.SimpleNamespace(
+            requires_page_zeroing=True,
+            zero_pages=lambda page_ids: trace.append(("zero", list(page_ids))),
+        )
+        fake = self._fake(pool, None, trace)
+        self.assertIsNone(ModelExecutor.zero_cache_pages(fake, [4, 5]))
+        self.assertEqual(trace, [("wait", "execution-stream"), ("zero", [4, 5])])
 
     def test_pure_attention_pool_ignores_page_reuse_list(self):
         # No zero_pages and not flagged as state-aliasing -> skip, no raise.


### PR DESCRIPTION
## Why

Follow-up to #1444 (merged before these landed on its branch).

1. **Codex P1 on #1444, confirmed.** `_start_writing` recorded the write stream's wait on the caller's stream and then called `prepare_backend` / `commit_block_transfers` outside any stream context, so the address-table allocation and the non-blocking block-table H2D went to the caller's stream *behind* that wait, with nothing ordering the payload kernel on the write stream after them. With the kernel backend the D2H could read a block table before it landed; the retirement event was also recorded on the write stream and so did not guard the copies it was meant to.

2. **`order_cache_operations` was a fence the caller had to remember.** `DeviceHandle.execute` called it from the write-back closure when the round had L2 work and from the zeroing closure otherwise — a coupling that only held because the two closures knew about each other. `ModelExecutor` also reached for `device_module.current_stream()` in five places to mean "the forward thread's own stream".

## What

- `_start_writing` wraps the metadata upload (and its retirement event) in `device_module.stream(write_stream)`, exactly as `_start_loading` does for the load stream. The unit test asserts the context and the upload → record → payload order inside it.
- `order_cache_operations` is gone. `zero_cache_pages` waits on `execution_stream` itself before touching a page; `L2CacheExecutor.submit_write_backs(plan, *, producer_stream)` orders every copy behind the stream the caller names — the execution stream, where the forwards wrote the pages — instead of behind whatever stream happened to be current. `DeviceHandle.execute` just passes `executor.execution_stream`.
- `ModelExecutor.default_stream = device_module.default_stream(device)` replaces the scattered `current_stream()` calls (verified identical to the forward thread's current stream on an H20).
- The metadata-reuse GPU test rewrote one Device source three times with no sync between submissions, which the decoupled write stream no longer tolerates — and neither does the contract: a pinned store's source is immutable while its copy is in flight. It now uses one source per batch and still catches a block table overwritten before its payload ran.

## Tests

- `test_host_executor.py` (21, incl. the CUDA round-trip / metadata-reuse / merged-draft integration tests on an H20, three consecutive runs), `test_device_handle.py`, `test_page_zeroing_contract.py` (new: the zeroing places its own fence on the execution stream), `test_model_executor_cache_state.py`, `test_forward_routing.py`, `test_l2_cache_hooks.py` — 72 passed.
- `pre-commit run --all-files` clean; CI ruff selection clean.
- Not run: end-to-end `--enable-kvstore` serving (dev box GPUs occupied; not used for regressions).

## Docs

`docs/design/cache-concepts.md` writeback paragraph: copies order behind the producer stream the caller names; zeroing orders itself, no caller-side fence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)