### PR TITLE
perf(amd): extend gfx1250 projected MLA decode

### DIFF
--- a/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
+++ b/test/ci/ut/ut-tokenspeed-kernel-mi450-sim.yaml
@@ -25,7 +25,7 @@ env:
     tokenspeed-kernel/test/ops/test_attention.py::test_mha_decode_with_kvcache_gluon_peeled_split
     tokenspeed-kernel/test/ops/test_attention_mla.py::test_mla_decode_with_kvcache[gluon-bh16bn64]
     tokenspeed-kernel/test/ops/test_attention_mla.py::test_mla_extend_with_kvcache[bf16]
-    tokenspeed-kernel/test/ops/test_attention_mla.py::test_mla_decode_with_kvcache_projected_value_matches_split_and_captures
+    tokenspeed-kernel/test/ops/test_attention_mla.py::test_mla_decode_with_kvcache_projected_value_matches_split[1]
     tokenspeed-kernel/test/ops/test_attention_mla.py::test_mla_normalize_project_query_split_output[12]
     tokenspeed-kernel/test/ops/test_kda_recurrent.py::test_kda_paged_prefill_preserves_native_state_layout
     tokenspeed-kernel/test/ops/test_kda_recurrent.py::test_kda_paged_decode_defaults_to_specialized_kernel_on_amd[2-8-8-False--5.0]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/decode.py
@@ -689,6 +689,25 @@ def _select_num_kv_splits(
     return triton.next_power_of_2(min(max_kv_splits, target))
 
 
+def _select_projected_value_num_kv_splits(
+    *,
+    batch_size: int,
+    num_sms: int,
+    num_q_programs: int,
+    max_seqlen_k: int,
+    tile_size: int,
+) -> int:
+    pages = max(1, math.ceil(max_seqlen_k / tile_size))
+    work_cap = max(16 if batch_size == 1 else 8, math.ceil(pages / 16))
+    occupancy_cap = max(1, 512 // batch_size)
+    split_cap = triton.next_power_of_2(min(64, occupancy_cap, work_cap))
+    target = max(
+        1,
+        (num_sms * 2) // max(1, num_q_programs),
+    )
+    return triton.next_power_of_2(min(pages, split_cap, target))
+
+
 def gluon_mla_decode_gfx1250(
     q: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -781,19 +800,20 @@ def gluon_mla_decode_gfx1250(
     total_num_q_blocks = batch_size * num_head_blocks
     num_sms = torch.cuda.get_device_properties(q.device).multi_processor_count
     if projected_value:
-        if max_seqlen_k > 32768:
-            split_cap = 32
-        else:
-            split_cap = 16
+        num_kv_splits = _select_projected_value_num_kv_splits(
+            batch_size=batch_size,
+            num_sms=num_sms,
+            num_q_programs=total_num_q_blocks,
+            max_seqlen_k=max_seqlen_k,
+            tile_size=page_size,
+        )
     else:
-        split_cap = 64
-    num_kv_splits = _select_num_kv_splits(
-        num_sms=num_sms,
-        num_q_programs=total_num_q_blocks,
-        max_seqlen_k=max_seqlen_k,
-        tile_size=page_size,
-        split_cap=split_cap,
-    )
+        num_kv_splits = _select_num_kv_splits(
+            num_sms=num_sms,
+            num_q_programs=total_num_q_blocks,
+            max_seqlen_k=max_seqlen_k,
+            tile_size=page_size,
+        )
 
     split_output = torch.empty(
         (batch_size, num_query_heads, num_kv_splits, kv_lora_rank),
@@ -928,10 +948,11 @@ def gluon_mla_decode_projected_value_gfx1250(
     """Decode MLA and fuse split reduction, BF16 projection, and sigmoid gating.
 
     Args:
-        q: FP8 absorbed query shaped ``[1, 1, heads, 576]`` for 12 or 16 heads.
+        q: FP8 absorbed query shaped ``[batch, 1, heads, 576]`` for 12 or
+            16 heads.
         kv_cache: Contiguous matching-FP8 paged cache with page size 64.
-        page_table: Int32 page table for the single sequence.
-        cache_seqlens: Int32 visible cache length for the sequence.
+        page_table: Batched Int32 page table.
+        cache_seqlens: Int32 visible cache length for each sequence.
         max_seqlen_k: Maximum visible KV length used for split selection.
         qk_nope_head_dim: Original non-RoPE head width, which must be 128.
         kv_lora_rank: Latent rank, which must be 512.
@@ -939,8 +960,8 @@ def gluon_mla_decode_projected_value_gfx1250(
         softmax_scale: Scale applied to QK logits.
         value_weight: Contiguous BF16 weights shaped ``[heads, 512, 128]``.
         gate: Optional contiguous BF16 raw sigmoid gate shaped
-            ``[1, heads * 128]``.
-        out: Contiguous BF16 output shaped ``[1, heads * 128]``.
+            ``[batch, heads * 128]``.
+        out: Contiguous BF16 output shaped ``[batch, heads * 128]``.
         logit_cap: Unsupported logit cap; must be zero.
 
     Returns:
@@ -955,9 +976,16 @@ def gluon_mla_decode_projected_value_gfx1250(
             "projected-value MLA requires qk_nope/kv_lora/qk_rope dimensions "
             "(128, 512, 64)"
         )
-    expected_weight = (q.shape[2], kv_lora_rank, out.shape[-1] // q.shape[2])
+    if value_weight.ndim != 3:
+        raise ValueError("value_weight must be rank-3")
+    batch, heads = q.shape[0], q.shape[2]
+    value = value_weight.shape[2]
+    expected_weight = (heads, kv_lora_rank, value)
     if tuple(value_weight.shape) != expected_weight:
         raise ValueError(f"value_weight must have shape {expected_weight}")
+    expected_out = (batch, heads * value)
+    if tuple(out.shape) != expected_out:
+        raise ValueError(f"out must have shape {expected_out}")
     if gate is not None and gate.shape != out.shape:
         raise ValueError("gate and out must have matching shapes")
     if (

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/project_value.py
@@ -26,8 +26,8 @@ import torch
 from tokenspeed_kernel_amd._triton import gl, gluon
 
 _LANES = gl.constexpr(32)
-_BLOCK_N = 8
-_NUM_WARPS = 8
+_BLOCK_N = 32
+_NUM_WARPS = 4
 
 
 @gluon.jit
@@ -36,15 +36,25 @@ def _mla_project_value_kernel(
     weight_ptr,
     gate_ptr,
     output_ptr,
+    HEADS: gl.constexpr,
     LATENT: gl.constexpr,
     VALUE: gl.constexpr,
+    GATE_STRIDE_B: gl.constexpr,
+    GATE_STRIDE_N: gl.constexpr,
     HAS_GATE: gl.constexpr,
+    BATCHED: gl.constexpr,
     BLOCK_N: gl.constexpr,
     NUM_WARPS: gl.constexpr,
 ):
     pid = gl.program_id(0)
     num_pid_n: gl.constexpr = VALUE // BLOCK_N
-    head = pid // num_pid_n
+    batch_head = pid // num_pid_n
+    if BATCHED:
+        batch = batch_head // HEADS
+        head = batch_head % HEADS
+    else:
+        batch = 0
+        head = batch_head
     pid_n = pid % num_pid_n
     layout: gl.constexpr = gl.BlockedLayout(
         [(BLOCK_N + NUM_WARPS - 1) // NUM_WARPS, LATENT // _LANES],
@@ -58,7 +68,7 @@ def _mla_project_value_kernel(
     offs_k = gl.arange(0, LATENT, layout=k_layout)
     attention = gl.amd.cdna5.buffer_load(
         attention_ptr,
-        (head * LATENT + offs_k).to(gl.int32),
+        (batch_head * LATENT + offs_k).to(gl.int32),
     ).to(gl.float32)
     weight = gl.amd.cdna5.buffer_load(
         weight_ptr,
@@ -72,10 +82,14 @@ def _mla_project_value_kernel(
     projected = gl.sum(weight.to(gl.float32) * attention, axis=1)
     projected = projected.to(gl.bfloat16).to(gl.float32)
     if HAS_GATE:
-        gate = gl.load(gate_ptr + head * VALUE + offs_n).to(gl.float32)
+        gate = gl.load(
+            gate_ptr
+            + batch * GATE_STRIDE_B
+            + (head * VALUE + offs_n) * GATE_STRIDE_N
+        ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(
-        output_ptr + head * VALUE + offs_n,
+        output_ptr + batch_head * VALUE + offs_n,
         projected.to(output_ptr.dtype.element_ty),
     )
 
@@ -87,30 +101,28 @@ def gluon_mla_project_value_gfx1250(
     gate: torch.Tensor | None = None,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Project one BF16 latent row per head and optionally apply a sigmoid gate.
+    """Project BF16 latent rows per head and optionally apply a sigmoid gate.
 
     Args:
-        attention: Contiguous BF16 latent values shaped ``[1, heads, latent]``.
+        attention: Contiguous BF16 latent values shaped ``[batch, heads, latent]``.
         weight: Contiguous BF16 projection weights shaped
             ``[heads, latent, value]``.
-        gate: Optional contiguous BF16 sigmoid gate shaped
-            ``[1, heads * value]``.
-        out: Optional contiguous BF16 output shaped ``[1, heads * value]``.
+        gate: Optional BF16 sigmoid gate shaped ``[batch, heads * value]``
+            with a contiguous inner dimension.
+        out: Optional contiguous BF16 output shaped ``[batch, heads * value]``.
 
     Returns:
         The projected values in ``out`` when supplied, otherwise a new tensor.
     """
 
     heads, latent, value = weight.shape
-    expected_attention = (1, heads, latent)
-    expected_output = (1, heads * value)
-    tensors = (
+    batch = attention.shape[0]
+    expected_attention = (batch, heads, latent)
+    expected_output = (batch, heads * value)
+    for tensor, shape, name in (
         (attention, expected_attention, "attention"),
         (weight, (heads, latent, value), "weight"),
-    )
-    if gate is not None:
-        tensors += ((gate, expected_output, "gate"),)
-    for tensor, shape, name in tensors:
+    ):
         if tuple(tensor.shape) != shape:
             raise ValueError(f"MLA value projection requires {name} {shape}")
         if tensor.dtype != torch.bfloat16:
@@ -123,6 +135,20 @@ def gluon_mla_project_value_gfx1250(
             raise ValueError(
                 f"MLA value projection requires contiguous colocated {name}"
             )
+    if gate is not None:
+        if gate.shape != expected_output or gate.dtype != torch.bfloat16:
+            raise ValueError(
+                f"MLA value projection requires BF16 gate {expected_output}"
+            )
+        if (
+            not gate.is_cuda
+            or gate.device != attention.device
+            or gate.stride(1) != 1
+        ):
+            raise ValueError(
+                "MLA value projection requires a colocated gate with "
+                "contiguous inner dimension"
+            )
     if out is None:
         out = attention.new_empty(expected_output)
     elif (
@@ -134,14 +160,18 @@ def gluon_mla_project_value_gfx1250(
         raise ValueError("MLA value projection out must be contiguous BF16")
 
     gate_tensor = attention if gate is None else gate
-    _mla_project_value_kernel[(heads * value // _BLOCK_N,)](
+    _mla_project_value_kernel[(batch * heads * value // _BLOCK_N,)](
         attention,
         weight,
         gate_tensor,
         out,
+        HEADS=heads,
         LATENT=latent,
         VALUE=value,
+        GATE_STRIDE_B=0 if gate is None else gate.stride(0),
+        GATE_STRIDE_N=0 if gate is None else gate.stride(1),
         HAS_GATE=gate is not None,
+        BATCHED=batch > 1,
         BLOCK_N=_BLOCK_N,
         NUM_WARPS=_NUM_WARPS,
         num_warps=_NUM_WARPS,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/project_value.py
@@ -83,9 +83,7 @@ def _mla_project_value_kernel(
     projected = projected.to(gl.bfloat16).to(gl.float32)
     if HAS_GATE:
         gate = gl.load(
-            gate_ptr
-            + batch * GATE_STRIDE_B
-            + (head * VALUE + offs_n) * GATE_STRIDE_N
+            gate_ptr + batch * GATE_STRIDE_B + (head * VALUE + offs_n) * GATE_STRIDE_N
         ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(
@@ -140,11 +138,7 @@ def gluon_mla_project_value_gfx1250(
             raise ValueError(
                 f"MLA value projection requires BF16 gate {expected_output}"
             )
-        if (
-            not gate.is_cuda
-            or gate.device != attention.device
-            or gate.stride(1) != 1
-        ):
+        if not gate.is_cuda or gate.device != attention.device or gate.stride(1) != 1:
             raise ValueError(
                 "MLA value projection requires a colocated gate with "
                 "contiguous inner dimension"

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/reduce_project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/reduce_project_value.py
@@ -76,15 +76,9 @@ def _mla_reduce_project_value_kernel(
     # Match the standalone decode reducer's split reduction layout and order.
     # This preserves its materialized BF16 latent boundary before projection.
     tpw_k: gl.constexpr = gl.constexpr(min(_LANES, LATENT))
-    wpc_k: gl.constexpr = gl.constexpr(
-        min(NUM_WARPS, LATENT // min(_LANES, LATENT))
-    )
+    wpc_k: gl.constexpr = gl.constexpr(min(NUM_WARPS, LATENT // min(_LANES, LATENT)))
     spt_k: gl.constexpr = gl.constexpr(
-        LATENT
-        // (
-            min(_LANES, LATENT)
-            * min(NUM_WARPS, LATENT // min(_LANES, LATENT))
-        )
+        LATENT // (min(_LANES, LATENT) * min(NUM_WARPS, LATENT // min(_LANES, LATENT)))
     )
     reduce_layout: gl.constexpr = gl.BlockedLayout(
         size_per_thread=[NUM_KV_SPLITS, spt_k],
@@ -121,9 +115,7 @@ def _mla_reduce_project_value_kernel(
     split_scale = gl.exp2(split_max - overall_max)
     overall_expsum = gl.sum(split_expsum * split_scale)
     partial = gl.load(
-        split_output_ptr
-        + split_offset[:, None] * LATENT
-        + reduce_offs_k[None, :],
+        split_output_ptr + split_offset[:, None] * LATENT + reduce_offs_k[None, :],
         mask=split_mask[:, None],
         other=0.0,
     ).to(gl.float32)
@@ -150,9 +142,7 @@ def _mla_reduce_project_value_kernel(
     output_offset = batch_head * VALUE + offs_n
     if HAS_GATE:
         gate = gl.load(
-            gate_ptr
-            + batch * GATE_STRIDE_B
-            + (head * VALUE + offs_n) * GATE_STRIDE_N
+            gate_ptr + batch * GATE_STRIDE_B + (head * VALUE + offs_n) * GATE_STRIDE_N
         ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/reduce_project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mla/reduce_project_value.py
@@ -26,8 +26,7 @@ import torch
 from tokenspeed_kernel_amd._triton import gl, gluon
 
 _LANES = gl.constexpr(32)
-_BLOCK_N = 8
-_NUM_WARPS = 8
+_BLOCK_N = 32
 
 
 @gluon.jit
@@ -41,7 +40,11 @@ def _mla_reduce_project_value_kernel(
     output_ptr,
     LATENT: gl.constexpr,
     VALUE: gl.constexpr,
+    HEADS: gl.constexpr,
+    GATE_STRIDE_B: gl.constexpr,
+    GATE_STRIDE_N: gl.constexpr,
     HAS_GATE: gl.constexpr,
+    BATCHED: gl.constexpr,
     BLOCK_N: gl.constexpr,
     NUM_WARPS: gl.constexpr,
     NUM_KV_SPLITS: gl.constexpr,
@@ -51,7 +54,13 @@ def _mla_reduce_project_value_kernel(
 
     pid = gl.program_id(0)
     blocks_per_head: gl.constexpr = VALUE // BLOCK_N
-    head = pid // blocks_per_head
+    batch_head = pid // blocks_per_head
+    if BATCHED:
+        batch = batch_head // HEADS
+        head = batch_head % HEADS
+    else:
+        batch = 0
+        head = batch_head
     pid_n = pid % blocks_per_head
     layout: gl.constexpr = gl.BlockedLayout(
         [(BLOCK_N + NUM_WARPS - 1) // NUM_WARPS, LATENT // _LANES],
@@ -64,40 +73,69 @@ def _mla_reduce_project_value_kernel(
     offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=n_layout)
     offs_k = gl.arange(0, LATENT, layout=k_layout)
 
-    seq_len = gl.load(seq_len_ptr)
+    # Match the standalone decode reducer's split reduction layout and order.
+    # This preserves its materialized BF16 latent boundary before projection.
+    tpw_k: gl.constexpr = gl.constexpr(min(_LANES, LATENT))
+    wpc_k: gl.constexpr = gl.constexpr(
+        min(NUM_WARPS, LATENT // min(_LANES, LATENT))
+    )
+    spt_k: gl.constexpr = gl.constexpr(
+        LATENT
+        // (
+            min(_LANES, LATENT)
+            * min(NUM_WARPS, LATENT // min(_LANES, LATENT))
+        )
+    )
+    reduce_layout: gl.constexpr = gl.BlockedLayout(
+        size_per_thread=[NUM_KV_SPLITS, spt_k],
+        threads_per_warp=[1, tpw_k],
+        warps_per_cta=[1, wpc_k],
+        order=[1, 0],
+    )
+    split_layout: gl.constexpr = gl.SliceLayout(1, reduce_layout)
+    reduce_k_layout: gl.constexpr = gl.SliceLayout(0, reduce_layout)
+    offs_split = gl.arange(0, NUM_KV_SPLITS, layout=split_layout)
+    reduce_offs_k = gl.arange(0, LATENT, layout=reduce_k_layout)
+
+    seq_len = gl.load(seq_len_ptr + batch)
     tiles_per_split = gl.cdiv(seq_len, NUM_KV_SPLITS * TILE_SIZE)
     active_splits = gl.cdiv(seq_len, tiles_per_split * TILE_SIZE)
-    e_sum = 0.0
-    e_max = -float("inf")
-    acc = gl.zeros([LATENT], gl.float32, k_layout)
-    for split in range(0, NUM_KV_SPLITS):
-        valid = split < active_splits
-        split_offset = head * NUM_KV_SPLITS + split
-        partial = gl.load(
-            split_output_ptr + split_offset * LATENT + offs_k,
-            mask=valid,
-            other=0.0,
-        ).to(gl.float32)
-        split_max = gl.load(
-            split_max_ptr + split_offset,
-            mask=valid,
-            other=-float("inf"),
-        ).to(gl.float32)
-        split_expsum = gl.load(
-            split_expsum_ptr + split_offset,
-            mask=valid,
-            other=0.0,
-        ).to(gl.float32)
-        next_max = gl.maximum(split_max, e_max)
-        old_scale = gl.exp2(e_max - next_max)
-        split_scale = gl.exp2(split_max - next_max)
-        acc = acc * old_scale + partial * split_scale
-        e_sum = e_sum * old_scale + split_expsum * split_scale
-        e_max = next_max
+    split_mask = offs_split < gl.full(
+        [NUM_KV_SPLITS],
+        active_splits,
+        dtype=gl.int32,
+        layout=split_layout,
+    )
+    split_offset = batch_head * NUM_KV_SPLITS + offs_split
+    split_max = gl.load(
+        split_max_ptr + split_offset,
+        mask=split_mask,
+        other=-float("inf"),
+    ).to(gl.float32)
+    overall_max = gl.max(split_max)
+    split_expsum = gl.load(
+        split_expsum_ptr + split_offset,
+        mask=split_mask,
+        other=0.0,
+    ).to(gl.float32)
+    split_scale = gl.exp2(split_max - overall_max)
+    overall_expsum = gl.sum(split_expsum * split_scale)
+    partial = gl.load(
+        split_output_ptr
+        + split_offset[:, None] * LATENT
+        + reduce_offs_k[None, :],
+        mask=split_mask[:, None],
+        other=0.0,
+    ).to(gl.float32)
+    acc_sum = gl.sum(partial * split_scale[:, None], axis=0)
 
     # Preserve both materialized BF16 boundaries: the latent reducer output
     # and the following value projection.
-    attention = gl.where(e_sum == 0.0, 0.0, acc / e_sum).to(gl.bfloat16)
+    attention = gl.where(
+        overall_expsum == 0.0,
+        0.0,
+        acc_sum / overall_expsum,
+    ).to(gl.bfloat16)
     weight = gl.amd.cdna5.buffer_load(
         weight_ptr,
         (
@@ -109,11 +147,16 @@ def _mla_reduce_project_value_kernel(
     attention = gl.convert_layout(attention[None, :], layout)
     projected = gl.sum(weight * attention.to(gl.float32), axis=1)
     projected = projected.to(gl.bfloat16).to(gl.float32)
+    output_offset = batch_head * VALUE + offs_n
     if HAS_GATE:
-        gate = gl.load(gate_ptr + head * VALUE + offs_n).to(gl.float32)
+        gate = gl.load(
+            gate_ptr
+            + batch * GATE_STRIDE_B
+            + (head * VALUE + offs_n) * GATE_STRIDE_N
+        ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(
-        output_ptr + head * VALUE + offs_n,
+        output_ptr + output_offset,
         projected.to(output_ptr.dtype.element_ty),
     )
 
@@ -131,27 +174,26 @@ def gluon_mla_reduce_project_value_gfx1250(
 ) -> torch.Tensor:
     """Reduce split attention and emit projected, optionally gated BF16 values."""
 
+    batch = split_output.shape[0]
     num_splits = split_output.shape[2]
     heads, latent, value = weight.shape
     expected = (
         (
             split_output,
-            (1, heads, num_splits, latent),
+            (batch, heads, num_splits, latent),
             torch.float32,
             "split output",
         ),
-        (split_max, (1, heads, num_splits), torch.float32, "split maxima"),
+        (split_max, (batch, heads, num_splits), torch.float32, "split maxima"),
         (
             split_expsum,
-            (1, heads, num_splits),
+            (batch, heads, num_splits),
             torch.float32,
             "split exponent sums",
         ),
-        (cache_seqlens, (1,), torch.int32, "sequence lengths"),
+        (cache_seqlens, (batch,), torch.int32, "sequence lengths"),
         (weight, (heads, latent, value), torch.bfloat16, "value weight"),
     )
-    if gate is not None:
-        expected += ((gate, (1, heads * value), torch.bfloat16, "gate"),)
     if page_size != 64:
         raise ValueError("MLA projected-value reducer requires page size 64")
     for tensor, shape, dtype, name in expected:
@@ -166,8 +208,20 @@ def gluon_mla_reduce_project_value_gfx1250(
                 f"MLA projected-value reducer requires contiguous colocated {name} "
                 f"{shape} {dtype}"
             )
+    gate_shape = (batch, heads * value)
+    if gate is not None and (
+        tuple(gate.shape) != gate_shape
+        or gate.dtype != torch.bfloat16
+        or not gate.is_cuda
+        or gate.device != split_output.device
+        or gate.stride(1) != 1
+    ):
+        raise ValueError(
+            "MLA projected-value reducer requires a colocated BF16 gate "
+            f"{gate_shape} with contiguous inner dimension"
+        )
     if (
-        tuple(out.shape) != (1, heads * value)
+        tuple(out.shape) != (batch, heads * value)
         or out.dtype != torch.bfloat16
         or not out.is_cuda
         or not out.is_contiguous()
@@ -175,11 +229,12 @@ def gluon_mla_reduce_project_value_gfx1250(
     ):
         raise ValueError(
             "MLA projected-value reducer requires contiguous colocated out "
-            f"{(1, heads * value)} {torch.bfloat16}"
+            f"{(batch, heads * value)} {torch.bfloat16}"
         )
 
     gate_tensor = split_output if gate is None else gate
-    _mla_reduce_project_value_kernel[(heads * value // _BLOCK_N,)](
+    num_warps = 8 if batch == 1 else 4
+    _mla_reduce_project_value_kernel[(batch * heads * value // _BLOCK_N,)](
         split_output,
         split_max,
         split_expsum,
@@ -189,12 +244,16 @@ def gluon_mla_reduce_project_value_gfx1250(
         out,
         LATENT=latent,
         VALUE=value,
+        HEADS=heads,
+        GATE_STRIDE_B=0 if gate is None else gate.stride(0),
+        GATE_STRIDE_N=0 if gate is None else gate.stride(1),
         HAS_GATE=gate is not None,
+        BATCHED=batch > 1,
         BLOCK_N=_BLOCK_N,
-        NUM_WARPS=_NUM_WARPS,
+        NUM_WARPS=num_warps,
         NUM_KV_SPLITS=num_splits,
         TILE_SIZE=page_size,
-        num_warps=_NUM_WARPS,
+        num_warps=num_warps,
         num_stages=1,
         waves_per_eu=0,
     )

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/decode.py
@@ -1574,6 +1574,17 @@ def _select_num_kv_splits_bh16bn128_fp8(
     return max(1, min(occupancy_cap, work_cap))
 
 
+def _select_projected_value_num_kv_splits(
+    *, batch: int, max_seqlen_k: int, block_n: int
+) -> int:
+    if batch == 1:
+        return 16
+    blocks = (max_seqlen_k + block_n - 1) // block_n
+    work_cap = max(4, (blocks + 7) // 8)
+    occupancy_cap = max(1, (_WAVE_WORKGROUPS // 2) // batch)
+    return max(1, min(64, occupancy_cap, work_cap))
+
+
 def _select_num_kv_splits_bh64(
     *, batch: int, nhead: int, num_xcds: int, block_h: int
 ) -> int:
@@ -1768,9 +1779,11 @@ def _gluon_mla_decode_gfx950(
         )
     elif regime == "bh16bn128":
         if value_weight is not None:
-            # The projected-value reducer uses a fixed split count to retain
-            # lower reduction overhead for native E4M3 decode.
-            num_kv_splits = 16
+            num_kv_splits = _select_projected_value_num_kv_splits(
+                batch=batch_size,
+                max_seqlen_k=max_seqlen_k,
+                block_n=block_n,
+            )
         else:
             split_selector = (
                 _select_num_kv_splits_bh16bn128_fp8
@@ -2128,7 +2141,7 @@ def gluon_mla_decode_projected_value_gfx950(
     out: torch.Tensor,
     logit_cap: float = 0.0,
 ) -> torch.Tensor:
-    """Run native FP8 MLA with a projected-value epilogue."""
+    """Run batched native FP8 MLA with a projected-value epilogue."""
     fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
     if q.dtype not in fp8_dtypes or kv_cache.dtype != q.dtype:
         raise NotImplementedError("projected-value MLA requires matching fp8 q and kv")
@@ -2137,9 +2150,16 @@ def gluon_mla_decode_projected_value_gfx950(
             "projected-value MLA requires qk_nope/kv_lora/qk_rope dimensions "
             "(128, 512, 64)"
         )
-    expected_weight = (q.shape[2], kv_lora_rank, out.shape[-1] // q.shape[2])
+    if value_weight.ndim != 3:
+        raise ValueError("value_weight must be rank-3")
+    batch, heads = q.shape[0], q.shape[2]
+    value = value_weight.shape[2]
+    expected_weight = (heads, kv_lora_rank, value)
     if tuple(value_weight.shape) != expected_weight:
         raise ValueError(f"value_weight must have shape {expected_weight}")
+    expected_out = (batch, heads * value)
+    if tuple(out.shape) != expected_out:
+        raise ValueError(f"out must have shape {expected_out}")
     if gate is not None and gate.shape != out.shape:
         raise ValueError("gate and out must have matching shapes")
     if (

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/project_value.py
@@ -83,9 +83,7 @@ def _mla_project_value_kernel(
     projected = projected.to(gl.bfloat16).to(gl.float32)
     if HAS_GATE:
         gate = gl.load(
-            gate_ptr
-            + batch * GATE_STRIDE_B
-            + (head * VALUE + offs_n) * GATE_STRIDE_N
+            gate_ptr + batch * GATE_STRIDE_B + (head * VALUE + offs_n) * GATE_STRIDE_N
         ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(
@@ -128,11 +126,7 @@ def gluon_mla_project_value_gfx950(
             raise ValueError(
                 f"MLA value projection requires BF16 gate {expected_output}"
             )
-        if (
-            not gate.is_cuda
-            or gate.device != attention.device
-            or gate.stride(1) != 1
-        ):
+        if not gate.is_cuda or gate.device != attention.device or gate.stride(1) != 1:
             raise ValueError(
                 "MLA value projection requires a colocated gate with "
                 "contiguous inner dimension"

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/project_value.py
@@ -36,15 +36,25 @@ def _mla_project_value_kernel(
     weight_ptr,
     gate_ptr,
     output_ptr,
+    HEADS: gl.constexpr,
     LATENT: gl.constexpr,
     VALUE: gl.constexpr,
+    GATE_STRIDE_B: gl.constexpr,
+    GATE_STRIDE_N: gl.constexpr,
     HAS_GATE: gl.constexpr,
+    BATCHED: gl.constexpr,
     BLOCK_N: gl.constexpr,
     NUM_WARPS: gl.constexpr,
 ):
     pid = gl.program_id(0)
     num_pid_n: gl.constexpr = VALUE // BLOCK_N
-    head = pid // num_pid_n
+    batch_head = pid // num_pid_n
+    if BATCHED:
+        batch = batch_head // HEADS
+        head = batch_head % HEADS
+    else:
+        batch = 0
+        head = batch_head
     pid_n = pid % num_pid_n
     layout: gl.constexpr = gl.BlockedLayout(
         [(BLOCK_N + NUM_WARPS - 1) // NUM_WARPS, LATENT // _LANES],
@@ -58,7 +68,7 @@ def _mla_project_value_kernel(
     offs_k = gl.arange(0, LATENT, layout=k_layout)
     attention = gl.amd.cdna4.buffer_load(
         attention_ptr,
-        (head * LATENT + offs_k).to(gl.int32),
+        (batch_head * LATENT + offs_k).to(gl.int32),
     ).to(gl.float32)
     weight = gl.amd.cdna4.buffer_load(
         weight_ptr,
@@ -72,10 +82,14 @@ def _mla_project_value_kernel(
     projected = gl.sum(weight.to(gl.float32) * attention, axis=1)
     projected = projected.to(gl.bfloat16).to(gl.float32)
     if HAS_GATE:
-        gate = gl.load(gate_ptr + head * VALUE + offs_n).to(gl.float32)
+        gate = gl.load(
+            gate_ptr
+            + batch * GATE_STRIDE_B
+            + (head * VALUE + offs_n) * GATE_STRIDE_N
+        ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(
-        output_ptr + head * VALUE + offs_n,
+        output_ptr + batch_head * VALUE + offs_n,
         projected.to(output_ptr.dtype.element_ty),
     )
 
@@ -90,15 +104,13 @@ def gluon_mla_project_value_gfx950(
     """Fuse per-head latent-to-value projection with optional sigmoid gating."""
 
     heads, latent, value = weight.shape
-    expected_attention = (1, heads, latent)
-    expected_output = (1, heads * value)
-    tensors = (
+    batch = attention.shape[0]
+    expected_attention = (batch, heads, latent)
+    expected_output = (batch, heads * value)
+    for tensor, shape, name in (
         (attention, expected_attention, "attention"),
         (weight, (heads, latent, value), "weight"),
-    )
-    if gate is not None:
-        tensors += ((gate, expected_output, "gate"),)
-    for tensor, shape, name in tensors:
+    ):
         if tuple(tensor.shape) != shape:
             raise ValueError(f"MLA value projection requires {name} {shape}")
         if tensor.dtype != torch.bfloat16:
@@ -111,6 +123,20 @@ def gluon_mla_project_value_gfx950(
             raise ValueError(
                 f"MLA value projection requires contiguous colocated {name}"
             )
+    if gate is not None:
+        if gate.shape != expected_output or gate.dtype != torch.bfloat16:
+            raise ValueError(
+                f"MLA value projection requires BF16 gate {expected_output}"
+            )
+        if (
+            not gate.is_cuda
+            or gate.device != attention.device
+            or gate.stride(1) != 1
+        ):
+            raise ValueError(
+                "MLA value projection requires a colocated gate with "
+                "contiguous inner dimension"
+            )
     if out is None:
         out = attention.new_empty(expected_output)
     elif (
@@ -122,14 +148,18 @@ def gluon_mla_project_value_gfx950(
         raise ValueError("MLA value projection out must be contiguous BF16")
 
     gate_tensor = attention if gate is None else gate
-    _mla_project_value_kernel[(heads * value // _BLOCK_N,)](
+    _mla_project_value_kernel[(batch * heads * value // _BLOCK_N,)](
         attention,
         weight,
         gate_tensor,
         out,
+        HEADS=heads,
         LATENT=latent,
         VALUE=value,
+        GATE_STRIDE_B=0 if gate is None else gate.stride(0),
+        GATE_STRIDE_N=0 if gate is None else gate.stride(1),
         HAS_GATE=gate is not None,
+        BATCHED=batch > 1,
         BLOCK_N=_BLOCK_N,
         NUM_WARPS=_NUM_WARPS,
         num_warps=_NUM_WARPS,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/reduce_project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/reduce_project_value.py
@@ -62,9 +62,7 @@ def _mla_reduce_project_value_kernel(
     for split in range(0, NUM_KV_SPLITS):
         valid = split * pages_per_split < num_pages
         partial = gl.load(
-            logits_ptr
-            + (batch_head * NUM_KV_SPLITS + split) * LATENT
-            + offs_k,
+            logits_ptr + (batch_head * NUM_KV_SPLITS + split) * LATENT + offs_k,
             mask=valid,
             other=0.0,
         ).to(gl.float32)
@@ -97,9 +95,7 @@ def _mla_reduce_project_value_kernel(
     output_offset = batch_head * VALUE + offs_n
     if HAS_GATE:
         gate = gl.load(
-            gate_ptr
-            + batch * GATE_STRIDE_B
-            + (head * VALUE + offs_n) * GATE_STRIDE_N
+            gate_ptr + batch * GATE_STRIDE_B + (head * VALUE + offs_n) * GATE_STRIDE_N
         ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/reduce_project_value.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/attention/mla/reduce_project_value.py
@@ -20,7 +20,11 @@ def _mla_reduce_project_value_kernel(
     output_ptr,
     LATENT: gl.constexpr,
     VALUE: gl.constexpr,
+    HEADS: gl.constexpr,
+    GATE_STRIDE_B: gl.constexpr,
+    GATE_STRIDE_N: gl.constexpr,
     HAS_GATE: gl.constexpr,
+    BATCHED: gl.constexpr,
     BLOCK_N: gl.constexpr,
     NUM_WARPS: gl.constexpr,
     NUM_KV_SPLITS: gl.constexpr,
@@ -30,7 +34,13 @@ def _mla_reduce_project_value_kernel(
 
     pid = gl.program_id(0)
     blocks_per_head: gl.constexpr = VALUE // BLOCK_N
-    head = pid // blocks_per_head
+    batch_head = pid // blocks_per_head
+    if BATCHED:
+        batch = batch_head // HEADS
+        head = batch_head % HEADS
+    else:
+        batch = 0
+        head = batch_head
     pid_n = pid % blocks_per_head
     layout: gl.constexpr = gl.BlockedLayout(
         [(BLOCK_N + NUM_WARPS - 1) // NUM_WARPS, LATENT // _LANES],
@@ -43,7 +53,7 @@ def _mla_reduce_project_value_kernel(
     offs_n = pid_n * BLOCK_N + gl.arange(0, BLOCK_N, layout=n_layout)
     offs_k = gl.arange(0, LATENT, layout=k_layout)
 
-    seq_len = gl.load(seq_len_ptr)
+    seq_len = gl.load(seq_len_ptr + batch)
     num_pages = gl.cdiv(seq_len, PAGE_SIZE)
     pages_per_split = gl.cdiv(num_pages, NUM_KV_SPLITS)
     e_sum = 0.0
@@ -52,12 +62,14 @@ def _mla_reduce_project_value_kernel(
     for split in range(0, NUM_KV_SPLITS):
         valid = split * pages_per_split < num_pages
         partial = gl.load(
-            logits_ptr + (head * NUM_KV_SPLITS + split) * LATENT + offs_k,
+            logits_ptr
+            + (batch_head * NUM_KV_SPLITS + split) * LATENT
+            + offs_k,
             mask=valid,
             other=0.0,
         ).to(gl.float32)
         split_lse = gl.load(
-            mid_lse_ptr + head * NUM_KV_SPLITS + split,
+            mid_lse_ptr + batch_head * NUM_KV_SPLITS + split,
             mask=valid,
             other=-float("inf"),
         ).to(gl.float32)
@@ -82,11 +94,16 @@ def _mla_reduce_project_value_kernel(
     attention = gl.convert_layout(attention[None, :], layout)
     projected = gl.sum(weight * attention.to(gl.float32), axis=1)
     projected = projected.to(gl.bfloat16).to(gl.float32)
+    output_offset = batch_head * VALUE + offs_n
     if HAS_GATE:
-        gate = gl.load(gate_ptr + head * VALUE + offs_n).to(gl.float32)
+        gate = gl.load(
+            gate_ptr
+            + batch * GATE_STRIDE_B
+            + (head * VALUE + offs_n) * GATE_STRIDE_N
+        ).to(gl.float32)
         projected *= 1.0 / (1.0 + gl.exp(-gate))
     gl.store(
-        output_ptr + head * VALUE + offs_n,
+        output_ptr + output_offset,
         projected.to(output_ptr.dtype.element_ty),
     )
 
@@ -103,16 +120,15 @@ def gluon_mla_reduce_project_value_gfx950(
 ) -> torch.Tensor:
     """Reduce split MLA partials and directly emit projected values."""
 
+    batch = logits.shape[0]
     num_splits = logits.shape[2]
     heads, latent, value = weight.shape
     expected = (
-        (logits, (1, heads, num_splits, latent), torch.bfloat16, "logits"),
-        (mid_lse, (1, heads, num_splits), torch.float32, "mid LSE"),
-        (cache_seqlens, (1,), torch.int32, "sequence lengths"),
+        (logits, (batch, heads, num_splits, latent), torch.bfloat16, "logits"),
+        (mid_lse, (batch, heads, num_splits), torch.float32, "mid LSE"),
+        (cache_seqlens, (batch,), torch.int32, "sequence lengths"),
         (weight, (heads, latent, value), torch.bfloat16, "value weight"),
     )
-    if gate is not None:
-        expected += ((gate, (1, heads * value), torch.bfloat16, "gate"),)
     if page_size != 64:
         raise ValueError("MLA projected-value reducer requires page size 64")
     for tensor, shape, dtype, name in expected:
@@ -127,10 +143,23 @@ def gluon_mla_reduce_project_value_gfx950(
                 f"MLA projected-value reducer requires contiguous colocated {name} "
                 f"{shape} {dtype}"
             )
+    gate_shape = (batch, heads * value)
+    if gate is not None and (
+        tuple(gate.shape) != gate_shape
+        or gate.dtype != torch.bfloat16
+        or not gate.is_cuda
+        or gate.device != logits.device
+        or gate.stride(1) != 1
+    ):
+        raise ValueError(
+            "MLA projected-value reducer requires a colocated BF16 gate "
+            f"{gate_shape} with contiguous inner dimension"
+        )
+    output_shape = (batch, heads * value)
     if out is None:
-        out = logits.new_empty((1, heads * value))
+        out = logits.new_empty(output_shape)
     elif (
-        tuple(out.shape) != (1, heads * value)
+        tuple(out.shape) != output_shape
         or out.dtype != torch.bfloat16
         or not out.is_cuda
         or not out.is_contiguous()
@@ -138,12 +167,12 @@ def gluon_mla_reduce_project_value_gfx950(
     ):
         raise ValueError(
             "MLA projected-value reducer requires contiguous colocated out "
-            f"{(1, heads * value)} {torch.bfloat16}"
+            f"{output_shape} {torch.bfloat16}"
         )
     block_n = 8
     num_warps = 8
     gate_tensor = logits if gate is None else gate
-    _mla_reduce_project_value_kernel[(heads * value // block_n,)](
+    _mla_reduce_project_value_kernel[(batch * heads * value // block_n,)](
         logits,
         mid_lse,
         cache_seqlens,
@@ -152,7 +181,11 @@ def gluon_mla_reduce_project_value_gfx950(
         out,
         LATENT=latent,
         VALUE=value,
+        HEADS=heads,
+        GATE_STRIDE_B=0 if gate is None else gate.stride(0),
+        GATE_STRIDE_N=0 if gate is None else gate.stride(1),
         HAS_GATE=gate is not None,
+        BATCHED=batch > 1,
         BLOCK_N=block_n,
         NUM_WARPS=num_warps,
         NUM_KV_SPLITS=num_splits,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/__init__.py
@@ -1024,7 +1024,7 @@ def mla_project_value(
         "inputs_contiguous": (
             attention.is_contiguous()
             and weight.is_contiguous()
-            and (gate is None or gate.is_contiguous())
+            and (gate is None or gate.stride(-1) == 1)
             and out.is_contiguous()
         ),
     }

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gluon/__init__.py
@@ -1232,7 +1232,7 @@ if current_platform().is_amd:
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "batch_size": frozenset({1}),
+            "batch_size": frozenset({1, 2, 4}),
             "q_len": frozenset({1}),
             "num_q_heads": frozenset({12, 16}),
             "page_size": frozenset({64}),
@@ -1265,7 +1265,7 @@ if current_platform().is_amd:
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "batch_size": frozenset({1}),
+            "batch_size": frozenset({1, 2, 4}),
             "num_heads": frozenset({12, 16}),
             "latent_dim": frozenset({512}),
             "value_dim": frozenset({128}),
@@ -1448,7 +1448,7 @@ if current_platform().is_amd:
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "batch_size": frozenset({1}),
+            "batch_size": frozenset({1, 2, 4, 8}),
             "q_len": frozenset({1}),
             "num_q_heads": frozenset({12, 16}),
             "page_size": frozenset({64}),
@@ -1481,7 +1481,7 @@ if current_platform().is_amd:
         ),
         priority=Priority.SPECIALIZED,
         traits={
-            "batch_size": frozenset({1}),
+            "batch_size": frozenset({1, 2, 4, 8}),
             "num_heads": frozenset({12, 16}),
             "latent_dim": frozenset({512}),
             "value_dim": frozenset({128}),

--- a/tokenspeed-kernel/test/ops/test_attention_mla.py
+++ b/tokenspeed-kernel/test/ops/test_attention_mla.py
@@ -9,6 +9,7 @@ from tokenspeed_kernel import (
     mla_decode_with_kvcache,
     mla_extend_with_kvcache,
     mla_prefill,
+    mla_project_value,
     supports_mla_decode_query_blocks,
 )
 from tokenspeed_kernel.platform import current_platform
@@ -854,28 +855,47 @@ def test_mla_decode_small_batch_fixed_entrypoints_use_out(
     )
 
 
-def test_mla_decode_with_kvcache_projected_value_matches_split_and_captures(
+@pytest.mark.parametrize("batch", [1, 4, 8])
+def test_mla_decode_with_kvcache_projected_value_matches_split(
     device: str,
+    batch: int,
 ) -> None:
     if not (platform.is_cdna4 or platform.is_cdna5):
         pytest.skip("K3 fused MLA epilogue requires CDNA4 or CDNA5")
-    from tokenspeed_kernel import mla_project_value
+    if platform.is_cdna4 and batch > 4:
+        pytest.skip("gfx950 projected MLA is restricted to batch <= 4")
 
     torch.manual_seed(67)
-    q = torch.randn(1, 1, 12, 576, device=device, dtype=torch.bfloat16).to(
+    q = torch.randn(batch, 1, 12, 576, device=device, dtype=torch.bfloat16).to(
         torch.float8_e4m3fn
     )
-    kv_cache = torch.randn(64, 64, 1, 576, device=device, dtype=torch.bfloat16).to(
-        torch.float8_e4m3fn
+    kv_cache = torch.randn(
+        batch * 64,
+        64,
+        1,
+        576,
+        device=device,
+        dtype=torch.bfloat16,
+    ).to(torch.float8_e4m3fn)
+    page_table = torch.arange(
+        batch * 64,
+        device=device,
+        dtype=torch.int32,
+    ).view(batch, 64)
+    cache_seqlens = torch.tensor(
+        [4096 - 64 * (index % 4) for index in range(batch)],
+        device=device,
+        dtype=torch.int32,
     )
-    page_table = torch.arange(64, device=device, dtype=torch.int32).view(1, 64)
-    cache_seqlens = torch.tensor([4096], device=device, dtype=torch.int32)
     weight = torch.randn(12, 512, 128, device=device, dtype=torch.bfloat16)
-    gate = torch.randn(1, 1536, device=device, dtype=torch.bfloat16)
-    output = torch.empty_like(gate)
-    projected_override = (
-        "gluon_mla_decode_projected_value_gfx1250" if platform.is_cdna5 else None
+    gate_storage = torch.randn(
+        batch,
+        3648,
+        device=device,
+        dtype=torch.bfloat16,
     )
+    gate = gate_storage[:, -1536:]
+    output = torch.empty_like(gate)
     attention = mla_decode_with_kvcache(
         q=q,
         kv_cache=kv_cache,
@@ -888,11 +908,12 @@ def test_mla_decode_with_kvcache_projected_value_matches_split_and_captures(
         softmax_scale=1.0 / math.sqrt(192),
         solution="gluon",
     )
-    expected = mla_project_value(
-        attention.reshape(1, 12, 512),
+    projected = torch.bmm(
+        attention.reshape(batch, 12, 512).transpose(0, 1).contiguous(),
         weight,
-        gate=gate,
     )
+    expected = projected.transpose(0, 1).contiguous().reshape_as(output)
+    expected = (expected.float() * torch.sigmoid(gate.float())).to(torch.bfloat16)
 
     mla_decode_with_kvcache(
         q=q,
@@ -907,7 +928,6 @@ def test_mla_decode_with_kvcache_projected_value_matches_split_and_captures(
         value_weight=weight,
         gate=gate,
         out=output,
-        override=projected_override,
     )
     eager_output = output.clone()
     graph = torch.cuda.CUDAGraph()
@@ -925,15 +945,17 @@ def test_mla_decode_with_kvcache_projected_value_matches_split_and_captures(
             value_weight=weight,
             gate=gate,
             out=output,
-            override=projected_override,
         )
     assert returned.data_ptr() == output.data_ptr()
+    output.fill_(float("nan"))
     graph.replay()
     torch.cuda.synchronize()
+    assert torch.isfinite(output).all()
     torch.testing.assert_close(output, eager_output, atol=0, rtol=0)
-    # Split scheduling and reducer order can differ from the generic
-    # composition. Validate within the established FP8 reduction envelope.
-    torch.testing.assert_close(output, expected, atol=0.125, rtol=0.05)
+    # Different split partitions are bitwise identical when matched, but can
+    # cross a BF16 rounding boundary when the optimized and composed paths use
+    # different split counts.
+    torch.testing.assert_close(output, expected, atol=0.25, rtol=0.05)
 
 
 @pytest.mark.parametrize("use_gate", [False, True])
@@ -1076,6 +1098,47 @@ def test_mla_project_value_fallback_preserves_fp32_gate_math(
 
     torch.testing.assert_close(output, expected, atol=0, rtol=0)
     assert not torch.equal(output, attention.reshape(1, 1) * gate.sigmoid())
+
+
+@pytest.mark.parametrize("batch", [1, 8])
+def test_mla_project_value_amd_batches(
+    device: str,
+    batch: int,
+) -> None:
+    if not (platform.is_cdna4 or platform.is_cdna5):
+        pytest.skip("batched MLA value projection requires CDNA4 or CDNA5")
+    if platform.is_cdna4 and batch not in {1, 2, 4}:
+        pytest.skip("gfx950 MLA value projection supports batches 1, 2, and 4")
+
+    torch.manual_seed(73 + batch)
+    attention = torch.randn(batch, 12, 512, device=device, dtype=torch.bfloat16)
+    weight = torch.randn(12, 512, 128, device=device, dtype=torch.bfloat16)
+    gate_storage = torch.randn(
+        batch,
+        3648,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    gate = gate_storage[:, -1536:]
+    out = torch.empty(batch, 1536, device=device, dtype=torch.bfloat16)
+    expected = torch.einsum("bhl,hlv->bhv", attention, weight).reshape_as(out)
+    expected = (expected.float() * torch.sigmoid(gate.float())).to(torch.bfloat16)
+
+    override = (
+        "gluon_mla_project_value_gfx1250"
+        if platform.is_cdna5
+        else "gluon_mla_project_value_gfx950"
+    )
+    returned = mla_project_value(
+        attention,
+        weight,
+        gate=gate,
+        out=out,
+        override=override,
+    )
+
+    assert returned.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(out, expected, atol=0.125, rtol=0.05)
 
 
 def test_mla_project_value_nvidia_fallback_writes_projection_directly(
@@ -1231,6 +1294,32 @@ def test_mla_normalize_project_query_split_output(
         rtol=2e-2,
     )
     torch.testing.assert_close(kv, expected_kv, atol=0, rtol=0)
+
+
+def test_gfx1250_projected_decode_split_policy() -> None:
+    if not current_platform().is_cdna5:
+        pytest.skip("K3 projected MLA split policy targets CDNA5")
+    from tokenspeed_kernel_amd.ops.gfx1250.attention.mla.decode import (
+        _select_projected_value_num_kv_splits,
+    )
+
+    def select(batch_size: int, max_seqlen_k: int) -> int:
+        return _select_projected_value_num_kv_splits(
+            batch_size=batch_size,
+            num_sms=256,
+            num_q_programs=batch_size,
+            max_seqlen_k=max_seqlen_k,
+            tile_size=64,
+        )
+
+    assert select(1, 64) == 1
+    assert select(1, 4097) == 16
+    assert select(2, 4097) == 8
+    assert select(8, 16384) == 16
+    assert select(16, 16384) == 16
+    assert select(16, 32768) == 32
+    assert select(8, 32769) == 64
+    assert select(16, 32769) == 32
 
 
 def test_gfx950_k3_decode_split_policy() -> None:

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1065,10 +1065,7 @@ def _attention_mla_decode_projected_value_amd(
     q = torch.empty((batch, 1, heads, 576), dtype=torch.float8_e4m3fn)
     kv_cache = torch.empty((64, 64, 1, 576), dtype=torch.float8_e4m3fn)
     page_table = (
-        torch.arange(64, dtype=torch.int32)
-        .view(1, 64)
-        .expand(batch, -1)
-        .contiguous()
+        torch.arange(64, dtype=torch.int32).view(1, 64).expand(batch, -1).contiguous()
     )
     cache_seqlens = torch.full((batch,), 4096, dtype=torch.int32)
     value_weight = torch.empty((heads, 512, 128), dtype=torch.bfloat16)

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -1057,13 +1057,22 @@ def _attention_mla_decode_fp8q_unsupported_heads() -> object:
     )
 
 
-def _attention_mla_decode_projected_value_gfx1250(heads: int = 12) -> object:
-    q = torch.empty((1, 1, heads, 576), dtype=torch.float8_e4m3fn)
+def _attention_mla_decode_projected_value_amd(
+    heads: int = 12,
+    *,
+    batch: int = 1,
+) -> object:
+    q = torch.empty((batch, 1, heads, 576), dtype=torch.float8_e4m3fn)
     kv_cache = torch.empty((64, 64, 1, 576), dtype=torch.float8_e4m3fn)
-    page_table = torch.arange(64, dtype=torch.int32).view(1, 64)
-    cache_seqlens = torch.tensor([4096], dtype=torch.int32)
+    page_table = (
+        torch.arange(64, dtype=torch.int32)
+        .view(1, 64)
+        .expand(batch, -1)
+        .contiguous()
+    )
+    cache_seqlens = torch.full((batch,), 4096, dtype=torch.int32)
     value_weight = torch.empty((heads, 512, 128), dtype=torch.bfloat16)
-    out = torch.empty((1, heads * 128), dtype=torch.bfloat16)
+    out = torch.empty((batch, heads * 128), dtype=torch.bfloat16)
     return tokenspeed_kernel.mla_decode_with_kvcache(
         q=q,
         kv_cache=kv_cache,
@@ -1079,14 +1088,15 @@ def _attention_mla_decode_projected_value_gfx1250(heads: int = 12) -> object:
     )
 
 
-def _attention_mla_project_value_gfx1250(
+def _attention_mla_project_value_amd(
     *,
+    batch: int = 1,
     heads: int = 12,
     use_gate: bool = False,
 ) -> object:
-    attention = torch.empty((1, heads, 512), dtype=torch.bfloat16)
+    attention = torch.empty((batch, heads, 512), dtype=torch.bfloat16)
     weight = torch.empty((heads, 512, 128), dtype=torch.bfloat16)
-    out = torch.empty((1, heads * 128), dtype=torch.bfloat16)
+    out = torch.empty((batch, heads * 128), dtype=torch.bfloat16)
     gate = torch.empty_like(out) if use_gate else None
     return tokenspeed_kernel.mla_project_value(
         attention,
@@ -3562,7 +3572,7 @@ _CASES = [
         "attention",
         "mla_decode_projected_value",
         "gluon_mla_decode_projected_value_gfx1250",
-        _attention_mla_decode_projected_value_gfx1250,
+        _attention_mla_decode_projected_value_amd,
     ),
     _case(
         _is_cdna5,
@@ -3570,16 +3580,17 @@ _CASES = [
         "attention",
         "mla_decode_projected_value",
         "gluon_mla_decode_projected_value_gfx1250",
-        lambda: _attention_mla_decode_projected_value_gfx1250(16),
+        lambda: _attention_mla_decode_projected_value_amd(16),
         id_suffix="h16",
     ),
     _case(
         _is_cdna5,
         "cdna5",
         "attention",
-        "mla_project_value",
-        "gluon_mla_project_value_gfx1250",
-        _attention_mla_project_value_gfx1250,
+        "mla_decode_projected_value",
+        "gluon_mla_decode_projected_value_gfx1250",
+        lambda: _attention_mla_decode_projected_value_amd(batch=8),
+        id_suffix="batch8",
     ),
     _case(
         _is_cdna5,
@@ -3587,8 +3598,25 @@ _CASES = [
         "attention",
         "mla_project_value",
         "gluon_mla_project_value_gfx1250",
-        lambda: _attention_mla_project_value_gfx1250(use_gate=True),
+        _attention_mla_project_value_amd,
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "mla_project_value",
+        "gluon_mla_project_value_gfx1250",
+        lambda: _attention_mla_project_value_amd(use_gate=True),
         id_suffix="sigmoid-gate",
+    ),
+    _case(
+        _is_cdna5,
+        "cdna5",
+        "attention",
+        "mla_project_value",
+        "gluon_mla_project_value_gfx1250",
+        lambda: _attention_mla_project_value_amd(batch=8, use_gate=True),
+        id_suffix="batch8-sigmoid-gate",
     ),
     _case(
         _is_cdna5,
@@ -4602,6 +4630,7 @@ _GLUON_MLA_FIXED_KERNELS = (
         pytest.param("num_q_heads", 12, True, id="matched"),
         pytest.param("num_q_heads", 16, True, id="h16"),
         pytest.param("num_q_heads", 32, False, id="unsupported-heads"),
+        pytest.param("batch_size", 16, False, id="batch16"),
         pytest.param("value_head_dim", 64, False, id="unsupported-value"),
         pytest.param("page_size", 128, False, id="unsupported-page"),
         pytest.param("support_logit_cap", True, False, id="unsupported-logit-cap"),
@@ -4627,6 +4656,32 @@ def test_gluon_mla_projected_value_gfx1250_traits_are_narrow(
         "support_logit_cap": False,
     }
     traits[trait] = value
+    assert spec_matches_traits(spec, traits) is matches
+
+
+@pytest.mark.parametrize(
+    "batch_size,matches",
+    [
+        pytest.param(1, True, id="batch1"),
+        pytest.param(8, True, id="batch8"),
+        pytest.param(16, False, id="batch16"),
+    ],
+)
+def test_gluon_mla_project_value_gfx1250_batch_traits(
+    batch_size: int,
+    matches: bool,
+) -> None:
+    spec = KernelRegistry.get().get_by_name("gluon_mla_project_value_gfx1250")
+    if spec is None:
+        pytest.skip("gfx1250 Gluon MLA projection registration is unavailable")
+    traits = {
+        "batch_size": batch_size,
+        "num_heads": 12,
+        "latent_dim": 512,
+        "value_dim": 128,
+        "gate_kind": "sigmoid",
+        "inputs_contiguous": True,
+    }
     assert spec_matches_traits(spec, traits) is matches
 
 


### PR DESCRIPTION
## Summary
- Extend packed projected MLA decode to gfx1250 batches `{1,2,4,8}` and gfx950 batches `{1,2,4}`.
- Accept packed last-dimension gates (`stride(-1) == 1`) instead of requiring a fully contiguous gate tensor.
- Keep the composed path as fallback outside those batches.

## Performance
Fused projected decode vs. main. Sequence length 4096.

gfx1250, split=8:
| Batch | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 113.37 | 67.00 | 1.69x |
| 2 | 112.43 | 67.42 | 1.67x |
| 4 | 111.53 | 65.86 | 1.69x |
| 8 | 113.25 | 70.71 | 1.60x |

gfx950, split=4:
| Batch | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 99.46 | 71.10 | 1.40x |
| 2 | 98.64 | 72.38 | 1.36x |
| 4 | 104.36 | 75.84 | 1.38x |
