### PR TITLE
perf(moe): port gfx1250 M=1 latent-input decode

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/fp16/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/fp16/__init__.py
@@ -1,0 +1,5 @@
+"""BF16 latent-MoE kernels for gfx1250."""
+
+from .latent_input_decode import gluon_latent_input_decode_gfx1250
+
+__all__ = ["gluon_latent_input_decode_gfx1250"]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/fp16/latent_input_decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/fp16/latent_input_decode.py
@@ -42,9 +42,7 @@ def _latent_input_decode_kernel(
         )
         n_layout: gl.constexpr = gl.SliceLayout(1, layout)
         k_layout: gl.constexpr = gl.SliceLayout(0, layout)
-        offs_n = pid * _ROUTER_BLOCK_N + gl.arange(
-            0, _ROUTER_BLOCK_N, layout=n_layout
-        )
+        offs_n = pid * _ROUTER_BLOCK_N + gl.arange(0, _ROUTER_BLOCK_N, layout=n_layout)
         acc = gl.zeros([_ROUTER_BLOCK_N], gl.float32, n_layout)
         for k0 in range(0, _HIDDEN, _BLOCK_K):
             offs_k = k0 + gl.arange(0, _BLOCK_K, layout=k_layout)
@@ -97,9 +95,7 @@ def _latent_input_decode_kernel(
     )
     n_layout: gl.constexpr = gl.SliceLayout(1, layout)
     k_layout: gl.constexpr = gl.SliceLayout(0, layout)
-    offs_n = pid_n * _SHARED_BLOCK_N + gl.arange(
-        0, _SHARED_BLOCK_N, layout=n_layout
-    )
+    offs_n = pid_n * _SHARED_BLOCK_N + gl.arange(0, _SHARED_BLOCK_N, layout=n_layout)
     gate_acc = gl.zeros([_SHARED_BLOCK_N], gl.float32, n_layout)
     up_acc = gl.zeros([_SHARED_BLOCK_N], gl.float32, n_layout)
     for k0 in range(0, _HIDDEN, _BLOCK_K):
@@ -110,8 +106,7 @@ def _latent_input_decode_kernel(
         gate_weight = gl.amd.cdna5.buffer_load(
             ptr=shared_weight_ptr,
             offsets=(
-                offs_n[:, None].to(gl.int64) * _HIDDEN
-                + offs_k[None, :].to(gl.int64)
+                offs_n[:, None].to(gl.int64) * _HIDDEN + offs_k[None, :].to(gl.int64)
             ).to(gl.int32),
         )
         up_weight = gl.amd.cdna5.buffer_load(

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/fp16/latent_input_decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/fp16/latent_input_decode.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 LightSeek Foundation
+
+"""Single-token latent-MoE input projections for gfx1250."""
+
+from __future__ import annotations
+
+import torch
+from tokenspeed_kernel_amd._triton import gl, gluon
+
+_HIDDEN = gl.constexpr(7168)
+_SHARED = gl.constexpr(768)
+_ROUTER_BLOCK_N = gl.constexpr(4)
+_LATENT_BLOCK_N = gl.constexpr(16)
+_SHARED_BLOCK_N = gl.constexpr(4)
+_BLOCK_K = gl.constexpr(1024)
+_NUM_WARPS = gl.constexpr(4)
+_LANES = gl.constexpr(32)
+_ROUTER_GRID = gl.constexpr(896 // 4)
+_LATENT_GRID = gl.constexpr(3584 // 16)
+_TOTAL_GRID = 896 // 4 + 3584 // 16 + 768 // 4
+
+
+@gluon.jit
+def _latent_input_decode_kernel(
+    hidden_ptr,
+    router_weight_ptr,
+    routed_weight_ptr,
+    shared_weight_ptr,
+    router_out_ptr,
+    routed_out_ptr,
+    shared_out_ptr,
+    beta,
+    linear_beta,
+    HAS_LINEAR_BETA: gl.constexpr,
+):
+    """Compute independent router, routed-down, and shared-up regions."""
+
+    pid = gl.program_id(0)
+    if pid < _ROUTER_GRID:
+        layout: gl.constexpr = gl.BlockedLayout(
+            [1, _BLOCK_K // _LANES], [1, _LANES], [_NUM_WARPS, 1], [1, 0]
+        )
+        n_layout: gl.constexpr = gl.SliceLayout(1, layout)
+        k_layout: gl.constexpr = gl.SliceLayout(0, layout)
+        offs_n = pid * _ROUTER_BLOCK_N + gl.arange(
+            0, _ROUTER_BLOCK_N, layout=n_layout
+        )
+        acc = gl.zeros([_ROUTER_BLOCK_N], gl.float32, n_layout)
+        for k0 in range(0, _HIDDEN, _BLOCK_K):
+            offs_k = k0 + gl.arange(0, _BLOCK_K, layout=k_layout)
+            activation = gl.amd.cdna5.buffer_load(
+                ptr=hidden_ptr, offsets=offs_k.to(gl.int32)
+            ).to(gl.float32)
+            weight = gl.amd.cdna5.buffer_load(
+                ptr=router_weight_ptr,
+                offsets=(
+                    offs_n[:, None].to(gl.int64) * _HIDDEN
+                    + offs_k[None, :].to(gl.int64)
+                ).to(gl.int32),
+            )
+            activation = gl.convert_layout(activation[None, :], layout)
+            acc += gl.sum(weight.to(gl.float32) * activation, axis=1)
+        gl.store(router_out_ptr + offs_n, acc)
+        return
+
+    if pid < _ROUTER_GRID + _LATENT_GRID:
+        pid_n = pid - _ROUTER_GRID
+        layout: gl.constexpr = gl.BlockedLayout(
+            [1, _BLOCK_K // _LANES], [1, _LANES], [_NUM_WARPS, 1], [1, 0]
+        )
+        n_layout: gl.constexpr = gl.SliceLayout(1, layout)
+        k_layout: gl.constexpr = gl.SliceLayout(0, layout)
+        offs_n = pid_n * _LATENT_BLOCK_N + gl.arange(
+            0, _LATENT_BLOCK_N, layout=n_layout
+        )
+        acc = gl.zeros([_LATENT_BLOCK_N], gl.float32, n_layout)
+        for k0 in range(0, _HIDDEN, _BLOCK_K):
+            offs_k = k0 + gl.arange(0, _BLOCK_K, layout=k_layout)
+            activation = gl.amd.cdna5.buffer_load(
+                ptr=hidden_ptr, offsets=offs_k.to(gl.int32)
+            ).to(gl.float32)
+            weight = gl.amd.cdna5.buffer_load(
+                ptr=routed_weight_ptr,
+                offsets=(
+                    offs_n[:, None].to(gl.int64) * _HIDDEN
+                    + offs_k[None, :].to(gl.int64)
+                ).to(gl.int32),
+            )
+            activation = gl.convert_layout(activation[None, :], layout)
+            acc += gl.sum(weight.to(gl.float32) * activation, axis=1)
+        gl.store(routed_out_ptr + offs_n, acc)
+        return
+
+    pid_n = pid - _ROUTER_GRID - _LATENT_GRID
+    layout: gl.constexpr = gl.BlockedLayout(
+        [1, _BLOCK_K // _LANES], [1, _LANES], [_NUM_WARPS, 1], [1, 0]
+    )
+    n_layout: gl.constexpr = gl.SliceLayout(1, layout)
+    k_layout: gl.constexpr = gl.SliceLayout(0, layout)
+    offs_n = pid_n * _SHARED_BLOCK_N + gl.arange(
+        0, _SHARED_BLOCK_N, layout=n_layout
+    )
+    gate_acc = gl.zeros([_SHARED_BLOCK_N], gl.float32, n_layout)
+    up_acc = gl.zeros([_SHARED_BLOCK_N], gl.float32, n_layout)
+    for k0 in range(0, _HIDDEN, _BLOCK_K):
+        offs_k = k0 + gl.arange(0, _BLOCK_K, layout=k_layout)
+        activation = gl.amd.cdna5.buffer_load(
+            ptr=hidden_ptr, offsets=offs_k.to(gl.int32)
+        ).to(gl.float32)
+        gate_weight = gl.amd.cdna5.buffer_load(
+            ptr=shared_weight_ptr,
+            offsets=(
+                offs_n[:, None].to(gl.int64) * _HIDDEN
+                + offs_k[None, :].to(gl.int64)
+            ).to(gl.int32),
+        )
+        up_weight = gl.amd.cdna5.buffer_load(
+            ptr=shared_weight_ptr,
+            offsets=(
+                (_SHARED + offs_n[:, None]).to(gl.int64) * _HIDDEN
+                + offs_k[None, :].to(gl.int64)
+            ).to(gl.int32),
+        )
+        activation = gl.convert_layout(activation[None, :], layout)
+        gate_acc += gl.sum(gate_weight.to(gl.float32) * activation, axis=1)
+        up_acc += gl.sum(up_weight.to(gl.float32) * activation, axis=1)
+    gate_raw = gate_acc.to(gl.bfloat16).to(gl.float32)
+    up = up_acc.to(gl.bfloat16).to(gl.float32)
+    gate = beta * gl.extra.libdevice.tanh(gate_raw / beta)
+    gate *= 1.0 / (1.0 + gl.exp(-gate_raw))
+    if HAS_LINEAR_BETA:
+        up = linear_beta * gl.extra.libdevice.tanh(up / linear_beta)
+    gl.store(shared_out_ptr + offs_n, gate * up)
+
+
+def gluon_latent_input_decode_gfx1250(
+    hidden_states: torch.Tensor,
+    router_weight: torch.Tensor,
+    routed_down_weight: torch.Tensor,
+    shared_gate_up_weight: torch.Tensor,
+    *,
+    beta: float,
+    linear_beta: float | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Project the exact Kimi-K3 M1 latent-MoE inputs in one launch."""
+
+    expected = (
+        (hidden_states, (1, 7168), "hidden states"),
+        (router_weight, (896, 7168), "router weight"),
+        (routed_down_weight, (3584, 7168), "routed-down weight"),
+        (shared_gate_up_weight, (1536, 7168), "shared gate/up weight"),
+    )
+    for tensor, shape, name in expected:
+        if tuple(tensor.shape) != shape:
+            raise ValueError(f"Kimi K3 {name} must have shape {shape}")
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"Kimi K3 {name} must be BF16")
+        if not tensor.is_cuda or not tensor.is_contiguous():
+            raise ValueError(f"Kimi K3 {name} must be contiguous on GPU")
+        if tensor.device != hidden_states.device:
+            raise ValueError("Kimi K3 MoE input tensors must be colocated")
+    if beta <= 0.0 or (linear_beta is not None and linear_beta <= 0.0):
+        raise ValueError("Kimi K3 SiTU beta values must be positive")
+
+    router_out = torch.empty((1, 896), dtype=torch.float32, device=hidden_states.device)
+    routed_out = torch.empty(
+        (1, 3584), dtype=torch.bfloat16, device=hidden_states.device
+    )
+    shared_out = torch.empty(
+        (1, 768), dtype=torch.bfloat16, device=hidden_states.device
+    )
+    _latent_input_decode_kernel[(_TOTAL_GRID,)](
+        hidden_states,
+        router_weight,
+        routed_down_weight,
+        shared_gate_up_weight,
+        router_out,
+        routed_out,
+        shared_out,
+        float(beta),
+        1.0 if linear_beta is None else float(linear_beta),
+        HAS_LINEAR_BETA=linear_beta is not None,
+        num_warps=4,
+        num_stages=1,
+        waves_per_eu=0,
+    )
+    return router_out, routed_out, shared_out
+
+
+__all__ = ["gluon_latent_input_decode_gfx1250"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/latent_input.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/latent_input.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 LightSeek Foundation
 
-"""Gluon registrations for gfx950 latent-MoE input projections."""
+"""Gluon registrations for AMD latent-MoE input projections."""
 
 from __future__ import annotations
 
@@ -15,8 +15,11 @@ from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
 if current_platform().is_amd:
+    from tokenspeed_kernel_amd.ops.gfx1250.moe.fp16.latent_input_decode import (
+        gluon_latent_input_decode_gfx1250 as _decode_gfx1250_impl,
+    )
     from tokenspeed_kernel_amd.ops.gfx950.moe.fp16.latent_input_decode import (
-        gluon_latent_input_decode_gfx950 as _decode_impl,
+        gluon_latent_input_decode_gfx950 as _decode_gfx950_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx950.moe.fp16.latent_input_small_batch import (
         gluon_latent_input_small_batch_gfx950 as _small_batch_impl,
@@ -37,6 +40,38 @@ if current_platform().is_amd:
         max_arch_version=ArchVersion(9, 5),
         vendors=frozenset({"amd"}),
     )
+    _GFX1250 = CapabilityRequirement(
+        min_arch_version=ArchVersion(12, 5),
+        max_arch_version=ArchVersion(12, 5),
+        vendors=frozenset({"amd"}),
+    )
+
+    @register_kernel(
+        "moe",
+        "latent_input",
+        name="gluon_latent_input_decode_gfx1250",
+        solution="gluon",
+        capability=_GFX1250,
+        signatures=_SIGNATURES,
+        priority=Priority.SPECIALIZED,
+        traits={
+            "tokens": frozenset({1}),
+            "hidden_size": frozenset({7168}),
+            "num_experts": frozenset({896}),
+            "latent_size": frozenset({3584}),
+            "shared_size": frozenset({768}),
+            "inputs_contiguous": frozenset({True}),
+        },
+    )
+    def gluon_latent_input_decode_gfx1250(**kwargs):
+        return _decode_gfx1250_impl(
+            kwargs["hidden_states"],
+            kwargs["router_weight"],
+            kwargs["routed_weight"],
+            kwargs["shared_gate_up_weight"],
+            beta=kwargs["gate_clamp"],
+            linear_beta=kwargs["up_clamp"],
+        )
 
     @register_kernel(
         "moe",
@@ -56,7 +91,7 @@ if current_platform().is_amd:
         },
     )
     def gluon_latent_input_decode_gfx950(**kwargs):
-        return _decode_impl(
+        return _decode_gfx950_impl(
             kwargs["hidden_states"],
             kwargs["router_weight"],
             kwargs["routed_weight"],

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/latent_input.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/gluon/latent_input.py
@@ -15,14 +15,14 @@ from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
 if current_platform().is_amd:
-    from tokenspeed_kernel_amd.ops.gfx1250.moe.fp16.latent_input_decode import (
-        gluon_latent_input_decode_gfx1250 as _decode_gfx1250_impl,
-    )
     from tokenspeed_kernel_amd.ops.gfx950.moe.fp16.latent_input_decode import (
         gluon_latent_input_decode_gfx950 as _decode_gfx950_impl,
     )
     from tokenspeed_kernel_amd.ops.gfx950.moe.fp16.latent_input_small_batch import (
         gluon_latent_input_small_batch_gfx950 as _small_batch_impl,
+    )
+    from tokenspeed_kernel_amd.ops.gfx1250.moe.fp16.latent_input_decode import (
+        gluon_latent_input_decode_gfx1250 as _decode_gfx1250_impl,
     )
 
     _SIGNATURES = frozenset(

--- a/tokenspeed-kernel/test/ops/moe/test_latent_input.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_input.py
@@ -32,6 +32,9 @@ def test_amd_latent_moe_registrations_are_platform_scoped() -> None:
         "gluon_latent_input_small_batch_gfx950": (
             "tokenspeed_kernel.ops.moe.gluon.latent_input"
         ),
+        "gluon_latent_input_decode_gfx1250": (
+            "tokenspeed_kernel.ops.moe.gluon.latent_input"
+        ),
     }
     implementations = {name: registry.get_impl(name) for name in expected_modules}
     if current_platform().is_amd:
@@ -122,6 +125,54 @@ def test_latent_input_without_up_clamp() -> None:
         * up.float()
     ).to(hidden.dtype)
     torch.testing.assert_close(shared, expected, atol=8e-3, rtol=8e-3)
+
+
+@pytest.mark.skipif(
+    not current_platform().is_cdna5,
+    reason="requires the gfx1250 single-token specialist",
+)
+def test_gfx1250_latent_input_decode_matches_and_replays() -> None:
+    hidden_size = 7168
+    widths = (896, 3584, 1536)
+    packed = torch.randn(
+        sum(widths), hidden_size, dtype=torch.bfloat16, device="cuda"
+    )
+    views = list(packed.split(widths))
+    hidden = torch.randn(1, hidden_size, dtype=torch.bfloat16, device="cuda")
+    gate_clamp, up_clamp = 4.0, 25.0
+
+    def run():
+        return latent_moe_input_projections(
+            hidden,
+            *views,
+            gate_clamp=gate_clamp,
+            up_clamp=up_clamp,
+            override="gluon_latent_input_decode_gfx1250",
+        )
+
+    router, routed, shared = run()
+    expected_router = torch.nn.functional.linear(hidden.float(), views[0].float())
+    expected_routed = torch.nn.functional.linear(hidden, views[1])
+    gate, up = torch.nn.functional.linear(hidden, views[2]).chunk(2, dim=-1)
+    expected_shared = (
+        gate_clamp
+        * torch.tanh(gate.float() / gate_clamp)
+        * torch.sigmoid(gate.float())
+        * (up_clamp * torch.tanh(up.float() / up_clamp))
+    ).to(hidden.dtype)
+    assert router.dtype == torch.float32
+    torch.testing.assert_close(router, expected_router, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(routed, expected_routed, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(shared, expected_shared, atol=2e-2, rtol=2e-2)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = run()
+    hidden.copy_(torch.randn_like(hidden))
+    graph.replay()
+    replay_expected = run()
+    for output, reference in zip(actual, replay_expected, strict=True):
+        torch.testing.assert_close(output, reference, atol=2e-2, rtol=2e-2)
 
 
 def test_latent_input_masks_partial_k_tile() -> None:

--- a/tokenspeed-kernel/test/ops/moe/test_latent_input.py
+++ b/tokenspeed-kernel/test/ops/moe/test_latent_input.py
@@ -134,9 +134,7 @@ def test_latent_input_without_up_clamp() -> None:
 def test_gfx1250_latent_input_decode_matches_and_replays() -> None:
     hidden_size = 7168
     widths = (896, 3584, 1536)
-    packed = torch.randn(
-        sum(widths), hidden_size, dtype=torch.bfloat16, device="cuda"
-    )
+    packed = torch.randn(sum(widths), hidden_size, dtype=torch.bfloat16, device="cuda")
     views = list(packed.split(widths))
     hidden = torch.randn(1, hidden_size, dtype=torch.bfloat16, device="cuda")
     gate_clamp, up_clamp = 4.0, 25.0


### PR DESCRIPTION
## Summary
- Port the gfx950 M=1 fused latent-input decode from #878 to gfx1250.
- One launch replaces the portable packed path for the K3 decode contract.

## Performance
Kernel latency vs. main on gfx1250.

| M | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 43.87 | 32.05 | 1.37x |
