### PR TITLE
fix(amd): distribute gfx1250 MXFP4 gather/scatter indices across warps

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/_triton.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/_triton.py
@@ -25,6 +25,7 @@
 import tokenspeed_triton as triton
 import tokenspeed_triton.experimental.gluon.language as gl
 from tokenspeed_triton import language as tl
+from tokenspeed_triton._C.libtriton import gluon_ir, ir
 from tokenspeed_triton.experimental import gluon
 from tokenspeed_triton.experimental.gluon.language.amd.cdna4 import (
     async_copy as cdna4_async_copy,
@@ -36,6 +37,8 @@ __all__ = [
     "cdna4_async_copy",
     "gl",
     "gluon",
+    "gluon_ir",
+    "ir",
     "tl",
     "triton",
 ]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/_triton.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/_triton.py
@@ -25,7 +25,6 @@
 import tokenspeed_triton as triton
 import tokenspeed_triton.experimental.gluon.language as gl
 from tokenspeed_triton import language as tl
-from tokenspeed_triton._C.libtriton import gluon_ir, ir
 from tokenspeed_triton.experimental import gluon
 from tokenspeed_triton.experimental.gluon.language.amd.cdna4 import (
     async_copy as cdna4_async_copy,
@@ -37,8 +36,6 @@ __all__ = [
     "cdna4_async_copy",
     "gl",
     "gluon",
-    "gluon_ir",
-    "ir",
     "tl",
     "triton",
 ]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
@@ -250,7 +250,18 @@ def get_blocked_layout(shape, dtype, num_warps, ndim=2):
 
 @gluon.constexpr_function
 def get_tdm_gather_scatter_idx_layout(NUM_INDICES, NUM_WARPS):
-    return gl.BlockedLayout([NUM_INDICES, 1], [1, 32], [1, NUM_WARPS], [1, 0])
+    # Partition the rows across warps rather than replicating them. When every
+    # warp holds the whole index list, the warp-id bits are free variables of
+    # the index tensor and the TDM lowering leaves one warp producing for the
+    # whole CTA.
+    assert NUM_WARPS > 0
+    assert NUM_INDICES % NUM_WARPS == 0
+    return gl.BlockedLayout(
+        [1, NUM_INDICES // NUM_WARPS],
+        [32, 1],
+        [1, NUM_WARPS],
+        [0, 1],
+    )
 
 
 @gluon.constexpr_function
@@ -515,12 +526,11 @@ def create_descriptor(
     SCALE_KWIDTH: gl.constexpr = cfg.SCALE_KWIDTH
 
     if cfg.USE_GATHER:
-        # For gather indices, use a layout where all indices are available per thread.
         NUM_INDICES: gl.constexpr = cfg.BLOCK_M
         IDX_BASE_LAYOUT: gl.constexpr = get_tdm_gather_scatter_idx_layout(
             NUM_INDICES, cfg.NUM_WARPS
         )
-        IDX_LAYOUT: gl.constexpr = gl.SliceLayout(1, IDX_BASE_LAYOUT)
+        IDX_LAYOUT: gl.constexpr = gl.SliceLayout(0, IDX_BASE_LAYOUT)
 
         GatherIndx_ptr = GatherIndx + start_m
         offs_m_gather = off_m + gl.arange(0, NUM_INDICES, IDX_LAYOUT)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
@@ -343,7 +343,7 @@ def _matmul_decode(
         IDX_BASE_LAYOUT: gl.constexpr = get_tdm_gather_scatter_idx_layout(
             BLOCK_M, cfg.NUM_WARPS
         )
-        IDX_LAYOUT: gl.constexpr = gl.SliceLayout(1, IDX_BASE_LAYOUT)
+        IDX_LAYOUT: gl.constexpr = gl.SliceLayout(0, IDX_BASE_LAYOUT)
 
         idx_offs = gl.arange(0, BLOCK_M, IDX_LAYOUT)
         idx_mask = (off_m + idx_offs < eM) & (

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
@@ -1081,7 +1081,7 @@ def _matmul(
         IDX_BASE_LAYOUT: gl.constexpr = get_tdm_gather_scatter_idx_layout(
             BLOCK_M, cfg.NUM_WARPS
         )
-        IDX_LAYOUT: gl.constexpr = gl.SliceLayout(1, IDX_BASE_LAYOUT)
+        IDX_LAYOUT: gl.constexpr = gl.SliceLayout(0, IDX_BASE_LAYOUT)
 
         idx_offs = gl.arange(0, BLOCK_M, IDX_LAYOUT)
         idx_mask = (off_m + idx_offs < eM) & (

--- a/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Off-device contract for gfx1250 MXFP4 index ownership, width and narrowing."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+from triton._C.libtriton import gluon_ir, ir
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+AMD_PACKAGE_ROOT = REPO_ROOT / "tokenspeed-kernel-amd" / "python"
+MXFP4_ROOT = (
+    AMD_PACKAGE_ROOT / "tokenspeed_kernel_amd" / "ops" / "gfx1250" / "moe" / "mxfp4"
+)
+
+# Checks below read kernel sources from this checkout, so import the package
+# from the same tree rather than from an unrelated installed copy.
+sys.path.insert(0, str(AMD_PACKAGE_ROOT))
+
+from tokenspeed_kernel_amd._triton import gl  # noqa: E402
+from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4._common import (  # noqa: E402
+    get_tdm_gather_scatter_idx_layout,
+)
+
+# ---------------------------------------------------------------------------
+# Index ownership: which warp holds which row
+# ---------------------------------------------------------------------------
+
+INDEX_LAYOUT_CONSUMERS = (
+    MXFP4_ROOT / "_common.py",
+    MXFP4_ROOT / "decode.py",
+    MXFP4_ROOT / "fused.py",
+)
+
+# (NUM_INDICES, NUM_WARPS); these kernels run 4 or 8 warps per CTA.
+INDEX_SHAPES = ((16, 4), (16, 8), (32, 4), (32, 8), (64, 8))
+
+_CONTEXT = ir.context()
+ir.load_dialects(_CONTEXT)
+_BUILDER = gluon_ir.GluonOpBuilder(_CONTEXT)
+
+
+def index_warp_bases(num_indices: int, num_warps: int, slice_dim: int) -> list[int]:
+    """Return the warp bases of the index layout a consumer builds."""
+    base = get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
+    layout = gl.SliceLayout(slice_dim, base)
+    linear = _BUILDER.to_linear_layout(layout._to_ir(_BUILDER), [num_indices])
+    assert len(linear.shape) == 1
+    return [basis[0] for basis in linear.warp_bases]
+
+
+def expected_warp_bases(num_indices: int, num_warps: int) -> list[int]:
+    """Warp bases that hand warp ``w`` the rows ``[w, w + 1) * rows_per_warp``."""
+    rows_per_warp = num_indices // num_warps
+    return [rows_per_warp << bit for bit in range(num_warps.bit_length() - 1)]
+
+
+def index_layout_slice_dim(path: Path) -> int:
+    """Return the dimension ``path`` slices away from the shared index layout."""
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    slice_dims = [
+        node.args[0].value
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "SliceLayout"
+        and len(node.args) == 2
+        and isinstance(node.args[0], ast.Constant)
+        and isinstance(node.args[1], ast.Name)
+        and node.args[1].id == "IDX_BASE_LAYOUT"
+    ]
+    assert len(slice_dims) == 1, f"{path} must slice the index layout exactly once"
+    return slice_dims[0]
+
+
+@pytest.mark.parametrize(("num_indices", "num_warps"), INDEX_SHAPES)
+def test_index_layout_partitions_rows_across_all_warps(
+    num_indices: int, num_warps: int
+) -> None:
+    # A zero warp basis is exactly the defect: the index does not depend on warp
+    # id, so every warp reads the same rows and the TDM lowering elects a single
+    # producer for the CTA.
+    assert index_warp_bases(num_indices, num_warps, 0) == expected_warp_bases(
+        num_indices, num_warps
+    )
+
+
+@pytest.mark.parametrize(("num_indices", "num_warps"), [(16, 0), (16, 32), (12, 8)])
+def test_index_layout_rejects_unpartitionable_warp_counts(
+    num_indices: int, num_warps: int
+) -> None:
+    with pytest.raises(AssertionError):
+        get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
+
+
+@pytest.mark.parametrize("path", INDEX_LAYOUT_CONSUMERS, ids=lambda p: p.name)
+def test_consumers_slice_the_dimension_that_leaves_rows_distributed(
+    path: Path,
+) -> None:
+    slice_dim = index_layout_slice_dim(path)
+
+    num_indices, num_warps = 16, 8
+    assert index_warp_bases(num_indices, num_warps, slice_dim) == expected_warp_bases(
+        num_indices, num_warps
+    )

--- a/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 from utils import is_amd
@@ -34,7 +35,7 @@ if not is_amd():
         allow_module_level=True,
     )
 
-from tokenspeed_kernel_amd._triton import gl, gluon_ir, ir  # noqa: E402
+from tokenspeed_kernel_amd._triton import gl  # noqa: E402
 from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4 import _common  # noqa: E402
 
 # Read sources from the tree the import resolved to, not the repo layout.
@@ -53,24 +54,21 @@ INDEX_LAYOUT_CONSUMERS = (
 # (NUM_INDICES, NUM_WARPS); these kernels run 4 or 8 warps per CTA.
 INDEX_SHAPES = ((16, 4), (16, 8), (32, 4), (32, 8), (64, 8))
 
-_CONTEXT = ir.context()
-ir.load_dialects(_CONTEXT)
-_BUILDER = gluon_ir.GluonOpBuilder(_CONTEXT)
+
+class IndexOwnership(NamedTuple):
+    """Warps over the index dimension, and the rows they cover between them."""
+
+    warps: int
+    rows_covered: int
 
 
-def index_warp_bases(num_indices: int, num_warps: int, slice_dim: int) -> list[int]:
-    """Return the warp bases of the index layout a consumer builds."""
-    base = _common.get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
-    layout = gl.SliceLayout(slice_dim, base)
-    linear = _BUILDER.to_linear_layout(layout._to_ir(_BUILDER), [num_indices])
-    assert len(linear.shape) == 1
-    return [basis[0] for basis in linear.warp_bases]
-
-
-def expected_warp_bases(num_indices: int, num_warps: int) -> list[int]:
-    """Warp bases that hand warp ``w`` the rows ``[w, w + 1) * rows_per_warp``."""
-    rows_per_warp = num_indices // num_warps
-    return [rows_per_warp << bit for bit in range(num_warps.bit_length() - 1)]
+def index_ownership(base: gl.BlockedLayout, slice_dim: int) -> IndexOwnership:
+    """Report how ``base`` spreads rows once ``slice_dim`` is sliced away."""
+    assert slice_dim in (0, 1), f"index layouts are rank 2, got slice dim {slice_dim}"
+    index_dim = 1 - slice_dim
+    warps = base.warps_per_cta[index_dim]
+    rows_per_warp = base.size_per_thread[index_dim] * base.threads_per_warp[index_dim]
+    return IndexOwnership(warps=warps, rows_covered=rows_per_warp * warps)
 
 
 def index_layout_slice_dim(path: Path) -> int:
@@ -95,11 +93,9 @@ def index_layout_slice_dim(path: Path) -> int:
 def test_index_layout_partitions_rows_across_all_warps(
     num_indices: int, num_warps: int
 ) -> None:
-    # A zero warp basis is exactly the defect: the index does not depend on warp
-    # id, so every warp reads the same rows and the TDM lowering elects a single
-    # producer for the CTA.
-    assert index_warp_bases(num_indices, num_warps, 0) == expected_warp_bases(
-        num_indices, num_warps
+    base = _common.get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
+    assert index_ownership(base, 0) == IndexOwnership(
+        warps=num_warps, rows_covered=num_indices
     )
 
 
@@ -118,6 +114,7 @@ def test_consumers_slice_the_dimension_that_leaves_rows_distributed(
     slice_dim = index_layout_slice_dim(path)
 
     num_indices, num_warps = 16, 8
-    assert index_warp_bases(num_indices, num_warps, slice_dim) == expected_warp_bases(
-        num_indices, num_warps
+    base = _common.get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
+    assert index_ownership(base, slice_dim) == IndexOwnership(
+        warps=num_warps, rows_covered=num_indices
     )

--- a/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
@@ -26,8 +26,16 @@ import ast
 from pathlib import Path
 
 import pytest
-from tokenspeed_kernel_amd._triton import gl, gluon_ir, ir
-from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4 import _common
+from utils import is_amd
+
+if not is_amd():
+    pytest.skip(
+        "tokenspeed-kernel-amd is installed on AMD CI only",
+        allow_module_level=True,
+    )
+
+from tokenspeed_kernel_amd._triton import gl, gluon_ir, ir  # noqa: E402
+from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4 import _common  # noqa: E402
 
 # Read sources from the tree the import resolved to, not the repo layout.
 MXFP4_ROOT = Path(_common.__file__).parent

--- a/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
@@ -23,26 +23,14 @@
 from __future__ import annotations
 
 import ast
-import sys
 from pathlib import Path
 
 import pytest
-from triton._C.libtriton import gluon_ir, ir
+from tokenspeed_kernel_amd._triton import gl, gluon_ir, ir
+from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4 import _common
 
-REPO_ROOT = Path(__file__).resolve().parents[4]
-AMD_PACKAGE_ROOT = REPO_ROOT / "tokenspeed-kernel-amd" / "python"
-MXFP4_ROOT = (
-    AMD_PACKAGE_ROOT / "tokenspeed_kernel_amd" / "ops" / "gfx1250" / "moe" / "mxfp4"
-)
-
-# Checks below read kernel sources from this checkout, so import the package
-# from the same tree rather than from an unrelated installed copy.
-sys.path.insert(0, str(AMD_PACKAGE_ROOT))
-
-from tokenspeed_kernel_amd._triton import gl  # noqa: E402
-from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4._common import (  # noqa: E402
-    get_tdm_gather_scatter_idx_layout,
-)
+# Read sources from the tree the import resolved to, not the repo layout.
+MXFP4_ROOT = Path(_common.__file__).parent
 
 # ---------------------------------------------------------------------------
 # Index ownership: which warp holds which row
@@ -64,7 +52,7 @@ _BUILDER = gluon_ir.GluonOpBuilder(_CONTEXT)
 
 def index_warp_bases(num_indices: int, num_warps: int, slice_dim: int) -> list[int]:
     """Return the warp bases of the index layout a consumer builds."""
-    base = get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
+    base = _common.get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
     layout = gl.SliceLayout(slice_dim, base)
     linear = _BUILDER.to_linear_layout(layout._to_ir(_BUILDER), [num_indices])
     assert len(linear.shape) == 1
@@ -112,7 +100,7 @@ def test_index_layout_rejects_unpartitionable_warp_counts(
     num_indices: int, num_warps: int
 ) -> None:
     with pytest.raises(AssertionError):
-        get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
+        _common.get_tdm_gather_scatter_idx_layout(num_indices, num_warps)
 
 
 @pytest.mark.parametrize("path", INDEX_LAYOUT_CONSUMERS, ids=lambda p: p.name)


### PR DESCRIPTION
The gfx1250 MXFP4 index layout gave a single warp ownership of the entire gather/scatter index list: `BlockedLayout([NUM_INDICES, 1], [1, 32], [1, NUM_WARPS], [1, 0])` sliced on dimension 1 leaves every index in one thread of one warp, replicated to all warps. The TDM lowering predicates off warps whose warp-id bits are free variables of the index tensor, because warps holding identical indices would issue identical redundant transfers, so exactly one warp ended up fetching X for the whole workgroup while the rest waited.

Return the row-distributed layout instead and slice dimension 0 in all three consumers, so warp `w` owns only its own slice of the index rows and every warp issues its share of the transfer. Guard the helper with the divisibility and positivity assumptions the partition relies on, and record the mechanism in a comment beside the layout it constrains.

Add `test_gfx1250_mxfp4_index_contract.py` as the off-device home for gfx1250 MXFP4 index invariants. It covers warp ownership here; further index invariants belong in the same file rather than in new ones.