### PR TITLE
perf(kimi3): port linear AttnRes partials to gfx1250

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
@@ -1,5 +1,6 @@
 """Dense 16-bit gfx1250 GEMM kernels."""
 
+from .linear_attnres_partials_gfx1250 import gluon_linear_attnres_partials_gfx1250
 from .mm import (
     gluon_mm_a16w16_largem_gfx1250,
     triton_mm_a16w16_add3_m16_gfx1250,
@@ -7,6 +8,7 @@ from .mm import (
 )
 
 __all__ = [
+    "gluon_linear_attnres_partials_gfx1250",
     "gluon_mm_a16w16_largem_gfx1250",
     "triton_mm_a16w16_add3_m16_gfx1250",
     "use_gluon_largem_gfx1250",

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/linear_attnres_partials_gfx1250.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/linear_attnres_partials_gfx1250.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Linear projection and dual-AttnRes partials for gfx1250 (M=1)."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon
+
+_INPUT_SIZE = gl.constexpr(7168)
+_BLOCK_N_SIZE = 16
+_BLOCK_N = gl.constexpr(_BLOCK_N_SIZE)
+_BLOCK_K = gl.constexpr(512)
+_NUM_WARPS = gl.constexpr(8)
+_LANES = gl.constexpr(32)
+_PARTIAL_BLOCK = gl.constexpr(8192)
+_KIMI3_MLA_OUTPUT_SIZE = 3648
+_KIMI3_KDA_OUTPUT_SIZE = 6288
+
+
+@gluon.jit
+def _linear_attnres_partials_kernel(
+    hidden_ptr,
+    weight_ptr,
+    output_ptr,
+    blocks_ptr,
+    score_weight_a_ptr,
+    score_weight_b_ptr,
+    max_a_ptr,
+    sum_a_ptr,
+    accumulator_a_ptr,
+    max_b_ptr,
+    sum_b_ptr,
+    accumulator_b_ptr,
+    num_blocks,
+    block_stride,
+    eps,
+    attnres_program_offset: gl.constexpr,
+    output_size: gl.constexpr,
+):
+    """Run shared-weight projection CTAs and one dual-AttnRes CTA per token."""
+    pid = gl.program_id(0)
+    is_attnres = (pid >= attnres_program_offset) & (pid < attnres_program_offset + 1)
+    projection_pid = pid if pid < attnres_program_offset else pid - 1
+    if not is_attnres:
+        layout: gl.constexpr = gl.BlockedLayout(
+            [1, _BLOCK_K // _LANES],
+            [1, _LANES],
+            [gl.num_warps(), 1],
+            [1, 0],
+        )
+        output_layout: gl.constexpr = gl.SliceLayout(1, layout)
+        input_layout: gl.constexpr = gl.SliceLayout(0, layout)
+        output_offsets = projection_pid * _BLOCK_N + gl.arange(
+            0, _BLOCK_N, layout=output_layout
+        )
+        accumulator = gl.zeros([_BLOCK_N], gl.float32, output_layout)
+        for input_start in range(0, _INPUT_SIZE, _BLOCK_K):
+            input_offsets = input_start + gl.arange(0, _BLOCK_K, layout=input_layout)
+            hidden = gl.amd.cdna5.buffer_load(
+                hidden_ptr,
+                input_offsets.to(gl.int32),
+            ).to(gl.float32)
+            weight = gl.amd.cdna5.buffer_load(
+                weight_ptr,
+                (
+                    output_offsets[:, None].to(gl.int64) * _INPUT_SIZE
+                    + input_offsets[None, :].to(gl.int64)
+                ).to(gl.int32),
+            ).to(gl.float32)
+            hidden = gl.convert_layout(hidden[None, :], layout)
+            accumulator += gl.sum(weight * hidden, axis=1)
+        gl.store(output_ptr + output_offsets, accumulator)
+        return
+
+    partial_layout: gl.constexpr = gl.BlockedLayout(
+        [_PARTIAL_BLOCK // (_LANES * gl.num_warps())],
+        [_LANES],
+        [gl.num_warps()],
+        [0],
+    )
+    offsets = gl.arange(0, _PARTIAL_BLOCK, layout=partial_layout)
+    mask = offsets < _INPUT_SIZE
+    score_weight_a = gl.amd.cdna5.buffer_load(
+        score_weight_a_ptr,
+        offsets.to(gl.int32),
+        mask=mask,
+        other=0.0,
+    ).to(gl.float32)
+    score_weight_b = gl.amd.cdna5.buffer_load(
+        score_weight_b_ptr,
+        offsets.to(gl.int32),
+        mask=mask,
+        other=0.0,
+    ).to(gl.float32)
+    accumulator_a = gl.zeros([_PARTIAL_BLOCK], gl.float32, partial_layout)
+    accumulator_b = gl.zeros([_PARTIAL_BLOCK], gl.float32, partial_layout)
+    max_a = gl.full((), -float("inf"), gl.float32)
+    sum_a = gl.full((), 0.0, gl.float32)
+    max_b = gl.full((), -float("inf"), gl.float32)
+    sum_b = gl.full((), 0.0, gl.float32)
+    block = 0
+    while block < num_blocks:
+        block_offset = block.to(gl.int64) * block_stride
+        value = gl.amd.cdna5.buffer_load(
+            blocks_ptr,
+            (block_offset + offsets).to(gl.int32),
+            mask=mask,
+            other=0.0,
+        ).to(gl.float32)
+        inverse_rms = gl.rsqrt(gl.sum(value * value, axis=0) / _INPUT_SIZE + eps)
+
+        logit_a = gl.sum(value * score_weight_a, axis=0) * inverse_rms
+        next_max_a = gl.maximum(max_a, logit_a)
+        correction_a = gl.exp(max_a - next_max_a)
+        weight_a = gl.exp(logit_a - next_max_a)
+        accumulator_a = accumulator_a * correction_a + value * weight_a
+        sum_a = sum_a * correction_a + weight_a
+        max_a = next_max_a
+
+        logit_b = gl.sum(value * score_weight_b, axis=0) * inverse_rms
+        next_max_b = gl.maximum(max_b, logit_b)
+        correction_b = gl.exp(max_b - next_max_b)
+        weight_b = gl.exp(logit_b - next_max_b)
+        accumulator_b = accumulator_b * correction_b + value * weight_b
+        sum_b = sum_b * correction_b + weight_b
+        max_b = next_max_b
+        block += 1
+
+    gl.amd.cdna5.buffer_store(
+        accumulator_a,
+        accumulator_a_ptr,
+        offsets.to(gl.int32),
+        mask=mask,
+    )
+    gl.amd.cdna5.buffer_store(
+        accumulator_b,
+        accumulator_b_ptr,
+        offsets.to(gl.int32),
+        mask=mask,
+    )
+    gl.store(max_a_ptr, max_a)
+    gl.store(sum_a_ptr, sum_a)
+    gl.store(max_b_ptr, max_b)
+    gl.store(sum_b_ptr, sum_b)
+
+
+def gluon_linear_attnres_partials_gfx1250(
+    hidden_states: torch.Tensor,
+    weight: torch.Tensor,
+    blocks: torch.Tensor,
+    score_weight_a: torch.Tensor,
+    score_weight_b: torch.Tensor,
+    scratch_a: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    scratch_b: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    *,
+    eps: float,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Run a decode projection and two AttnRes block reductions."""
+    num_tokens = hidden_states.shape[0]
+    if num_tokens != 1:
+        raise ValueError("tokens must be 1")
+    output_size = weight.shape[0]
+    if output_size not in (_KIMI3_MLA_OUTPUT_SIZE, _KIMI3_KDA_OUTPUT_SIZE):
+        raise ValueError(
+            f"output size must be one of {_KIMI3_MLA_OUTPUT_SIZE, _KIMI3_KDA_OUTPUT_SIZE}"
+        )
+    if output_size % _BLOCK_N_SIZE != 0:
+        raise ValueError(f"output size must be divisible by {_BLOCK_N_SIZE}")
+    expected = (
+        (hidden_states, (num_tokens, 7168), "hidden states"),
+        (weight, (output_size, 7168), "weight"),
+        (score_weight_a, (7168,), "first score weight"),
+        (score_weight_b, (7168,), "second score weight"),
+        (out, (num_tokens, output_size), "output"),
+    )
+    for tensor, shape, name in expected:
+        if tuple(tensor.shape) != shape or tensor.dtype != torch.bfloat16:
+            raise ValueError(f"{name} must be contiguous BF16 {shape}")
+        if (
+            not tensor.is_cuda
+            or not tensor.is_contiguous()
+            or tensor.device != hidden_states.device
+        ):
+            raise ValueError(f"{name} must be contiguous and colocated")
+    if (
+        blocks.ndim != 3
+        or not 1 <= blocks.shape[0] <= 11
+        or tuple(blocks.shape[1:]) != (num_tokens, 7168)
+        or blocks.dtype != torch.bfloat16
+        or not blocks.is_cuda
+        or not blocks.is_contiguous()
+        or blocks.device != hidden_states.device
+    ):
+        raise ValueError("residual blocks must be contiguous BF16 [KB,tokens,7168]")
+    expected_scratch = (
+        (num_tokens,),
+        (num_tokens,),
+        (num_tokens, 7168),
+    )
+    for scratch in (scratch_a, scratch_b):
+        if len(scratch) != 3:
+            raise ValueError("scratch must be an (max, sum, accumulator) tuple")
+        for tensor, shape in zip(scratch, expected_scratch, strict=True):
+            if (
+                tuple(tensor.shape) != shape
+                or tensor.dtype != torch.float32
+                or not tensor.is_cuda
+                or not tensor.is_contiguous()
+                or tensor.device != hidden_states.device
+            ):
+                raise ValueError(
+                    f"scratch must contain contiguous FP32 {expected_scratch}"
+                )
+    if eps <= 0.0:
+        raise ValueError("AttnRes epsilon must be positive")
+
+    projection_programs = output_size // _BLOCK_N_SIZE
+    _linear_attnres_partials_kernel[(projection_programs + num_tokens,)](
+        hidden_states,
+        weight,
+        out,
+        blocks,
+        score_weight_a,
+        score_weight_b,
+        *scratch_a,
+        *scratch_b,
+        blocks.shape[0],
+        blocks.stride(0),
+        float(eps),
+        projection_programs,
+        output_size,
+        num_warps=_NUM_WARPS,
+        num_stages=1,
+        waves_per_eu=1,
+    )
+    return out
+
+
+__all__ = ["gluon_linear_attnres_partials_gfx1250"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/gluon.py
@@ -112,44 +112,56 @@ if current_platform().is_amd:
         return output
 
     if current_platform().is_cdna5:
-        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.linear_attnres_partials_gfx1250 import (
-            gluon_linear_attnres_partials_gfx1250 as _linear_attnres_partials_gfx1250_impl,
-        )
+        try:
+            from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.linear_attnres_partials_gfx1250 import (
+                gluon_linear_attnres_partials_gfx1250 as _linear_attnres_partials_gfx1250_impl,
+            )
+        except ImportError:
+            _linear_attnres_partials_gfx1250_impl = None
+        if _linear_attnres_partials_gfx1250_impl is None:
 
-        @register_kernel(
-            "gemm",
-            "linear_attnres_partials",
-            name="gluon_linear_attnres_partials_gfx1250",
-            solution="gluon",
-            capability=CapabilityRequirement(
-                min_arch_version=ArchVersion(12, 5),
-                max_arch_version=ArchVersion(12, 5),
-                vendors=frozenset({"amd"}),
-            ),
-            signatures=frozenset(
-                {
-                    format_signature(
-                        hidden_states=dense_tensor_format(torch.bfloat16),
-                        weight=dense_tensor_format(torch.bfloat16),
-                        blocks=dense_tensor_format(torch.bfloat16),
-                        score_weight_a=dense_tensor_format(torch.bfloat16),
-                        score_weight_b=dense_tensor_format(torch.bfloat16),
-                        out=dense_tensor_format(torch.bfloat16),
-                    )
-                }
-            ),
-            priority=Priority.SPECIALIZED,
-            traits={
-                "tokens": frozenset({1}),
-                "input_size": frozenset({KIMI3_HIDDEN_SIZE}),
-                "output_size": frozenset({3648, KIMI3_QKVFAB_SIZE}),
-                "num_blocks": frozenset(range(1, 12)),
-                "inputs_contiguous": frozenset({True}),
-                "gfx1250_linear_attnres_enabled": frozenset({True}),
-            },
-        )
-        def gluon_linear_attnres_partials_gfx1250(**kwargs):
-            return _linear_attnres_partials_gfx1250_impl(**kwargs)
+            def gluon_linear_attnres_partials_gfx1250(**kwargs):
+                raise RuntimeError(
+                    "gluon_linear_attnres_partials_gfx1250 requires "
+                    "tokenspeed-kernel-amd with the gfx1250 AttnRes kernel"
+                )
+
+        else:
+
+            @register_kernel(
+                "gemm",
+                "linear_attnres_partials",
+                name="gluon_linear_attnres_partials_gfx1250",
+                solution="gluon",
+                capability=CapabilityRequirement(
+                    min_arch_version=ArchVersion(12, 5),
+                    max_arch_version=ArchVersion(12, 5),
+                    vendors=frozenset({"amd"}),
+                ),
+                signatures=frozenset(
+                    {
+                        format_signature(
+                            hidden_states=dense_tensor_format(torch.bfloat16),
+                            weight=dense_tensor_format(torch.bfloat16),
+                            blocks=dense_tensor_format(torch.bfloat16),
+                            score_weight_a=dense_tensor_format(torch.bfloat16),
+                            score_weight_b=dense_tensor_format(torch.bfloat16),
+                            out=dense_tensor_format(torch.bfloat16),
+                        )
+                    }
+                ),
+                priority=Priority.SPECIALIZED,
+                traits={
+                    "tokens": frozenset({1}),
+                    "input_size": frozenset({KIMI3_HIDDEN_SIZE}),
+                    "output_size": frozenset({3648, KIMI3_QKVFAB_SIZE}),
+                    "num_blocks": frozenset(range(1, 12)),
+                    "inputs_contiguous": frozenset({True}),
+                    "gfx1250_linear_attnres_enabled": frozenset({True}),
+                },
+            )
+            def gluon_linear_attnres_partials_gfx1250(**kwargs):
+                return _linear_attnres_partials_gfx1250_impl(**kwargs)
 
     else:
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/gluon.py
@@ -111,6 +111,53 @@ if current_platform().is_amd:
             output.mul_(alpha.to(device=output.device, dtype=output.dtype))
         return output
 
+    if current_platform().is_cdna5:
+        from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.linear_attnres_partials_gfx1250 import (
+            gluon_linear_attnres_partials_gfx1250 as _linear_attnres_partials_gfx1250_impl,
+        )
+
+        @register_kernel(
+            "gemm",
+            "linear_attnres_partials",
+            name="gluon_linear_attnres_partials_gfx1250",
+            solution="gluon",
+            capability=CapabilityRequirement(
+                min_arch_version=ArchVersion(12, 5),
+                max_arch_version=ArchVersion(12, 5),
+                vendors=frozenset({"amd"}),
+            ),
+            signatures=frozenset(
+                {
+                    format_signature(
+                        hidden_states=dense_tensor_format(torch.bfloat16),
+                        weight=dense_tensor_format(torch.bfloat16),
+                        blocks=dense_tensor_format(torch.bfloat16),
+                        score_weight_a=dense_tensor_format(torch.bfloat16),
+                        score_weight_b=dense_tensor_format(torch.bfloat16),
+                        out=dense_tensor_format(torch.bfloat16),
+                    )
+                }
+            ),
+            priority=Priority.SPECIALIZED,
+            traits={
+                "tokens": frozenset({1}),
+                "input_size": frozenset({KIMI3_HIDDEN_SIZE}),
+                "output_size": frozenset({3648, KIMI3_QKVFAB_SIZE}),
+                "num_blocks": frozenset(range(1, 12)),
+                "inputs_contiguous": frozenset({True}),
+                "gfx1250_linear_attnres_enabled": frozenset({True}),
+            },
+        )
+        def gluon_linear_attnres_partials_gfx1250(**kwargs):
+            return _linear_attnres_partials_gfx1250_impl(**kwargs)
+
+    else:
+
+        def gluon_linear_attnres_partials_gfx1250(**kwargs):
+            raise RuntimeError(
+                "gluon_linear_attnres_partials_gfx1250 requires CDNA5"
+            )
+
     if _linear_attnres_partials_impl is not None:
 
         @register_kernel(
@@ -161,5 +208,13 @@ else:
             "gluon_linear_attnres_partials_gfx950 requires tokenspeed-kernel-amd"
         )
 
+    def gluon_linear_attnres_partials_gfx1250(**kwargs):
+        raise ImportError(
+            "gluon_linear_attnres_partials_gfx1250 requires tokenspeed-kernel-amd"
+        )
 
-__all__ = ["gluon_linear_attnres_partials_gfx950"]
+
+__all__ = [
+    "gluon_linear_attnres_partials_gfx950",
+    "gluon_linear_attnres_partials_gfx1250",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/gluon.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/gluon.py
@@ -154,9 +154,7 @@ if current_platform().is_amd:
     else:
 
         def gluon_linear_attnres_partials_gfx1250(**kwargs):
-            raise RuntimeError(
-                "gluon_linear_attnres_partials_gfx1250 requires CDNA5"
-            )
+            raise RuntimeError("gluon_linear_attnres_partials_gfx1250 requires CDNA5")
 
     if _linear_attnres_partials_impl is not None:
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/linear_attnres_partials.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/linear_attnres_partials.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import torch
 from tokenspeed_kernel.ops.gemm.kimi3 import KIMI3_HIDDEN_SIZE
+from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
@@ -129,6 +130,12 @@ def _select_registered_kernel(
         )
         and (out is None or out.is_contiguous()),
     }
+    try:
+        platform = current_platform()
+    except RuntimeError:
+        platform = None
+    if platform is not None and platform.is_cdna5:
+        traits["gfx1250_linear_attnres_enabled"] = True
     if not hidden_states.is_cuda:
         return None, traits
     try:

--- a/tokenspeed-kernel/test/ops/test_gemm.py
+++ b/tokenspeed-kernel/test/ops/test_gemm.py
@@ -456,6 +456,162 @@ def test_linear_attnres_partials_gfx950_matches_composition(
         )
 
 
+def _kimi3_linear_attnres_inputs(
+    tokens: int,
+    output_size: int,
+    *,
+    seed: int = 29,
+) -> tuple:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    hidden = (torch.randn(tokens, 7168, device="cuda", generator=generator) * 0.1).to(
+        torch.bfloat16
+    )
+    weight = (
+        torch.randn(output_size, 7168, device="cuda", generator=generator) * 0.01
+    ).to(torch.bfloat16)
+    blocks = (
+        torch.randn(4, tokens, 7168, device="cuda", generator=generator) * 0.1
+    ).to(torch.bfloat16)
+    scores = tuple(
+        (torch.randn(7168, device="cuda", generator=generator) * 0.02).to(
+            torch.bfloat16
+        )
+        for _ in range(2)
+    )
+    scratch = tuple(
+        (
+            torch.empty(tokens, device="cuda", dtype=torch.float32),
+            torch.empty(tokens, device="cuda", dtype=torch.float32),
+            torch.empty(tokens, 7168, device="cuda", dtype=torch.float32),
+        )
+        for _ in range(2)
+    )
+    return hidden, weight, blocks, scores, scratch
+
+
+def _assert_linear_attnres_matches_composition(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    blocks: torch.Tensor,
+    scores: tuple[torch.Tensor, torch.Tensor],
+    scratch: tuple,
+    actual: torch.Tensor,
+    *,
+    eps: float = 1e-6,
+) -> None:
+    torch.testing.assert_close(
+        actual,
+        torch.nn.functional.linear(hidden, weight),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    values = blocks.float()
+    inverse_rms = torch.rsqrt(values.square().mean(dim=-1) + eps)
+    for score, outputs in zip(scores, scratch, strict=True):
+        logits = torch.einsum("bth,h->bt", values, score.float()) * inverse_rms
+        maxima = logits.max(dim=0).values
+        unnormalized = torch.exp(logits - maxima)
+        torch.testing.assert_close(outputs[0], maxima, atol=2e-4, rtol=2e-4)
+        torch.testing.assert_close(
+            outputs[1], unnormalized.sum(dim=0), atol=2e-4, rtol=2e-4
+        )
+        torch.testing.assert_close(
+            outputs[2],
+            torch.einsum("bt,bth->th", unnormalized, values),
+            atol=2e-4,
+            rtol=2e-4,
+        )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or "gfx1250" not in getattr(torch.cuda.get_device_properties(0), "gcnArchName", ""),
+    reason="gfx1250 is required",
+)
+@pytest.mark.parametrize("output_size", [3648, 6288])
+def test_linear_attnres_partials_gfx1250_matches_composition(output_size: int) -> None:
+    hidden, weight, blocks, scores, scratch = _kimi3_linear_attnres_inputs(1, output_size)
+    assert linear_attnres_partials_available(
+        hidden,
+        weight,
+        blocks,
+        *scores,
+        *scratch,
+        eps=1e-6,
+    )
+    actual = linear_attnres_partials(
+        hidden,
+        weight,
+        blocks,
+        *scores,
+        *scratch,
+        eps=1e-6,
+        override="gluon_linear_attnres_partials_gfx1250",
+    )
+    _assert_linear_attnres_matches_composition(
+        hidden, weight, blocks, scores, scratch, actual
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or "gfx1250" not in getattr(torch.cuda.get_device_properties(0), "gcnArchName", ""),
+    reason="gfx1250 is required",
+)
+@pytest.mark.parametrize("output_size", [3648, 6288])
+def test_linear_attnres_partials_gfx1250_cuda_graph_replay(output_size: int) -> None:
+    hidden, weight, blocks, scores, scratch = _kimi3_linear_attnres_inputs(
+        1, output_size, seed=31
+    )
+    out = torch.empty(1, output_size, device="cuda", dtype=torch.bfloat16)
+
+    def run() -> torch.Tensor:
+        for outputs in scratch:
+            outputs[0].zero_()
+            outputs[1].zero_()
+            outputs[2].zero_()
+        return linear_attnres_partials(
+            hidden,
+            weight,
+            blocks,
+            *scores,
+            *scratch,
+            eps=1e-6,
+            out=out,
+            override="gluon_linear_attnres_partials_gfx1250",
+        )
+
+    run()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = run()
+    hidden.copy_(torch.randn_like(hidden))
+    blocks.copy_(torch.randn_like(blocks))
+    graph.replay()
+    torch.cuda.synchronize()
+    replay_expected = run()
+    torch.testing.assert_close(captured, replay_expected, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or "gfx1250" not in getattr(torch.cuda.get_device_properties(0), "gcnArchName", ""),
+    reason="gfx1250 is required",
+)
+def test_linear_attnres_partials_gfx1250_rejects_unsupported_tokens() -> None:
+    hidden, weight, blocks, scores, scratch = _kimi3_linear_attnres_inputs(2, 6288)
+    with pytest.raises(ValueError, match="tokens must be 1"):
+        linear_attnres_partials(
+            hidden,
+            weight,
+            blocks,
+            *scores,
+            *scratch,
+            eps=1e-6,
+            override="gluon_linear_attnres_partials_gfx1250",
+        )
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA/ROCm is required")
 def test_linear_attnres_partials_cuda_portable_strided_inputs() -> None:
     generator = torch.Generator(device="cuda").manual_seed(37)

--- a/tokenspeed-kernel/test/ops/test_gemm.py
+++ b/tokenspeed-kernel/test/ops/test_gemm.py
@@ -530,7 +530,9 @@ def _assert_linear_attnres_matches_composition(
 )
 @pytest.mark.parametrize("output_size", [3648, 6288])
 def test_linear_attnres_partials_gfx1250_matches_composition(output_size: int) -> None:
-    hidden, weight, blocks, scores, scratch = _kimi3_linear_attnres_inputs(1, output_size)
+    hidden, weight, blocks, scores, scratch = _kimi3_linear_attnres_inputs(
+        1, output_size
+    )
     assert linear_attnres_partials_available(
         hidden,
         weight,

--- a/tokenspeed-kernel/test/ops/test_gemm.py
+++ b/tokenspeed-kernel/test/ops/test_gemm.py
@@ -586,13 +586,14 @@ def test_linear_attnres_partials_gfx1250_cuda_graph_replay(output_size: int) -> 
     run()
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        captured = run()
+        run()
     hidden.copy_(torch.randn_like(hidden))
     blocks.copy_(torch.randn_like(blocks))
     graph.replay()
     torch.cuda.synchronize()
-    replay_expected = run()
-    torch.testing.assert_close(captured, replay_expected, atol=2e-2, rtol=2e-2)
+    replayed = out.clone()
+    expected = run()
+    torch.testing.assert_close(replayed, expected, atol=2e-2, rtol=2e-2)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- Port the gfx950 M1 `linear_attnres_partials` fusion from #959 to gfx1250.
- Stacks on the new `gfx1250/gemm` package from the large-M projection PR.
- Restricted to M=1 and K3 outputs 3648/6288, same as gfx950.

## Performance
Kernel latency vs. main on gfx1250. Main is the two-kernel GEMV + dual-partial path.

| Path | Main (µs) | PR (µs) | Speedup vs. main |
|---|----------:|--------:|-----------------:|
| M=1 projection + partials | 17.95 | 13.55 | 1.32x |
