### PR TITLE
perf(cache): reduce cache block zeroing overhead

### DIFF
--- a/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/arena.py
@@ -68,6 +68,9 @@ class CacheArena:
                 "cache arena requires at least one cache group spec to publish"
             )
         self.plan = plan
+        # Materialize immutable byte geometry at setup, not on first hand-out.
+        for group in plan.groups:
+            plan.block_byte_segments(group.group_id, [])
         self.device = device
         self._cache_group_specs_by_id = {
             spec.group_id: spec for spec in cache_group_specs
@@ -234,16 +237,7 @@ class CacheArena:
     def block_byte_segments(
         self, group_id: str, block_ids: list[int]
     ) -> list[tuple[int, int]]:
-        self.plan.group(group_id)
-        fields = [field for field in self.plan.fields if field.group_id == group_id]
-        return [
-            (
-                self.field_block_byte_offset(field.field_id, block_id),
-                field.payload_bytes,
-            )
-            for block_id in block_ids
-            for field in fields
-        ]
+        return self.plan.block_byte_segments(group_id, block_ids)
 
     @property
     def supports_disaggregation(self) -> bool:

--- a/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
+++ b/python/tokenspeed/runtime/layers/attention/kv_cache/recipes/plan.py
@@ -26,6 +26,7 @@ import math
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from functools import cached_property
 from itertools import pairwise
 from typing import TYPE_CHECKING
 
@@ -299,6 +300,56 @@ class CacheMemoryPlan:
             + page_id * field.page_stride_bytes
             + field.field_offset_bytes
         )
+
+    @cached_property
+    def _block_byte_layouts(
+        self,
+    ) -> dict[str, tuple[int, tuple[tuple[int, int, int], ...]]]:
+        """Resolve immutable field geometry once, before repeated block hand-outs."""
+        return {
+            group.group_id: (
+                group.page_count,
+                tuple(
+                    (
+                        self.field_page_byte_offset(field.field_id, 0),
+                        field.page_stride_bytes,
+                        field.payload_bytes,
+                    )
+                    for field in self.fields
+                    if field.group_id == group.group_id
+                ),
+            )
+            for group in self.groups
+        }
+
+    def block_byte_segments(
+        self, group_id: str, block_ids: list[int]
+    ) -> list[tuple[int, int]]:
+        """Return field payload ranges for blocks, preserving caller/field order.
+
+        Args:
+            group_id: The planned cache group owning the blocks.
+            block_ids: Physical group block IDs, including zero when requested.
+
+        Returns:
+            Byte offset and byte count pairs, excluding field/stride padding.
+        """
+        page_count, fields = self._block_byte_layouts[group_id]
+        for block_id in block_ids:
+            if (
+                isinstance(block_id, bool)
+                or not isinstance(block_id, int)
+                or block_id < 0
+                or block_id >= page_count
+            ):
+                raise IndexError(
+                    f"page_id {block_id} outside [0, {page_count}) for group {group_id!r}"
+                )
+        return [
+            (base + block_id * stride, size)
+            for block_id in block_ids
+            for base, stride, size in fields
+        ]
 
     def capacity_report(
         self,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -383,14 +383,17 @@ def _zero_byte_ranges_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     range_id = tl.program_id(0)
-    byte_offsets = tl.program_id(1) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     range_offset = tl.load(ranges_ptr + range_id * 2)
     range_size = tl.load(ranges_ptr + range_id * 2 + 1)
-    tl.store(
-        backing_ptr + range_offset + byte_offsets,
-        0,
-        mask=byte_offsets < range_size,
-    )
+    for start in range(
+        tl.program_id(1) * BLOCK_SIZE, range_size, tl.num_programs(1) * BLOCK_SIZE
+    ):
+        byte_offsets = start + tl.arange(0, BLOCK_SIZE)
+        tl.store(
+            backing_ptr + range_offset + byte_offsets,
+            0,
+            mask=byte_offsets < range_size,
+        )
 
 
 def zero_byte_ranges(backing: torch.Tensor, ranges: list[tuple[int, int]]) -> None:
@@ -404,8 +407,9 @@ def zero_byte_ranges(backing: torch.Tensor, ranges: list[tuple[int, int]]) -> No
         return
     if backing.dtype != torch.uint8 or not backing.is_contiguous():
         raise ValueError("backing must be a contiguous uint8 tensor")
+    backing_size = backing.numel()
     if any(
-        offset < 0 or size <= 0 or offset + size > backing.numel()
+        offset < 0 or size <= 0 or offset + size > backing_size
         for offset, size in ranges
     ):
         raise ValueError("ranges must be non-empty and lie within backing")
@@ -419,7 +423,11 @@ def zero_byte_ranges(backing: torch.Tensor, ranges: list[tuple[int, int]]) -> No
     block_size = 1024
     max_size = max(size for _, size in ranges)
 
-    grid = (len(ranges), triton.cdiv(max_size, block_size))
+    # A short range must not launch one CTA for every tile of the largest
+    # state field. Bound the rectangle and let each CTA stride its own range.
+    # Few large ranges still need enough CTAs to occupy the device.
+    tiles_per_range = max(32, triton.cdiv(1024, len(ranges)))
+    grid = (len(ranges), min(tiles_per_range, triton.cdiv(max_size, block_size)))
 
     _zero_byte_ranges_kernel[grid](
         backing,

--- a/tokenspeed-kernel/test/ops/test_kvcache.py
+++ b/tokenspeed-kernel/test/ops/test_kvcache.py
@@ -30,7 +30,28 @@ from tokenspeed_kernel.ops.kvcache.triton import (
     transfer_kv_all_layer_mla,
     transfer_kv_per_layer,
     transfer_kv_per_layer_mla,
+    zero_byte_ranges,
 )
+
+
+@pytest.mark.parametrize("extra_ranges", [0, 60])
+def test_zero_byte_ranges_strides_and_preserves_neighbors(
+    device: str, extra_ranges: int
+) -> None:
+    # Four ranges use a 256-CTA Y cap; 64 ranges use the 32-CTA cap.
+    # The largest payload extends three bytes past three 256-KiB spans,
+    # exercising repeated loop iterations and a partial final tile.
+    ranges = [(3, 7), (31, 27648), (30003, 73729), (110001, 786435)]
+    ranges.extend((900001 + i * 16, 3) for i in range(extra_ranges))
+    backing = torch.full((901025,), 173, dtype=torch.uint8, device=device)
+    expected = torch.full((901025,), 173, dtype=torch.uint8, device="cpu")
+    for offset, size in ranges:
+        expected[offset : offset + size] = 0
+
+    zero_byte_ranges(backing, ranges)
+
+    # Compare every byte, including leading/trailing guards and inter-range gaps.
+    torch.testing.assert_close(backing.cpu(), expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("tokens", [1, 4, 32])


### PR DESCRIPTION
Cache block initialization repeatedly resolves immutable field geometry and launches a rectangular zeroing grid sized to the largest field. For mixed-size cache fields, this adds CPU overhead and launches many GPU thread blocks whose stores are entirely masked.

Cache per-group field bases, strides, and payload sizes in `CacheMemoryPlan`, and materialize them during arena setup. Bound the zeroing grid and let each thread block loop over its assigned range, retaining sufficient parallelism for small numbers of large ranges. Read the backing allocation size once during range validation.

The change preserves the selected byte ranges, bounds checks, and stream ordering, including the zero initialization needed to prevent stale cache tails from contaminating attention outputs.
