### PR TITLE
perf(kimi3): add gfx1250 large-M WMMA projections

### DIFF
--- a/python/tokenspeed/runtime/layers/dense/unquant.py
+++ b/python/tokenspeed/runtime/layers/dense/unquant.py
@@ -66,6 +66,12 @@ class UnquantizedLinearMethod(LinearMethodBase):
 
         if bias is None and decode_gemv_routed(x, layer.weight):
             return decode_gemv(x, layer.weight)
+        if bias is None:
+            from tokenspeed_kernel.ops.gemm.kimi3 import _try_gluon_largem_gfx1250
+
+            largem = _try_gluon_largem_gfx1250(x, layer.weight)
+            if largem is not None:
+                return largem
         return tokenspeed_kernel.mm(
             x,
             layer.weight,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/__init__.py
@@ -1,0 +1,1 @@
+"""gfx1250 GEMM kernels."""

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
@@ -3,9 +3,11 @@
 from .mm import (
     gluon_mm_a16w16_largem_gfx1250,
     triton_mm_a16w16_add3_m16_gfx1250,
+    use_gluon_largem_gfx1250,
 )
 
 __all__ = [
     "gluon_mm_a16w16_largem_gfx1250",
     "triton_mm_a16w16_add3_m16_gfx1250",
+    "use_gluon_largem_gfx1250",
 ]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
@@ -1,0 +1,11 @@
+"""Dense 16-bit gfx1250 GEMM kernels."""
+
+from .mm import (
+    gluon_mm_a16w16_largem_gfx1250,
+    triton_mm_a16w16_add3_m16_gfx1250,
+)
+
+__all__ = [
+    "gluon_mm_a16w16_largem_gfx1250",
+    "triton_mm_a16w16_add3_m16_gfx1250",
+]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
@@ -118,12 +118,8 @@ def _wmma_tdm_dense_m16_kernel(
     )
 
     for tile in gl.static_range(NUM_BUFFERS - 1):
-        gl.amd.cdna5.tdm.async_load(
-            a_desc, [0, tile * BLOCK_K], a_smem.index(tile)
-        )
-        gl.amd.cdna5.tdm.async_load(
-            b_desc, [0, tile * BLOCK_K], b_smem.index(tile)
-        )
+        gl.amd.cdna5.tdm.async_load(a_desc, [0, tile * BLOCK_K], a_smem.index(tile))
+        gl.amd.cdna5.tdm.async_load(b_desc, [0, tile * BLOCK_K], b_smem.index(tile))
 
     acc = gl.zeros((M, BLOCK_N), gl.float32, wmma_layout)
     num_k_tiles: gl.constexpr = K // BLOCK_K
@@ -156,9 +152,9 @@ def _wmma_tdm_dense_m16_kernel(
     offs_m = gl.arange(0, M, gl.SliceLayout(1, wmma_layout))
     offs_n = gl.arange(0, BLOCK_N, gl.SliceLayout(0, wmma_layout))
     tile_n = pid_n * BLOCK_N + offs_n
-    output_offsets = (
-        offs_m[:, None] * stride_om + tile_n[None, :] * stride_on
-    ).to(gl.int32)
+    output_offsets = (offs_m[:, None] * stride_om + tile_n[None, :] * stride_on).to(
+        gl.int32
+    )
     gl.amd.cdna5.buffer_store(
         acc.to(gl.bfloat16),
         out_ptr,
@@ -266,8 +262,7 @@ def gluon_wmma_tdm_kda_qkvfab_gfx1250(
         or out.device != A.device
     ):
         raise ValueError(
-            f"out must be contiguous GPU BF16 ({A.shape[0]}, 6288) "
-            "colocated with A"
+            f"out must be contiguous GPU BF16 ({A.shape[0]}, 6288) " "colocated with A"
         )
     _launch_wmma_tdm_dense_tiles(
         A,
@@ -356,12 +351,8 @@ def _wmma_tdm_add3_m16_kernel(
 
     # Two tiles are prefetched before the steady-state issue/wait/WMMA loop.
     for tile in gl.static_range(NUM_BUFFERS - 1):
-        gl.amd.cdna5.tdm.async_load(
-            a_desc, [0, tile * BLOCK_K], a_smem.index(tile)
-        )
-        gl.amd.cdna5.tdm.async_load(
-            b_desc, [0, tile * BLOCK_K], b_smem.index(tile)
-        )
+        gl.amd.cdna5.tdm.async_load(a_desc, [0, tile * BLOCK_K], a_smem.index(tile))
+        gl.amd.cdna5.tdm.async_load(b_desc, [0, tile * BLOCK_K], b_smem.index(tile))
 
     acc = gl.zeros((M, BLOCK_N), gl.float32, wmma_layout)
     num_k_tiles: gl.constexpr = K // BLOCK_K
@@ -396,25 +387,19 @@ def _wmma_tdm_add3_m16_kernel(
     offs_n = gl.arange(0, BLOCK_N, gl.SliceLayout(0, wmma_layout))
     tile_n = pid_n * BLOCK_N + offs_n
     addend_a_offsets = (
-        offs_m[:, None] * stride_addend_am
-        + tile_n[None, :] * stride_addend_an
+        offs_m[:, None] * stride_addend_am + tile_n[None, :] * stride_addend_an
     ).to(gl.int32)
     addend_b_offsets = (
-        offs_m[:, None] * stride_addend_bm
-        + tile_n[None, :] * stride_addend_bn
+        offs_m[:, None] * stride_addend_bm + tile_n[None, :] * stride_addend_bn
     ).to(gl.int32)
-    output_offsets = (
-        offs_m[:, None] * stride_om + tile_n[None, :] * stride_on
-    ).to(gl.int32)
+    output_offsets = (offs_m[:, None] * stride_om + tile_n[None, :] * stride_on).to(
+        gl.int32
+    )
 
     # Preserve the materialized BF16 projection boundary used by torch.mm.
     projected = acc.to(gl.bfloat16)
-    addend_a = gl.amd.cdna5.buffer_load(
-        addend_a_ptr, addend_a_offsets
-    )
-    addend_b = gl.amd.cdna5.buffer_load(
-        addend_b_ptr, addend_b_offsets
-    )
+    addend_a = gl.amd.cdna5.buffer_load(addend_a_ptr, addend_a_offsets)
+    addend_b = gl.amd.cdna5.buffer_load(addend_b_ptr, addend_b_offsets)
     gl.amd.cdna5.buffer_store(
         (projected + addend_a + addend_b).to(gl.bfloat16),
         out_ptr,
@@ -729,28 +714,20 @@ def _wmma_tdm_dense_largem_kernel(
         )
         gl.amd.cdna5.tdm.async_wait(2)
         a = a_smem.index(i % NUM_BUFFERS).load(layout=dot_layout_a)
-        b = (
-            b_smem.index(i % NUM_BUFFERS)
-            .permute([1, 0])
-            .load(layout=dot_layout_b)
-        )
+        b = b_smem.index(i % NUM_BUFFERS).permute([1, 0]).load(layout=dot_layout_b)
         acc = gl.amd.cdna5.wmma(a, b, acc)
 
     gl.amd.cdna5.tdm.async_wait(0)
     last_idx = num_k_tiles - 1
     a = a_smem.index(last_idx % NUM_BUFFERS).load(layout=dot_layout_a)
-    b = (
-        b_smem.index(last_idx % NUM_BUFFERS)
-        .permute([1, 0])
-        .load(layout=dot_layout_b)
-    )
+    b = b_smem.index(last_idx % NUM_BUFFERS).permute([1, 0]).load(layout=dot_layout_b)
     acc = gl.amd.cdna5.wmma(a, b, acc)
 
     offs_m = off_m + gl.arange(0, BLOCK_M, gl.SliceLayout(1, wmma_layout))
     offs_n = off_n + gl.arange(0, BLOCK_N, gl.SliceLayout(0, wmma_layout))
-    output_offsets = (
-        offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
-    ).to(gl.int32)
+    output_offsets = (offs_m[:, None] * stride_om + offs_n[None, :] * stride_on).to(
+        gl.int32
+    )
     gl.amd.cdna5.buffer_store(
         acc.to(gl.bfloat16),
         out_ptr,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
@@ -1,0 +1,855 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Dense16 WMMA GEMM epilogues for gfx1250."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon, tl, triton
+
+_LARGEM_MIN_M = 512
+_LARGEM_BLOCK_M_CROSSOVER = 12288
+_LARGEM_SHAPES = {
+    (512, 3072),
+    (768, 7168),
+    (1536, 7168),
+    (1536, 2304),
+    (3584, 7168),
+    (4224, 7168),
+    (7168, 1536),
+    (7168, 2112),
+    (7168, 3584),
+    (7168, 6288),
+    (7168, 8448),
+}
+
+
+@gluon.jit
+def _wmma_tdm_dense_m16_kernel(
+    a_ptr,
+    b_ptr,
+    out_ptr,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_om,
+    stride_on,
+    ACTUAL_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+):
+    """Fixed-M/K CDNA5 dense projection candidate."""
+    M: gl.constexpr = 16
+    K: gl.constexpr = 7168
+    pid_n = gl.program_id(0)
+
+    gl.static_assert(
+        BLOCK_N == 16 or BLOCK_N == 64,
+        "candidate supports one or four WMMA output tiles",
+    )
+    gl.static_assert(0 < ACTUAL_M and ACTUAL_M <= M)
+    gl.static_assert(BLOCK_K == 128, "candidate is tuned for 128-wide K tiles")
+    gl.static_assert(NUM_BUFFERS == 3, "candidate uses a triple-buffer TDM pipeline")
+
+    warp_bases: gl.constexpr = [] if BLOCK_N == 16 else [[0, 1], [0, 2]]
+    wmma_layout: gl.constexpr = gl.amd.AMDWMMALayout(
+        version=3,
+        transposed=True,
+        warp_bases=warp_bases,
+        reg_bases=[],
+        instr_shape=[16, 16, 32],
+    )
+    dot_layout_a: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=wmma_layout, k_width=8
+    )
+    dot_layout_b: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=wmma_layout, k_width=8
+    )
+    shared_layout_a: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 8]], [M, BLOCK_K], [1, 0]
+    )
+    shared_layout_b: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 8]], [BLOCK_N, BLOCK_K], [1, 0]
+    )
+
+    a_smem = gl.allocate_shared_memory(
+        a_ptr.dtype.element_ty,
+        [NUM_BUFFERS, M, BLOCK_K],
+        shared_layout_a,
+    )
+    b_smem = gl.allocate_shared_memory(
+        b_ptr.dtype.element_ty,
+        [NUM_BUFFERS, BLOCK_N, BLOCK_K],
+        shared_layout_b,
+    )
+    a_desc = gl.amd.cdna5.tdm.make_tensor_descriptor(
+        base=a_ptr,
+        shape=(ACTUAL_M, K),
+        strides=(stride_am, stride_ak),
+        block_shape=(M, BLOCK_K),
+        layout=shared_layout_a,
+    )
+    b_desc = gl.amd.cdna5.tdm.make_tensor_descriptor(
+        base=b_ptr + pid_n * BLOCK_N * stride_bn,
+        shape=(BLOCK_N, K),
+        strides=(stride_bn, stride_bk),
+        block_shape=(BLOCK_N, BLOCK_K),
+        layout=shared_layout_b,
+    )
+
+    for tile in gl.static_range(NUM_BUFFERS - 1):
+        gl.amd.cdna5.tdm.async_load(
+            a_desc, [0, tile * BLOCK_K], a_smem.index(tile)
+        )
+        gl.amd.cdna5.tdm.async_load(
+            b_desc, [0, tile * BLOCK_K], b_smem.index(tile)
+        )
+
+    acc = gl.zeros((M, BLOCK_N), gl.float32, wmma_layout)
+    num_k_tiles: gl.constexpr = K // BLOCK_K
+    gl.amd.cdna5.tdm.async_wait(2 * (NUM_BUFFERS - 2))
+    for tile in gl.static_range(num_k_tiles):
+        with gl.amd.warp_pipeline_stage("tdm+lds", priority=1):
+            a = a_smem.index(tile % NUM_BUFFERS).load(layout=dot_layout_a)
+            b = (
+                b_smem.index(tile % NUM_BUFFERS)
+                .permute([1, 0])
+                .load(layout=dot_layout_b)
+            )
+            gl.amd.cdna5.tdm.async_load(
+                a_desc,
+                [0, (tile + NUM_BUFFERS - 1) * BLOCK_K],
+                a_smem.index((tile + NUM_BUFFERS - 1) % NUM_BUFFERS),
+                pred=tile + NUM_BUFFERS - 1 < num_k_tiles,
+            )
+            gl.amd.cdna5.tdm.async_load(
+                b_desc,
+                [0, (tile + NUM_BUFFERS - 1) * BLOCK_K],
+                b_smem.index((tile + NUM_BUFFERS - 1) % NUM_BUFFERS),
+                pred=tile + NUM_BUFFERS - 1 < num_k_tiles,
+            )
+        gl.amd.cdna5.tdm.async_wait(2 * (NUM_BUFFERS - 2))
+        with gl.amd.warp_pipeline_stage("wmma", priority=0):
+            acc = gl.amd.cdna5.wmma(a, b, acc)
+    gl.amd.cdna5.tdm.async_wait(0)
+
+    offs_m = gl.arange(0, M, gl.SliceLayout(1, wmma_layout))
+    offs_n = gl.arange(0, BLOCK_N, gl.SliceLayout(0, wmma_layout))
+    tile_n = pid_n * BLOCK_N + offs_n
+    output_offsets = (
+        offs_m[:, None] * stride_om + tile_n[None, :] * stride_on
+    ).to(gl.int32)
+    gl.amd.cdna5.buffer_store(
+        acc.to(gl.bfloat16),
+        out_ptr,
+        output_offsets,
+        mask=offs_m[:, None] < ACTUAL_M,
+    )
+
+
+def _launch_wmma_tdm_dense_tiles(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    out: torch.Tensor,
+    *,
+    block_n: int,
+    num_warps: int,
+) -> None:
+    block_k, num_buffers = 128, 3
+    for start in range(0, A.shape[0], 16):
+        a_tile = A[start : start + 16]
+        out_tile = out[start : start + 16]
+        _wmma_tdm_dense_m16_kernel[(B.shape[0] // block_n,)](
+            a_tile,
+            B,
+            out_tile,
+            a_tile.stride(0),
+            a_tile.stride(1),
+            B.stride(0),
+            B.stride(1),
+            out_tile.stride(0),
+            out_tile.stride(1),
+            ACTUAL_M=a_tile.shape[0],
+            BLOCK_N=block_n,
+            BLOCK_K=block_k,
+            NUM_BUFFERS=num_buffers,
+            num_warps=num_warps,
+            num_stages=1,
+            waves_per_eu=1,
+        )
+
+
+def gluon_wmma_tdm_mla_qkv_gate_gfx1250(
+    A: torch.Tensor,
+    B: torch.Tensor,
+) -> torch.Tensor:
+    """Run the CDNA5 MLA QKV/gate projection candidate."""
+    if A.shape[0] not in {1, 2, 4, 8, 16, 32}:
+        raise ValueError("A must contain 1, 2, 4, 8, 16, or 32 rows")
+    for name, tensor, shape in (
+        ("A", A, (A.shape[0], 7168)),
+        ("B", B, (3648, 7168)),
+    ):
+        if (
+            tuple(tensor.shape) != shape
+            or tensor.dtype != torch.bfloat16
+            or not tensor.is_cuda
+            or not tensor.is_contiguous()
+            or tensor.device != A.device
+        ):
+            raise ValueError(
+                f"{name} must be contiguous GPU BF16 {shape} colocated with A"
+            )
+
+    out = A.new_empty((A.shape[0], 3648))
+    _launch_wmma_tdm_dense_tiles(
+        A,
+        B,
+        out,
+        block_n=64,
+        num_warps=4,
+    )
+    return out
+
+
+def gluon_wmma_tdm_kda_qkvfab_gfx1250(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run the CDNA5 KDA QKVFAB projection candidate."""
+    if A.shape[0] not in {1, 2, 4, 8, 16, 32}:
+        raise ValueError("A must contain 1, 2, 4, 8, 16, or 32 rows")
+    for name, tensor, shape in (
+        ("A", A, (A.shape[0], 7168)),
+        ("B", B, (6288, 7168)),
+    ):
+        if (
+            tuple(tensor.shape) != shape
+            or tensor.dtype != torch.bfloat16
+            or not tensor.is_cuda
+            or not tensor.is_contiguous()
+            or tensor.device != A.device
+        ):
+            raise ValueError(
+                f"{name} must be contiguous GPU BF16 {shape} colocated with A"
+            )
+
+    if out is None:
+        out = A.new_empty((A.shape[0], 6288))
+    elif (
+        tuple(out.shape) != (A.shape[0], 6288)
+        or out.dtype != torch.bfloat16
+        or not out.is_cuda
+        or not out.is_contiguous()
+        or out.device != A.device
+    ):
+        raise ValueError(
+            f"out must be contiguous GPU BF16 ({A.shape[0]}, 6288) "
+            "colocated with A"
+        )
+    _launch_wmma_tdm_dense_tiles(
+        A,
+        B,
+        out,
+        block_n=16,
+        num_warps=1,
+    )
+    return out
+
+
+@gluon.jit
+def _wmma_tdm_add3_m16_kernel(
+    a_ptr,
+    b_ptr,
+    addend_a_ptr,
+    addend_b_ptr,
+    out_ptr,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_addend_am,
+    stride_addend_an,
+    stride_addend_bm,
+    stride_addend_bn,
+    stride_om,
+    stride_on,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+):
+    """Fixed-shape CDNA5 TDM/LDS/WMMA projection-plus-add3 kernel."""
+    M: gl.constexpr = 16
+    K: gl.constexpr = 3584
+    pid_n = gl.program_id(0)
+
+    gl.static_assert(BLOCK_N == 64, "candidate uses one 16x64 WMMA output tile")
+    gl.static_assert(BLOCK_K == 128, "candidate is tuned for 128-wide K tiles")
+    gl.static_assert(NUM_BUFFERS == 3, "candidate uses a triple-buffer TDM pipeline")
+
+    wmma_layout: gl.constexpr = gl.amd.AMDWMMALayout(
+        version=3,
+        transposed=True,
+        warp_bases=[[0, 1], [0, 2]],
+        reg_bases=[],
+        instr_shape=[16, 16, 32],
+    )
+    dot_layout_a: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=wmma_layout, k_width=8
+    )
+    dot_layout_b: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=wmma_layout, k_width=8
+    )
+    shared_layout_a: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 8]], [M, BLOCK_K], [1, 0]
+    )
+    shared_layout_b: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 8]], [BLOCK_N, BLOCK_K], [1, 0]
+    )
+
+    a_smem = gl.allocate_shared_memory(
+        a_ptr.dtype.element_ty,
+        [NUM_BUFFERS, M, BLOCK_K],
+        shared_layout_a,
+    )
+    b_smem = gl.allocate_shared_memory(
+        b_ptr.dtype.element_ty,
+        [NUM_BUFFERS, BLOCK_N, BLOCK_K],
+        shared_layout_b,
+    )
+    a_desc = gl.amd.cdna5.tdm.make_tensor_descriptor(
+        base=a_ptr,
+        shape=(M, K),
+        strides=(stride_am, stride_ak),
+        block_shape=(M, BLOCK_K),
+        layout=shared_layout_a,
+    )
+    b_desc = gl.amd.cdna5.tdm.make_tensor_descriptor(
+        base=b_ptr + pid_n * BLOCK_N * stride_bn,
+        shape=(BLOCK_N, K),
+        strides=(stride_bn, stride_bk),
+        block_shape=(BLOCK_N, BLOCK_K),
+        layout=shared_layout_b,
+    )
+
+    # Two tiles are prefetched before the steady-state issue/wait/WMMA loop.
+    for tile in gl.static_range(NUM_BUFFERS - 1):
+        gl.amd.cdna5.tdm.async_load(
+            a_desc, [0, tile * BLOCK_K], a_smem.index(tile)
+        )
+        gl.amd.cdna5.tdm.async_load(
+            b_desc, [0, tile * BLOCK_K], b_smem.index(tile)
+        )
+
+    acc = gl.zeros((M, BLOCK_N), gl.float32, wmma_layout)
+    num_k_tiles: gl.constexpr = K // BLOCK_K
+    gl.amd.cdna5.tdm.async_wait(2 * (NUM_BUFFERS - 2))
+    for tile in gl.static_range(num_k_tiles):
+        with gl.amd.warp_pipeline_stage("tdm+lds", priority=1):
+            a = a_smem.index(tile % NUM_BUFFERS).load(layout=dot_layout_a)
+            b = (
+                b_smem.index(tile % NUM_BUFFERS)
+                .permute([1, 0])
+                .load(layout=dot_layout_b)
+            )
+            gl.amd.cdna5.tdm.async_load(
+                a_desc,
+                [0, (tile + NUM_BUFFERS - 1) * BLOCK_K],
+                a_smem.index((tile + NUM_BUFFERS - 1) % NUM_BUFFERS),
+                pred=tile + NUM_BUFFERS - 1 < num_k_tiles,
+            )
+            gl.amd.cdna5.tdm.async_load(
+                b_desc,
+                [0, (tile + NUM_BUFFERS - 1) * BLOCK_K],
+                b_smem.index((tile + NUM_BUFFERS - 1) % NUM_BUFFERS),
+                pred=tile + NUM_BUFFERS - 1 < num_k_tiles,
+            )
+        # Keep one complete A/B batch in flight while consuming the oldest.
+        gl.amd.cdna5.tdm.async_wait(2 * (NUM_BUFFERS - 2))
+        with gl.amd.warp_pipeline_stage("wmma", priority=0):
+            acc = gl.amd.cdna5.wmma(a, b, acc)
+    gl.amd.cdna5.tdm.async_wait(0)
+
+    offs_m = gl.arange(0, M, gl.SliceLayout(1, wmma_layout))
+    offs_n = gl.arange(0, BLOCK_N, gl.SliceLayout(0, wmma_layout))
+    tile_n = pid_n * BLOCK_N + offs_n
+    addend_a_offsets = (
+        offs_m[:, None] * stride_addend_am
+        + tile_n[None, :] * stride_addend_an
+    ).to(gl.int32)
+    addend_b_offsets = (
+        offs_m[:, None] * stride_addend_bm
+        + tile_n[None, :] * stride_addend_bn
+    ).to(gl.int32)
+    output_offsets = (
+        offs_m[:, None] * stride_om + tile_n[None, :] * stride_on
+    ).to(gl.int32)
+
+    # Preserve the materialized BF16 projection boundary used by torch.mm.
+    projected = acc.to(gl.bfloat16)
+    addend_a = gl.amd.cdna5.buffer_load(
+        addend_a_ptr, addend_a_offsets
+    )
+    addend_b = gl.amd.cdna5.buffer_load(
+        addend_b_ptr, addend_b_offsets
+    )
+    gl.amd.cdna5.buffer_store(
+        (projected + addend_a + addend_b).to(gl.bfloat16),
+        out_ptr,
+        output_offsets,
+    )
+
+
+def gluon_wmma_tdm_add3_m16_gfx1250(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    addend_a: torch.Tensor,
+    addend_b: torch.Tensor,
+) -> torch.Tensor:
+    """Run the Kimi-K3 M=16 CDNA5 TDM/LDS/WMMA projection-plus-add3 path."""
+    for name, tensor, shape in (
+        ("A", A, (16, 3584)),
+        ("B", B, (7168, 3584)),
+    ):
+        if (
+            tuple(tensor.shape) != shape
+            or tensor.dtype != torch.bfloat16
+            or not tensor.is_cuda
+            or not tensor.is_contiguous()
+            or tensor.device != A.device
+        ):
+            raise ValueError(
+                f"{name} must be contiguous GPU BF16 {shape} colocated with A"
+            )
+    for name, tensor in (("addend_a", addend_a), ("addend_b", addend_b)):
+        if (
+            tuple(tensor.shape) != (16, 7168)
+            or tensor.dtype != torch.bfloat16
+            or not tensor.is_cuda
+            or tensor.device != A.device
+            or tensor.stride(1) != 1
+        ):
+            raise ValueError(
+                f"{name} must be GPU BF16 (16, 7168) with unit inner stride "
+                "colocated with A"
+            )
+
+    out = A.new_empty((16, 7168))
+    block_n, block_k, num_buffers = 64, 128, 3
+    _wmma_tdm_add3_m16_kernel[(7168 // block_n,)](
+        A,
+        B,
+        addend_a,
+        addend_b,
+        out,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        addend_a.stride(0),
+        addend_a.stride(1),
+        addend_b.stride(0),
+        addend_b.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        NUM_BUFFERS=num_buffers,
+        num_warps=4,
+        num_stages=1,
+        waves_per_eu=1,
+    )
+    return out
+
+
+@triton.jit
+def _mm_a16w16_add3_m16_kernel(
+    A,
+    B,
+    AddendA,
+    AddendB,
+    Out,
+    stride_am: tl.constexpr,
+    stride_ak: tl.constexpr,
+    stride_bn: tl.constexpr,
+    stride_bk: tl.constexpr,
+    stride_aam: tl.constexpr,
+    stride_aan: tl.constexpr,
+    stride_abm: tl.constexpr,
+    stride_abn: tl.constexpr,
+    stride_om: tl.constexpr,
+    stride_on: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    BF16_BOUNDARY: tl.constexpr,
+):
+    """Wave32 WMMA projection with a BF16-boundary add3 epilogue."""
+
+    pid_n = tl.program_id(0)
+    offs_m = tl.arange(0, 16)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    acc = tl.zeros((16, BLOCK_N), dtype=tl.float32)
+
+    a_ptrs = A + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = B + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    for _ in range(0, K, BLOCK_K):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs, mask=offs_n[None, :] < N, other=0.0)
+        acc = tl.dot(a, b, acc)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+
+    output_mask = offs_n[None, :] < N
+    if BF16_BOUNDARY:
+        # Match torch.mm's materialized BF16 output before the add3 operation.
+        projected = acc.to(tl.bfloat16)
+    else:
+        # Match gfx950's fused MFMA epilogue: add in FP32, cast at store.
+        projected = acc
+    add_a = tl.load(
+        AddendA + offs_m[:, None] * stride_aam + offs_n[None, :] * stride_aan,
+        mask=output_mask,
+    )
+    add_b = tl.load(
+        AddendB + offs_m[:, None] * stride_abm + offs_n[None, :] * stride_abn,
+        mask=output_mask,
+    )
+    tl.store(
+        Out + offs_m[:, None] * stride_om + offs_n[None, :] * stride_on,
+        projected + add_a + add_b,
+        mask=output_mask,
+    )
+
+
+def triton_mm_a16w16_add3_m16_gfx1250(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    addend_a: torch.Tensor,
+    addend_b: torch.Tensor,
+    *,
+    block_n: int = 32,
+    block_k: int = 32,
+    num_warps: int = 2,
+    num_stages: int = 1,
+    waves_per_eu: int = 1,
+    bf16_boundary: bool = True,
+) -> torch.Tensor:
+    """Compute the Kimi K3 M16 projection-plus-add3 with wave32 WMMA."""
+
+    if A.shape != (16, 3584) or B.shape != (7168, 3584):
+        raise ValueError(
+            "gfx1250 add3 requires A [16,3584] and B [7168,3584], "
+            f"got {tuple(A.shape)} and {tuple(B.shape)}"
+        )
+    for name, tensor, expected_shape in (
+        ("addend_a", addend_a, (16, 7168)),
+        ("addend_b", addend_b, (16, 7168)),
+    ):
+        if tensor.shape != expected_shape:
+            raise ValueError(f"{name} must have shape {expected_shape}")
+    for name, tensor in (("B", B), ("addend_a", addend_a), ("addend_b", addend_b)):
+        if tensor.device != A.device or tensor.dtype != A.dtype:
+            raise ValueError(f"{name} must be colocated with A and have A's dtype")
+    if A.dtype != torch.bfloat16 or not A.is_cuda or not A.is_contiguous():
+        raise ValueError("A must be a contiguous GPU BF16 tensor")
+    if not B.is_contiguous():
+        raise ValueError("B must be contiguous")
+    if addend_a.stride(1) != 1 or addend_b.stride(1) != 1:
+        raise ValueError("addends must have unit inner stride")
+    if block_n not in (16, 32, 64, 128) or block_k not in (
+        16,
+        32,
+        64,
+        128,
+        256,
+    ):
+        raise ValueError("unsupported add3 output or K tile")
+    if num_stages not in (1, 2, 3, 4):
+        raise ValueError("num_stages must be between 1 and 4")
+
+    out = torch.empty_like(addend_a)
+    _mm_a16w16_add3_m16_kernel[(triton.cdiv(B.shape[0], block_n),)](
+        A,
+        B,
+        addend_a,
+        addend_b,
+        out,
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(1),
+        addend_a.stride(0),
+        addend_a.stride(1),
+        addend_b.stride(0),
+        addend_b.stride(1),
+        out.stride(0),
+        out.stride(1),
+        N=B.shape[0],
+        K=A.shape[1],
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        BF16_BOUNDARY=bf16_boundary,
+        num_warps=num_warps,
+        num_stages=num_stages,
+        waves_per_eu=waves_per_eu,
+        matrix_instr_nonkdim=16,
+    )
+    return out
+
+
+@gluon.jit
+def _largem_swizzle2d(pid, grid_m, grid_n, GROUP_M: gl.constexpr):
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = gl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
+    gl.assume(group_size >= 0)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // group_size
+    return pid_m, pid_n
+
+
+@gluon.jit
+def _wmma_tdm_dense_largem_kernel(
+    a_ptr,
+    b_ptr,
+    out_ptr,
+    stride_am,
+    stride_ak,
+    stride_bn,
+    stride_bk,
+    stride_om,
+    stride_on,
+    M,
+    N,
+    K,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    GROUP_M: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+):
+    """Dense BF16 CDNA5 TDM/WMMA GEMM for large aligned K3 prefixes."""
+    gl.static_assert(BLOCK_K == 128, "large-M path is tuned for 128-wide K tiles")
+    gl.static_assert(NUM_BUFFERS == 2, "large-M path uses a double-buffer TDM pipeline")
+
+    pid = gl.program_id(0)
+    grid_m = gl.cdiv(M, BLOCK_M)
+    grid_n = gl.cdiv(N, BLOCK_N)
+    pid_m, pid_n = _largem_swizzle2d(pid, grid_m, grid_n, GROUP_M)
+    off_m = pid_m * BLOCK_M
+    off_n = pid_n * BLOCK_N
+
+    wmma_layout: gl.constexpr = gl.amd.AMDWMMALayout(
+        version=3,
+        transposed=True,
+        warp_bases=[[0, 1], [1, 0]],
+        reg_bases=[],
+        instr_shape=[16, 16, 32],
+    )
+    dot_layout_a: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0, parent=wmma_layout, k_width=8
+    )
+    dot_layout_b: gl.constexpr = gl.DotOperandLayout(
+        operand_index=1, parent=wmma_layout, k_width=8
+    )
+    shared_layout_a: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 8]], [BLOCK_M, BLOCK_K], [1, 0]
+    )
+    shared_layout_b: gl.constexpr = gl.PaddedSharedLayout.with_identity_for(
+        [[256, 8]], [BLOCK_N, BLOCK_K], [1, 0]
+    )
+
+    a_smem = gl.allocate_shared_memory(
+        a_ptr.dtype.element_ty,
+        [NUM_BUFFERS, BLOCK_M, BLOCK_K],
+        shared_layout_a,
+    )
+    b_smem = gl.allocate_shared_memory(
+        b_ptr.dtype.element_ty,
+        [NUM_BUFFERS, BLOCK_N, BLOCK_K],
+        shared_layout_b,
+    )
+    a_desc = gl.amd.cdna5.tdm.make_tensor_descriptor(
+        base=a_ptr + off_m * stride_am,
+        shape=(M - off_m, K),
+        strides=(stride_am, stride_ak),
+        block_shape=(BLOCK_M, BLOCK_K),
+        layout=shared_layout_a,
+    )
+    b_desc = gl.amd.cdna5.tdm.make_tensor_descriptor(
+        base=b_ptr + off_n * stride_bn,
+        shape=(N - off_n, K),
+        strides=(stride_bn, stride_bk),
+        block_shape=(BLOCK_N, BLOCK_K),
+        layout=shared_layout_b,
+    )
+
+    gl.amd.cdna5.tdm.async_load(a_desc, [0, 0], a_smem.index(0))
+    gl.amd.cdna5.tdm.async_load(b_desc, [0, 0], b_smem.index(0))
+
+    acc = gl.zeros((BLOCK_M, BLOCK_N), gl.float32, wmma_layout)
+    num_k_tiles = gl.cdiv(K, BLOCK_K)
+    gl.assume(num_k_tiles > 0)
+    for i in range(0, num_k_tiles - 1):
+        next_idx = i + 1
+        gl.amd.cdna5.tdm.async_load(
+            a_desc,
+            [0, next_idx * BLOCK_K],
+            a_smem.index(next_idx % NUM_BUFFERS),
+        )
+        gl.amd.cdna5.tdm.async_load(
+            b_desc,
+            [0, next_idx * BLOCK_K],
+            b_smem.index(next_idx % NUM_BUFFERS),
+        )
+        gl.amd.cdna5.tdm.async_wait(2)
+        a = a_smem.index(i % NUM_BUFFERS).load(layout=dot_layout_a)
+        b = (
+            b_smem.index(i % NUM_BUFFERS)
+            .permute([1, 0])
+            .load(layout=dot_layout_b)
+        )
+        acc = gl.amd.cdna5.wmma(a, b, acc)
+
+    gl.amd.cdna5.tdm.async_wait(0)
+    last_idx = num_k_tiles - 1
+    a = a_smem.index(last_idx % NUM_BUFFERS).load(layout=dot_layout_a)
+    b = (
+        b_smem.index(last_idx % NUM_BUFFERS)
+        .permute([1, 0])
+        .load(layout=dot_layout_b)
+    )
+    acc = gl.amd.cdna5.wmma(a, b, acc)
+
+    offs_m = off_m + gl.arange(0, BLOCK_M, gl.SliceLayout(1, wmma_layout))
+    offs_n = off_n + gl.arange(0, BLOCK_N, gl.SliceLayout(0, wmma_layout))
+    output_offsets = (
+        offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+    ).to(gl.int32)
+    gl.amd.cdna5.buffer_store(
+        acc.to(gl.bfloat16),
+        out_ptr,
+        output_offsets,
+        mask=(offs_m[:, None] < M) & (offs_n[None, :] < N),
+    )
+
+
+def gluon_mm_a16w16_largem_gfx1250(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run K3 BF16 projections with CDNA5 WMMA prefixes and vendor tails."""
+
+    if A.ndim != 2 or B.ndim != 2 or A.shape[1] != B.shape[1]:
+        raise ValueError("gfx1250 large-M projection expects A [M,K], B [N,K]")
+    m, k = map(int, A.shape)
+    n = int(B.shape[0])
+    if m < _LARGEM_MIN_M or (k, n) not in _LARGEM_SHAPES:
+        raise ValueError(
+            f"gfx1250 large-M projection requires M >= {_LARGEM_MIN_M} "
+            f"and a K3 shape, got M={m} N={n} K={k}"
+        )
+    if (
+        A.dtype != torch.bfloat16
+        or B.dtype != torch.bfloat16
+        or not A.is_cuda
+        or A.device != B.device
+        or not A.is_contiguous()
+        or not B.is_contiguous()
+    ):
+        raise ValueError(
+            "gfx1250 large-M projection requires contiguous GPU BF16 inputs"
+        )
+    if k % 128 != 0:
+        raise ValueError(
+            f"gfx1250 large-M projection requires K divisible by 128, got K={k}"
+        )
+
+    if out is None:
+        out = A.new_empty((m, n))
+    elif (
+        out.shape != (m, n)
+        or out.dtype != A.dtype
+        or out.device != A.device
+        or not out.is_contiguous()
+    ):
+        raise ValueError(
+            "gfx1250 large-M output must be contiguous BF16 with shape "
+            f"{(m, n)} on {A.device}"
+        )
+
+    block_m = 128 if m < _LARGEM_BLOCK_M_CROSSOVER else 256
+    tiled_n = n - n % 32
+    block_n = next(
+        candidate for candidate in (block_m, 128, 64, 32) if tiled_n % candidate == 0
+    )
+    tiled_m = m - m % block_m
+    prefix_out = out if tiled_n == n else A.new_empty((m, tiled_n))
+    if tiled_m > 0 and tiled_n > 0:
+        a_prefix = A[:tiled_m]
+        b_prefix = B[:tiled_n]
+        out_prefix = prefix_out[:tiled_m]
+        grid = (tiled_m // block_m) * (tiled_n // block_n)
+        _wmma_tdm_dense_largem_kernel[(grid,)](
+            a_prefix,
+            b_prefix,
+            out_prefix,
+            a_prefix.stride(0),
+            a_prefix.stride(1),
+            b_prefix.stride(0),
+            b_prefix.stride(1),
+            out_prefix.stride(0),
+            out_prefix.stride(1),
+            tiled_m,
+            tiled_n,
+            k,
+            BLOCK_M=block_m,
+            BLOCK_N=block_n,
+            BLOCK_K=128,
+            GROUP_M=8,
+            NUM_BUFFERS=2,
+            num_warps=4,
+            num_stages=1,
+        )
+    if tiled_m != m:
+        torch.mm(A[tiled_m:], B[:tiled_n].T, out=prefix_out[tiled_m:])
+    if tiled_n != n:
+        out[:, :tiled_n].copy_(prefix_out)
+        out[:, tiled_n:].copy_(torch.nn.functional.linear(A, B[tiled_n:]))
+    return out
+
+
+__all__ = [
+    "gluon_mm_a16w16_largem_gfx1250",
+    "gluon_wmma_tdm_kda_qkvfab_gfx1250",
+    "gluon_wmma_tdm_mla_qkv_gate_gfx1250",
+    "gluon_wmma_tdm_add3_m16_gfx1250",
+    "triton_mm_a16w16_add3_m16_gfx1250",
+]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
@@ -42,6 +42,12 @@ _LARGEM_SHAPES = {
 }
 
 
+def use_gluon_largem_gfx1250(m: int, k: int, n: int) -> bool:
+    """Return whether CDNA5 large-M WMMA accepts this K3 projection shape."""
+
+    return m >= _LARGEM_MIN_M and (k, n) in _LARGEM_SHAPES
+
+
 @gluon.jit
 def _wmma_tdm_dense_m16_kernel(
     a_ptr,
@@ -748,7 +754,7 @@ def gluon_mm_a16w16_largem_gfx1250(
         raise ValueError("gfx1250 large-M projection expects A [M,K], B [N,K]")
     m, k = map(int, A.shape)
     n = int(B.shape[0])
-    if m < _LARGEM_MIN_M or (k, n) not in _LARGEM_SHAPES:
+    if not use_gluon_largem_gfx1250(m, k, n):
         raise ValueError(
             f"gfx1250 large-M projection requires M >= {_LARGEM_MIN_M} "
             f"and a K3 shape, got M={m} N={n} K={k}"
@@ -824,6 +830,7 @@ def gluon_mm_a16w16_largem_gfx1250(
 
 
 __all__ = [
+    "use_gluon_largem_gfx1250",
     "gluon_mm_a16w16_largem_gfx1250",
     "gluon_wmma_tdm_kda_qkvfab_gfx1250",
     "gluon_wmma_tdm_mla_qkv_gate_gfx1250",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -1308,8 +1308,6 @@ def mla_normalize_project_query(
         else:
             from tokenspeed_kernel.ops.layernorm.cuda import rmsnorm_fused_parallel
 
-        from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
-
         query_norm = torch.empty_like(query)
         rmsnorm_fused_parallel(
             input1=query,
@@ -1320,7 +1318,24 @@ def mla_normalize_project_query(
             output2=kv,
             eps=eps,
         )
-        decode_gemv(query_norm, projection_weight, out=projection_out)
+        if current_platform().is_cdna5 and tokens > 1:
+            from tokenspeed_kernel.ops.gemm.kimi3 import _try_gluon_largem_gfx1250
+
+            if (
+                _try_gluon_largem_gfx1250(
+                    query_norm,
+                    projection_weight,
+                    out=projection_out,
+                )
+                is None
+            ):
+                from tokenspeed_kernel.ops.gemm import mm
+
+                mm(query_norm, projection_weight, out=projection_out)
+        else:
+            from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
+
+            decode_gemv(query_norm, projection_weight, out=projection_out)
     else:
         query_fp32 = query.float()
         query_norm = query_fp32 * torch.rsqrt(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -70,23 +70,19 @@ def _use_gluon_largem(m: int, k: int, n: int) -> bool:
 
 
 def _use_gluon_largem_gfx1250(m: int, k: int, n: int) -> bool:
-    return (
-        m >= 512
-        and (k, n)
-        in {
-            (512, 3072),
-            (768, KIMI3_HIDDEN_SIZE),
-            (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, KIMI3_HIDDEN_SIZE),
-            (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, 2304),
-            (KIMI3_LATENT_SIZE, KIMI3_HIDDEN_SIZE),
-            (4224, KIMI3_HIDDEN_SIZE),
-            (KIMI3_HIDDEN_SIZE, 1536),
-            (KIMI3_HIDDEN_SIZE, 2112),
-            (KIMI3_HIDDEN_SIZE, KIMI3_LATENT_SIZE),
-            (KIMI3_HIDDEN_SIZE, KIMI3_QKVFAB_SIZE),
-            (KIMI3_HIDDEN_SIZE, 8448),
-        }
-    )
+    return m >= 512 and (k, n) in {
+        (512, 3072),
+        (768, KIMI3_HIDDEN_SIZE),
+        (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, KIMI3_HIDDEN_SIZE),
+        (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, 2304),
+        (KIMI3_LATENT_SIZE, KIMI3_HIDDEN_SIZE),
+        (4224, KIMI3_HIDDEN_SIZE),
+        (KIMI3_HIDDEN_SIZE, 1536),
+        (KIMI3_HIDDEN_SIZE, 2112),
+        (KIMI3_HIDDEN_SIZE, KIMI3_LATENT_SIZE),
+        (KIMI3_HIDDEN_SIZE, KIMI3_QKVFAB_SIZE),
+        (KIMI3_HIDDEN_SIZE, 8448),
+    }
 
 
 def _try_gluon_largem_gfx1250(

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -19,6 +19,16 @@ from tokenspeed_kernel._triton import libdevice, tl, triton
 from tokenspeed_kernel.ops.gemm.routed_gemv import decode_gemv_routed
 from tokenspeed_kernel.platform import Platform, pdl_enabled
 
+try:
+    from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+        use_gluon_largem_gfx1250,
+    )
+except ImportError:
+
+    def use_gluon_largem_gfx1250(m: int, k: int, n: int) -> bool:
+        return False
+
+
 # FP8 storage dtypes served by the w8a8 projection branch (matches the
 # runtime quantization layers' width: e4m3fn on NVIDIA, e4m3fnuz on ROCm).
 _FP8_WEIGHT_DTYPES = (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
@@ -69,22 +79,6 @@ def _use_gluon_largem(m: int, k: int, n: int) -> bool:
     return m >= min_m and m % 256 == 0
 
 
-def _use_gluon_largem_gfx1250(m: int, k: int, n: int) -> bool:
-    return m >= 512 and (k, n) in {
-        (512, 3072),
-        (768, KIMI3_HIDDEN_SIZE),
-        (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, KIMI3_HIDDEN_SIZE),
-        (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, 2304),
-        (KIMI3_LATENT_SIZE, KIMI3_HIDDEN_SIZE),
-        (4224, KIMI3_HIDDEN_SIZE),
-        (KIMI3_HIDDEN_SIZE, 1536),
-        (KIMI3_HIDDEN_SIZE, 2112),
-        (KIMI3_HIDDEN_SIZE, KIMI3_LATENT_SIZE),
-        (KIMI3_HIDDEN_SIZE, KIMI3_QKVFAB_SIZE),
-        (KIMI3_HIDDEN_SIZE, 8448),
-    }
-
-
 def _try_gluon_largem_gfx1250(
     activation: torch.Tensor,
     weight: torch.Tensor,
@@ -116,7 +110,7 @@ def _try_gluon_largem_gfx1250(
                 or not out.is_contiguous()
             )
         )
-        or not _use_gluon_largem_gfx1250(
+        or not use_gluon_largem_gfx1250(
             int(activation.shape[0]),
             int(activation.shape[1]),
             int(weight.shape[0]),
@@ -388,7 +382,7 @@ def kimi3_latent_projection(
         elif (
             Platform.get().is_cdna5
             and specialized
-            and _use_gluon_largem_gfx1250(m, k, n)
+            and use_gluon_largem_gfx1250(m, k, n)
             and (out is None or out.is_contiguous())
         ):
             solution = "gluon_largem_gfx1250"
@@ -448,7 +442,7 @@ def kimi3_latent_projection(
         if not (
             Platform.get().is_cdna5
             and specialized
-            and _use_gluon_largem_gfx1250(m, k, n)
+            and use_gluon_largem_gfx1250(m, k, n)
         ):
             raise ValueError(
                 "Kimi K3 gfx1250 Gluon projection requires a contiguous BF16 "
@@ -526,8 +520,8 @@ def kimi3_mla_qkv_gate_projection(
             and weight.dtype == torch.bfloat16
             and hidden_states.is_contiguous()
             and weight.is_contiguous()
-            and _use_gluon_largem_gfx1250(m, hidden_states.shape[1], qkv_width)
-            and _use_gluon_largem_gfx1250(
+            and use_gluon_largem_gfx1250(m, hidden_states.shape[1], qkv_width)
+            and use_gluon_largem_gfx1250(
                 m,
                 hidden_states.shape[1],
                 output_width - qkv_width,
@@ -585,8 +579,8 @@ def kimi3_mla_qkv_gate_projection(
             and weight.dtype == torch.bfloat16
             and hidden_states.is_contiguous()
             and weight.is_contiguous()
-            and _use_gluon_largem_gfx1250(m, hidden_states.shape[1], qkv_width)
-            and _use_gluon_largem_gfx1250(
+            and use_gluon_largem_gfx1250(m, hidden_states.shape[1], qkv_width)
+            and use_gluon_largem_gfx1250(
                 m,
                 hidden_states.shape[1],
                 output_width - qkv_width,
@@ -1027,7 +1021,7 @@ def kimi3_shared_down_projection(
             and hidden_states.is_contiguous()
             and weight.is_contiguous()
             and out.is_contiguous()
-            and _use_gluon_largem_gfx1250(
+            and use_gluon_largem_gfx1250(
                 m,
                 input_width,
                 output_width,
@@ -1061,7 +1055,7 @@ def kimi3_shared_down_projection(
             and weight.dtype == torch.bfloat16
             and hidden_states.is_contiguous()
             and weight.is_contiguous()
-            and _use_gluon_largem_gfx1250(m, input_width, output_width)
+            and use_gluon_largem_gfx1250(m, input_width, output_width)
         ):
             raise ValueError(
                 "Kimi K3 gfx1250 shared down projection requires a contiguous "
@@ -1194,7 +1188,7 @@ def kimi3_qkvfab_projection(
             Platform.get().is_cdna5
             and hidden_states.is_cuda
             and weight.is_cuda
-            and _use_gluon_largem_gfx1250(m, input_width, output_width)
+            and use_gluon_largem_gfx1250(m, input_width, output_width)
             and hidden_states.dtype == torch.bfloat16
             and weight.dtype == torch.bfloat16
             and hidden_states.is_contiguous()
@@ -1259,7 +1253,7 @@ def kimi3_qkvfab_projection(
     if solution == "gluon_largem_gfx1250":
         if not (
             Platform.get().is_cdna5
-            and _use_gluon_largem_gfx1250(m, input_width, output_width)
+            and use_gluon_largem_gfx1250(m, input_width, output_width)
             and hidden_states.dtype == torch.bfloat16
             and weight.dtype == torch.bfloat16
             and hidden_states.is_contiguous()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -103,9 +103,19 @@ def _try_gluon_largem_gfx1250(
         or weight.ndim != 2
         or activation.dtype != torch.bfloat16
         or weight.dtype != torch.bfloat16
+        or not activation.is_cuda
+        or not weight.is_cuda
+        or weight.device != activation.device
         or not activation.is_contiguous()
         or not weight.is_contiguous()
-        or (out is not None and not out.is_contiguous())
+        or (
+            out is not None
+            and (
+                not out.is_cuda
+                or out.device != activation.device
+                or not out.is_contiguous()
+            )
+        )
         or not _use_gluon_largem_gfx1250(
             int(activation.shape[0]),
             int(activation.shape[1]),
@@ -497,6 +507,8 @@ def kimi3_mla_qkv_gate_projection(
     if solution == "auto":
         gfx1250_tdm = (
             Platform.get().is_cdna5
+            and hidden_states.is_cuda
+            and weight.is_cuda
             and m in {2, 4, 8, 16, 32}
             and input_width == KIMI3_HIDDEN_SIZE
             and qkv_width == 2112
@@ -508,6 +520,8 @@ def kimi3_mla_qkv_gate_projection(
         )
         gfx1250_largem = (
             Platform.get().is_cdna5
+            and hidden_states.is_cuda
+            and weight.is_cuda
             and hidden_states.dtype == torch.bfloat16
             and weight.dtype == torch.bfloat16
             and hidden_states.is_contiguous()
@@ -938,7 +952,11 @@ def kimi3_shared_situ_projection(
 
         gate_up = decode_gemv(hidden_states, gate_up_weight)
     else:
-        gate_up = _try_gluon_largem_gfx1250(hidden_states, gate_up_weight)
+        gate_up = (
+            _try_gluon_largem_gfx1250(hidden_states, gate_up_weight)
+            if solution == "auto"
+            else None
+        )
         if gate_up is None:
             gate_up = torch.nn.functional.linear(hidden_states, gate_up_weight)
     if gate_up.is_cuda:
@@ -1162,6 +1180,8 @@ def kimi3_qkvfab_projection(
     if solution == "auto":
         if (
             Platform.get().is_cdna5
+            and hidden_states.is_cuda
+            and weight.is_cuda
             and m in {2, 4, 8, 16, 32}
             and input_width == KIMI3_HIDDEN_SIZE
             and output_width == KIMI3_QKVFAB_SIZE
@@ -1174,6 +1194,8 @@ def kimi3_qkvfab_projection(
             solution = "gluon_wmma_gfx1250"
         elif (
             Platform.get().is_cdna5
+            and hidden_states.is_cuda
+            and weight.is_cuda
             and _use_gluon_largem_gfx1250(m, input_width, output_width)
             and hidden_states.dtype == torch.bfloat16
             and weight.dtype == torch.bfloat16

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -953,9 +953,7 @@ def kimi3_shared_situ_projection(
         gate_up = decode_gemv(hidden_states, gate_up_weight)
     else:
         gate_up = (
-            _try_gluon_largem_gfx1250(hidden_states, gate_up_weight)
-            if solution == "auto"
-            else None
+            _try_gluon_largem_gfx1250(hidden_states, gate_up_weight) if routed else None
         )
         if gate_up is None:
             gate_up = torch.nn.functional.linear(hidden_states, gate_up_weight)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/kimi3.py
@@ -16,6 +16,7 @@ from functools import lru_cache
 
 import torch
 from tokenspeed_kernel._triton import libdevice, tl, triton
+from tokenspeed_kernel.ops.gemm.routed_gemv import decode_gemv_routed
 from tokenspeed_kernel.platform import Platform, pdl_enabled
 
 # FP8 storage dtypes served by the w8a8 projection branch (matches the
@@ -26,7 +27,6 @@ KIMI3_HIDDEN_SIZE = 7168
 KIMI3_LATENT_SIZE = 3584
 KIMI3_QKVFAB_SIZE = 6288
 KIMI3_ROUTER_SIZE = 896
-from tokenspeed_kernel.ops.gemm.routed_gemv import decode_gemv_routed
 
 KIMI3_SHARED_LOCAL_SIZE = 768
 
@@ -67,6 +67,61 @@ def _use_gluon_largem(m: int, k: int, n: int) -> bool:
     else:
         return False
     return m >= min_m and m % 256 == 0
+
+
+def _use_gluon_largem_gfx1250(m: int, k: int, n: int) -> bool:
+    return (
+        m >= 512
+        and (k, n)
+        in {
+            (512, 3072),
+            (768, KIMI3_HIDDEN_SIZE),
+            (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, KIMI3_HIDDEN_SIZE),
+            (KIMI3_SHARED_GATE_UP_LOCAL_SIZE, 2304),
+            (KIMI3_LATENT_SIZE, KIMI3_HIDDEN_SIZE),
+            (4224, KIMI3_HIDDEN_SIZE),
+            (KIMI3_HIDDEN_SIZE, 1536),
+            (KIMI3_HIDDEN_SIZE, 2112),
+            (KIMI3_HIDDEN_SIZE, KIMI3_LATENT_SIZE),
+            (KIMI3_HIDDEN_SIZE, KIMI3_QKVFAB_SIZE),
+            (KIMI3_HIDDEN_SIZE, 8448),
+        }
+    )
+
+
+def _try_gluon_largem_gfx1250(
+    activation: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor | None:
+    """Run the CDNA5 large-M kernel, or return None when the call is ineligible.
+
+    Named K3 APIs and BF16 ``UnquantizedLinearMethod`` layers use this instead
+    of registering the kernel on generic ``mm()``.
+    """
+
+    if (
+        not Platform.get().is_cdna5
+        or activation.ndim != 2
+        or weight.ndim != 2
+        or activation.dtype != torch.bfloat16
+        or weight.dtype != torch.bfloat16
+        or not activation.is_contiguous()
+        or not weight.is_contiguous()
+        or (out is not None and not out.is_contiguous())
+        or not _use_gluon_largem_gfx1250(
+            int(activation.shape[0]),
+            int(activation.shape[1]),
+            int(weight.shape[0]),
+        )
+    ):
+        return None
+    from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+        gluon_mm_a16w16_largem_gfx1250,
+    )
+
+    return gluon_mm_a16w16_largem_gfx1250(activation, weight, out=out)
 
 
 @triton.jit
@@ -181,8 +236,7 @@ def _validate_inputs(
         raise ValueError(f"Kimi K3 projection K mismatch: {k} != {weight_k}")
     if (k, n) not in _KIMI3_SHAPES:
         raise ValueError(
-            "Kimi K3 projection only supports 7168->3584 or 3584->7168, "
-            f"got {k}->{n}"
+            f"Kimi K3 projection only supports 7168->3584 or 3584->7168, got {k}->{n}"
         )
     if hidden_states.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
         raise TypeError("Kimi K3 projection requires BF16 input and weight")
@@ -304,6 +358,7 @@ def kimi3_latent_projection(
         "gluon_smallm",
         "gluon_mediumm",
         "gluon_largem",
+        "gluon_largem_gfx1250",
     }:
         raise ValueError(f"unknown Kimi K3 projection solution {solution!r}")
     specialized = (
@@ -324,6 +379,13 @@ def kimi3_latent_projection(
             solution = "gluon_mediumm"
         elif Platform.get().is_cdna4 and specialized and _use_gluon_largem(m, k, n):
             solution = "gluon_largem"
+        elif (
+            Platform.get().is_cdna5
+            and specialized
+            and _use_gluon_largem_gfx1250(m, k, n)
+            and (out is None or out.is_contiguous())
+        ):
+            solution = "gluon_largem_gfx1250"
         else:
             solution = "torch"
     elif solution != "torch" and not specialized:
@@ -376,6 +438,25 @@ def kimi3_latent_projection(
                 "Kimi K3 Gluon latent projection requires an aligned large-M shape"
             )
         return output
+    if solution == "gluon_largem_gfx1250":
+        if not (
+            Platform.get().is_cdna5
+            and specialized
+            and _use_gluon_largem_gfx1250(m, k, n)
+        ):
+            raise ValueError(
+                "Kimi K3 gfx1250 Gluon projection requires a contiguous BF16 "
+                "K3 shape with M >= 512"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            gluon_mm_a16w16_largem_gfx1250,
+        )
+
+        return gluon_mm_a16w16_largem_gfx1250(
+            hidden_states,
+            weight,
+            out=out,
+        )
     if routed and decode_gemv_routed(hidden_states, weight):
         from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
 
@@ -399,7 +480,7 @@ def kimi3_mla_qkv_gate_projection(
     tensors so callers can communicate only the QKV rows.
     """
 
-    m, output_width, _ = _validate_fallback_projection(
+    m, output_width, input_width = _validate_fallback_projection(
         hidden_states,
         weight,
         None,
@@ -407,13 +488,78 @@ def kimi3_mla_qkv_gate_projection(
     )
     if not 0 < qkv_width < output_width:
         raise ValueError(
-            f"Kimi K3 MLA qkv_width must be within (0, {output_width}), "
-            f"got {qkv_width}"
+            f"Kimi K3 MLA qkv_width must be within (0, {output_width}), got {qkv_width}"
         )
-    if solution not in {"auto", "fused", "split"}:
+    if solution not in {
+        "auto",
+        "fused",
+        "split",
+        "gluon_wmma_gfx1250",
+        "gluon_largem_gfx1250",
+    }:
         raise ValueError(f"unknown Kimi K3 MLA projection solution {solution!r}")
     if solution == "auto":
-        solution = "split" if m > 32 else "fused"
+        gfx1250_tdm = (
+            Platform.get().is_cdna5
+            and m in {2, 4, 8, 16, 32}
+            and input_width == KIMI3_HIDDEN_SIZE
+            and qkv_width == 2112
+            and output_width - qkv_width == 1536
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+        )
+        gfx1250_largem = (
+            Platform.get().is_cdna5
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and _use_gluon_largem_gfx1250(m, hidden_states.shape[1], qkv_width)
+            and _use_gluon_largem_gfx1250(
+                m,
+                hidden_states.shape[1],
+                output_width - qkv_width,
+            )
+        )
+        solution = (
+            "gluon_wmma_gfx1250"
+            if gfx1250_tdm
+            else (
+                "gluon_largem_gfx1250"
+                if gfx1250_largem
+                else ("split" if m > 32 else "fused")
+            )
+        )
+
+    if solution == "gluon_wmma_gfx1250":
+        if not (
+            Platform.get().is_cdna5
+            and m in {2, 4, 8, 16, 32}
+            and input_width == KIMI3_HIDDEN_SIZE
+            and qkv_width == 2112
+            and output_width - qkv_width == 1536
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+        ):
+            raise ValueError(
+                "Kimi K3 gfx1250 MLA WMMA projection requires contiguous BF16 "
+                "A [M,7168] for M in {2,4,8,16,32}, weight [3648,7168], "
+                "and qkv_width=2112"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            gluon_wmma_tdm_mla_qkv_gate_gfx1250,
+        )
+
+        packed = gluon_wmma_tdm_mla_qkv_gate_gfx1250(
+            hidden_states,
+            weight,
+        )
+        qkv, gate = packed.split((qkv_width, output_width - qkv_width), dim=-1)
+        return Kimi3MLAQKVGateProjection(qkv=qkv, gate=gate, packed=packed)
 
     if solution == "fused":
         from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
@@ -421,6 +567,38 @@ def kimi3_mla_qkv_gate_projection(
         packed = decode_gemv(hidden_states, weight)
         qkv, gate = packed.split((qkv_width, output_width - qkv_width), dim=-1)
         return Kimi3MLAQKVGateProjection(qkv=qkv, gate=gate, packed=packed)
+
+    if solution == "gluon_largem_gfx1250":
+        if not (
+            Platform.get().is_cdna5
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and _use_gluon_largem_gfx1250(m, hidden_states.shape[1], qkv_width)
+            and _use_gluon_largem_gfx1250(
+                m,
+                hidden_states.shape[1],
+                output_width - qkv_width,
+            )
+        ):
+            raise ValueError(
+                "Kimi K3 gfx1250 MLA Gluon projection requires contiguous "
+                "BF16 K3 QKV/gate shapes with M >= 512"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            gluon_mm_a16w16_largem_gfx1250,
+        )
+
+        qkv = gluon_mm_a16w16_largem_gfx1250(
+            hidden_states,
+            weight[:qkv_width],
+        )
+        gate = gluon_mm_a16w16_largem_gfx1250(
+            hidden_states,
+            weight[qkv_width:],
+        )
+        return Kimi3MLAQKVGateProjection(qkv=qkv, gate=gate, packed=None)
 
     qkv = torch.nn.functional.linear(hidden_states, weight[:qkv_width])
     gate = torch.nn.functional.linear(hidden_states, weight[qkv_width:])
@@ -451,9 +629,10 @@ def kimi3_latent_projection_add3(
         solution: ``"auto"`` selects the dual-residual skinny epilogue where
             it holds a measured win (sm103, M <= 2), the fused row-CTA GEMV
             for other one-token execution, the fused MFMA epilogue for the
-            tuned M=16 tile, and otherwise composes the registered projection
+            tuned CDNA4 M=16 tile, and otherwise composes the registered projection
             and add kernels. ``"rowcta_gemv"``, ``"skinny_add3"``,
-            ``"gluon_mfma_add3"``, and ``"composed"`` force an implementation.
+            ``"gluon_mfma_add3"``, ``"gluon_wmma_add3"``,
+            ``"triton_wmma_add3"``, and ``"composed"`` force an implementation.
 
     Returns:
         ``prefix + hidden_states @ weight.T + shared_output`` shaped ``[M, N]``.
@@ -486,6 +665,8 @@ def kimi3_latent_projection_add3(
         "rowcta_gemv",
         "skinny_add3",
         "gluon_mfma_add3",
+        "gluon_wmma_add3",
+        "triton_wmma_add3",
         "composed",
     }:
         raise ValueError(f"unknown Kimi K3 projection-add3 solution {solution!r}")
@@ -560,6 +741,13 @@ def kimi3_latent_projection_add3(
             solution = "rowcta_gemv"
         elif Platform.get().is_cdna4 and m == 16 and specialized:
             solution = "gluon_mfma_add3"
+        elif (
+            Platform.get().is_cdna5
+            and m == 16
+            and (k, n) == (KIMI3_LATENT_SIZE, KIMI3_HIDDEN_SIZE)
+            and specialized
+        ):
+            solution = "gluon_wmma_add3"
         else:
             solution = "composed"
     if solution == "skinny_add3":
@@ -607,6 +795,52 @@ def kimi3_latent_projection_add3(
             weight,
             prefix,
             shared_output,
+        )
+    if solution == "gluon_wmma_add3":
+        if (
+            not Platform.get().is_cdna5
+            or m != 16
+            or (k, n) != (KIMI3_LATENT_SIZE, KIMI3_HIDDEN_SIZE)
+            or not specialized
+        ):
+            raise ValueError(
+                "gluon_wmma_add3 projection-add3 requires 16 contiguous CUDA "
+                "BF16 rows with the K3 3584->7168 shape on CDNA5"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            gluon_wmma_tdm_add3_m16_gfx1250,
+        )
+
+        return gluon_wmma_tdm_add3_m16_gfx1250(
+            hidden_states,
+            weight,
+            prefix,
+            shared_output,
+        )
+    if solution == "triton_wmma_add3":
+        if (
+            not Platform.get().is_cdna5
+            or m != 16
+            or (k, n) != (KIMI3_LATENT_SIZE, KIMI3_HIDDEN_SIZE)
+            or not specialized
+        ):
+            raise ValueError(
+                "triton_wmma_add3 projection-add3 requires 16 contiguous CUDA "
+                "BF16 rows with the K3 3584->7168 shape on CDNA5"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            triton_mm_a16w16_add3_m16_gfx1250,
+        )
+
+        return triton_mm_a16w16_add3_m16_gfx1250(
+            hidden_states,
+            weight,
+            prefix,
+            shared_output,
+            block_n=32,
+            block_k=64,
+            num_warps=2,
+            waves_per_eu=1,
         )
 
     projected = kimi3_latent_projection(hidden_states, weight)
@@ -708,7 +942,9 @@ def kimi3_shared_situ_projection(
 
         gate_up = decode_gemv(hidden_states, gate_up_weight)
     else:
-        gate_up = torch.nn.functional.linear(hidden_states, gate_up_weight)
+        gate_up = _try_gluon_largem_gfx1250(hidden_states, gate_up_weight)
+        if gate_up is None:
+            gate_up = torch.nn.functional.linear(hidden_states, gate_up_weight)
     if gate_up.is_cuda:
         from tokenspeed_kernel.ops.activation import situ_and_mul
 
@@ -755,7 +991,7 @@ def kimi3_shared_down_projection(
     expected_output = (m, output_width)
     if out is None:
         out = hidden_states.new_empty(expected_output)
-    if solution not in {"auto", "triton_gemv", "torch"}:
+    if solution not in {"auto", "triton_gemv", "gluon_largem_gfx1250", "torch"}:
         raise ValueError(f"unknown Kimi K3 shared down solution {solution!r}")
     specialized = (
         hidden_states.is_cuda
@@ -769,7 +1005,25 @@ def kimi3_shared_down_projection(
     )
     routed = solution == "auto"
     if solution == "auto":
-        solution = "triton_gemv" if Platform.get().is_cdna4 and specialized else "torch"
+        if Platform.get().is_cdna4 and specialized:
+            solution = "triton_gemv"
+        elif (
+            Platform.get().is_cdna5
+            and hidden_states.is_cuda
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and out.is_contiguous()
+            and _use_gluon_largem_gfx1250(
+                m,
+                input_width,
+                output_width,
+            )
+        ):
+            solution = "gluon_largem_gfx1250"
+        else:
+            solution = "torch"
     if routed and decode_gemv_routed(hidden_states, weight):
         from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
 
@@ -786,6 +1040,29 @@ def kimi3_shared_down_projection(
             out=out,
             config=(8, 512, 8, 1),
             validate=False,
+        )
+    if solution == "gluon_largem_gfx1250":
+        if not (
+            Platform.get().is_cdna5
+            and hidden_states.is_cuda
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and _use_gluon_largem_gfx1250(m, input_width, output_width)
+        ):
+            raise ValueError(
+                "Kimi K3 gfx1250 shared down projection requires a contiguous "
+                "BF16 K3 shape with M >= 512"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            gluon_mm_a16w16_largem_gfx1250,
+        )
+
+        return gluon_mm_a16w16_largem_gfx1250(
+            hidden_states,
+            weight,
+            out=out,
         )
     return torch.mm(hidden_states, weight.T, out=out)
 
@@ -822,8 +1099,9 @@ def kimi3_qkvfab_projection(
         prepacked_scales: Optional flashinfer MN-major prepacked scales; when
             given the flashinfer blockscale kernel is pinned.
         out: Optional contiguous BF16 output buffer shaped ``[M, N]``.
-        solution: ``"auto"`` selects the gfx950 Triton GEMV and otherwise
-            falls back to Torch; ``"triton_gemv"`` and ``"torch"`` force one.
+        solution: ``"auto"`` selects the architecture-specific BF16 route;
+            ``"triton_gemv"``, ``"gluon_wmma_gfx1250"``,
+            ``"gluon_largem_gfx1250"``, and ``"torch"`` force one.
             (BF16 path only.)
 
     Returns:
@@ -866,7 +1144,14 @@ def kimi3_qkvfab_projection(
         raise ValueError(
             "weight_scale / prepacked_scales are only valid with FP8 weights"
         )
-    if solution not in {"auto", "decode_gemv", "triton_gemv", "torch"}:
+    if solution not in {
+        "auto",
+        "decode_gemv",
+        "triton_gemv",
+        "gluon_wmma_gfx1250",
+        "gluon_largem_gfx1250",
+        "torch",
+    }:
         raise ValueError(f"unknown Kimi K3 QKVFAB solution {solution!r}")
     specialized = (
         hidden_states.is_cuda
@@ -879,13 +1164,61 @@ def kimi3_qkvfab_projection(
         and output_width == KIMI3_QKVFAB_SIZE
     )
     if solution == "auto":
-        if Platform.get().is_cdna4 and specialized and m == 1:
+        if (
+            Platform.get().is_cdna5
+            and m in {2, 4, 8, 16, 32}
+            and input_width == KIMI3_HIDDEN_SIZE
+            and output_width == KIMI3_QKVFAB_SIZE
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and (out is None or out.is_contiguous())
+        ):
+            solution = "gluon_wmma_gfx1250"
+        elif (
+            Platform.get().is_cdna5
+            and _use_gluon_largem_gfx1250(m, input_width, output_width)
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and (out is None or out.is_contiguous())
+        ):
+            solution = "gluon_largem_gfx1250"
+        elif Platform.get().is_cdna4 and specialized and m == 1:
             solution = "triton_gemv"
         elif specialized:
             # Let the registry pick per (M, N, K); unlisted shapes hit torch.mm.
             solution = "decode_gemv"
         else:
             solution = "torch"
+    if solution == "gluon_wmma_gfx1250":
+        if not (
+            Platform.get().is_cdna5
+            and m in {2, 4, 8, 16, 32}
+            and input_width == KIMI3_HIDDEN_SIZE
+            and output_width == KIMI3_QKVFAB_SIZE
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and (out is None or out.is_contiguous())
+        ):
+            raise ValueError(
+                "Kimi K3 gfx1250 QKVFAB WMMA projection requires contiguous "
+                "BF16 A [M,7168] for M in {2,4,8,16,32} and weight "
+                "[6288,7168]"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            gluon_wmma_tdm_kda_qkvfab_gfx1250,
+        )
+
+        return gluon_wmma_tdm_kda_qkvfab_gfx1250(
+            hidden_states,
+            weight,
+            out=out,
+        )
     if solution == "decode_gemv":
         from tokenspeed_kernel.ops.gemm.triton_gemv import decode_gemv
 
@@ -906,6 +1239,29 @@ def kimi3_qkvfab_projection(
             out=out,
             config=(8, 512, 8, 1),
             validate=False,
+        )
+    if solution == "gluon_largem_gfx1250":
+        if not (
+            Platform.get().is_cdna5
+            and _use_gluon_largem_gfx1250(m, input_width, output_width)
+            and hidden_states.dtype == torch.bfloat16
+            and weight.dtype == torch.bfloat16
+            and hidden_states.is_contiguous()
+            and weight.is_contiguous()
+            and (out is None or out.is_contiguous())
+        ):
+            raise ValueError(
+                "Kimi K3 gfx1250 QKVFAB Gluon projection requires contiguous "
+                "BF16 [M,7168] input and [6288,7168] weight with M >= 512"
+            )
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+            gluon_mm_a16w16_largem_gfx1250,
+        )
+
+        return gluon_mm_a16w16_largem_gfx1250(
+            hidden_states,
+            weight,
+            out=out,
         )
     if out is None:
         return torch.nn.functional.linear(hidden_states, weight)

--- a/tokenspeed-kernel/test/ops/test_kimi3_projection_gfx1250.py
+++ b/tokenspeed-kernel/test/ops/test_kimi3_projection_gfx1250.py
@@ -1,0 +1,454 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+from __future__ import annotations
+
+import pytest
+import tokenspeed_kernel
+import torch
+from tokenspeed_kernel.ops.attention import mla_normalize_project_query
+from utils import is_cdna5
+
+if not is_cdna5():
+    pytest.skip(
+        "AMD CDNA5 is required for Kimi K3 gfx1250 projection tests",
+        allow_module_level=True,
+    )
+
+
+def test_kimi3_m16_add3_auto_matches_composed_and_captures() -> None:
+    torch.manual_seed(1250)
+    hidden_states = torch.randn(16, 3584, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(7168, 3584, device="cuda", dtype=torch.bfloat16)
+    prefix = torch.randn(16, 7168, device="cuda", dtype=torch.bfloat16)
+    lane = torch.randn(16, 10752, device="cuda", dtype=torch.bfloat16)
+    shared_output = lane[:, 3584:]
+
+    composed = tokenspeed_kernel.kimi3_latent_projection_add3(
+        hidden_states,
+        weight,
+        prefix,
+        shared_output,
+        solution="composed",
+    )
+    forced = tokenspeed_kernel.kimi3_latent_projection_add3(
+        hidden_states,
+        weight,
+        prefix,
+        shared_output,
+        solution="gluon_wmma_add3",
+    )
+    triton_control = tokenspeed_kernel.kimi3_latent_projection_add3(
+        hidden_states,
+        weight,
+        prefix,
+        shared_output,
+        solution="triton_wmma_add3",
+    )
+    automatic = tokenspeed_kernel.kimi3_latent_projection_add3(
+        hidden_states,
+        weight,
+        prefix,
+        shared_output,
+    )
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(forced, composed, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(triton_control, composed, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(automatic, composed, rtol=2e-2, atol=2e-2)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = tokenspeed_kernel.kimi3_latent_projection_add3(
+            hidden_states,
+            weight,
+            prefix,
+            shared_output,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, composed, rtol=2e-2, atol=2e-2)
+
+    hidden_states.copy_(torch.randn_like(hidden_states))
+    prefix.copy_(torch.randn_like(prefix))
+    shared_output.copy_(torch.randn_like(shared_output))
+    mutated_expected = tokenspeed_kernel.kimi3_latent_projection_add3(
+        hidden_states,
+        weight,
+        prefix,
+        shared_output,
+        solution="composed",
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, mutated_expected, rtol=2e-2, atol=2e-2)
+
+
+def test_kimi3_m16_add3_rejects_non_target_projection() -> None:
+    hidden_states = torch.empty(16, 7168, device="cuda", dtype=torch.bfloat16)
+    weight = torch.empty(3584, 7168, device="cuda", dtype=torch.bfloat16)
+    addend = torch.empty(16, 3584, device="cuda", dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="3584->7168"):
+        tokenspeed_kernel.kimi3_latent_projection_add3(
+            hidden_states,
+            weight,
+            addend,
+            addend,
+            solution="gluon_wmma_add3",
+        )
+
+
+@pytest.mark.parametrize("num_tokens", [2, 4, 8, 16, 32])
+def test_kimi3_mla_qkv_gate_tdm_auto_matches_and_captures(
+    num_tokens: int,
+) -> None:
+    torch.manual_seed(3648 + num_tokens)
+    hidden_states = torch.randn(
+        num_tokens,
+        7168,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    weight = torch.randn(3648, 7168, device="cuda", dtype=torch.bfloat16)
+    expected = torch.nn.functional.linear(hidden_states, weight)
+
+    forced = tokenspeed_kernel.kimi3_mla_qkv_gate_projection(
+        hidden_states,
+        weight,
+        2112,
+        solution="gluon_wmma_gfx1250",
+    )
+    automatic = tokenspeed_kernel.kimi3_mla_qkv_gate_projection(
+        hidden_states,
+        weight,
+        2112,
+    )
+    torch.cuda.synchronize()
+    assert forced.packed is not None
+    assert automatic.packed is not None
+    torch.testing.assert_close(forced.packed, expected, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(automatic.packed, expected, rtol=2e-2, atol=2e-2)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = tokenspeed_kernel.kimi3_mla_qkv_gate_projection(
+            hidden_states,
+            weight,
+            2112,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    assert captured.packed is not None
+    torch.testing.assert_close(captured.packed, expected, rtol=2e-2, atol=2e-2)
+
+    hidden_states.copy_(torch.randn_like(hidden_states))
+    mutated_expected = torch.nn.functional.linear(hidden_states, weight)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        captured.packed,
+        mutated_expected,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [512, 4095, 4096, 4097, 8192, 12289])
+def test_kimi3_gfx1250_large_m_latent_projection_matches_and_captures(
+    num_tokens: int,
+) -> None:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(1250 + num_tokens)
+    hidden_states = torch.randn(
+        num_tokens,
+        3584,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    weight = torch.randn(
+        7168,
+        3584,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    expected = torch.nn.functional.linear(hidden_states, weight)
+    output = torch.empty_like(expected)
+
+    actual = tokenspeed_kernel.kimi3_latent_projection(
+        hidden_states,
+        weight,
+        out=output,
+    )
+    torch.cuda.synchronize()
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = tokenspeed_kernel.kimi3_latent_projection(
+            hidden_states,
+            weight,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [512, 4095, 4097, 8192, 12289])
+def test_kimi3_gfx1250_large_m_shared_down_matches(
+    num_tokens: int,
+) -> None:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(2500 + num_tokens)
+    hidden_states = torch.randn(
+        num_tokens,
+        768,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    weight = torch.randn(
+        7168,
+        768,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    expected = torch.nn.functional.linear(hidden_states, weight)
+    output = torch.empty_like(expected)
+
+    actual = tokenspeed_kernel.kimi3_shared_down_projection(
+        hidden_states,
+        weight,
+        out=output,
+    )
+    torch.cuda.synchronize()
+    assert actual.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [513, 4095, 8192])
+def test_kimi3_gfx1250_large_m_mla_qkv_gate_matches(
+    num_tokens: int,
+) -> None:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(3250 + num_tokens)
+    hidden_states = torch.randn(
+        num_tokens,
+        7168,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    weight = torch.randn(
+        3648,
+        7168,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    expected = torch.nn.functional.linear(hidden_states, weight)
+
+    projection = tokenspeed_kernel.kimi3_mla_qkv_gate_projection(
+        hidden_states,
+        weight,
+        2112,
+    )
+    torch.cuda.synchronize()
+    assert projection.packed is None
+    torch.testing.assert_close(
+        projection.qkv,
+        expected[:, :2112],
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    torch.testing.assert_close(
+        projection.gate,
+        expected[:, 2112:],
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+def test_kimi3_gfx1250_large_m_mla_query_matches() -> None:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(3400)
+    query = torch.randn(
+        513,
+        1536,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    kv = torch.randn(
+        513,
+        512,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    query_norm_weight = torch.randn(
+        1536,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    kv_norm_weight = torch.randn(
+        512,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    projection_weight = torch.randn(
+        2304,
+        1536,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    eps = 1e-6
+    query_fp32 = query.float()
+    expected_query_norm = (
+        query_fp32
+        * torch.rsqrt(query_fp32.square().mean(dim=-1, keepdim=True) + eps)
+        * query_norm_weight.float()
+    ).to(query.dtype)
+    kv_fp32 = kv.float()
+    expected_kv = (
+        kv_fp32
+        * torch.rsqrt(kv_fp32.square().mean(dim=-1, keepdim=True) + eps)
+        * kv_norm_weight.float()
+    ).to(kv.dtype)
+    expected_query = torch.nn.functional.linear(
+        expected_query_norm,
+        projection_weight,
+    )
+
+    actual_query, absorbed_query = mla_normalize_project_query(
+        query,
+        kv,
+        query_norm_weight,
+        kv_norm_weight,
+        projection_weight,
+        eps=eps,
+    )
+    torch.cuda.synchronize()
+    assert absorbed_query is None
+    torch.testing.assert_close(
+        actual_query,
+        expected_query,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+    torch.testing.assert_close(kv, expected_kv, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [2, 4, 8, 16, 32])
+def test_kimi3_kda_qkvfab_tdm_auto_matches_and_captures(
+    num_tokens: int,
+) -> None:
+    torch.manual_seed(6288 + num_tokens)
+    hidden_states = torch.randn(
+        num_tokens,
+        7168,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    weight = torch.randn(6288, 7168, device="cuda", dtype=torch.bfloat16)
+    expected = torch.nn.functional.linear(hidden_states, weight)
+    output = torch.empty_like(expected)
+
+    forced = tokenspeed_kernel.kimi3_qkvfab_projection(
+        hidden_states,
+        weight,
+        solution="gluon_wmma_gfx1250",
+    )
+    automatic = tokenspeed_kernel.kimi3_qkvfab_projection(
+        hidden_states,
+        weight,
+        out=output,
+    )
+    torch.cuda.synchronize()
+    assert automatic.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(forced, expected, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(automatic, expected, rtol=2e-2, atol=2e-2)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = tokenspeed_kernel.kimi3_qkvfab_projection(
+            hidden_states,
+            weight,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(captured, expected, rtol=2e-2, atol=2e-2)
+
+    hidden_states.copy_(torch.randn_like(hidden_states))
+    mutated_expected = torch.nn.functional.linear(hidden_states, weight)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        captured,
+        mutated_expected,
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [513, 4095, 8192])
+def test_kimi3_gfx1250_large_m_qkvfab_matches(
+    num_tokens: int,
+) -> None:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(3500 + num_tokens)
+    hidden_states = torch.randn(
+        num_tokens,
+        7168,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    weight = torch.randn(
+        6288,
+        7168,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    expected = torch.nn.functional.linear(hidden_states, weight)
+
+    actual = tokenspeed_kernel.kimi3_qkvfab_projection(
+        hidden_states,
+        weight,
+    )
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_kimi3_gfx1250_large_m_linear_o_proj_shape_matches() -> None:
+    from tokenspeed_kernel.ops.gemm.kimi3 import _try_gluon_largem_gfx1250
+
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(3600)
+    hidden_states = torch.randn(
+        512,
+        1536,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    weight = torch.randn(
+        7168,
+        1536,
+        device="cuda",
+        dtype=torch.bfloat16,
+        generator=generator,
+    )
+    expected = torch.nn.functional.linear(hidden_states, weight)
+
+    actual = _try_gluon_largem_gfx1250(hidden_states, weight)
+    torch.cuda.synchronize()
+    assert actual is not None
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)

--- a/tokenspeed-kernel/test/test_kimi_prefill_ops.py
+++ b/tokenspeed-kernel/test/test_kimi_prefill_ops.py
@@ -70,7 +70,7 @@ def test_kimi3_router_projection_auto_splits_on_token_count() -> None:
     weight = torch.randn(
         kimi3_module.KIMI3_ROUTER_SIZE, kimi3_module.KIMI3_HIDDEN_SIZE
     ).to(torch.bfloat16)
-    platform = SimpleNamespace(is_cdna4=False, is_hopper_plus=True)
+    platform = SimpleNamespace(is_cdna4=False, is_cdna5=False, is_hopper_plus=True)
 
     def solution_for(m: int) -> str:
         x = hidden_states.expand(m, -1).contiguous()
@@ -134,7 +134,7 @@ def test_kimi3_mla_projection_owns_schedule_selection() -> None:
     with mock.patch.object(
         kimi3_module.Platform,
         "get",
-        return_value=SimpleNamespace(is_cdna4=True),
+        return_value=SimpleNamespace(is_cdna4=True, is_cdna5=False),
     ):
         decode = kimi3_mla_qkv_gate_projection(torch.ones(1, 5), weight, 6)
         prefill = kimi3_mla_qkv_gate_projection(torch.ones(33, 5), weight, 6)
@@ -152,7 +152,7 @@ def test_kimi3_mla_projection_preserves_non_cdna_prefill_schedule() -> None:
     with mock.patch.object(
         kimi3_module.Platform,
         "get",
-        return_value=SimpleNamespace(is_cdna4=False),
+        return_value=SimpleNamespace(is_cdna4=False, is_cdna5=False),
     ):
         projection = kimi3_mla_qkv_gate_projection(hidden_states, weight, 6)
 


### PR DESCRIPTION
## Summary
- Port gfx950 large-M dense16 WMMA from #598 to gfx1250 named Kimi APIs and the unquantized Linear path.
- Add CDNA5 TDM for KDA QKVFAB, MLA QKV/gate, and add3.
- Keep large-M off generic `mm()`, matching gfx950: only the Kimi projection helpers and Linear apply select it.

## Performance
Kernel latency vs. main on gfx1250.

KDA QKVFAB TDM (`K=7168, N=6288`):
| M | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 59.25 | 23.51 | 2.52x |
| 2 | 59.87 | 22.81 | 2.62x |
| 4 | 60.99 | 22.89 | 2.66x |
| 8 | 61.97 | 22.81 | 2.72x |
| 16 | 63.70 | 24.92 | 2.56x |
| 32 | 66.64 | 39.20 | 1.70x |

MLA QKV/gate TDM:
| M | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 16 | 57.37 | 23.90 | 2.40x |
| 32 | 62.87 | 40.82 | 1.54x |

Add3 M=16 (`K=3584, N=7168`): Main 40.78 µs, PR 24.04 µs, 1.70x vs. main.

Large-M Gluon vs. main (BM128):
| Shape | M | Main (µs) | PR (µs) | Speedup vs. main |
|---|--:|----------:|--------:|-----------------:|
| shared-down 7168→1536 | 512 | 85.73 | 70.47 | 1.22x |
| shared-down | 4096 | 522.94 | 113.77 | 4.60x |
| shared-down | 8192 | 1022.17 | 167.77 | 6.09x |
| routed-down 3584→7168 | 512 | 178.63 | 96.79 | 1.85x |
| routed-down | 4096 | 1178.41 | 184.32 | 6.39x |
| routed-down | 8192 | 2329.33 | 283.67 | 8.21x |
| routed-up 7168→3584 | 512 | 170.34 | 79.04 | 2.16x |
| routed-up | 4096 | 1174.36 | 176.83 | 6.64x |
| routed-up | 8192 | 2323.40 | 288.31 | 8.06x |
