### PR TITLE
refactor(l2): name every stream the executor orders against; refuse cache ops with no transfers

### DIFF
--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -232,13 +232,17 @@ Each op says how the scheduler guards its Device sources
 (`source_pinned`, see `scheduler.md` §2). A pinned op's sources stay cached
 and unevictable until the ACK, so its copy overlaps whatever the round does
 next and nobody waits on it. An unpinned op's sources may be re-granted in the
-same plan, so it is launched first and the caller's stream waits on its
-completion event before the plan's page zeroing is enqueued — the zeroing,
-load-backs, forwards and RDMA triggers behind it inherit the fence (the
-forward by waiting on the default stream in its prologue; that wait is
-one-way, the zeroing's and the writeback's own waits are what order the
-default and write streams behind the forwards). The two
-kinds use separate staging lanes: each lane uploads block metadata
+same plan, so it is launched first and the fence stream the caller names --
+the default stream, where the plan's page zeroing runs -- waits on its
+completion event before the zeroing is enqueued — the zeroing, load-backs,
+forwards and RDMA triggers behind it inherit the fence (the forward by
+waiting on the default stream in its prologue; that wait is one-way, the
+zeroing's and the writeback's own waits are what order the default and write
+streams behind the forwards). Load-backs likewise name their producer stream
+-- the default stream that zeroed their destinations -- rather than
+recording their start event on whatever stream is current: every stream the
+L2 executor orders against is an argument, never ambient thread state. The
+two kinds use separate staging lanes: each lane uploads block metadata
 asynchronously and records an event after both metadata copies to protect its
 pinned CPU staging tables — before refilling them, the next submission on
 that lane waits only if that event is incomplete. This does not wait for the
@@ -254,6 +258,14 @@ layer readiness alone does not retire metadata still read by the transfer.
 On submission failure, retirement fences protect reuse without publishing a
 successful load ACK. If neither event publication nor stream synchronization
 can establish retirement, the executor must reject further loads.
+
+An op is acknowledged only by its copy's completion event, so every op on the
+wire carries at least one transfer, and no (group, source, destination)
+repeats within one plan: a store skips keys already in flight, a load targets
+freshly acquired pages. The scheduler asserts both when batching a plan's ops
+and the runtime refuses an op with nothing to copy; neither side dedups or
+invents an acknowledgement, because an op that never completes a copy would
+hold its tickets forever.
 
 ## block vs. page
 

--- a/docs/design/cache-concepts.md
+++ b/docs/design/cache-concepts.md
@@ -224,10 +224,12 @@ blocks, the transfer boundary validates the loaded block count and returns
 before mapping Host pointers or touching the accelerator runtime. Flagged
 loads still publish readiness for empty consumers.
 
-Writeback runs on the executor's write stream, ordered after the producer
-stream the caller names -- the model executor's execution stream, where the
-forwards wrote the pages. (Page zeroing likewise orders itself behind that
-stream inside `zero_cache_pages`; there is no caller-side fence to remember.)
+Every L2 copy is ordered after the prerequisite stream the caller names per
+submission: the stream whose completed work the copy must observe. Writeback
+runs on the executor's write stream, ordered after the model executor's
+execution stream, where the forwards wrote the source pages. (Page zeroing
+likewise orders itself behind that stream inside `zero_cache_pages`; there is
+no caller-side fence to remember.)
 Each op says how the scheduler guards its Device sources
 (`source_pinned`, see `scheduler.md` §2). A pinned op's sources stay cached
 and unevictable until the ACK, so its copy overlaps whatever the round does
@@ -238,10 +240,10 @@ completion event before the zeroing is enqueued — the zeroing, load-backs,
 forwards and RDMA triggers behind it inherit the fence (the forward by
 waiting on the default stream in its prologue; that wait is one-way, the
 zeroing's and the writeback's own waits are what order the default and write
-streams behind the forwards). Load-backs likewise name their producer stream
--- the default stream that zeroed their destinations -- rather than
-recording their start event on whatever stream is current: every stream the
-L2 executor orders against is an argument, never ambient thread state. The
+streams behind the forwards). A load-back's prerequisite stream is the
+default stream that zeroed its destinations; its start event is recorded
+there rather than on whatever stream is current. Every stream the L2
+executor orders against is an argument, never ambient thread state. The
 two kinds use separate staging lanes: each lane uploads block metadata
 asynchronously and records an event after both metadata copies to protect its
 pinned CPU staging tables — before refilling them, the next submission on

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -177,17 +177,17 @@ class L2CacheExecutor:
             tracker = LayerwiseLoadTracker(len(layout.consumers))
             pool.register_layerwise_load_tracker(tracker)
             self._load_trackers.append((tracker, len(layout.consumers)))
-        # Write-backs run on their own stream, ordered after the producer
-        # stream the caller names per submission -- the one the forwards wrote
-        # the pages on. What differs per op is who waits on the copy: a
-        # stream-ordered op (a retraction's snapshot, whose sources this very
-        # plan may re-grant) fences the fence stream the caller names on its
-        # completion, so the plan's zeroing, load-backs and forwards stay
-        # behind it; a pinned op (an ordinary publication, whose sources the
-        # scheduler holds until the ACK) fences nothing and never holds up the
-        # round. Loads keep their own stream, ordered after the producer stream
-        # that zeroed their destinations: their consumers are fenced per layer
-        # by the tracker events.
+        # Every copy runs on its own stream, ordered after the prerequisite
+        # stream the caller names per submission: for a write-back the one
+        # the forwards wrote the source pages on, for a load the one that
+        # zeroed the destination pages. What differs per write-back op is who
+        # waits on the copy: a stream-ordered op (a retraction's snapshot,
+        # whose sources this very plan may re-grant) fences the fence stream
+        # the caller names on its completion, so the plan's zeroing,
+        # load-backs and forwards stay behind it; a pinned op (an ordinary
+        # publication, whose sources the scheduler holds until the ACK) fences
+        # nothing and never holds up the round. A load's consumers are fenced
+        # per layer by the tracker events.
         self.write_stream = _new_cache_stream(None)
         self.load_stream = _new_cache_stream(_load_stream_priority())
         device = self.layout.buffers[0].device
@@ -281,24 +281,25 @@ class L2CacheExecutor:
         self._load_acks: list[_Ack] = []
         self._load_poisoned = False
 
-    def submit_write_backs(self, plan, *, producer_stream, fence_stream) -> None:
+    def submit_write_backs(self, plan, *, prerequisite_stream, fence_stream) -> None:
         """Enqueue the plan's D2H copies on the write stream.
 
         Must run BEFORE the plan's page zeroing. Every copy is ordered behind
-        ``producer_stream`` -- the stream the forwards wrote the source pages
-        on -- so it reads their final bytes. The scheduler marks each op
-        ``source_pinned``: a pinned op's sources stay cached and unevictable
-        until the ACK, so its copy rides the write stream and nobody waits on
-        it; an unpinned op's sources may already be granted to another request
-        in this very plan, so it goes first and ``fence_stream`` waits on its
-        completion -- the plan's zeroing, load-backs and forwards are ordered
-        behind that wait.
+        ``prerequisite_stream`` -- here the stream the forwards wrote the
+        source pages on -- so it reads their final bytes. The scheduler marks
+        each op ``source_pinned``: a pinned op's sources stay cached and
+        unevictable until the ACK, so its copy rides the write stream and
+        nobody waits on it; an unpinned op's sources may already be granted to
+        another request in this very plan, so it goes first and
+        ``fence_stream`` waits on its completion -- the plan's zeroing,
+        load-backs and forwards are ordered behind that wait.
 
         Args:
             plan: The round's ExecutionPlan; its ``Cache.WriteBackOp``
                 entries are read here.
-            producer_stream: The stream whose completed work every copy must
-                observe -- the model executor's execution stream.
+            prerequisite_stream: The stream whose completed work every copy
+                must observe -- the model executor's execution stream, where
+                the forwards wrote the source pages.
             fence_stream: The stream a stream-ordered op's completion fences
                 -- the one the plan's page zeroing runs on next.
         """
@@ -319,7 +320,7 @@ class L2CacheExecutor:
             ordered_op_ids,
             ordered_transfers,
             lane=self._ordered_write_lane,
-            producer_stream=producer_stream,
+            prerequisite_stream=prerequisite_stream,
         )
         if fence is not None:
             fence_stream.wait_event(fence)
@@ -327,17 +328,18 @@ class L2CacheExecutor:
             pinned_op_ids,
             pinned_transfers,
             lane=self._pinned_write_lane,
-            producer_stream=producer_stream,
+            prerequisite_stream=prerequisite_stream,
         )
 
-    def submit_load_backs(self, plan, *, producer_stream) -> None:
+    def submit_load_backs(self, plan, *, prerequisite_stream) -> None:
         """Launch the plan's H2D loads; runs after the plan's page zeroing.
 
         Args:
             plan: The round's ExecutionPlan; its ``Cache.LoadBackOp``
                 entries are read here.
-            producer_stream: The stream whose completed work every copy must
-                observe -- the one that zeroed the destination pages.
+            prerequisite_stream: The stream whose completed work every copy
+                must observe -- the one the plan's page zeroing ran on, so the
+                loads land on zeroed destination pages.
         """
         op_ids: list[int] = []
         transfers: list[tuple[int, int, int]] = []
@@ -353,7 +355,7 @@ class L2CacheExecutor:
                     source_is_device=False,
                 )
         load_index = self._start_loading(
-            op_ids, transfers, producer_stream=producer_stream
+            op_ids, transfers, prerequisite_stream=prerequisite_stream
         )
         for tracker, _ in self._load_trackers:
             tracker.set_consumers(load_index if load_index is not None else -1)
@@ -425,7 +427,7 @@ class L2CacheExecutor:
         transfers: Sequence[tuple[int, int, int]],
         *,
         lane: _WriteLane,
-        producer_stream,
+        prerequisite_stream,
     ):
         """Launch one D2H batch on the write stream; return its completion event.
 
@@ -443,7 +445,7 @@ class L2CacheExecutor:
             )
         # Behind the forwards that wrote the source pages: that is what lets
         # the copy read their final bytes.
-        self.write_stream.wait_stream(producer_stream)
+        self.write_stream.wait_stream(prerequisite_stream)
         # CPU writes are not ordered by stream FIFO. Retire the previous
         # metadata upload before refilling its pinned source, not at submit.
         if lane.metadata_done is not None and not lane.metadata_done.query():
@@ -498,7 +500,7 @@ class L2CacheExecutor:
         op_ids: Sequence[int],
         transfers: Sequence[tuple[int, int, int]],
         *,
-        producer_stream,
+        prerequisite_stream,
     ) -> int | None:
         if self._load_poisoned:
             raise RuntimeError(
@@ -516,7 +518,7 @@ class L2CacheExecutor:
                 len(transfers),
             )
 
-        # EventLoop zeroes freshly allocated Device blocks on the producer
+        # EventLoop zeroes freshly allocated Device blocks on the prerequisite
         # stream before submitting the load. Recording the start event there
         # makes the H2D copy wait for that zeroing; per-layer ready flags
         # (Triton) or events (DMA) then keep model consumers from reading
@@ -537,7 +539,7 @@ class L2CacheExecutor:
                     load_index = current_load_index
                 elif current_load_index != load_index:
                     raise RuntimeError("target and draft Host-load trackers diverged")
-                load_events.start_event.record(producer_stream)
+                load_events.start_event.record(prerequisite_stream)
                 load_events.start_event.wait(self.load_stream)
             if load_index is None:
                 raise RuntimeError("cache transfer layout has no layer consumers")

--- a/python/tokenspeed/runtime/cache/l2/executor.py
+++ b/python/tokenspeed/runtime/cache/l2/executor.py
@@ -27,7 +27,6 @@ from collections.abc import Iterable, Sequence
 from typing import NamedTuple
 
 import psutil
-import torch
 from tokenspeed_kernel.ops.kvcache.host_transfer import (
     HostTransferWorkspace,
     build_host_transfer_geometry,
@@ -88,7 +87,7 @@ class _WriteLane:
     (stream-ordered, then pinned) never wait on each other's staging.
     """
 
-    __slots__ = ("workspace", "metadata_done")
+    __slots__ = ("metadata_done", "workspace")
 
     def __init__(self) -> None:
         self.workspace = HostTransferWorkspace()
@@ -182,12 +181,13 @@ class L2CacheExecutor:
         # stream the caller names per submission -- the one the forwards wrote
         # the pages on. What differs per op is who waits on the copy: a
         # stream-ordered op (a retraction's snapshot, whose sources this very
-        # plan may re-grant) fences the caller's stream on its completion, so
-        # the plan's zeroing, load-backs and forwards stay behind it; a pinned
-        # op (an ordinary publication, whose sources the scheduler holds until
-        # the ACK) fences nothing and never holds up the round. Loads keep
-        # their own stream: their consumers are fenced per layer by the
-        # tracker events.
+        # plan may re-grant) fences the fence stream the caller names on its
+        # completion, so the plan's zeroing, load-backs and forwards stay
+        # behind it; a pinned op (an ordinary publication, whose sources the
+        # scheduler holds until the ACK) fences nothing and never holds up the
+        # round. Loads keep their own stream, ordered after the producer stream
+        # that zeroed their destinations: their consumers are fenced per layer
+        # by the tracker events.
         self.write_stream = _new_cache_stream(None)
         self.load_stream = _new_cache_stream(_load_stream_priority())
         device = self.layout.buffers[0].device
@@ -279,11 +279,9 @@ class L2CacheExecutor:
         self._ack_lock = threading.Lock()
         self._write_acks: list[_Ack] = []
         self._load_acks: list[_Ack] = []
-        self._ready_write_op_ids: list[int] = []
-        self._ready_load_op_ids: list[int] = []
         self._load_poisoned = False
 
-    def submit_write_backs(self, plan, *, producer_stream) -> None:
+    def submit_write_backs(self, plan, *, producer_stream, fence_stream) -> None:
         """Enqueue the plan's D2H copies on the write stream.
 
         Must run BEFORE the plan's page zeroing. Every copy is ordered behind
@@ -292,15 +290,17 @@ class L2CacheExecutor:
         ``source_pinned``: a pinned op's sources stay cached and unevictable
         until the ACK, so its copy rides the write stream and nobody waits on
         it; an unpinned op's sources may already be granted to another request
-        in this very plan, so it goes first and the caller's stream waits on
-        its completion -- the plan's zeroing, load-backs and forwards are
-        ordered behind that wait.
+        in this very plan, so it goes first and ``fence_stream`` waits on its
+        completion -- the plan's zeroing, load-backs and forwards are ordered
+        behind that wait.
 
         Args:
             plan: The round's ExecutionPlan; its ``Cache.WriteBackOp``
                 entries are read here.
             producer_stream: The stream whose completed work every copy must
                 observe -- the model executor's execution stream.
+            fence_stream: The stream a stream-ordered op's completion fences
+                -- the one the plan's page zeroing runs on next.
         """
         ordered_op_ids: list[int] = []
         ordered_transfers: list[tuple[int, int, int]] = []
@@ -322,7 +322,7 @@ class L2CacheExecutor:
             producer_stream=producer_stream,
         )
         if fence is not None:
-            device_module.current_stream().wait_event(fence)
+            fence_stream.wait_event(fence)
         self._start_writing(
             pinned_op_ids,
             pinned_transfers,
@@ -330,8 +330,15 @@ class L2CacheExecutor:
             producer_stream=producer_stream,
         )
 
-    def submit_load_backs(self, plan) -> None:
-        """Launch the plan's H2D loads; runs after the plan's page zeroing."""
+    def submit_load_backs(self, plan, *, producer_stream) -> None:
+        """Launch the plan's H2D loads; runs after the plan's page zeroing.
+
+        Args:
+            plan: The round's ExecutionPlan; its ``Cache.LoadBackOp``
+                entries are read here.
+            producer_stream: The stream whose completed work every copy must
+                observe -- the one that zeroed the destination pages.
+        """
         op_ids: list[int] = []
         transfers: list[tuple[int, int, int]] = []
         for operation in plan.cache:
@@ -345,7 +352,9 @@ class L2CacheExecutor:
                     transfers=transfers,
                     source_is_device=False,
                 )
-        load_index = self._start_loading(op_ids, transfers)
+        load_index = self._start_loading(
+            op_ids, transfers, producer_stream=producer_stream
+        )
         for tracker, _ in self._load_trackers:
             tracker.set_consumers(load_index if load_index is not None else -1)
 
@@ -398,6 +407,11 @@ class L2CacheExecutor:
         ):
             if not (len(groups) == len(sources) == len(destinations)):
                 raise ValueError(f"ragged cache operation {op_id}")
+            # An op is acknowledged by its copy's completion event; one with
+            # nothing to copy could never be acknowledged and the scheduler
+            # would hold its tickets forever.
+            if not groups:
+                raise ValueError(f"cache operation {op_id} carries no transfers")
             collected_op_ids.append(int(op_id))
             for group, source, destination in zip(groups, sources, destinations):
                 device_block_id, host_block_id = (
@@ -415,16 +429,11 @@ class L2CacheExecutor:
     ):
         """Launch one D2H batch on the write stream; return its completion event.
 
-        Returns None when nothing was launched (no ops, or ops with no
-        transfers, which are acknowledged at the next poll).
+        Returns None when the lane has no ops this round.
         """
         if not op_ids:
             return None
         op_ids = _ordered_unique(op_ids)
-        if not transfers:
-            with self._ack_lock:
-                self._ready_write_op_ids.extend(op_ids)
-            return None
         if self.attn_tp_rank == 0:
             logger.info(
                 "[L2] writeback started: operations=%d blocks=%d pinned=%s",
@@ -434,13 +443,11 @@ class L2CacheExecutor:
             )
         # Behind the forwards that wrote the source pages: that is what lets
         # the copy read their final bytes.
-        stream = self.write_stream
-        stream.wait_stream(producer_stream)
+        self.write_stream.wait_stream(producer_stream)
         # CPU writes are not ordered by stream FIFO. Retire the previous
         # metadata upload before refilling its pinned source, not at submit.
-        if lane.metadata_done is not None:
-            if not lane.metadata_done.query():
-                lane.metadata_done.synchronize()
+        if lane.metadata_done is not None and not lane.metadata_done.query():
+            lane.metadata_done.synchronize()
         num_blocks, _ = lane.workspace.load_block_transfers(
             transfers, geometry=self._transfer_geometry
         )
@@ -448,7 +455,7 @@ class L2CacheExecutor:
         # the write stream itself: the payload kernel below reads those tables
         # from that stream, and a copy issued on the caller's stream would sit
         # behind the wait recorded above with nothing ordering it first.
-        with device_module.stream(stream):
+        with device_module.stream(self.write_stream):
             mode = lane.workspace.prepare_backend(
                 self.layout.buffers,
                 self.host_storage.host_buffer,
@@ -465,14 +472,14 @@ class L2CacheExecutor:
                     # Also protect a partially submitted upload if staging
                     # fails. This event excludes the payload transfer; Device
                     # table reuse remains ordered by the write stream's FIFO.
-                    lane.metadata_done.record(stream)
+                    lane.metadata_done.record(self.write_stream)
         transfer_cache_blocks(
             "d2h",
             self.layout.buffers,
             self.host_storage.host_buffer,
             self._transfer_geometry,
             lane.workspace,
-            stream,
+            self.write_stream,
             num_blocks=num_blocks,
             geometry_offset=0,
             num_geometry_rows=self._transfer_geometry.num_field_rows,
@@ -481,7 +488,7 @@ class L2CacheExecutor:
             layer_ready_flags=None,
         )
         finish = device_module.Event()
-        finish.record(stream)
+        finish.record(self.write_stream)
         with self._ack_lock:
             self._write_acks.append(_Ack(finish, op_ids))
         return finish
@@ -490,6 +497,8 @@ class L2CacheExecutor:
         self,
         op_ids: Sequence[int],
         transfers: Sequence[tuple[int, int, int]],
+        *,
+        producer_stream,
     ) -> int | None:
         if self._load_poisoned:
             raise RuntimeError(
@@ -500,10 +509,6 @@ class L2CacheExecutor:
         if get_is_capture_mode():
             raise RuntimeError("Host cache load must run outside CUDA Graph capture")
         op_ids = _ordered_unique(op_ids)
-        if not transfers:
-            with self._ack_lock:
-                self._ready_load_op_ids.extend(op_ids)
-            return None
         if self.attn_tp_rank == 0:
             logger.info(
                 "[L2] load started: operations=%d blocks=%d",
@@ -511,10 +516,11 @@ class L2CacheExecutor:
                 len(transfers),
             )
 
-        # EventLoop zeroes freshly allocated Device blocks before submitting the
-        # load. Recording the start event here makes the H2D copy wait for that
-        # zeroing; per-layer ready flags (Triton) or events (DMA) then keep
-        # model consumers from reading partially restored cache state.
+        # EventLoop zeroes freshly allocated Device blocks on the producer
+        # stream before submitting the load. Recording the start event there
+        # makes the H2D copy wait for that zeroing; per-layer ready flags
+        # (Triton) or events (DMA) then keep model consumers from reading
+        # partially restored cache state.
         load_index = None
         finish = None
         flags = None
@@ -531,7 +537,7 @@ class L2CacheExecutor:
                     load_index = current_load_index
                 elif current_load_index != load_index:
                     raise RuntimeError("target and draft Host-load trackers diverged")
-                load_events.start_event.record()
+                load_events.start_event.record(producer_stream)
                 load_events.start_event.wait(self.load_stream)
             if load_index is None:
                 raise RuntimeError("cache transfer layout has no layer consumers")
@@ -653,11 +659,8 @@ class L2CacheExecutor:
                         pass
 
     def poll_results(self) -> list:
+        results: list = []
         with self._ack_lock:
-            results = [self._write_done(op_id) for op_id in self._ready_write_op_ids]
-            self._ready_write_op_ids.clear()
-            results.extend(self._load_done(op_id) for op_id in self._ready_load_op_ids)
-            self._ready_load_op_ids.clear()
             self._write_acks[:] = self._drain(
                 self._write_acks, self._write_done, results
             )
@@ -687,17 +690,13 @@ class L2CacheExecutor:
         return event
 
     def shutdown(self) -> None:
-        # The caller's stream carries the fences the transfers were ordered
-        # behind; the write and load streams carry the transfers themselves.
-        torch.cuda.current_stream().synchronize()
-        self.write_stream.synchronize()
-        self.load_stream.synchronize()
+        # The fences and start events live on streams the callers named per
+        # submission; the whole device covers them and the transfer streams.
+        device_module.synchronize()
 
     def reset(self) -> None:
         self.shutdown()
         self._write_acks.clear()
         self._load_acks.clear()
-        self._ready_write_op_ids.clear()
-        self._ready_load_op_ids.clear()
         for tracker, _ in self._load_trackers:
             tracker.reset()

--- a/python/tokenspeed/runtime/execution/device.py
+++ b/python/tokenspeed/runtime/execution/device.py
@@ -310,13 +310,15 @@ class DeviceHandle:
         if l2 is not None:
             # Ahead of the zeroing: a stream-ordered store's sources may be
             # this very plan's pages_to_zero, and its fence lands on the
-            # forward thread's stream here, before the zeroing is enqueued.
-            # The copies themselves order behind the execution stream, where
-            # the forwards wrote the pages.
+            # default stream the zeroing runs on, before the zeroing is
+            # enqueued. The copies themselves order behind the execution
+            # stream, where the forwards wrote the pages.
             self._l2_submissions.append(
                 self._thread.submit(
                     lambda: l2.submit_write_backs(
-                        execution_plan, producer_stream=executor.execution_stream
+                        execution_plan,
+                        producer_stream=executor.execution_stream,
+                        fence_stream=executor.default_stream,
                     )
                 )
             )
@@ -327,8 +329,14 @@ class DeviceHandle:
             else None
         )
         if l2 is not None:
+            # Behind the zeroing: the loads' destinations were zeroed on the
+            # default stream, so that is the producer they order after.
             self._l2_submissions.append(
-                self._thread.submit(lambda: l2.submit_load_backs(execution_plan))
+                self._thread.submit(
+                    lambda: l2.submit_load_backs(
+                        execution_plan, producer_stream=executor.default_stream
+                    )
+                )
             )
 
         # The transfer peer's streams: prefills or decodes the peer NODE runs,

--- a/python/tokenspeed/runtime/execution/device.py
+++ b/python/tokenspeed/runtime/execution/device.py
@@ -317,7 +317,7 @@ class DeviceHandle:
                 self._thread.submit(
                     lambda: l2.submit_write_backs(
                         execution_plan,
-                        producer_stream=executor.execution_stream,
+                        prerequisite_stream=executor.execution_stream,
                         fence_stream=executor.default_stream,
                     )
                 )
@@ -330,11 +330,11 @@ class DeviceHandle:
         )
         if l2 is not None:
             # Behind the zeroing: the loads' destinations were zeroed on the
-            # default stream, so that is the producer they order after.
+            # default stream, so that is the prerequisite they order after.
             self._l2_submissions.append(
                 self._thread.submit(
                     lambda: l2.submit_load_backs(
-                        execution_plan, producer_stream=executor.default_stream
+                        execution_plan, prerequisite_stream=executor.default_stream
                     )
                 )
             )

--- a/python/tokenspeed/runtime/execution/model_executor.py
+++ b/python/tokenspeed/runtime/execution/model_executor.py
@@ -496,12 +496,12 @@ class ModelExecutor:
 
         self.device_module = torch.get_device_module(self.device)
         # Two streams, named once. `default_stream` is the forward thread's
-        # own: everything the data plane enqueues outside an explicit stream
-        # context -- page zeroing, the cache ops' fences and start events --
-        # lands here. `execution_stream` carries the model launches and the
-        # runtime-state writes. Dependencies between them are placed by the
-        # consumer: each forward waits on the default stream in its prologue;
-        # zeroing and write-back wait on the execution stream themselves.
+        # own: page zeroing runs here, and the cache ops take it by name for
+        # their fences and start events. `execution_stream` carries the model
+        # launches and the runtime-state writes. Dependencies between them are
+        # placed by the consumer: each forward waits on the default stream in
+        # its prologue; zeroing and write-back wait on the execution stream
+        # themselves.
         self.default_stream = self.device_module.default_stream(self.device)
         self.execution_stream = self.device_module.Stream()
         # The data plane: every CUDA-touching operation after startup is

--- a/test/runtime/test_device_handle.py
+++ b/test/runtime/test_device_handle.py
@@ -253,11 +253,13 @@ def test_one_plan_orders_write_backs_zeroing_then_load_backs():
     handle = _handle(
         trace,
         l2_cache_executor=SimpleNamespace(
-            submit_write_backs=lambda p, *, producer_stream, fence_stream: (
-                trace.append(("write_backs", p.cache, producer_stream, fence_stream))
+            submit_write_backs=lambda p, *, prerequisite_stream, fence_stream: (
+                trace.append(
+                    ("write_backs", p.cache, prerequisite_stream, fence_stream)
+                )
             ),
-            submit_load_backs=lambda p, *, producer_stream: trace.append(
-                ("load_backs", p.cache, producer_stream)
+            submit_load_backs=lambda p, *, prerequisite_stream: trace.append(
+                ("load_backs", p.cache, prerequisite_stream)
             ),
             poll_results=lambda: ["done"],
         ),
@@ -295,14 +297,14 @@ def test_a_failed_cache_submission_surfaces_at_the_next_poll():
     would leave its ops counted in flight forever."""
     trace: list = []
 
-    def exploding(plan, *, producer_stream, fence_stream):
+    def exploding(plan, *, prerequisite_stream, fence_stream):
         raise ValueError("bad cache op")
 
     handle = _handle(
         trace,
         l2_cache_executor=SimpleNamespace(
             submit_write_backs=exploding,
-            submit_load_backs=lambda p, *, producer_stream: None,
+            submit_load_backs=lambda p, *, prerequisite_stream: None,
             poll_results=lambda: [],
         ),
     )

--- a/test/runtime/test_device_handle.py
+++ b/test/runtime/test_device_handle.py
@@ -132,6 +132,7 @@ def _handle(trace, **kwargs):
             forward_thread=_ForwardThread(trace),
             execute_forward_op=lambda *a, **k: trace.append("forward"),
             execution_stream="execution-stream",
+            default_stream="default-stream",
             write_remote_spec_candidate_ids=lambda idx, ids: trace.append(
                 ("candidates", idx, list(ids))
             ),
@@ -242,18 +243,22 @@ def test_an_aborted_request_still_lands_its_candidates_but_is_not_armed():
 def test_one_plan_orders_write_backs_zeroing_then_load_backs():
     """The FIFO carries the correctness order for same-round page reuse: the
     write-backs are submitted ahead of the new owner's zeroing (a
-    stream-ordered snapshot copy lands its fence there), and the load-backs
-    target zeroed pages. The copies are told which stream wrote the pages;
-    the zeroing orders itself behind that stream."""
+    stream-ordered snapshot copy lands its fence on the default stream the
+    zeroing runs on), and the load-backs target zeroed pages. Every stream is
+    named: the copies are told which stream wrote the pages and which one
+    the fence lands on; the loads are told which stream zeroed their
+    destinations."""
     trace: list = []
     plan = _plan(pages_to_zero=[3, 4], cache=["op"])
     handle = _handle(
         trace,
         l2_cache_executor=SimpleNamespace(
-            submit_write_backs=lambda p, *, producer_stream: trace.append(
-                ("write_backs", p.cache, producer_stream)
+            submit_write_backs=lambda p, *, producer_stream, fence_stream: (
+                trace.append(("write_backs", p.cache, producer_stream, fence_stream))
             ),
-            submit_load_backs=lambda p: trace.append(("load_backs", p.cache)),
+            submit_load_backs=lambda p, *, producer_stream: trace.append(
+                ("load_backs", p.cache, producer_stream)
+            ),
             poll_results=lambda: ["done"],
         ),
     )
@@ -265,11 +270,11 @@ def test_one_plan_orders_write_backs_zeroing_then_load_backs():
 
     assert trace == [
         "submit",
-        ("write_backs", ["op"], "execution-stream"),
+        ("write_backs", ["op"], "execution-stream", "default-stream"),
         "submit",
         ("zero", (3, 4)),
         "submit",
-        ("load_backs", ["op"]),
+        ("load_backs", ["op"], "default-stream"),
     ]
     # Polling never touches the FIFO — the round head must not wait on it.
     assert handle.poll_cache_results() == ["done"]
@@ -290,14 +295,14 @@ def test_a_failed_cache_submission_surfaces_at_the_next_poll():
     would leave its ops counted in flight forever."""
     trace: list = []
 
-    def exploding(plan, *, producer_stream):
+    def exploding(plan, *, producer_stream, fence_stream):
         raise ValueError("bad cache op")
 
     handle = _handle(
         trace,
         l2_cache_executor=SimpleNamespace(
             submit_write_backs=exploding,
-            submit_load_backs=lambda p: None,
+            submit_load_backs=lambda p, *, producer_stream: None,
             poll_results=lambda: [],
         ),
     )

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -178,7 +178,6 @@ class GroupAwareWireTest(unittest.TestCase):
         )
         executor._ack_lock = threading.Lock()
         executor.attn_tp_rank = 0
-        executor._ready_load_op_ids = []
         executor._load_acks = []
         executor._load_poisoned = False
         executor.load_stream = object() if load_stream is None else load_stream
@@ -300,7 +299,7 @@ class GroupAwareWireTest(unittest.TestCase):
         executor._load_trackers = [(tracker, 1)]
         executor._load_poisoned = False
 
-        executor.submit_load_backs(SimpleNamespace(cache=[]))
+        executor.submit_load_backs(SimpleNamespace(cache=[]), producer_stream=object())
 
         tracker.set_consumers.assert_called_once_with(-1)
 
@@ -326,7 +325,6 @@ class GroupAwareWireTest(unittest.TestCase):
         executor = L2CacheExecutor.__new__(L2CacheExecutor)
         executor._ack_lock = threading.Lock()
         executor.attn_tp_rank = 0
-        executor._ready_write_op_ids = []
         device = SimpleNamespace(type="cuda")
         executor.layout = SimpleNamespace(buffers=(SimpleNamespace(device=device),))
         executor.host_storage = SimpleNamespace(host_buffer="host")
@@ -351,17 +349,19 @@ class GroupAwareWireTest(unittest.TestCase):
         executor_module = self._executor_module()
         executor, device = self._make_write_executor(executor_module)
         lane = executor._pinned_write_lane
-        caller_stream = object()
         producer_stream = object()
         finish = Mock()
         metadata_done = Mock()
+        # Every stream the executor touches is one the caller named; the
+        # thread's current stream is never consulted.
+        no_current_stream = patch.object(
+            executor_module.device_module,
+            "current_stream",
+            side_effect=AssertionError("current stream must not be consulted"),
+        )
 
         with (
-            patch.object(
-                executor_module.device_module,
-                "current_stream",
-                return_value=caller_stream,
-            ),
+            no_current_stream,
             patch.object(executor_module.device_module, "stream") as stream_ctx,
             patch.object(
                 executor_module.device_module,
@@ -375,10 +375,9 @@ class GroupAwareWireTest(unittest.TestCase):
             )
 
         # On the write stream, ordered after the producer stream the caller
-        # named (the forwards that wrote the pages) -- not after whatever
-        # stream happens to be current. The completion event is handed back
-        # so a stream-ordered submission can fence the caller on it; a pinned
-        # one simply drops it.
+        # named (the forwards that wrote the pages). The completion event is
+        # handed back so a stream-ordered submission can fence the caller's
+        # fence stream on it; a pinned one simply drops it.
         self.assertIs(fence, finish)
         executor.write_stream.wait_stream.assert_called_once_with(producer_stream)
         # The address tables and the metadata H2D are enqueued on the write
@@ -424,11 +423,7 @@ class GroupAwareWireTest(unittest.TestCase):
                 order.attach_mock(lane.workspace.commit_block_transfers, "upload")
                 order.attach_mock(metadata_done.record, "record")
                 with (
-                    patch.object(
-                        executor_module.device_module,
-                        "current_stream",
-                        return_value=caller_stream,
-                    ),
+                    no_current_stream,
                     patch.object(executor_module.device_module, "stream") as stream_ctx,
                     patch.object(
                         executor_module.device_module, "Event", return_value=finish
@@ -459,7 +454,7 @@ class GroupAwareWireTest(unittest.TestCase):
     def test_submit_write_backs_fences_only_stream_ordered_ops(self):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
-        caller_stream = Mock(name="caller_stream")
+        fence_stream = Mock(name="fence_stream")
         producer = object()
         ordered_finish = Mock(name="ordered_finish")
         pinned_finish = Mock(name="pinned_finish")
@@ -485,11 +480,6 @@ class GroupAwareWireTest(unittest.TestCase):
                 executor_module.Cache, "WriteBackOp", WriteBackOp, create=True
             ),
             patch.object(
-                executor_module.device_module,
-                "current_stream",
-                return_value=caller_stream,
-            ),
-            patch.object(
                 executor_module.device_module, "stream", return_value=nullcontext()
             ),
             patch.object(
@@ -500,12 +490,15 @@ class GroupAwareWireTest(unittest.TestCase):
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
         ):
             executor.submit_write_backs(
-                SimpleNamespace(cache=[WriteBackOp()]), producer_stream=producer
+                SimpleNamespace(cache=[WriteBackOp()]),
+                producer_stream=producer,
+                fence_stream=fence_stream,
             )
 
-        # The stream-ordered op (12) launches first and the caller's stream
-        # waits on ITS completion only; the pinned ops (11, 13) follow on the
-        # write stream and fence nothing -- the scheduler holds their sources.
+        # The stream-ordered op (12) launches first and the fence stream the
+        # caller named waits on ITS completion only; the pinned ops (11, 13)
+        # follow on the write stream and fence nothing -- the scheduler holds
+        # their sources.
         ordered_lane = executor._ordered_write_lane
         pinned_lane = executor._pinned_write_lane
         ordered_lane.workspace.load_block_transfers.assert_called_once_with(
@@ -518,7 +511,7 @@ class GroupAwareWireTest(unittest.TestCase):
             [call.args[4] for call in transfer.call_args_list],
             [ordered_lane.workspace, pinned_lane.workspace],
         )
-        caller_stream.wait_event.assert_called_once_with(ordered_finish)
+        fence_stream.wait_event.assert_called_once_with(ordered_finish)
         self.assertEqual(
             [(ack.finish_event, ack.op_ids) for ack in executor._write_acks],
             [(ordered_finish, [12]), (pinned_finish, [11, 13])],
@@ -532,7 +525,7 @@ class GroupAwareWireTest(unittest.TestCase):
     def test_submit_write_backs_without_stream_ordered_ops_fences_nothing(self):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
-        caller_stream = Mock(name="caller_stream")
+        fence_stream = Mock(name="fence_stream")
         producer = object()
 
         class WriteBackOp:
@@ -548,21 +541,18 @@ class GroupAwareWireTest(unittest.TestCase):
                 executor_module.Cache, "WriteBackOp", WriteBackOp, create=True
             ),
             patch.object(
-                executor_module.device_module,
-                "current_stream",
-                return_value=caller_stream,
-            ),
-            patch.object(
                 executor_module.device_module, "stream", return_value=nullcontext()
             ),
             patch.object(executor_module.device_module, "Event", side_effect=Mock),
             patch.object(executor_module, "transfer_cache_blocks"),
         ):
             executor.submit_write_backs(
-                SimpleNamespace(cache=[WriteBackOp()]), producer_stream=producer
+                SimpleNamespace(cache=[WriteBackOp()]),
+                producer_stream=producer,
+                fence_stream=fence_stream,
             )
 
-        caller_stream.wait_event.assert_not_called()
+        fence_stream.wait_event.assert_not_called()
         executor._ordered_write_lane.workspace.load_block_transfers.assert_not_called()
 
     def test_submit_write_backs_rejects_ragged_guard_vector(self):
@@ -583,8 +573,30 @@ class GroupAwareWireTest(unittest.TestCase):
         ):
             with self.assertRaises(ValueError):
                 executor.submit_write_backs(
-                    SimpleNamespace(cache=[WriteBackOp()]), producer_stream=producer
+                    SimpleNamespace(cache=[WriteBackOp()]),
+                    producer_stream=producer,
+                    fence_stream=object(),
                 )
+
+    def test_cache_operation_without_transfers_is_refused(self):
+        # An op is acknowledged by its copy's completion event, so one with
+        # nothing to copy could never be acknowledged; the scheduler never
+        # emits one, and the runtime refuses rather than inventing an ack.
+        L2CacheExecutor = self._executor_module().L2CacheExecutor
+        for source_is_device in (True, False):
+            with self.subTest(source_is_device=source_is_device):
+                op_ids: list[int] = []
+                transfers: list[tuple[int, int, int]] = []
+                with self.assertRaisesRegex(ValueError, "operation 11 carries no"):
+                    L2CacheExecutor._append_transfers(
+                        [7, 11],
+                        [[0], []],
+                        [[1], []],
+                        [[5], []],
+                        collected_op_ids=op_ids,
+                        transfers=transfers,
+                        source_is_device=source_is_device,
+                    )
 
     def test_loadback_logs_non_empty_batch(self):
         executor_module, executor, _, geometry, workspace = self._make_load_executor(
@@ -600,6 +612,7 @@ class GroupAwareWireTest(unittest.TestCase):
         tracker.event_sets = [load_events]
         executor._load_trackers = [(tracker, 1)]
         finish = Mock()
+        producer_stream = object()
 
         with (
             patch.object(executor_module, "get_is_capture_mode", return_value=False),
@@ -610,7 +623,9 @@ class GroupAwareWireTest(unittest.TestCase):
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
             patch.object(executor_module.logger, "info") as log_info,
         ):
-            executor._start_loading([9], [(0, 2, 1), (0, 5, 4)])
+            executor._start_loading(
+                [9], [(0, 2, 1), (0, 5, 4)], producer_stream=producer_stream
+            )
 
         workspace.load_block_transfers.assert_called_once_with(
             [(0, 2, 1), (0, 5, 4)], geometry=geometry
@@ -620,6 +635,10 @@ class GroupAwareWireTest(unittest.TestCase):
         log_info.assert_called_once_with(
             "[L2] load started: operations=%d blocks=%d", 1, 2
         )
+        # The load orders after the producer stream the caller named -- the
+        # one that zeroed its destinations -- not after the current stream.
+        load_events.start_event.record.assert_called_once_with(producer_stream)
+        load_events.start_event.wait.assert_called_once_with(executor.load_stream)
 
     def test_resolved_transport_selects_events_even_with_device_geometry(self):
         for uses_device_tables in (False, True):
@@ -647,7 +666,7 @@ class GroupAwareWireTest(unittest.TestCase):
                     ),
                     patch.object(module, "transfer_cache_blocks") as transfer,
                 ):
-                    executor._start_loading([9], [(0, 1, 1)])
+                    executor._start_loading([9], [(0, 1, 1)], producer_stream=object())
                 self.assertEqual(
                     workspace.commit_block_transfers.call_count, int(uses_device_tables)
                 )
@@ -882,15 +901,15 @@ class GroupAwareWireTest(unittest.TestCase):
             for name, sentinel in sentinels.items():
                 self.assertIs(sys.modules[name], sentinel)
 
-    def test_two_isolated_loads_preserve_imported_torch_modules(self):
+    def test_two_isolated_loads_preserve_imported_real_modules(self):
         first = _load_executor_module_without_triton(force_isolated=True)
-        first_torch = first.torch
+        first_psutil = first.psutil
 
-        self.assertIs(sys.modules["torch"], first_torch)
+        self.assertIs(sys.modules["psutil"], first_psutil)
         second = _load_executor_module_without_triton(force_isolated=True)
 
-        self.assertIs(second.torch, first_torch)
-        self.assertIs(sys.modules["torch"], first_torch)
+        self.assertIs(second.psutil, first_psutil)
+        self.assertIs(sys.modules["psutil"], first_psutil)
 
     def test_loadback_commits_block_ids_once_and_launches_one_flagged_kernel(self):
         executor_module, executor, device, geometry, workspace = (
@@ -926,7 +945,7 @@ class GroupAwareWireTest(unittest.TestCase):
             patch.object(executor_module.device_module, "Event", return_value=finish),
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
         ):
-            executor._start_loading([9], [(0, 2, 1)])
+            executor._start_loading([9], [(0, 2, 1)], producer_stream=object())
 
         workspace.load_block_transfers.assert_called_once_with(
             [(0, 2, 1)], geometry=geometry
@@ -1003,7 +1022,7 @@ class GroupAwareWireTest(unittest.TestCase):
             ) as transfer,
         ):
             with self.assertRaisesRegex(RuntimeError, "layer launch failed"):
-                executor._start_loading([9], [(0, 2, 1)])
+                executor._start_loading([9], [(0, 2, 1)], producer_stream=object())
 
         self.assertEqual(transfer.call_count, 1)
         retirement.record.assert_called_once_with(executor.load_stream)
@@ -1023,7 +1042,6 @@ class GroupAwareWireTest(unittest.TestCase):
             load_stream=Mock(),
         )
         executor._write_acks = []
-        executor._ready_write_op_ids = []
         load_events = _LoadEvents(
             start_event=Mock(),
             layer_done_events=[Mock()],
@@ -1059,7 +1077,7 @@ class GroupAwareWireTest(unittest.TestCase):
             ),
         ):
             with self.assertRaises(RuntimeError) as raised:
-                executor._start_loading([9], [(0, 2, 1)])
+                executor._start_loading([9], [(0, 2, 1)], producer_stream=object())
 
             self.assertIs(raised.exception, original_error)
             self.assertEqual(str(raised.exception), "original layer launch failed")
@@ -1073,7 +1091,7 @@ class GroupAwareWireTest(unittest.TestCase):
             executor.reset()
             self.assertTrue(executor._load_poisoned)
             with self.assertRaisesRegex(RuntimeError, "poisoned"):
-                executor._start_loading([10], [(0, 3, 2)])
+                executor._start_loading([10], [(0, 3, 2)], producer_stream=object())
 
         tracker.begin_load.assert_called_once_with()
 
@@ -1188,6 +1206,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         load_index = executor._start_loading(  # pylint: disable=protected-access
             [9],
             [(0, 2, 1), (0, 5, 4), (1, 4, 3)],
+            producer_stream=torch.cuda.current_stream(),
         )
         self.assertIsNotNone(load_index)
         pool.load_tracker.set_consumers(load_index)
@@ -1236,7 +1255,9 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
             torch.cuda.current_stream().wait_stream(executor.write_stream)
             device.fill_(0xEE)
             load_index = executor._start_loading(
-                [9], [(0, block, block) for block in range(1, 4)]
+                [9],
+                [(0, block, block) for block in range(1, 4)],
+                producer_stream=torch.cuda.current_stream(),
             )
             pool.load_tracker.set_consumers(load_index)
             pool.load_tracker.wait_for_layer(0)
@@ -1280,7 +1301,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         device.fill_(0xEE)
         torch.cuda.synchronize()
         load_index = executor._start_loading(  # pylint: disable=protected-access
-            [9], [(0, 2, 1)]
+            [9], [(0, 2, 1)], producer_stream=torch.cuda.current_stream()
         )
         self.assertIsNotNone(load_index)
         target_pool.load_tracker.set_consumers(load_index)

--- a/test/runtime/test_host_executor.py
+++ b/test/runtime/test_host_executor.py
@@ -299,7 +299,9 @@ class GroupAwareWireTest(unittest.TestCase):
         executor._load_trackers = [(tracker, 1)]
         executor._load_poisoned = False
 
-        executor.submit_load_backs(SimpleNamespace(cache=[]), producer_stream=object())
+        executor.submit_load_backs(
+            SimpleNamespace(cache=[]), prerequisite_stream=object()
+        )
 
         tracker.set_consumers.assert_called_once_with(-1)
 
@@ -349,7 +351,7 @@ class GroupAwareWireTest(unittest.TestCase):
         executor_module = self._executor_module()
         executor, device = self._make_write_executor(executor_module)
         lane = executor._pinned_write_lane
-        producer_stream = object()
+        prerequisite_stream = object()
         finish = Mock()
         metadata_done = Mock()
         # Every stream the executor touches is one the caller named; the
@@ -371,15 +373,15 @@ class GroupAwareWireTest(unittest.TestCase):
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
         ):
             fence = executor._start_writing(
-                [7], [(0, 5, 9)], lane=lane, producer_stream=producer_stream
+                [7], [(0, 5, 9)], lane=lane, prerequisite_stream=prerequisite_stream
             )
 
-        # On the write stream, ordered after the producer stream the caller
-        # named (the forwards that wrote the pages). The completion event is
-        # handed back so a stream-ordered submission can fence the caller's
-        # fence stream on it; a pinned one simply drops it.
+        # On the write stream, ordered after the prerequisite stream the
+        # caller named (the forwards that wrote the pages). The completion
+        # event is handed back so a stream-ordered submission can fence the
+        # caller's fence stream on it; a pinned one simply drops it.
         self.assertIs(fence, finish)
-        executor.write_stream.wait_stream.assert_called_once_with(producer_stream)
+        executor.write_stream.wait_stream.assert_called_once_with(prerequisite_stream)
         # The address tables and the metadata H2D are enqueued on the write
         # stream too: the payload kernel reads them from that stream, and a
         # copy left on the caller's stream would land behind the wait above
@@ -433,7 +435,10 @@ class GroupAwareWireTest(unittest.TestCase):
                     order.attach_mock(stream_ctx, "stream")
                     order.attach_mock(transfer, "payload")
                     executor._start_writing(
-                        [8], [(0, 6, 10)], lane=lane, producer_stream=producer_stream
+                        [8],
+                        [(0, 6, 10)],
+                        lane=lane,
+                        prerequisite_stream=prerequisite_stream,
                     )
                 names = [call[0] for call in order.mock_calls]
                 self.assertEqual(
@@ -455,7 +460,7 @@ class GroupAwareWireTest(unittest.TestCase):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
         fence_stream = Mock(name="fence_stream")
-        producer = object()
+        prerequisite = object()
         ordered_finish = Mock(name="ordered_finish")
         pinned_finish = Mock(name="pinned_finish")
         events = iter(
@@ -491,7 +496,7 @@ class GroupAwareWireTest(unittest.TestCase):
         ):
             executor.submit_write_backs(
                 SimpleNamespace(cache=[WriteBackOp()]),
-                producer_stream=producer,
+                prerequisite_stream=prerequisite,
                 fence_stream=fence_stream,
             )
 
@@ -518,15 +523,15 @@ class GroupAwareWireTest(unittest.TestCase):
         )
         self.assertEqual(
             executor.write_stream.wait_stream.call_args_list,
-            [call(producer), call(producer)],
-            "both launches order behind the producer stream the caller named",
+            [call(prerequisite), call(prerequisite)],
+            "both launches order behind the prerequisite stream the caller named",
         )
 
     def test_submit_write_backs_without_stream_ordered_ops_fences_nothing(self):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
         fence_stream = Mock(name="fence_stream")
-        producer = object()
+        prerequisite = object()
 
         class WriteBackOp:
             def __init__(self):
@@ -548,7 +553,7 @@ class GroupAwareWireTest(unittest.TestCase):
         ):
             executor.submit_write_backs(
                 SimpleNamespace(cache=[WriteBackOp()]),
-                producer_stream=producer,
+                prerequisite_stream=prerequisite,
                 fence_stream=fence_stream,
             )
 
@@ -558,7 +563,7 @@ class GroupAwareWireTest(unittest.TestCase):
     def test_submit_write_backs_rejects_ragged_guard_vector(self):
         executor_module = self._executor_module()
         executor, _ = self._make_write_executor(executor_module)
-        producer = object()
+        prerequisite = object()
 
         class WriteBackOp:
             def __init__(self):
@@ -574,7 +579,7 @@ class GroupAwareWireTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 executor.submit_write_backs(
                     SimpleNamespace(cache=[WriteBackOp()]),
-                    producer_stream=producer,
+                    prerequisite_stream=prerequisite,
                     fence_stream=object(),
                 )
 
@@ -612,7 +617,7 @@ class GroupAwareWireTest(unittest.TestCase):
         tracker.event_sets = [load_events]
         executor._load_trackers = [(tracker, 1)]
         finish = Mock()
-        producer_stream = object()
+        prerequisite_stream = object()
 
         with (
             patch.object(executor_module, "get_is_capture_mode", return_value=False),
@@ -624,7 +629,7 @@ class GroupAwareWireTest(unittest.TestCase):
             patch.object(executor_module.logger, "info") as log_info,
         ):
             executor._start_loading(
-                [9], [(0, 2, 1), (0, 5, 4)], producer_stream=producer_stream
+                [9], [(0, 2, 1), (0, 5, 4)], prerequisite_stream=prerequisite_stream
             )
 
         workspace.load_block_transfers.assert_called_once_with(
@@ -635,9 +640,9 @@ class GroupAwareWireTest(unittest.TestCase):
         log_info.assert_called_once_with(
             "[L2] load started: operations=%d blocks=%d", 1, 2
         )
-        # The load orders after the producer stream the caller named -- the
-        # one that zeroed its destinations -- not after the current stream.
-        load_events.start_event.record.assert_called_once_with(producer_stream)
+        # The load orders after the prerequisite stream the caller named --
+        # the one that zeroed its destinations -- not after the current stream.
+        load_events.start_event.record.assert_called_once_with(prerequisite_stream)
         load_events.start_event.wait.assert_called_once_with(executor.load_stream)
 
     def test_resolved_transport_selects_events_even_with_device_geometry(self):
@@ -666,7 +671,9 @@ class GroupAwareWireTest(unittest.TestCase):
                     ),
                     patch.object(module, "transfer_cache_blocks") as transfer,
                 ):
-                    executor._start_loading([9], [(0, 1, 1)], producer_stream=object())
+                    executor._start_loading(
+                        [9], [(0, 1, 1)], prerequisite_stream=object()
+                    )
                 self.assertEqual(
                     workspace.commit_block_transfers.call_count, int(uses_device_tables)
                 )
@@ -945,7 +952,7 @@ class GroupAwareWireTest(unittest.TestCase):
             patch.object(executor_module.device_module, "Event", return_value=finish),
             patch.object(executor_module, "transfer_cache_blocks") as transfer,
         ):
-            executor._start_loading([9], [(0, 2, 1)], producer_stream=object())
+            executor._start_loading([9], [(0, 2, 1)], prerequisite_stream=object())
 
         workspace.load_block_transfers.assert_called_once_with(
             [(0, 2, 1)], geometry=geometry
@@ -1022,7 +1029,7 @@ class GroupAwareWireTest(unittest.TestCase):
             ) as transfer,
         ):
             with self.assertRaisesRegex(RuntimeError, "layer launch failed"):
-                executor._start_loading([9], [(0, 2, 1)], producer_stream=object())
+                executor._start_loading([9], [(0, 2, 1)], prerequisite_stream=object())
 
         self.assertEqual(transfer.call_count, 1)
         retirement.record.assert_called_once_with(executor.load_stream)
@@ -1077,7 +1084,7 @@ class GroupAwareWireTest(unittest.TestCase):
             ),
         ):
             with self.assertRaises(RuntimeError) as raised:
-                executor._start_loading([9], [(0, 2, 1)], producer_stream=object())
+                executor._start_loading([9], [(0, 2, 1)], prerequisite_stream=object())
 
             self.assertIs(raised.exception, original_error)
             self.assertEqual(str(raised.exception), "original layer launch failed")
@@ -1091,7 +1098,7 @@ class GroupAwareWireTest(unittest.TestCase):
             executor.reset()
             self.assertTrue(executor._load_poisoned)
             with self.assertRaisesRegex(RuntimeError, "poisoned"):
-                executor._start_loading([10], [(0, 3, 2)], producer_stream=object())
+                executor._start_loading([10], [(0, 3, 2)], prerequisite_stream=object())
 
         tracker.begin_load.assert_called_once_with()
 
@@ -1191,7 +1198,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
             [7],
             [(0, 1, 1), (0, 4, 4), (1, 3, 3)],
             lane=executor._pinned_write_lane,  # pylint: disable=protected-access
-            producer_stream=torch.cuda.current_stream(),
+            prerequisite_stream=torch.cuda.current_stream(),
         )
         executor.write_stream.synchronize()
         write_results = executor.poll_results()
@@ -1206,7 +1213,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         load_index = executor._start_loading(  # pylint: disable=protected-access
             [9],
             [(0, 2, 1), (0, 5, 4), (1, 4, 3)],
-            producer_stream=torch.cuda.current_stream(),
+            prerequisite_stream=torch.cuda.current_stream(),
         )
         self.assertIsNotNone(load_index)
         pool.load_tracker.set_consumers(load_index)
@@ -1248,7 +1255,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
                     [block],
                     [(0, block, block)],
                     lane=executor._pinned_write_lane,
-                    producer_stream=torch.cuda.current_stream(),
+                    prerequisite_stream=torch.cuda.current_stream(),
                 )
             # The load below has no scheduler ACK to wait for, so order it
             # behind the copies the way a stream-ordered submission would.
@@ -1257,7 +1264,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
             load_index = executor._start_loading(
                 [9],
                 [(0, block, block) for block in range(1, 4)],
-                producer_stream=torch.cuda.current_stream(),
+                prerequisite_stream=torch.cuda.current_stream(),
             )
             pool.load_tracker.set_consumers(load_index)
             pool.load_tracker.wait_for_layer(0)
@@ -1293,7 +1300,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
             [7],
             [(0, 1, 1)],
             lane=executor._pinned_write_lane,
-            producer_stream=torch.cuda.current_stream(),
+            prerequisite_stream=torch.cuda.current_stream(),
         )
         torch.cuda.synchronize()
         self.assertEqual([int(event.op_id) for event in executor.poll_results()], [7])
@@ -1301,7 +1308,7 @@ class CompactLayoutRoundTripTest(unittest.TestCase):
         device.fill_(0xEE)
         torch.cuda.synchronize()
         load_index = executor._start_loading(  # pylint: disable=protected-access
-            [9], [(0, 2, 1)], producer_stream=torch.cuda.current_stream()
+            [9], [(0, 2, 1)], prerequisite_stream=torch.cuda.current_stream()
         )
         self.assertIsNotNone(load_index)
         target_pool.load_tracker.set_consumers(load_index)

--- a/tokenspeed-scheduler/csrc/cache/tier/transfer.h
+++ b/tokenspeed-scheduler/csrc/cache/tier/transfer.h
@@ -30,6 +30,8 @@
 #include <variant>
 #include <vector>
 
+#include "utils.h"
+
 namespace tokenspeed {
 
 struct CacheTransfer {
@@ -73,6 +75,12 @@ struct WriteBackOperation {
     bool source_pinned{false};
 };
 
+// Every op on the wire carries at least one transfer, and no (group, source,
+// destination) repeats within one plan: a store skips keys already in flight
+// and a load targets freshly acquired pages. The runtime relies on both -- an
+// op is acknowledged by its copy's completion event, so an empty op would
+// never be acknowledged and its tickets would leak. A violation is a
+// scheduler bug and fails here rather than being papered over.
 struct WriteBackBatch {
     std::vector<std::uint32_t> op_ids;
     std::vector<std::vector<std::uint32_t>> group_ids;
@@ -86,15 +94,15 @@ struct WriteBackBatch {
     explicit WriteBackBatch(const std::vector<WriteBackOperation>& ops) {
         std::unordered_set<CacheTransfer, CacheTransferHash> seen;
         for (const auto& op : ops) {
+            _assert(!op.transfers.empty(), "write-back op carries no transfers");
             std::vector<std::uint32_t> operation_groups;
             std::vector<std::int32_t> operation_sources;
             std::vector<std::int32_t> operation_destinations;
             for (const auto& transfer : op.transfers) {
-                if (seen.insert(transfer).second) {
-                    operation_groups.push_back(transfer.group_id);
-                    operation_sources.push_back(transfer.source_page);
-                    operation_destinations.push_back(transfer.destination_page);
-                }
+                _assert(seen.insert(transfer).second, "duplicate write-back transfer within one plan");
+                operation_groups.push_back(transfer.group_id);
+                operation_sources.push_back(transfer.source_page);
+                operation_destinations.push_back(transfer.destination_page);
             }
 
             op_ids.push_back(op.op_id);
@@ -120,15 +128,15 @@ struct LoadBackBatch {
     explicit LoadBackBatch(const std::vector<LoadBackOperation>& ops) {
         std::unordered_set<CacheTransfer, CacheTransferHash> seen;
         for (const auto& op : ops) {
+            _assert(!op.transfers.empty(), "load-back op carries no transfers");
             std::vector<std::uint32_t> operation_groups;
             std::vector<std::int32_t> operation_sources;
             std::vector<std::int32_t> operation_destinations;
             for (const auto& transfer : op.transfers) {
-                if (seen.insert(transfer).second) {
-                    operation_groups.push_back(transfer.group_id);
-                    operation_sources.push_back(transfer.source_page);
-                    operation_destinations.push_back(transfer.destination_page);
-                }
+                _assert(seen.insert(transfer).second, "duplicate load-back transfer within one plan");
+                operation_groups.push_back(transfer.group_id);
+                operation_sources.push_back(transfer.source_page);
+                operation_destinations.push_back(transfer.destination_page);
             }
 
             op_ids.push_back(op.op_id);

--- a/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
+++ b/tokenspeed-scheduler/tests/cpp/test_cache_operations.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdlib>
+#include <stdexcept>
 #include <type_traits>
 
 #include "cache/core/block_pool.h"
@@ -16,20 +17,16 @@ namespace tokenspeed::test {
 static_assert(std::is_aggregate_v<WriteBackOperation>);
 static_assert(std::is_aggregate_v<LoadBackOperation>);
 
-TEST(CacheOperationTest, WriteBackDeduplicatesTransfersAcrossBatch) {
+TEST(CacheOperationTest, WriteBackFlattensOpsInOrderWithPerOpGuard) {
     WriteBackOperation op;
     op.op_id = 7;
-    op.transfers = {
-        CacheTransfer{0, 1, 11},
-        CacheTransfer{0, 2, 22},
-        CacheTransfer{0, 1, 11},
-    };
-    WriteBackOperation duplicate;
-    duplicate.op_id = 8;
-    duplicate.transfers = {CacheTransfer{0, 2, 22}, CacheTransfer{0, 3, 33}};
-    duplicate.source_pinned = true;
+    op.transfers = {CacheTransfer{0, 1, 11}, CacheTransfer{0, 2, 22}};
+    WriteBackOperation pinned;
+    pinned.op_id = 8;
+    pinned.transfers = {CacheTransfer{0, 3, 33}};
+    pinned.source_pinned = true;
 
-    WriteBackBatch batch({op, duplicate});
+    WriteBackBatch batch({op, pinned});
 
     ASSERT_EQ(batch.op_ids, std::vector<std::uint32_t>({7, 8}));
     EXPECT_EQ(batch.group_ids[0], std::vector<std::uint32_t>({0, 0}));
@@ -39,6 +36,41 @@ TEST(CacheOperationTest, WriteBackDeduplicatesTransfersAcrossBatch) {
     EXPECT_EQ(batch.dst_pages[1], std::vector<std::int32_t>({33}));
     EXPECT_EQ(batch.source_pinned, std::vector<bool>({false, true}))
         << "the guard travels per op; an unset op reads as stream-ordered";
+}
+
+TEST(CacheOperationTest, RepeatedTransferWithinOnePlanIsASchedulerBug) {
+    // A store skips keys already in flight and a load targets freshly acquired
+    // pages, so the same (group, source, destination) cannot legitimately
+    // appear twice in one plan -- neither within an op nor across ops. The
+    // wire type refuses it instead of silently dropping the repeat, which
+    // would hand the runtime an op it can never acknowledge.
+    WriteBackOperation within;
+    within.op_id = 7;
+    within.transfers = {CacheTransfer{0, 1, 11}, CacheTransfer{0, 1, 11}};
+    EXPECT_THROW(WriteBackBatch{{within}}, std::runtime_error);
+
+    WriteBackOperation first;
+    first.op_id = 7;
+    first.transfers = {CacheTransfer{0, 2, 22}};
+    WriteBackOperation second;
+    second.op_id = 8;
+    second.transfers = {CacheTransfer{0, 2, 22}};
+    EXPECT_THROW(WriteBackBatch({first, second}), std::runtime_error);
+
+    LoadBackOperation load;
+    load.op_id = 9;
+    load.transfers = {CacheTransfer{0, 10, 20}, CacheTransfer{0, 10, 20}};
+    EXPECT_THROW(LoadBackBatch{{load}}, std::runtime_error);
+}
+
+TEST(CacheOperationTest, OpWithoutTransfersIsASchedulerBug) {
+    WriteBackOperation store;
+    store.op_id = 7;
+    EXPECT_THROW(WriteBackBatch{{store}}, std::runtime_error);
+
+    LoadBackOperation load;
+    load.op_id = 9;
+    EXPECT_THROW(LoadBackBatch{{load}}, std::runtime_error);
 }
 
 TEST(CacheOperationTest, SamePagesInDifferentGroupsAreDistinctTransfers) {


### PR DESCRIPTION
## Summary

Two related tightenings of the L2 (Host cache) executor's contracts, both replacing implicit state with an explicit argument or an explicit failure.

### 1. Every stream the executor orders against is named by the caller

`submit_write_backs` takes `fence_stream` -- the stream a stream-ordered op's completion fences -- and `submit_load_backs` takes `producer_stream` -- the stream that zeroed its destinations -- mirroring how the write side already names the stream that wrote its sources (#1450).

Until now the fence (`device_module.current_stream().wait_event(fence)`) and the load start event (`start_event.record()`) landed on whatever stream was current on the forward thread. That was correct only by convention: `ForwardThread` never sets a stream, so "current" resolves to the device's default stream, which is also where `zero_cache_pages` runs. Nothing in the code expressed that dependency. The call site in `DeviceHandle.execute` now reads as the argument -- zeroing runs on `executor.default_stream`, the fence lands on `executor.default_stream`, the loads order after `executor.default_stream`.

`shutdown` synchronizes the device instead of the caller's current stream (and no longer bypasses `device_module` via `torch.cuda`). The tests that patched `current_stream` to inject a fake now pass the stream in; one asserts the executor never consults it.

### 2. Cache ops with no transfers are refused, not acknowledged

`WriteBackBatch` / `LoadBackBatch` deduplicated `(group, source, destination)` across the ops of one plan, so the runtime had to accept an op whose page lists came through empty and acknowledge it at the next poll without a copy (`_ready_write_op_ids` / `_ready_load_op_ids`). Neither path is reachable: `StartPendingStores` skips keys already in flight (`store_keys_`) and dedups keys within a call, and each load pair's destination is a freshly acquired page (`AppendHostExtension`), so a transfer cannot repeat within a plan and an op cannot arrive empty.

The batch constructors now `_assert` both invariants, the runtime raises on an op with no transfers, and the side channel in `poll_results` is gone. An op is acknowledged by its copy's completion event alone; an op that never copies would hold its tickets forever, so a violation fails loudly rather than being papered over. The invariant is recorded in `docs/design/cache-concepts.md`.

The two halves are independent: the runtime change is safe against the currently pinned scheduler (it never emits an empty op), and the scheduler change ships with its next release.

Also drops the `stream` local alias in `_start_writing` in favour of the explicit `self.write_stream`, matching `_start_loading`.

## Test plan

- [x] `tokenspeed_scheduler_tests`: 462 gtest cases pass, including the rewritten `CacheOperationTest` (flatten order, repeated transfer refused within and across ops, empty op refused). The new assertions run inside every scheduler-plan scenario test without firing.
- [x] `tokenspeed-scheduler/python/tests`: 65 binding tests pass against the rebuilt extension.
- [x] `test/runtime/test_host_executor.py` + `test/runtime/test_device_handle.py`: 47 cases pass; `test_l2_cache_hooks.py` passes.
- [x] `pre-commit run --all-files` clean.
- [ ] End-to-end run with the Host cache enabled (kvstore config) to confirm the assertions stay silent under real load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
