### PR TITLE
 refactor(iris): size all-reduce buffers independently and centralize kernel parameters

### DIFF
--- a/python/tokenspeed/runtime/distributed/comm_backend/triton_allreduce.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/triton_allreduce.py
@@ -69,6 +69,9 @@ class TritonAllReduceBackend(CommBackend):
         state = create_state(
             group=pg_manager.get_process_group("nccl", group),
             rank_in_group=group.index(dist.get_rank()),
+            attnres_max_numel=0,
+            max_tokens=0,
+            hidden_size=0,
             max_numel=self._max_numel,
             max_bytes=self._producer_direct_max_bytes,
             device=torch.device(f"cuda:{torch.cuda.current_device()}"),

--- a/python/tokenspeed/runtime/distributed/comm_backend/triton_rsag.py
+++ b/python/tokenspeed/runtime/distributed/comm_backend/triton_rsag.py
@@ -64,8 +64,12 @@ class TritonRSAGBackend:
         state = create_state(
             group=pg_manager.get_process_group("nccl", group),
             rank_in_group=group.index(dist.get_rank()),
+            attnres_max_numel=0,
             max_tokens=max_num_tokens,
             hidden_size=hidden_size,
+            device=None,
+            max_numel=0,
+            max_bytes=0,
         )
         self._instances[key] = state
         return state

--- a/python/tokenspeed/runtime/layers/logits_processor.py
+++ b/python/tokenspeed/runtime/layers/logits_processor.py
@@ -390,8 +390,12 @@ class LogitsProcessor(nn.Module):
             self._LOGITS_AG_STATES[key] = create_state(
                 group=pg_manager.get_process_group("nccl", self.tp_group),
                 rank_in_group=self.tp_rank,
+                attnres_max_numel=0,
                 max_tokens=self._LOGITS_AG_MAX_TOKENS,
                 hidden_size=vocab_padded,
+                device=None,
+                max_numel=0,
+                max_bytes=0,
             )
         return self._LOGITS_AG_STATES[key]
 

--- a/python/tokenspeed/runtime/models/kimi_k3_comm.py
+++ b/python/tokenspeed/runtime/models/kimi_k3_comm.py
@@ -549,8 +549,8 @@ def _acquire_symm_join_outputs(
     The pair matters, not just the memory: ``AutoBackend.all_reduce`` only
     consults ``can_reduce_outputs`` on its tuple branch, so a single
     concatenated operand can never reach the symmetric kernel however it was
-    allocated. This is the shape ``latent_moe_expert_shared_all_reduce`` uses
-    for EP-only layouts.
+    allocated. ``latent_moe_expert_shared_all_reduce`` uses this pair on AMD
+    for both TP/TP and TP/EP mappings; the collective group is MoE TP x EP.
 
     Collective in the same sense the acquire is: every rank of the MoE TP x EP
     group reaches this with rank-uniform shapes, so none can disagree about

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -22,6 +22,7 @@ import importlib
 import logging
 import math
 import pkgutil
+from dataclasses import dataclass
 from typing import List, Tuple
 
 import torch
@@ -63,7 +64,10 @@ logger = logging.getLogger(__file__)
 _platform = current_platform()
 
 __all__ = [
+    "IRIS_ALL_REDUCE_KERNEL_CONFIG",
     "IrisAllReduce",
+    "IrisAllReduceKernelConfig",
+    "KimiK3AttnResKernelConfig",
     "IrisRSAG",
     "IrisAllReduceResidualRMSNorm",
     "create_iris_state",
@@ -71,6 +75,7 @@ __all__ = [
     "iris_acquire_outputs",
     "iris_all_reduce_symmetric",
     "iris_all_reduce_residual_attnres",
+    "producer_direct_all_reduce_can_run",
     "create_iris_rsag_state",
     "create_iris_ar_rmsnorm_state",
     "iris_allreduce_residual_rmsnorm",
@@ -88,21 +93,195 @@ _PRODUCER_DIRECT_GL_DTYPES = {
 }
 
 
-def _use_two_stage_producer_direct(
+@dataclass(frozen=True)
+class _StagedAllReduceKernelConfig:
+    block_size: int
+    num_subgroups: int
+    input_slots: int
+
+    def __post_init__(self) -> None:
+        if self.block_size <= 0 or self.num_subgroups <= 0 or self.input_slots < 2:
+            raise ValueError("invalid staged Iris kernel configuration")
+
+    def max_programs(self, max_numel: int) -> int:
+        return triton.cdiv(max_numel, self.block_size)
+
+
+@dataclass(frozen=True)
+class _ProducerDirectAllReduceKernelConfig:
+    supported_world_sizes: tuple[int, ...]
+    packed_word_bytes: int
+    block_size: int
+    max_programs: int
+    one_stage_num_subgroups: int
+    one_stage_words_per_lane: int
+    two_stage_num_subgroups: int
+    two_stage_words_per_lane: int
+    two_stage_min_bytes: tuple[tuple[int, int], ...]
+    publish_ready: bool
+
+    def __post_init__(self) -> None:
+        if (
+            not self.supported_world_sizes
+            or len(set(self.supported_world_sizes)) != len(self.supported_world_sizes)
+            or any(world_size <= 1 for world_size in self.supported_world_sizes)
+            or self.packed_word_bytes <= 0
+            or self.block_size <= 0
+            or self.max_programs <= 0
+            or self.one_stage_num_subgroups <= 0
+            or self.one_stage_words_per_lane <= 0
+            or self.two_stage_num_subgroups <= 0
+            or self.two_stage_words_per_lane <= 0
+        ):
+            raise ValueError("invalid producer-direct Iris kernel configuration")
+        threshold_world_sizes = tuple(
+            world_size for world_size, _ in self.two_stage_min_bytes
+        )
+        if len(set(threshold_world_sizes)) != len(threshold_world_sizes) or any(
+            world_size not in self.supported_world_sizes
+            or min_bytes <= 0
+            or self.two_stage_num_subgroups % world_size != 0
+            for world_size, min_bytes in self.two_stage_min_bytes
+        ):
+            raise ValueError("invalid producer-direct Iris two-stage thresholds")
+
+    def supports_world_size(self, world_size: int) -> bool:
+        return world_size in self.supported_world_sizes
+
+    def two_stage_threshold(self, world_size: int) -> int | None:
+        return dict(self.two_stage_min_bytes).get(world_size)
+
+    def scratch_numel(self, max_numel: int, world_size: int) -> int:
+        if max_numel == 0 or self.two_stage_threshold(world_size) is None:
+            return 0
+        return triton.cdiv(max_numel, world_size)
+
+    def use_two_stage(
+        self,
+        world_size: int,
+        total_numel: int,
+        dtype: torch.dtype,
+    ) -> bool:
+        min_bytes = self.two_stage_threshold(world_size)
+        if min_bytes is None or self.packed_word_bytes % dtype.itemsize != 0:
+            return False
+        elements_per_word = self.packed_word_bytes // dtype.itemsize
+        return (
+            total_numel * dtype.itemsize >= min_bytes
+            and total_numel % (world_size * elements_per_word) == 0
+        )
+
+    def two_stage_block_words(self, world_size: int, subgroup_size: int) -> int:
+        assert self.two_stage_threshold(world_size) is not None
+        assert self.two_stage_num_subgroups % world_size == 0
+        return (
+            self.two_stage_num_subgroups
+            * subgroup_size
+            * self.two_stage_words_per_lane
+            // world_size
+        )
+
+
+@dataclass(frozen=True)
+class KimiK3AttnResKernelConfig:
+    """Kimi-K3 fused attention-TP all-reduce and AttnRes contract."""
+
+    hidden_size: int
+    max_profitable_tokens_by_world_size: tuple[tuple[int, int], ...]
+    num_subgroups: int
+    elements_per_thread: int
+    input_slots: int
+
+    def __post_init__(self) -> None:
+        world_sizes = tuple(
+            world_size for world_size, _ in self.max_profitable_tokens_by_world_size
+        )
+        if (
+            self.hidden_size <= 0
+            or not world_sizes
+            or len(set(world_sizes)) != len(world_sizes)
+            or any(
+                world_size <= 1 or max_tokens <= 0
+                for world_size, max_tokens in self.max_profitable_tokens_by_world_size
+            )
+            or self.num_subgroups <= 0
+            or self.elements_per_thread <= 0
+            or self.input_slots < 2
+        ):
+            raise ValueError("invalid Kimi-K3 AttnRes Iris kernel configuration")
+
+    def max_profitable_num_tokens(self, world_size: int) -> int:
+        return dict(self.max_profitable_tokens_by_world_size).get(world_size, 0)
+
+    def supports_world_size(self, world_size: int) -> bool:
+        return self.max_profitable_num_tokens(world_size) > 0
+
+
+@dataclass(frozen=True)
+class IrisAllReduceKernelConfig:
+    """Launch and workspace contract for TokenSpeed's Iris all-reduces.
+
+    ``staged`` and ``producer_direct`` are generic AMD collective protocols.
+    The producer-direct path is used by Kimi-K3 MoE for both TP/TP and TP/EP;
+    it is not EP-specific. ``kimi_k3_attnres`` is model-specific and operates
+    only on Kimi-K3's attention tensor-parallel group.
+    """
+
+    subgroup_size: int
+    staged: _StagedAllReduceKernelConfig
+    producer_direct: _ProducerDirectAllReduceKernelConfig
+    kimi_k3_attnres: KimiK3AttnResKernelConfig
+
+    def __post_init__(self) -> None:
+        if self.subgroup_size <= 0 or self.subgroup_size & (self.subgroup_size - 1):
+            raise ValueError("Iris subgroup size must be a positive power of two")
+
+
+IRIS_ALL_REDUCE_KERNEL_CONFIG = IrisAllReduceKernelConfig(
+    subgroup_size=64,
+    staged=_StagedAllReduceKernelConfig(
+        block_size=2048,
+        num_subgroups=4,
+        input_slots=2,
+    ),
+    producer_direct=_ProducerDirectAllReduceKernelConfig(
+        supported_world_sizes=(2, 4, 8),
+        packed_word_bytes=8,
+        block_size=512,
+        max_programs=84,
+        one_stage_num_subgroups=1,
+        one_stage_words_per_lane=2,
+        two_stage_num_subgroups=8,
+        two_stage_words_per_lane=2,
+        two_stage_min_bytes=((4, 160 << 10), (8, 96 << 10)),
+        publish_ready=False,
+    ),
+    kimi_k3_attnres=KimiK3AttnResKernelConfig(
+        hidden_size=7168,
+        max_profitable_tokens_by_world_size=((8, 16),),
+        num_subgroups=4,
+        elements_per_thread=1,
+        input_slots=2,
+    ),
+)
+
+
+def producer_direct_all_reduce_can_run(
     world_size: int,
     total_numel: int,
     dtype: torch.dtype,
+    max_bytes: int,
 ) -> bool:
-    if world_size == 8:
-        min_bytes = 96 << 10
-    elif world_size == 4:
-        min_bytes = 160 << 10
-    else:
-        return False
-    elements_per_word = 8 // dtype.itemsize
+    """Return whether the generic AMD producer-direct kernel supports a payload."""
+    config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
+    element_bytes = dtype.itemsize
     return (
-        total_numel * dtype.itemsize >= min_bytes
-        and total_numel % (world_size * elements_per_word) == 0
+        config.supports_world_size(world_size)
+        and total_numel > 0
+        and dtype in _PRODUCER_DIRECT_GL_DTYPES
+        and config.packed_word_bytes % element_bytes == 0
+        and total_numel % (config.packed_word_bytes // element_bytes) == 0
+        and total_numel * element_bytes <= max_bytes
     )
 
 
@@ -130,21 +309,16 @@ def _use_two_stage_plain(
     kernel's structural one -- the payload has to split evenly into per-rank
     partitions of whole 64-bit words.
     """
-    if world_size not in (4, 8):
+    kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
+    if kernel_config.two_stage_threshold(world_size) is None:
         return False
     # The kernel packs elements into 64-bit words through
     # _PRODUCER_DIRECT_GL_DTYPES; anything outside it (or wider than a word,
     # which would make elements_per_word zero) stays on one-shot.
     if dtype not in _PRODUCER_DIRECT_GL_DTYPES:
         return False
-    elements_per_word = 8 // dtype.itemsize
+    elements_per_word = kernel_config.packed_word_bytes // dtype.itemsize
     return numel % (world_size * elements_per_word) == 0
-
-
-# Staging slots the one-shot all-reduce rotates through. Two is enough to keep
-# the reclaim wait off the critical path: a rank may be a whole invocation ahead
-# of its slowest peer before it has to wait for that peer to finish reading.
-_STAGED_SLOTS = 2
 
 
 def _get_available_gpu_memory(gpu_id: int, empty_cache: bool = True) -> float:
@@ -377,11 +551,13 @@ class IrisAllReduce(object):
         self,
         group: dist.ProcessGroup,
         rank_in_group: int,
-        max_numel: int,
+        staged_max_numel: int,
+        producer_direct_max_numel: int,
+        attnres_max_numel: int,
+        attnres_max_rows: int,
         dtype: torch.dtype = torch.bfloat16,
         heap_size: int | None = None,
         device: torch.device = None,
-        config=None,
     ) -> None:
         assert (
             type(group) == dist.ProcessGroup
@@ -397,17 +573,37 @@ class IrisAllReduce(object):
 
         self.group = group
         self.rank_in_group = rank_in_group
-        self.max_numel = max_numel
+        self.staged_max_numel = staged_max_numel
+        self.producer_direct_max_numel = producer_direct_max_numel
+        self.attnres_max_numel = attnres_max_numel
+        self.attnres_max_rows = attnres_max_rows
         self.dtype = dtype
-        self._elements_per_word = 8 // dtype.itemsize
         self.device = device or torch.device(f"cuda:{torch.cuda.current_device()}")
-        self._config = config or _IrisConfig(
-            block_size_m=1,
-            block_size_n=256,
-            swizzle_size=4,
-            comm_sms=64,
-            all_reduce_variant="one_shot",
-            all_reduce_distribution=1,
+        self.world_size = group.size()
+        if (
+            min(
+                staged_max_numel,
+                producer_direct_max_numel,
+                attnres_max_numel,
+                attnres_max_rows,
+            )
+            < 0
+        ):
+            raise ValueError("Iris all-reduce capacities must be non-negative")
+        if bool(attnres_max_numel) != bool(attnres_max_rows):
+            raise ValueError(
+                "AttnRes element and row capacities must both be zero or non-zero"
+            )
+        self._kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG
+        producer_config = self._kernel_config.producer_direct
+        staged_config = self._kernel_config.staged
+        self._elements_per_word = producer_config.packed_word_bytes // dtype.itemsize
+        self._producer_direct_scratch_numel = producer_config.scratch_numel(
+            max_numel=producer_direct_max_numel,
+            world_size=self.world_size,
+        )
+        self._staged_max_programs = staged_config.max_programs(
+            max_numel=staged_max_numel
         )
 
         # Whether this state can ever dispatch a two-stage reduction. Platform,
@@ -417,51 +613,97 @@ class IrisAllReduce(object):
         # stays in _use_two_stage_plain.
         self._two_stage_supported = (
             _platform.is_cdna4
-            and group.size() in (4, 8)
+            and staged_max_numel > 0
+            and producer_config.two_stage_threshold(self.world_size) is not None
             and dtype in _PRODUCER_DIRECT_GL_DTYPES
         )
+        self._staged_two_stage_scratch_numel = (
+            triton.cdiv(staged_max_numel, self.world_size)
+            if self._two_stage_supported
+            else 0
+        )
 
-        # Leave generous heap headroom for the symmetric input and Iris
-        # bookkeeping such as ring/spinlock flags.
         if heap_size is None:
-            buf_bytes = max_numel * dtype.itemsize
-            # _input_buf, _attnres_input_buf (2), _producer_direct_scratch_buf,
-            # and the staged path's rotating slots (_STAGED_SLOTS).
-            buffers = 4 + _STAGED_SLOTS
-            if self._two_stage_supported:
-                # its staging buffer, plus the scratch partition counted as a
-                # whole buffer rather than 1/world_size
-                buffers += 2
-            heap_size = max(1 << 28, buffers * buf_bytes + (16 << 20))
+            payload_numel = (
+                producer_direct_max_numel
+                + self._producer_direct_scratch_numel
+                + staged_config.input_slots * staged_max_numel
+                + self._kernel_config.kimi_k3_attnres.input_slots * attnres_max_numel
+                + (staged_max_numel if self._two_stage_supported else 0)
+                + self._staged_two_stage_scratch_numel
+            )
+            flag_numel = self.world_size * (
+                self._staged_max_programs
+                + 2 * attnres_max_rows
+                + (producer_config.max_programs if producer_direct_max_numel else 0)
+                + (producer_config.max_programs if self._two_stage_supported else 0)
+            )
+            heap_size = max(
+                1 << 28,
+                payload_numel * dtype.itemsize
+                + flag_numel * torch.int32.itemsize
+                + (16 << 20),
+            )
 
         free_gpu_memory_begin = _get_available_gpu_memory(torch.cuda.current_device())
         self._ctx = _get_or_create_iris_context(heap_size)
-        self.world_size = group.size()
         group_ranks = dist.get_process_group_ranks(group)
         assert len(group_ranks) == self.world_size
         assert group_ranks[rank_in_group] == dist.get_rank()
-        self._input_buf = self._ctx.zeros((max_numel,), dtype=dtype)
-        self._attnres_input_buf = self._ctx.zeros((2, max_numel), dtype=dtype)
-        self._attnres_ready_flags = self._ctx.zeros(
-            (32, self.world_size), dtype=torch.int32
+        self._input_buf = (
+            self._ctx.zeros((producer_direct_max_numel,), dtype=dtype)
+            if producer_direct_max_numel
+            else None
         )
-        self._attnres_consumed_flags = self._ctx.zeros(
-            (32, self.world_size), dtype=torch.int32
+        self._attnres_input_buf = (
+            self._ctx.zeros(
+                (
+                    self._kernel_config.kimi_k3_attnres.input_slots,
+                    attnres_max_numel,
+                ),
+                dtype=dtype,
+            )
+            if attnres_max_numel
+            else None
         )
-        self._producer_direct_scratch_buf = self._ctx.zeros((max_numel,), dtype=dtype)
-        self._producer_direct_output_buf = torch.empty(
-            max_numel, dtype=dtype, device=self.device
+        self._attnres_ready_flags = (
+            self._ctx.zeros((attnres_max_rows, self.world_size), dtype=torch.int32)
+            if attnres_max_numel
+            else None
         )
-        self._block_size = 2048
-        self._max_blocks = triton.cdiv(max_numel, self._block_size)
-        self._ready_flags = self._ctx.zeros(
-            (self._max_blocks, self.world_size), dtype=torch.int32
+        self._attnres_consumed_flags = (
+            self._ctx.zeros((attnres_max_rows, self.world_size), dtype=torch.int32)
+            if attnres_max_numel
+            else None
+        )
+        self._producer_direct_scratch_buf = (
+            self._ctx.zeros((self._producer_direct_scratch_numel,), dtype=dtype)
+            if self._producer_direct_scratch_numel
+            else None
+        )
+        output_max_numel = max(
+            producer_direct_max_numel,
+            staged_max_numel if self._two_stage_supported else 0,
+        )
+        self._reduced_output_buf = (
+            torch.empty(output_max_numel, dtype=dtype, device=self.device)
+            if output_max_numel
+            else None
+        )
+        self._ready_flags = (
+            self._ctx.zeros(
+                (self._staged_max_programs, self.world_size), dtype=torch.int32
+            )
+            if staged_max_numel
+            else None
         )
         # The staged one-shot rotates across its own slots rather than sharing
         # _input_buf: that buffer is handed out by acquire_outputs for
         # producer-direct reductions, so its layout is not ours to rotate.
-        self._staged_input_buf = self._ctx.zeros(
-            (_STAGED_SLOTS, max_numel), dtype=dtype
+        self._staged_input_buf = (
+            self._ctx.zeros((staged_config.input_slots, staged_max_numel), dtype=dtype)
+            if staged_max_numel
+            else None
         )
         # Two-stage plain all-reduce. One-shot stages inside its own kernel and
         # picks a slot from its per-block epoch; the two-stage kernel instead
@@ -480,30 +722,34 @@ class IrisAllReduce(object):
         # buffer and a scratch partition it can never use, and an explicit
         # heap_size sized for the previous allocations would fail to fit them.
         if self._two_stage_supported:
-            self._two_stage_input_buf = self._ctx.zeros((max_numel,), dtype=dtype)
+            self._two_stage_input_buf = self._ctx.zeros(
+                (staged_max_numel,), dtype=dtype
+            )
             # Each rank reduces only its own partition and peers read it at the
             # same offset, so scratch holds one partition, not the whole payload.
             self._two_stage_scratch_buf = self._ctx.zeros(
-                (max_numel // self.world_size,), dtype=dtype
+                (self._staged_two_stage_scratch_numel,), dtype=dtype
             )
         else:
             self._two_stage_input_buf = None
             self._two_stage_scratch_buf = None
-        self._producer_direct_block_size = 512
-        # Use one program per tile for small payloads, capped to limit contention.
-        self._producer_direct_max_programs = 84
-        # Experimental alternative: publish readiness into peer-local memory.
-        self._producer_direct_publish_ready = False
-        self._producer_direct_ready_flags = self._ctx.zeros(
-            (self._producer_direct_max_programs, self.world_size),
-            dtype=torch.int32,
+        self._producer_direct_ready_flags = (
+            self._ctx.zeros(
+                (
+                    producer_config.max_programs,
+                    self.world_size,
+                ),
+                dtype=torch.int32,
+            )
+            if producer_direct_max_numel
+            else None
         )
         # Separate epochs from the producer-direct reduce: in a tensor-parallel
         # MoE both collectives run inside one layer, and a shared counter would
         # let one path's epoch satisfy the other's barrier.
         self._two_stage_ready_flags = (
             self._ctx.zeros(
-                (self._producer_direct_max_programs, self.world_size),
+                (producer_config.max_programs, self.world_size),
                 dtype=torch.int32,
             )
             if self._two_stage_supported
@@ -542,9 +788,9 @@ class IrisAllReduce(object):
             f"backend={self.dtype}"
         )
         numel = tensor.numel()
-        assert numel <= self.max_numel, (
+        assert 0 < numel <= self.staged_max_numel, (
             f"tensor numel ({numel}) exceeds iris buffer capacity "
-            f"({self.max_numel})"
+            f"({self.staged_max_numel})"
         )
         # One-shot has every rank publish the whole payload and read world_size
         # copies of it, so its cost grows with the payload; the two-stage form
@@ -560,7 +806,9 @@ class IrisAllReduce(object):
             self.world_size, numel, self.dtype
         ):
             return self._all_reduce_two_stage(tensor, numel, safe=safe)
-        iris_stage_one_shot_allreduce_kernel[(triton.cdiv(numel, self._block_size),)](
+        kernel_config = self._kernel_config.staged
+        block_size = kernel_config.block_size
+        iris_stage_one_shot_allreduce_kernel[(triton.cdiv(numel, block_size),)](
             tensor.view(-1),
             self._staged_input_buf.view(-1),
             tensor.view(-1),
@@ -569,10 +817,10 @@ class IrisAllReduce(object):
             numel,
             RANK=self._iris_rank,
             WORLD_SIZE=self.world_size,
-            BLOCK_SIZE=self._block_size,
-            SLOT_STRIDE=self.max_numel,
-            NUM_SLOTS=_STAGED_SLOTS,
-            num_warps=4,
+            BLOCK_SIZE=block_size,
+            SLOT_STRIDE=self.staged_max_numel,
+            NUM_SLOTS=kernel_config.input_slots,
+            num_warps=kernel_config.num_subgroups,
         )
 
         return tensor.clone() if safe else tensor
@@ -597,8 +845,9 @@ class IrisAllReduce(object):
         """Return consecutive views of the symmetric Iris input buffer."""
         if not shapes or any(math.prod(shape) <= 0 for shape in shapes):
             raise ValueError("Iris requires non-empty symmetric output shapes")
-        if sum(math.prod(shape) for shape in shapes) > self.max_numel:
+        if sum(math.prod(shape) for shape in shapes) > self.producer_direct_max_numel:
             raise ValueError("Iris symmetric outputs exceed the input buffer")
+        assert self._input_buf is not None
         return self._views(self._input_buf, shapes)
 
     def owns_outputs(self, tensors: tuple[torch.Tensor, ...]) -> bool:
@@ -611,13 +860,18 @@ class IrisAllReduce(object):
             for tensor in tensors
         ):
             return False
+        if self._input_buf is None:
+            return False
         element_size = self._input_buf.element_size()
         offset = 0
         for tensor in tensors:
             if tensor.data_ptr() != self._input_buf.data_ptr() + offset * element_size:
                 return False
             offset += tensor.numel()
-        return offset % self._elements_per_word == 0 and offset <= self.max_numel
+        return (
+            offset % self._elements_per_word == 0
+            and offset <= self.producer_direct_max_numel
+        )
 
     def _all_reduce_two_stage(
         self, tensor: torch.Tensor, numel: int, safe: bool
@@ -639,11 +893,15 @@ class IrisAllReduce(object):
 
         partition_numel = numel // self.world_size
         partition_words = partition_numel // self._elements_per_word
-        # 512 threads move 16 bytes each, split evenly across ranks.
-        block_words = 1024 // self.world_size
+        kernel_config = self._kernel_config.producer_direct
+        block_words = kernel_config.two_stage_block_words(
+            world_size=self.world_size,
+            subgroup_size=self._kernel_config.subgroup_size,
+        )
         num_tiles = triton.cdiv(partition_words, block_words)
-        num_programs = min(num_tiles, self._producer_direct_max_programs)
-        output = self._producer_direct_output_buf[:numel]
+        num_programs = min(num_tiles, kernel_config.max_programs)
+        assert self._reduced_output_buf is not None
+        output = self._reduced_output_buf[:numel]
         iris_reduce_symmetric_two_stage_gluon_kernel[(num_programs,)](
             staged,
             self._two_stage_scratch_buf,
@@ -656,11 +914,13 @@ class IrisAllReduce(object):
             BLOCK_WORDS=block_words,
             NUM_PROGRAMS=num_programs,
             NUM_TILES=num_tiles,
-            NUM_WARPS=8,
+            NUM_WARPS=kernel_config.two_stage_num_subgroups,
+            SUBGROUP_SIZE=self._kernel_config.subgroup_size,
+            WORDS_PER_LANE=kernel_config.two_stage_words_per_lane,
             ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
             ELEMENTS_PER_WORD=self._elements_per_word,
             EXIT_BARRIER=True,
-            num_warps=8,
+            num_warps=kernel_config.two_stage_num_subgroups,
         )
         tensor.view(-1).copy_(output)
         return tensor.clone() if safe else tensor
@@ -672,28 +932,42 @@ class IrisAllReduce(object):
         assert self.owns_outputs(tensors)
         if not _platform.is_cdna4:
             raise RuntimeError("producer-direct Iris all-reduce requires CDNA4")
+        kernel_config = self._kernel_config.producer_direct
+        if not kernel_config.supports_world_size(self.world_size):
+            raise RuntimeError(
+                "producer-direct Iris all-reduce does not support group size "
+                f"{self.world_size}"
+            )
+        if self.dtype not in _PRODUCER_DIRECT_GL_DTYPES:
+            raise RuntimeError(
+                f"producer-direct Iris all-reduce does not support {self.dtype}"
+            )
 
         total_numel = sum(tensor.numel() for tensor in tensors)
+        assert self._reduced_output_buf is not None
         outputs = self._views(
-            self._producer_direct_output_buf,
+            self._reduced_output_buf,
             tuple(tuple(tensor.shape) for tensor in tensors),
         )
-        use_two_stage = _use_two_stage_producer_direct(
-            self.world_size,
-            total_numel,
-            self.dtype,
+        use_two_stage = kernel_config.use_two_stage(
+            world_size=self.world_size,
+            total_numel=total_numel,
+            dtype=self.dtype,
         )
         if use_two_stage:
+            assert self._producer_direct_scratch_buf is not None
             partition_numel = total_numel // self.world_size
             partition_words = partition_numel // self._elements_per_word
-            # 512 threads move 16 bytes each, split evenly across ranks.
-            block_words = 1024 // self.world_size
+            block_words = kernel_config.two_stage_block_words(
+                world_size=self.world_size,
+                subgroup_size=self._kernel_config.subgroup_size,
+            )
             num_tiles = triton.cdiv(partition_words, block_words)
-            num_programs = min(num_tiles, self._producer_direct_max_programs)
+            num_programs = min(num_tiles, kernel_config.max_programs)
             iris_reduce_symmetric_two_stage_gluon_kernel[(num_programs,)](
                 self._input_buf,
                 self._producer_direct_scratch_buf,
-                self._producer_direct_output_buf,
+                self._reduced_output_buf,
                 self._producer_direct_ready_flags,
                 *self._heap_base_addresses,
                 RANK=self._iris_rank,
@@ -702,31 +976,36 @@ class IrisAllReduce(object):
                 BLOCK_WORDS=block_words,
                 NUM_PROGRAMS=num_programs,
                 NUM_TILES=num_tiles,
-                NUM_WARPS=8,
+                NUM_WARPS=kernel_config.two_stage_num_subgroups,
+                SUBGROUP_SIZE=self._kernel_config.subgroup_size,
+                WORDS_PER_LANE=kernel_config.two_stage_words_per_lane,
                 ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
                 ELEMENTS_PER_WORD=self._elements_per_word,
                 EXIT_BARRIER=False,
-                num_warps=8,
+                num_warps=kernel_config.two_stage_num_subgroups,
             )
         else:
-            num_tiles = triton.cdiv(total_numel, self._producer_direct_block_size)
-            num_programs = min(num_tiles, self._producer_direct_max_programs)
+            block_size = kernel_config.block_size
+            num_tiles = triton.cdiv(total_numel, block_size)
+            num_programs = min(num_tiles, kernel_config.max_programs)
             iris_reduce_symmetric_gluon_kernel[(num_programs,)](
                 self._input_buf,
-                self._producer_direct_output_buf,
+                self._reduced_output_buf,
                 self._producer_direct_ready_flags,
                 *self._heap_base_addresses,
                 RANK=self._iris_rank,
                 WORLD_SIZE=self.world_size,
                 TOTAL_NUMEL=total_numel,
-                BLOCK_SIZE=self._producer_direct_block_size,
+                BLOCK_SIZE=block_size,
                 NUM_PROGRAMS=num_programs,
                 NUM_TILES=num_tiles,
-                NUM_WARPS=1,
-                PUBLISH_READY=self._producer_direct_publish_ready,
+                NUM_WARPS=kernel_config.one_stage_num_subgroups,
+                SUBGROUP_SIZE=self._kernel_config.subgroup_size,
+                WORDS_PER_LANE=kernel_config.one_stage_words_per_lane,
+                PUBLISH_READY=kernel_config.publish_ready,
                 ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
                 ELEMENTS_PER_WORD=self._elements_per_word,
-                num_warps=1,
+                num_warps=kernel_config.one_stage_num_subgroups,
             )
         return outputs
 
@@ -744,24 +1023,27 @@ class IrisAllReduce(object):
         if op is None:
             op = dist.ReduceOp.SUM
         assert op == dist.ReduceOp.SUM, f"Iris all-reduce only supports SUM, got {op}"
-        assert _platform.is_cdna4 and self.world_size == 8
+        kernel_config = self._kernel_config.kimi_k3_attnres
+        assert _platform.is_cdna4 and kernel_config.supports_world_size(self.world_size)
         num_tokens = partial.shape[0]
-        assert 0 < num_tokens <= 32
-        assert partial.shape == residual.shape == (num_tokens, 7168)
+        assert 0 < num_tokens <= self.attnres_max_rows
+        expected_shape = (num_tokens, kernel_config.hidden_size)
+        assert partial.shape == residual.shape == expected_shape
         assert partial.dtype == residual.dtype == self.dtype == torch.bfloat16
         assert partial.device == residual.device == self.device
         assert partial.is_contiguous() and residual.is_contiguous()
-        assert partial.numel() <= self.max_numel, (
+        assert 0 < partial.numel() <= self.attnres_max_numel, (
             f"tensor numel ({partial.numel()}) exceeds iris buffer capacity "
-            f"({self.max_numel})"
+            f"({self.attnres_max_numel})"
         )
-        assert score_weight.shape == output_weight.shape == (7168,)
+        assert self._attnres_input_buf is not None
+        assert score_weight.shape == output_weight.shape == (kernel_config.hidden_size,)
         assert score_weight.dtype == output_weight.dtype == torch.bfloat16
         assert score_weight.device == output_weight.device == self.device
         assert score_weight.is_contiguous() and output_weight.is_contiguous()
         m, s_, acc = scratch
         assert m.shape == s_.shape == (num_tokens,)
-        assert acc.shape == (num_tokens, 7168)
+        assert acc.shape == expected_shape
         assert m.dtype == s_.dtype == acc.dtype == torch.float32
         assert m.device == s_.device == acc.device == self.device
         assert m.is_contiguous() and s_.is_contiguous() and acc.is_contiguous()
@@ -786,13 +1068,15 @@ class IrisAllReduce(object):
             RANK=self._iris_rank,
             WORLD_SIZE=self.world_size,
             M=num_tokens,
-            HIDDEN=7168,
-            BLOCK=8192,
-            INPUT_SLOT_STRIDE=self.max_numel,
+            HIDDEN=kernel_config.hidden_size,
+            BLOCK=triton.next_power_of_2(kernel_config.hidden_size),
+            INPUT_SLOT_STRIDE=self.attnres_max_numel,
+            NUM_SLOTS=kernel_config.input_slots,
             EPS=eps,
-            ELEMENTS_PER_THREAD=1,
-            NUM_WARPS=4,
-            num_warps=4,
+            ELEMENTS_PER_THREAD=kernel_config.elements_per_thread,
+            NUM_WARPS=kernel_config.num_subgroups,
+            SUBGROUP_SIZE=self._kernel_config.subgroup_size,
+            num_warps=kernel_config.num_subgroups,
         )
         return hidden, residual_out
 
@@ -820,13 +1104,12 @@ def iris_stage_one_shot_allreduce_kernel(
     next collective's data. No error, no hang, just wrong numbers on whichever
     ranks lagged.
 
-    Rotating over two slots closes it, and the existing entry barrier is what
-    makes two enough. Writing epoch E+1 lands on the other slot, so it cannot
-    disturb a peer still reading E. Reaching E+2 -- which returns to E's slot --
-    means passing the entry wait at E+1, which blocks until every peer published
-    ready(E+1); a peer publishes that only after it has finished reading at E.
-    So by the time a slot is reused, every peer is provably done with it, and no
-    consumption flag or exit barrier has to be paid for.
+    Rotating over at least two slots closes it, and the existing entry barrier
+    makes two sufficient. Writing epoch E+1 lands on a different slot. Before a
+    rank can wrap back to E's slot, it must pass the entry wait at E+1; a peer
+    publishes ready(E+1) only after it has finished reading E. By the time a
+    slot is reused, every peer is provably done with it, and no consumption flag
+    or exit barrier has to be paid for.
 
     Epochs are per-block, so a grid that shrinks between calls leaves the higher
     blocks' counters where they were. That is consistent across ranks -- every
@@ -922,10 +1205,13 @@ def _iris_sync_rank_epoch(
     RANK: gl.constexpr,
     WORLD_SIZE: gl.constexpr,
     NUM_WARPS: gl.constexpr,
+    SUBGROUP_SIZE: gl.constexpr,
     PUBLISH: gl.constexpr,
 ):
     """Synchronize by polling peer epochs or publishing them locally."""
-    ready_layout: gl.constexpr = gl.BlockedLayout([1], [64], [NUM_WARPS], [0])
+    ready_layout: gl.constexpr = gl.BlockedLayout(
+        [1], [SUBGROUP_SIZE], [NUM_WARPS], [0]
+    )
     peer_ids = gl.arange(0, WORLD_SIZE, layout=ready_layout)
     peer_heaps = gl.where(peer_ids == 0, heap_base_0, heap_base_7)
     peer_heaps = gl.where(peer_ids == 1, heap_base_1, peer_heaps)
@@ -1038,6 +1324,8 @@ def iris_reduce_symmetric_gluon_kernel(
     NUM_PROGRAMS: gl.constexpr,
     NUM_TILES: gl.constexpr,
     NUM_WARPS: gl.constexpr,
+    SUBGROUP_SIZE: gl.constexpr,
+    WORDS_PER_LANE: gl.constexpr,
     PUBLISH_READY: gl.constexpr,
     ELEMENT_DTYPE: gl.constexpr,
     ELEMENTS_PER_WORD: gl.constexpr,
@@ -1073,11 +1361,14 @@ def iris_reduce_symmetric_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        SUBGROUP_SIZE,
         PUBLISH=PUBLISH_READY,
     )
 
     input_heap_offset = tl.cast(input_sym_ptr, gl.uint64) - local_heap
-    layout: gl.constexpr = gl.BlockedLayout([2], [64], [NUM_WARPS], [0])
+    layout: gl.constexpr = gl.BlockedLayout(
+        [WORDS_PER_LANE], [SUBGROUP_SIZE], [NUM_WARPS], [0]
+    )
     lane = gl.arange(0, BLOCK_SIZE // ELEMENTS_PER_WORD, layout=layout)
     total_packed: gl.constexpr = TOTAL_NUMEL // ELEMENTS_PER_WORD
     tile_id = block_id
@@ -1159,6 +1450,7 @@ def iris_reduce_symmetric_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        SUBGROUP_SIZE,
         PUBLISH=PUBLISH_READY,
     )
 
@@ -1184,6 +1476,8 @@ def iris_reduce_symmetric_two_stage_gluon_kernel(
     NUM_PROGRAMS: gl.constexpr,
     NUM_TILES: gl.constexpr,
     NUM_WARPS: gl.constexpr,
+    SUBGROUP_SIZE: gl.constexpr,
+    WORDS_PER_LANE: gl.constexpr,
     ELEMENT_DTYPE: gl.constexpr,
     ELEMENTS_PER_WORD: gl.constexpr,
     EXIT_BARRIER: gl.constexpr,
@@ -1219,16 +1513,20 @@ def iris_reduce_symmetric_two_stage_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        SUBGROUP_SIZE,
         PUBLISH=True,
     )
 
     input_heap_offset = tl.cast(input_sym_ptr, gl.uint64) - local_heap
     scratch_heap_offset = tl.cast(scratch_sym_ptr, gl.uint64) - local_heap
     load_layout: gl.constexpr = gl.BlockedLayout(
-        [1, 2], [1, 64], [WORLD_SIZE, NUM_WARPS // WORLD_SIZE], [1, 0]
+        [1, WORDS_PER_LANE],
+        [1, SUBGROUP_SIZE],
+        [WORLD_SIZE, NUM_WARPS // WORLD_SIZE],
+        [1, 0],
     )
     reduce_layout: gl.constexpr = gl.BlockedLayout(
-        [WORLD_SIZE, 1], [1, 64], [1, NUM_WARPS], [0, 1]
+        [WORLD_SIZE, 1], [1, SUBGROUP_SIZE], [1, NUM_WARPS], [0, 1]
     )
     peer_layout: gl.constexpr = gl.SliceLayout(1, load_layout)
     word_layout: gl.constexpr = gl.SliceLayout(0, load_layout)
@@ -1317,6 +1615,7 @@ def iris_reduce_symmetric_two_stage_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        SUBGROUP_SIZE,
         PUBLISH=True,
     )
 
@@ -1398,14 +1697,16 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
     HIDDEN: gl.constexpr,
     BLOCK: gl.constexpr,
     INPUT_SLOT_STRIDE: gl.constexpr,
+    NUM_SLOTS: gl.constexpr,
     EPS: gl.constexpr,
     ELEMENTS_PER_THREAD: gl.constexpr,
     NUM_WARPS: gl.constexpr,
+    SUBGROUP_SIZE: gl.constexpr,
 ):
     """Kimi-K3 attention AR, residual, and split AttnRes combine."""
     row = gl.program_id(0)
     layout: gl.constexpr = gl.BlockedLayout(
-        [ELEMENTS_PER_THREAD], [64], [NUM_WARPS], [0]
+        [ELEMENTS_PER_THREAD], [SUBGROUP_SIZE], [NUM_WARPS], [0]
     )
     offset = gl.arange(0, BLOCK, layout=layout)
     mask = offset < HIDDEN
@@ -1431,7 +1732,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         heap_base_6,
         heap_base_7,
     )
-    reuse_epoch = gl.maximum(epoch - 2, 0)
+    reuse_epoch = gl.maximum(epoch - NUM_SLOTS, 0)
     _iris_sync_rank_epoch(
         consumed_flags,
         row,
@@ -1448,10 +1749,15 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        SUBGROUP_SIZE,
         PUBLISH=False,
     )
 
-    input_slot_ptr = input_sym_ptr + (epoch & 1) * INPUT_SLOT_STRIDE
+    if NUM_SLOTS & (NUM_SLOTS - 1) == 0:
+        input_slot = epoch & (NUM_SLOTS - 1)
+    else:
+        input_slot = epoch % NUM_SLOTS
+    input_slot_ptr = input_sym_ptr + input_slot * INPUT_SLOT_STRIDE
     gl.amd.cdna4.buffer_store(
         local.to(input_slot_ptr.dtype.element_ty),
         input_slot_ptr,
@@ -1478,6 +1784,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         RANK,
         WORLD_SIZE,
         NUM_WARPS,
+        SUBGROUP_SIZE,
         PUBLISH=True,
     )
 
@@ -1864,15 +2171,37 @@ class IrisAllReduceResidualRMSNorm(object):
 def create_iris_state(
     group: dist.ProcessGroup,
     rank_in_group: int,
-    max_numel: int,
+    staged_max_numel: int,
+    producer_direct_max_numel: int,
+    attnres_max_numel: int,
+    attnres_max_rows: int,
     dtype: torch.dtype = torch.bfloat16,
     heap_size: int | None = None,
     device: torch.device = None,
 ) -> "IrisAllReduce":
+    """Create an Iris all-reduce state with protocol-specific capacities.
+
+    Args:
+        group: Process group used by the collectives.
+        rank_in_group: This process's rank within ``group``.
+        staged_max_numel: Maximum ordinary staged all-reduce payload.
+        producer_direct_max_numel: Maximum producer-direct payload.
+        attnres_max_numel: Maximum fused attention/AttnRes payload.
+        attnres_max_rows: Maximum fused attention/AttnRes rows.
+        dtype: Element type for all payload buffers.
+        heap_size: Optional symmetric heap size in bytes.
+        device: Device on which buffers are allocated.
+
+    Returns:
+        The initialized all-reduce state.
+    """
     return IrisAllReduce(
         group=group,
         rank_in_group=rank_in_group,
-        max_numel=max_numel,
+        staged_max_numel=staged_max_numel,
+        producer_direct_max_numel=producer_direct_max_numel,
+        attnres_max_numel=attnres_max_numel,
+        attnres_max_rows=attnres_max_rows,
         dtype=dtype,
         heap_size=heap_size,
         device=device,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -184,19 +184,26 @@ class _ProducerDirectAllReduceKernelConfig:
 
 @dataclass(frozen=True)
 class KimiK3AttnResKernelConfig:
-    """Kimi-K3 fused attention-TP all-reduce and AttnRes contract."""
+    """Kimi-K3 fused attention-TP all-reduce and AttnRes contract.
 
+    Attributes:
+        world_size: Required attention tensor-parallel group size.
+        hidden_size: Kimi-K3 attention output width.
+        num_subgroups: Number of subgroups in each kernel workgroup.
+        elements_per_thread: Number of hidden elements processed per thread.
+    """
+
+    world_size: int
     hidden_size: int
     num_subgroups: int
     elements_per_thread: int
-    input_slots: int
 
     def __post_init__(self) -> None:
         if (
-            self.hidden_size <= 0
+            self.world_size <= 1
+            or self.hidden_size <= 0
             or self.num_subgroups <= 0
             or self.elements_per_thread <= 0
-            or self.input_slots < 2
         ):
             raise ValueError("invalid Kimi-K3 AttnRes Iris kernel configuration")
 
@@ -205,10 +212,17 @@ class KimiK3AttnResKernelConfig:
 class IrisAllReduceKernelConfig:
     """Launch and workspace contract for TokenSpeed's Iris all-reduces.
 
-    ``staged`` and ``producer_direct`` are generic AMD collective protocols.
+    ``staged`` and ``producer_direct`` are generic AMD all-reduce paths.
     The producer-direct path is used by Kimi-K3 MoE for both TP/TP and TP/EP;
     it is not EP-specific. ``kimi_k3_attnres`` is model-specific and operates
     only on Kimi-K3's attention tensor-parallel group.
+
+    Attributes:
+        subgroup_size: Hardware subgroup width used by the Gluon kernels.
+        staged: Launch and workspace parameters for staged all-reduce.
+        producer_direct: Launch, workspace, and eligibility parameters for
+            producer-direct all-reduce.
+        kimi_k3_attnres: Launch and shape parameters for Kimi-K3 AttnRes.
     """
 
     subgroup_size: int
@@ -241,10 +255,10 @@ IRIS_ALL_REDUCE_KERNEL_CONFIG = IrisAllReduceKernelConfig(
         publish_ready=False,
     ),
     kimi_k3_attnres=KimiK3AttnResKernelConfig(
+        world_size=8,
         hidden_size=7168,
         num_subgroups=4,
         elements_per_thread=1,
-        input_slots=2,
     ),
 )
 
@@ -255,7 +269,18 @@ def producer_direct_all_reduce_can_run(
     dtype: torch.dtype,
     max_bytes: int,
 ) -> bool:
-    """Return whether the generic AMD producer-direct kernel supports a payload."""
+    """Check the generic AMD producer-direct kernel's payload requirements.
+
+    Args:
+        world_size: Number of ranks participating in the all-reduce.
+        total_numel: Total number of elements in the payload.
+        dtype: Element type of the payload.
+        max_bytes: Byte capacity of the producer-direct symmetric input buffer.
+
+    Returns:
+        Whether the group size and element type are supported and the payload is
+        positive, packed-word aligned, and within the input-buffer capacity.
+    """
     config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
     element_bytes = dtype.itemsize
     return (
@@ -538,9 +563,9 @@ class IrisAllReduce(object):
         producer_direct_max_numel: int,
         attnres_max_numel: int,
         attnres_max_rows: int,
-        dtype: torch.dtype = torch.bfloat16,
-        heap_size: int | None = None,
-        device: torch.device = None,
+        dtype: torch.dtype,
+        heap_size: int | None,
+        device: torch.device | None,
     ) -> None:
         assert (
             type(group) == dist.ProcessGroup
@@ -611,7 +636,7 @@ class IrisAllReduce(object):
                 producer_direct_max_numel
                 + self._producer_direct_scratch_numel
                 + staged_config.input_slots * staged_max_numel
-                + self._kernel_config.kimi_k3_attnres.input_slots * attnres_max_numel
+                + 2 * attnres_max_numel
                 + (staged_max_numel if self._two_stage_supported else 0)
                 + self._staged_two_stage_scratch_numel
             )
@@ -639,13 +664,7 @@ class IrisAllReduce(object):
             else None
         )
         self._attnres_input_buf = (
-            self._ctx.zeros(
-                (
-                    self._kernel_config.kimi_k3_attnres.input_slots,
-                    attnres_max_numel,
-                ),
-                dtype=dtype,
-            )
+            self._ctx.zeros((2, attnres_max_numel), dtype=dtype)
             if attnres_max_numel
             else None
         )
@@ -1007,7 +1026,7 @@ class IrisAllReduce(object):
             op = dist.ReduceOp.SUM
         assert op == dist.ReduceOp.SUM, f"Iris all-reduce only supports SUM, got {op}"
         kernel_config = self._kernel_config.kimi_k3_attnres
-        assert _platform.is_cdna4 and self.world_size == 8
+        assert _platform.is_cdna4 and self.world_size == kernel_config.world_size
         num_tokens = partial.shape[0]
         assert 0 < num_tokens <= self.attnres_max_rows
         expected_shape = (num_tokens, kernel_config.hidden_size)
@@ -1054,7 +1073,6 @@ class IrisAllReduce(object):
             HIDDEN=kernel_config.hidden_size,
             BLOCK=triton.next_power_of_2(kernel_config.hidden_size),
             INPUT_SLOT_STRIDE=self.attnres_max_numel,
-            NUM_SLOTS=kernel_config.input_slots,
             EPS=eps,
             ELEMENTS_PER_THREAD=kernel_config.elements_per_thread,
             NUM_WARPS=kernel_config.num_subgroups,
@@ -1680,7 +1698,6 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
     HIDDEN: gl.constexpr,
     BLOCK: gl.constexpr,
     INPUT_SLOT_STRIDE: gl.constexpr,
-    NUM_SLOTS: gl.constexpr,
     EPS: gl.constexpr,
     ELEMENTS_PER_THREAD: gl.constexpr,
     NUM_WARPS: gl.constexpr,
@@ -1715,7 +1732,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         heap_base_6,
         heap_base_7,
     )
-    reuse_epoch = gl.maximum(epoch - NUM_SLOTS, 0)
+    reuse_epoch = gl.maximum(epoch - 2, 0)
     _iris_sync_rank_epoch(
         consumed_flags,
         row,
@@ -1736,11 +1753,7 @@ def iris_stage_one_shot_allreduce_residual_attnres_gluon_kernel(
         PUBLISH=False,
     )
 
-    if NUM_SLOTS & (NUM_SLOTS - 1) == 0:
-        input_slot = epoch & (NUM_SLOTS - 1)
-    else:
-        input_slot = epoch % NUM_SLOTS
-    input_slot_ptr = input_sym_ptr + input_slot * INPUT_SLOT_STRIDE
+    input_slot_ptr = input_sym_ptr + (epoch & 1) * INPUT_SLOT_STRIDE
     gl.amd.cdna4.buffer_store(
         local.to(input_slot_ptr.dtype.element_ty),
         input_slot_ptr,
@@ -2158,11 +2171,11 @@ def create_iris_state(
     producer_direct_max_numel: int,
     attnres_max_numel: int,
     attnres_max_rows: int,
-    dtype: torch.dtype = torch.bfloat16,
-    heap_size: int | None = None,
-    device: torch.device = None,
+    dtype: torch.dtype,
+    heap_size: int | None,
+    device: torch.device | None,
 ) -> "IrisAllReduce":
-    """Create an Iris all-reduce state with protocol-specific capacities.
+    """Create an Iris all-reduce state with separate capacities for each path.
 
     Args:
         group: Process group used by the collectives.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -187,34 +187,18 @@ class KimiK3AttnResKernelConfig:
     """Kimi-K3 fused attention-TP all-reduce and AttnRes contract."""
 
     hidden_size: int
-    max_profitable_tokens_by_world_size: tuple[tuple[int, int], ...]
     num_subgroups: int
     elements_per_thread: int
     input_slots: int
 
     def __post_init__(self) -> None:
-        world_sizes = tuple(
-            world_size for world_size, _ in self.max_profitable_tokens_by_world_size
-        )
         if (
             self.hidden_size <= 0
-            or not world_sizes
-            or len(set(world_sizes)) != len(world_sizes)
-            or any(
-                world_size <= 1 or max_tokens <= 0
-                for world_size, max_tokens in self.max_profitable_tokens_by_world_size
-            )
             or self.num_subgroups <= 0
             or self.elements_per_thread <= 0
             or self.input_slots < 2
         ):
             raise ValueError("invalid Kimi-K3 AttnRes Iris kernel configuration")
-
-    def max_profitable_num_tokens(self, world_size: int) -> int:
-        return dict(self.max_profitable_tokens_by_world_size).get(world_size, 0)
-
-    def supports_world_size(self, world_size: int) -> bool:
-        return self.max_profitable_num_tokens(world_size) > 0
 
 
 @dataclass(frozen=True)
@@ -258,7 +242,6 @@ IRIS_ALL_REDUCE_KERNEL_CONFIG = IrisAllReduceKernelConfig(
     ),
     kimi_k3_attnres=KimiK3AttnResKernelConfig(
         hidden_size=7168,
-        max_profitable_tokens_by_world_size=((8, 16),),
         num_subgroups=4,
         elements_per_thread=1,
         input_slots=2,
@@ -1024,7 +1007,7 @@ class IrisAllReduce(object):
             op = dist.ReduceOp.SUM
         assert op == dist.ReduceOp.SUM, f"Iris all-reduce only supports SUM, got {op}"
         kernel_config = self._kernel_config.kimi_k3_attnres
-        assert _platform.is_cdna4 and kernel_config.supports_world_size(self.world_size)
+        assert _platform.is_cdna4 and self.world_size == 8
         num_tokens = partial.shape[0]
         assert 0 < num_tokens <= self.attnres_max_rows
         expected_shape = (num_tokens, kernel_config.hidden_size)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -110,13 +110,10 @@ class _StagedAllReduceKernelConfig:
 @dataclass(frozen=True)
 class _ProducerDirectAllReduceKernelConfig:
     supported_world_sizes: tuple[int, ...]
-    packed_word_bytes: int
-    block_size: int
-    max_programs: int
+    one_stage_block_size: int
+    one_stage_max_programs: int
     one_stage_num_subgroups: int
     one_stage_words_per_lane: int
-    two_stage_num_subgroups: int
-    two_stage_words_per_lane: int
     two_stage_min_bytes: tuple[tuple[int, int], ...]
     publish_ready: bool
 
@@ -125,22 +122,17 @@ class _ProducerDirectAllReduceKernelConfig:
             not self.supported_world_sizes
             or len(set(self.supported_world_sizes)) != len(self.supported_world_sizes)
             or any(world_size <= 1 for world_size in self.supported_world_sizes)
-            or self.packed_word_bytes <= 0
-            or self.block_size <= 0
-            or self.max_programs <= 0
+            or self.one_stage_block_size <= 0
+            or self.one_stage_max_programs <= 0
             or self.one_stage_num_subgroups <= 0
             or self.one_stage_words_per_lane <= 0
-            or self.two_stage_num_subgroups <= 0
-            or self.two_stage_words_per_lane <= 0
         ):
             raise ValueError("invalid producer-direct Iris kernel configuration")
         threshold_world_sizes = tuple(
             world_size for world_size, _ in self.two_stage_min_bytes
         )
         if len(set(threshold_world_sizes)) != len(threshold_world_sizes) or any(
-            world_size not in self.supported_world_sizes
-            or min_bytes <= 0
-            or self.two_stage_num_subgroups % world_size != 0
+            world_size not in self.supported_world_sizes or min_bytes <= 0
             for world_size, min_bytes in self.two_stage_min_bytes
         ):
             raise ValueError("invalid producer-direct Iris two-stage thresholds")
@@ -151,35 +143,50 @@ class _ProducerDirectAllReduceKernelConfig:
     def two_stage_threshold(self, world_size: int) -> int | None:
         return dict(self.two_stage_min_bytes).get(world_size)
 
-    def scratch_numel(self, max_numel: int, world_size: int) -> int:
-        if max_numel == 0 or self.two_stage_threshold(world_size) is None:
-            return 0
-        return triton.cdiv(max_numel, world_size)
 
-    def use_two_stage(
+@dataclass(frozen=True)
+class _TwoStageAllReduceKernelConfig:
+    supported_world_sizes: tuple[int, ...]
+    max_programs: int
+    num_subgroups: int
+    words_per_lane: int
+
+    def __post_init__(self) -> None:
+        if (
+            not self.supported_world_sizes
+            or len(set(self.supported_world_sizes)) != len(self.supported_world_sizes)
+            or self.num_subgroups <= 0
+            or any(
+                world_size <= 1 or self.num_subgroups % world_size != 0
+                for world_size in self.supported_world_sizes
+            )
+            or self.max_programs <= 0
+            or self.words_per_lane <= 0
+        ):
+            raise ValueError("invalid two-stage Iris kernel configuration")
+
+    def supports_world_size(self, world_size: int) -> bool:
+        return world_size in self.supported_world_sizes
+
+    def can_partition(
         self,
         world_size: int,
         total_numel: int,
-        dtype: torch.dtype,
+        elements_per_word: int,
     ) -> bool:
-        min_bytes = self.two_stage_threshold(world_size)
-        if min_bytes is None or self.packed_word_bytes % dtype.itemsize != 0:
-            return False
-        elements_per_word = self.packed_word_bytes // dtype.itemsize
         return (
-            total_numel * dtype.itemsize >= min_bytes
+            self.supports_world_size(world_size)
             and total_numel % (world_size * elements_per_word) == 0
         )
 
-    def two_stage_block_words(self, world_size: int, subgroup_size: int) -> int:
-        assert self.two_stage_threshold(world_size) is not None
-        assert self.two_stage_num_subgroups % world_size == 0
-        return (
-            self.two_stage_num_subgroups
-            * subgroup_size
-            * self.two_stage_words_per_lane
-            // world_size
-        )
+    def scratch_numel(self, max_numel: int, world_size: int) -> int:
+        if max_numel == 0 or not self.supports_world_size(world_size):
+            return 0
+        return triton.cdiv(max_numel, world_size)
+
+    def block_words(self, world_size: int, subgroup_size: int) -> int:
+        assert self.supports_world_size(world_size)
+        return self.num_subgroups * subgroup_size * self.words_per_lane // world_size
 
 
 @dataclass(frozen=True)
@@ -219,24 +226,41 @@ class IrisAllReduceKernelConfig:
 
     Attributes:
         subgroup_size: Hardware subgroup width used by the Gluon kernels.
+        packed_word_bytes: Packed element width used by the symmetric kernels.
         staged: Launch and workspace parameters for staged all-reduce.
-        producer_direct: Launch, workspace, and eligibility parameters for
-            producer-direct all-reduce.
+        producer_direct: Launch and eligibility parameters for producer-direct
+            all-reduce.
+        two_stage: Launch and workspace parameters shared by ordinary staged and
+            producer-direct two-stage all-reduce.
         kimi_k3_attnres: Launch and shape parameters for Kimi-K3 AttnRes.
     """
 
     subgroup_size: int
+    packed_word_bytes: int
     staged: _StagedAllReduceKernelConfig
     producer_direct: _ProducerDirectAllReduceKernelConfig
+    two_stage: _TwoStageAllReduceKernelConfig
     kimi_k3_attnres: KimiK3AttnResKernelConfig
 
     def __post_init__(self) -> None:
-        if self.subgroup_size <= 0 or self.subgroup_size & (self.subgroup_size - 1):
-            raise ValueError("Iris subgroup size must be a positive power of two")
+        if (
+            self.subgroup_size <= 0
+            or self.subgroup_size & (self.subgroup_size - 1)
+            or self.packed_word_bytes <= 0
+        ):
+            raise ValueError("invalid Iris all-reduce kernel configuration")
+        if any(
+            not self.two_stage.supports_world_size(world_size)
+            for world_size, _ in self.producer_direct.two_stage_min_bytes
+        ):
+            raise ValueError(
+                "producer-direct two-stage thresholds require kernel support"
+            )
 
 
 IRIS_ALL_REDUCE_KERNEL_CONFIG = IrisAllReduceKernelConfig(
     subgroup_size=64,
+    packed_word_bytes=8,
     staged=_StagedAllReduceKernelConfig(
         block_size=2048,
         num_subgroups=4,
@@ -244,15 +268,18 @@ IRIS_ALL_REDUCE_KERNEL_CONFIG = IrisAllReduceKernelConfig(
     ),
     producer_direct=_ProducerDirectAllReduceKernelConfig(
         supported_world_sizes=(2, 4, 8),
-        packed_word_bytes=8,
-        block_size=512,
-        max_programs=84,
+        one_stage_block_size=512,
+        one_stage_max_programs=84,
         one_stage_num_subgroups=1,
         one_stage_words_per_lane=2,
-        two_stage_num_subgroups=8,
-        two_stage_words_per_lane=2,
         two_stage_min_bytes=((4, 160 << 10), (8, 96 << 10)),
         publish_ready=False,
+    ),
+    two_stage=_TwoStageAllReduceKernelConfig(
+        supported_world_sizes=(4, 8),
+        max_programs=84,
+        num_subgroups=8,
+        words_per_lane=2,
     ),
     kimi_k3_attnres=KimiK3AttnResKernelConfig(
         world_size=8,
@@ -281,15 +308,35 @@ def producer_direct_all_reduce_can_run(
         Whether the group size and element type are supported and the payload is
         positive, packed-word aligned, and within the input-buffer capacity.
     """
-    config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
+    kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG
+    config = kernel_config.producer_direct
     element_bytes = dtype.itemsize
     return (
         config.supports_world_size(world_size)
         and total_numel > 0
         and dtype in _PRODUCER_DIRECT_GL_DTYPES
-        and config.packed_word_bytes % element_bytes == 0
-        and total_numel % (config.packed_word_bytes // element_bytes) == 0
+        and kernel_config.packed_word_bytes % element_bytes == 0
+        and total_numel % (kernel_config.packed_word_bytes // element_bytes) == 0
         and total_numel * element_bytes <= max_bytes
+    )
+
+
+def _use_two_stage_producer_direct(
+    world_size: int,
+    total_numel: int,
+    dtype: torch.dtype,
+) -> bool:
+    kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG
+    min_bytes = kernel_config.producer_direct.two_stage_threshold(world_size)
+    if min_bytes is None or dtype not in _PRODUCER_DIRECT_GL_DTYPES:
+        return False
+    elements_per_word = kernel_config.packed_word_bytes // dtype.itemsize
+    return total_numel * dtype.itemsize >= min_bytes and (
+        kernel_config.two_stage.can_partition(
+            world_size=world_size,
+            total_numel=total_numel,
+            elements_per_word=elements_per_word,
+        )
     )
 
 
@@ -317,16 +364,18 @@ def _use_two_stage_plain(
     kernel's structural one -- the payload has to split evenly into per-rank
     partitions of whole 64-bit words.
     """
-    kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
-    if kernel_config.two_stage_threshold(world_size) is None:
-        return False
     # The kernel packs elements into 64-bit words through
     # _PRODUCER_DIRECT_GL_DTYPES; anything outside it (or wider than a word,
     # which would make elements_per_word zero) stays on one-shot.
     if dtype not in _PRODUCER_DIRECT_GL_DTYPES:
         return False
+    kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG
     elements_per_word = kernel_config.packed_word_bytes // dtype.itemsize
-    return numel % (world_size * elements_per_word) == 0
+    return kernel_config.two_stage.can_partition(
+        world_size=world_size,
+        total_numel=numel,
+        elements_per_word=elements_per_word,
+    )
 
 
 def _get_available_gpu_memory(gpu_id: int, empty_cache: bool = True) -> float:
@@ -605,10 +654,30 @@ class IrisAllReduce(object):
         self._kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG
         producer_config = self._kernel_config.producer_direct
         staged_config = self._kernel_config.staged
-        self._elements_per_word = producer_config.packed_word_bytes // dtype.itemsize
-        self._producer_direct_scratch_numel = producer_config.scratch_numel(
-            max_numel=producer_direct_max_numel,
-            world_size=self.world_size,
+        two_stage_config = self._kernel_config.two_stage
+        self._elements_per_word = (
+            self._kernel_config.packed_word_bytes // dtype.itemsize
+        )
+        self._producer_direct_two_stage_workspace_required = (
+            producer_direct_max_numel > 0
+            and producer_config.two_stage_threshold(self.world_size) is not None
+            and two_stage_config.supports_world_size(self.world_size)
+        )
+        self._producer_direct_scratch_numel = (
+            two_stage_config.scratch_numel(
+                max_numel=producer_direct_max_numel,
+                world_size=self.world_size,
+            )
+            if self._producer_direct_two_stage_workspace_required
+            else 0
+        )
+        self._producer_direct_max_programs = max(
+            producer_config.one_stage_max_programs,
+            (
+                two_stage_config.max_programs
+                if self._producer_direct_two_stage_workspace_required
+                else 0
+            ),
         )
         self._staged_max_programs = staged_config.max_programs(
             max_numel=staged_max_numel
@@ -619,15 +688,18 @@ class IrisAllReduce(object):
         # so deciding once here keeps the buffers, the heap estimate and the
         # dispatch from disagreeing. Only the payload size is per-call, and it
         # stays in _use_two_stage_plain.
-        self._two_stage_supported = (
+        self._staged_two_stage_supported = (
             _platform.is_cdna4
             and staged_max_numel > 0
-            and producer_config.two_stage_threshold(self.world_size) is not None
+            and two_stage_config.supports_world_size(self.world_size)
             and dtype in _PRODUCER_DIRECT_GL_DTYPES
         )
         self._staged_two_stage_scratch_numel = (
-            triton.cdiv(staged_max_numel, self.world_size)
-            if self._two_stage_supported
+            two_stage_config.scratch_numel(
+                max_numel=staged_max_numel,
+                world_size=self.world_size,
+            )
+            if self._staged_two_stage_supported
             else 0
         )
 
@@ -637,14 +709,22 @@ class IrisAllReduce(object):
                 + self._producer_direct_scratch_numel
                 + staged_config.input_slots * staged_max_numel
                 + 2 * attnres_max_numel
-                + (staged_max_numel if self._two_stage_supported else 0)
+                + (staged_max_numel if self._staged_two_stage_supported else 0)
                 + self._staged_two_stage_scratch_numel
             )
             flag_numel = self.world_size * (
                 self._staged_max_programs
                 + 2 * attnres_max_rows
-                + (producer_config.max_programs if producer_direct_max_numel else 0)
-                + (producer_config.max_programs if self._two_stage_supported else 0)
+                + (
+                    self._producer_direct_max_programs
+                    if producer_direct_max_numel
+                    else 0
+                )
+                + (
+                    two_stage_config.max_programs
+                    if self._staged_two_stage_supported
+                    else 0
+                )
             )
             heap_size = max(
                 1 << 28,
@@ -685,7 +765,7 @@ class IrisAllReduce(object):
         )
         output_max_numel = max(
             producer_direct_max_numel,
-            staged_max_numel if self._two_stage_supported else 0,
+            staged_max_numel if self._staged_two_stage_supported else 0,
         )
         self._reduced_output_buf = (
             torch.empty(output_max_numel, dtype=dtype, device=self.device)
@@ -723,22 +803,22 @@ class IrisAllReduce(object):
         # or a group of some other size would otherwise reserve a payload
         # buffer and a scratch partition it can never use, and an explicit
         # heap_size sized for the previous allocations would fail to fit them.
-        if self._two_stage_supported:
-            self._two_stage_input_buf = self._ctx.zeros(
+        if self._staged_two_stage_supported:
+            self._staged_two_stage_input_buf = self._ctx.zeros(
                 (staged_max_numel,), dtype=dtype
             )
             # Each rank reduces only its own partition and peers read it at the
             # same offset, so scratch holds one partition, not the whole payload.
-            self._two_stage_scratch_buf = self._ctx.zeros(
+            self._staged_two_stage_scratch_buf = self._ctx.zeros(
                 (self._staged_two_stage_scratch_numel,), dtype=dtype
             )
         else:
-            self._two_stage_input_buf = None
-            self._two_stage_scratch_buf = None
+            self._staged_two_stage_input_buf = None
+            self._staged_two_stage_scratch_buf = None
         self._producer_direct_ready_flags = (
             self._ctx.zeros(
                 (
-                    producer_config.max_programs,
+                    self._producer_direct_max_programs,
                     self.world_size,
                 ),
                 dtype=torch.int32,
@@ -749,12 +829,12 @@ class IrisAllReduce(object):
         # Separate epochs from the producer-direct reduce: in a tensor-parallel
         # MoE both collectives run inside one layer, and a shared counter would
         # let one path's epoch satisfy the other's barrier.
-        self._two_stage_ready_flags = (
+        self._staged_two_stage_ready_flags = (
             self._ctx.zeros(
-                (producer_config.max_programs, self.world_size),
+                (two_stage_config.max_programs, self.world_size),
                 dtype=torch.int32,
             )
-            if self._two_stage_supported
+            if self._staged_two_stage_supported
             else None
         )
         heap_bases = self._ctx.get_heap_bases()
@@ -804,7 +884,7 @@ class IrisAllReduce(object):
         # The two-stage kernel stores through a CDNA4 buffer intrinsic, so it is
         # gated the same way the producer-direct reduce is; older AMD parts keep
         # the portable one-shot path.
-        if self._two_stage_supported and _use_two_stage_plain(
+        if self._staged_two_stage_supported and _use_two_stage_plain(
             self.world_size, numel, self.dtype
         ):
             return self._all_reduce_two_stage(tensor, numel, safe=safe)
@@ -890,13 +970,13 @@ class IrisAllReduce(object):
         Returns:
             The reduction across the group; a clone of ``tensor`` when ``safe``.
         """
-        staged = self._two_stage_input_buf
+        staged = self._staged_two_stage_input_buf
         staged[:numel].copy_(tensor.view(-1))
 
         partition_numel = numel // self.world_size
         partition_words = partition_numel // self._elements_per_word
-        kernel_config = self._kernel_config.producer_direct
-        block_words = kernel_config.two_stage_block_words(
+        kernel_config = self._kernel_config.two_stage
+        block_words = kernel_config.block_words(
             world_size=self.world_size,
             subgroup_size=self._kernel_config.subgroup_size,
         )
@@ -906,9 +986,9 @@ class IrisAllReduce(object):
         output = self._reduced_output_buf[:numel]
         iris_reduce_symmetric_two_stage_gluon_kernel[(num_programs,)](
             staged,
-            self._two_stage_scratch_buf,
+            self._staged_two_stage_scratch_buf,
             output,
-            self._two_stage_ready_flags,
+            self._staged_two_stage_ready_flags,
             *self._heap_base_addresses,
             RANK=self._iris_rank,
             WORLD_SIZE=self.world_size,
@@ -916,13 +996,13 @@ class IrisAllReduce(object):
             BLOCK_WORDS=block_words,
             NUM_PROGRAMS=num_programs,
             NUM_TILES=num_tiles,
-            NUM_WARPS=kernel_config.two_stage_num_subgroups,
+            NUM_WARPS=kernel_config.num_subgroups,
             SUBGROUP_SIZE=self._kernel_config.subgroup_size,
-            WORDS_PER_LANE=kernel_config.two_stage_words_per_lane,
+            WORDS_PER_LANE=kernel_config.words_per_lane,
             ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
             ELEMENTS_PER_WORD=self._elements_per_word,
             EXIT_BARRIER=True,
-            num_warps=kernel_config.two_stage_num_subgroups,
+            num_warps=kernel_config.num_subgroups,
         )
         tensor.view(-1).copy_(output)
         return tensor.clone() if safe else tensor
@@ -951,21 +1031,22 @@ class IrisAllReduce(object):
             self._reduced_output_buf,
             tuple(tuple(tensor.shape) for tensor in tensors),
         )
-        use_two_stage = kernel_config.use_two_stage(
+        use_two_stage = _use_two_stage_producer_direct(
             world_size=self.world_size,
             total_numel=total_numel,
             dtype=self.dtype,
         )
         if use_two_stage:
+            two_stage_config = self._kernel_config.two_stage
             assert self._producer_direct_scratch_buf is not None
             partition_numel = total_numel // self.world_size
             partition_words = partition_numel // self._elements_per_word
-            block_words = kernel_config.two_stage_block_words(
+            block_words = two_stage_config.block_words(
                 world_size=self.world_size,
                 subgroup_size=self._kernel_config.subgroup_size,
             )
             num_tiles = triton.cdiv(partition_words, block_words)
-            num_programs = min(num_tiles, kernel_config.max_programs)
+            num_programs = min(num_tiles, two_stage_config.max_programs)
             iris_reduce_symmetric_two_stage_gluon_kernel[(num_programs,)](
                 self._input_buf,
                 self._producer_direct_scratch_buf,
@@ -978,18 +1059,18 @@ class IrisAllReduce(object):
                 BLOCK_WORDS=block_words,
                 NUM_PROGRAMS=num_programs,
                 NUM_TILES=num_tiles,
-                NUM_WARPS=kernel_config.two_stage_num_subgroups,
+                NUM_WARPS=two_stage_config.num_subgroups,
                 SUBGROUP_SIZE=self._kernel_config.subgroup_size,
-                WORDS_PER_LANE=kernel_config.two_stage_words_per_lane,
+                WORDS_PER_LANE=two_stage_config.words_per_lane,
                 ELEMENT_DTYPE=_PRODUCER_DIRECT_GL_DTYPES[self.dtype],
                 ELEMENTS_PER_WORD=self._elements_per_word,
                 EXIT_BARRIER=False,
-                num_warps=kernel_config.two_stage_num_subgroups,
+                num_warps=two_stage_config.num_subgroups,
             )
         else:
-            block_size = kernel_config.block_size
+            block_size = kernel_config.one_stage_block_size
             num_tiles = triton.cdiv(total_numel, block_size)
-            num_programs = min(num_tiles, kernel_config.max_programs)
+            num_programs = min(num_tiles, kernel_config.one_stage_max_programs)
             iris_reduce_symmetric_gluon_kernel[(num_programs,)](
                 self._input_buf,
                 self._reduced_output_buf,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/iris.py
@@ -1666,6 +1666,7 @@ def iris_reduce_symmetric_two_stage_gluon_kernel(
             RANK,
             WORLD_SIZE,
             NUM_WARPS,
+            SUBGROUP_SIZE,
             PUBLISH=True,
         )
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
@@ -63,6 +63,7 @@ class TritonCommState:
     device: torch.device
     max_numel: int = 0
     max_bytes: int = 0
+    attnres_max_numel: int = 0
     max_token_num: int = 0
     hidden_dim: int = 0
     comm_buff: torch.Tensor | None = None
@@ -1883,11 +1884,12 @@ def create_state(
     device: torch.device = None,
     max_numel: int = 0,
     max_bytes: int = 0,
+    attnres_max_numel: int = 0,
 ) -> TritonCommState:
     assert (
         type(group) == dist.ProcessGroup
     ), f"Expected dist.ProcessGroup, got {type(group)}"
-    if max_numel:
+    if max_numel or max_bytes or attnres_max_numel:
         device = device or torch.device(f"cuda:{torch.cuda.current_device()}")
         world_size = group.size()
         comm_buff = None
@@ -1906,6 +1908,7 @@ def create_state(
             device=device,
             max_numel=max_numel,
             max_bytes=max_bytes or max_numel * torch.bfloat16.itemsize,
+            attnres_max_numel=attnres_max_numel,
             comm_buff=comm_buff,
             symm_mem_hdl=symm_mem_hdl,
         )
@@ -1947,17 +1950,32 @@ def all_reduce_can_run(state: TritonCommState, tensor: torch.Tensor, op=None) ->
     )
 
 
+def _iris_state_key(state: TritonCommState, dtype: torch.dtype) -> tuple:
+    producer_direct_max_numel = state.max_bytes // dtype.itemsize
+    return (
+        id(state.group),
+        state.max_numel,
+        producer_direct_max_numel,
+        state.attnres_max_numel,
+        state.max_token_num,
+        dtype,
+    )
+
+
 def _get_or_create_iris_state(state: TritonCommState, dtype: torch.dtype):
     """Return the Iris state sized for this communication backing buffer."""
     import tokenspeed_kernel.ops.communication.iris as _iris_mod
 
-    key = (id(state.group), state.max_bytes, dtype)
+    key = _iris_state_key(state, dtype)
     iris_state = _iris_mod.IRIS_AR_STATES.get(key)
     if iris_state is None:
         iris_state = _iris_mod.create_iris_state(
             group=state.group,
             rank_in_group=state.rank_in_group,
-            max_numel=max(state.max_numel, state.max_bytes // dtype.itemsize),
+            staged_max_numel=state.max_numel,
+            producer_direct_max_numel=state.max_bytes // dtype.itemsize,
+            attnres_max_numel=state.attnres_max_numel,
+            attnres_max_rows=state.max_token_num,
             dtype=dtype,
             device=state.device,
         )
@@ -1997,19 +2015,22 @@ def symm_outputs_can_run(
     if op is None:
         op = torch.distributed.ReduceOp.SUM
     numels = tuple(math.prod(shape) for shape in shapes)
-    element_bytes = dtype.itemsize
-    elements_per_word = 8 // element_bytes
     total_numel = sum(numels)
-    return (
-        current_platform().is_cdna4
-        and state.world_size in (2, 4, 8)
-        and dtype in (torch.bfloat16, torch.float16, torch.float32)
-        and op == torch.distributed.ReduceOp.SUM
-        and bool(numels)
-        and all(numel > 0 for numel in numels)
-        and 8 % element_bytes == 0
-        and total_numel % elements_per_word == 0
-        and total_numel * element_bytes <= state.max_bytes
+    if (
+        not current_platform().is_cdna4
+        or op != torch.distributed.ReduceOp.SUM
+        or not numels
+        or any(numel <= 0 for numel in numels)
+    ):
+        return False
+
+    import tokenspeed_kernel.ops.communication.iris as _iris_mod
+
+    return _iris_mod.producer_direct_all_reduce_can_run(
+        world_size=state.world_size,
+        total_numel=total_numel,
+        dtype=dtype,
+        max_bytes=state.max_bytes,
     )
 
 
@@ -2041,7 +2062,7 @@ def all_reduce_symm_can_run(
         return False
     import tokenspeed_kernel.ops.communication.iris as _iris_mod
 
-    key = (id(state.group), state.max_bytes, tensors[0].dtype)
+    key = _iris_state_key(state, tensors[0].dtype)
     iris_state = _iris_mod.IRIS_AR_STATES.get(key)
     return iris_state is not None and iris_state.owns_outputs(tensors)
 
@@ -2053,7 +2074,7 @@ def all_reduce_symmetric(
     """Reduce consecutive Iris producer outputs in one launch."""
     import tokenspeed_kernel.ops.communication.iris as _iris_mod
 
-    key = (id(state.group), state.max_bytes, tensors[0].dtype)
+    key = _iris_state_key(state, tensors[0].dtype)
     iris_state = _iris_mod.IRIS_AR_STATES[key]
     return _iris_mod.iris_all_reduce_symmetric(iris_state, tensors)
 
@@ -2072,16 +2093,22 @@ def _all_reduce_residual_attnres_can_run(
         op = torch.distributed.ReduceOp.SUM
     m, s_, acc = scratch
     platform = current_platform()
+    if not platform.is_cdna4:
+        return False
+
+    import tokenspeed_kernel.ops.communication.iris as _iris_mod
+
+    kernel_config = _iris_mod.IRIS_ALL_REDUCE_KERNEL_CONFIG.kimi_k3_attnres
     num_tokens = partial.shape[0] if partial.ndim == 2 else 0
     return (
-        platform.is_cdna4
-        and state.world_size == 8
+        kernel_config.supports_world_size(state.world_size)
         and op == torch.distributed.ReduceOp.SUM
-        and 0 < num_tokens <= 16
-        and partial.shape == residual.shape == (num_tokens, 7168)
-        and score_weight.shape == output_weight.shape == (7168,)
+        and 0 < num_tokens <= kernel_config.max_profitable_num_tokens(state.world_size)
+        and num_tokens <= state.max_token_num
+        and partial.shape == residual.shape == (num_tokens, kernel_config.hidden_size)
+        and score_weight.shape == output_weight.shape == (kernel_config.hidden_size,)
         and m.shape == s_.shape == (num_tokens,)
-        and acc.shape == (num_tokens, 7168)
+        and acc.shape == (num_tokens, kernel_config.hidden_size)
         and partial.dtype
         == residual.dtype
         == score_weight.dtype
@@ -2108,7 +2135,7 @@ def _all_reduce_residual_attnres_can_run(
                 acc,
             )
         )
-        and partial.numel() <= state.max_numel
+        and partial.numel() <= state.attnres_max_numel
     )
 
 
@@ -2150,7 +2177,7 @@ def _all_reduce_residual_attnres(
         scratch,
         op=op,
     )
-    from . import iris as _iris_mod
+    import tokenspeed_kernel.ops.communication.iris as _iris_mod
 
     iris_state = _get_or_create_iris_state(state, partial.dtype)
     return _iris_mod.iris_all_reduce_residual_attnres(
@@ -2170,14 +2197,13 @@ def _attnres_comm_state(
     rank: int,
     group: dist.ProcessGroup,
 ) -> TritonCommState:
-    max_numel = input_tensor.numel()
     return TritonCommState(
         group=group,
         rank_in_group=rank,
         world_size=group.size(),
         device=input_tensor.device,
-        max_numel=max_numel,
-        max_bytes=max_numel * input_tensor.dtype.itemsize,
+        attnres_max_numel=input_tensor.numel(),
+        max_token_num=input_tensor.shape[0],
     )
 
 
@@ -2237,7 +2263,7 @@ def allreduce_residual_attnres_combine(
         output_weight: Output RMSNorm weight shaped ``[7168]``.
         scratch: FP32 ``(max_logit, exp_sum, weighted_sum)`` partials.
         rank: Rank within ``group``.
-        group: Eight-rank node-local attention process group.
+        group: Validated node-local Kimi-K3 attention process group.
         local_world_size: Number of processes on each node.
         eps: Positive epsilon for AttnRes scoring and output RMSNorm.
         op: Reduction operation. Only ``SUM`` is supported.

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
@@ -2101,9 +2101,9 @@ def _all_reduce_residual_attnres_can_run(
     kernel_config = _iris_mod.IRIS_ALL_REDUCE_KERNEL_CONFIG.kimi_k3_attnres
     num_tokens = partial.shape[0] if partial.ndim == 2 else 0
     return (
-        kernel_config.supports_world_size(state.world_size)
+        state.world_size == 8
         and op == torch.distributed.ReduceOp.SUM
-        and 0 < num_tokens <= kernel_config.max_profitable_num_tokens(state.world_size)
+        and 0 < num_tokens <= 16
         and num_tokens <= state.max_token_num
         and partial.shape == residual.shape == (num_tokens, kernel_config.hidden_size)
         and score_weight.shape == output_weight.shape == (kernel_config.hidden_size,)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
@@ -61,13 +61,13 @@ class TritonCommState:
     rank_in_group: int
     world_size: int
     device: torch.device
-    max_numel: int = 0
-    max_bytes: int = 0
-    attnres_max_numel: int = 0
-    max_token_num: int = 0
-    hidden_dim: int = 0
-    comm_buff: torch.Tensor | None = None
-    symm_mem_hdl: object | None = None
+    attnres_max_numel: int
+    max_numel: int
+    max_bytes: int
+    max_token_num: int
+    hidden_dim: int
+    comm_buff: torch.Tensor | None
+    symm_mem_hdl: object | None
 
 
 @dataclass
@@ -1042,9 +1042,13 @@ def nvidia_create_rsag_state(
         rank_in_group=rank_in_group,
         world_size=group.size(),
         device=device,
+        attnres_max_numel=0,
+        max_numel=0,
+        max_bytes=0,
         max_token_num=max_tokens,
         hidden_dim=hidden_size,
         comm_buff=comm_buff,
+        symm_mem_hdl=None,
     )
 
 
@@ -1506,6 +1510,9 @@ def amd_create_rsag_state(
         rank_in_group=rank_in_group,
         world_size=world_size,
         device=device,
+        attnres_max_numel=0,
+        max_numel=0,
+        max_bytes=0,
         max_token_num=max_tokens,
         hidden_dim=hidden_size,
         comm_buff=comm_buff,
@@ -1715,6 +1722,9 @@ def create_allreduce_residual_rmsnorm_state(
         rank_in_group=rank_in_group,
         world_size=world_size,
         device=device,
+        attnres_max_numel=0,
+        max_numel=0,
+        max_bytes=0,
         max_token_num=max_token_num,
         hidden_dim=hidden_dim,
         comm_buff=comm_buff,
@@ -1879,13 +1889,29 @@ def allreduce_residual_rmsnorm(
 def create_state(
     group: dist.ProcessGroup,
     rank_in_group: int,
-    max_tokens: int = 0,
-    hidden_size: int = 0,
-    device: torch.device = None,
-    max_numel: int = 0,
-    max_bytes: int = 0,
-    attnres_max_numel: int = 0,
+    max_tokens: int,
+    hidden_size: int,
+    device: torch.device | None,
+    max_numel: int,
+    max_bytes: int,
+    attnres_max_numel: int,
 ) -> TritonCommState:
+    """Create an all-reduce or reduce-scatter/all-gather communication state.
+
+    Args:
+        group: Process group used by the collective.
+        rank_in_group: This process's rank within ``group``.
+        max_tokens: Maximum gathered token count for an RS/AG state.
+        hidden_size: Hidden width for an RS/AG state.
+        device: Device on which communication storage is allocated.
+        max_numel: Maximum staged all-reduce payload in elements.
+        max_bytes: Maximum producer-direct all-reduce payload in bytes.
+        attnres_max_numel: Maximum fused attention/AttnRes payload in elements;
+            pass zero when the state does not use AttnRes.
+
+    Returns:
+        The initialized communication state.
+    """
     assert (
         type(group) == dist.ProcessGroup
     ), f"Expected dist.ProcessGroup, got {type(group)}"
@@ -1909,6 +1935,8 @@ def create_state(
             max_numel=max_numel,
             max_bytes=max_bytes or max_numel * torch.bfloat16.itemsize,
             attnres_max_numel=attnres_max_numel,
+            max_token_num=0,
+            hidden_dim=0,
             comm_buff=comm_buff,
             symm_mem_hdl=symm_mem_hdl,
         )
@@ -1977,6 +2005,7 @@ def _get_or_create_iris_state(state: TritonCommState, dtype: torch.dtype):
             attnres_max_numel=state.attnres_max_numel,
             attnres_max_rows=state.max_token_num,
             dtype=dtype,
+            heap_size=None,
             device=state.device,
         )
         _iris_mod.IRIS_AR_STATES[key] = iris_state
@@ -2101,7 +2130,7 @@ def _all_reduce_residual_attnres_can_run(
     kernel_config = _iris_mod.IRIS_ALL_REDUCE_KERNEL_CONFIG.kimi_k3_attnres
     num_tokens = partial.shape[0] if partial.ndim == 2 else 0
     return (
-        state.world_size == 8
+        state.world_size == kernel_config.world_size
         and op == torch.distributed.ReduceOp.SUM
         and 0 < num_tokens <= 16
         and num_tokens <= state.max_token_num
@@ -2203,7 +2232,12 @@ def _attnres_comm_state(
         world_size=group.size(),
         device=input_tensor.device,
         attnres_max_numel=input_tensor.numel(),
+        max_numel=0,
+        max_bytes=0,
         max_token_num=input_tensor.shape[0],
+        hidden_dim=0,
+        comm_buff=None,
+        symm_mem_hdl=None,
     )
 
 

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/communication/triton.py
@@ -1933,7 +1933,7 @@ def create_state(
             world_size=world_size,
             device=device,
             max_numel=max_numel,
-            max_bytes=max_bytes or max_numel * torch.bfloat16.itemsize,
+            max_bytes=max_bytes,
             attnres_max_numel=attnres_max_numel,
             max_token_num=0,
             hidden_dim=0,

--- a/tokenspeed-kernel/test/ops/test_communcation.py
+++ b/tokenspeed-kernel/test/ops/test_communcation.py
@@ -162,6 +162,12 @@ def check_all_reduce(rank: int, world_size: int, device) -> None:
         max_bytes=0,
         device=device,
     )
+    assert state.max_bytes == 0
+    assert not triton_communication.symm_outputs_can_run(
+        state,
+        ((4,),),
+        torch.bfloat16,
+    )
 
     for numel in [2880, 20160, 23040, 92160, 184320]:
         tensor = torch.full((numel,), rank + 1, dtype=torch.bfloat16, device=device)

--- a/tokenspeed-kernel/test/ops/test_communcation.py
+++ b/tokenspeed-kernel/test/ops/test_communcation.py
@@ -106,8 +106,12 @@ def worker_main(rank: int, world_size: int, port: int, hidden_size: int) -> None
         rsag = create_state(
             group=dist.group.WORLD,
             rank_in_group=rank,
+            attnres_max_numel=0,
             max_tokens=max_tokens,
             hidden_size=hidden_size,
+            device=None,
+            max_numel=0,
+            max_bytes=0,
         )
 
         for tokens in cases:
@@ -151,7 +155,11 @@ def check_all_reduce(rank: int, world_size: int, device) -> None:
     state = create_state(
         group=dist.group.WORLD,
         rank_in_group=rank,
+        attnres_max_numel=0,
+        max_tokens=0,
+        hidden_size=0,
         max_numel=max_numel,
+        max_bytes=0,
         device=device,
     )
 

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -22,7 +22,6 @@
 import socket
 import sys
 import traceback
-from dataclasses import replace
 from types import SimpleNamespace
 from typing import List, Tuple
 
@@ -100,57 +99,6 @@ def test_iris_state_uses_protocol_capacities(monkeypatch):
     assert iris_state.attnres_max_rows == 5
     assert triton_ops._get_or_create_iris_state(state, torch.bfloat16) is iris_state
     assert len(created) == 1
-
-
-def test_attnres_admission_uses_kernel_config(monkeypatch):
-    from tokenspeed_kernel.ops.communication import iris as iris_ops
-    from tokenspeed_kernel.ops.communication import triton as triton_ops
-
-    attnres_config = iris_ops.KimiK3AttnResKernelConfig(
-        hidden_size=11,
-        max_profitable_tokens_by_world_size=((2, 3),),
-        num_subgroups=1,
-        elements_per_thread=1,
-        input_slots=2,
-    )
-    kernel_config = replace(
-        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG,
-        kimi_k3_attnres=attnres_config,
-    )
-    monkeypatch.setattr(
-        iris_ops,
-        "IRIS_ALL_REDUCE_KERNEL_CONFIG",
-        kernel_config,
-    )
-    monkeypatch.setattr(
-        triton_ops,
-        "current_platform",
-        lambda: SimpleNamespace(is_cdna4=True),
-    )
-
-    partial = torch.empty((3, 11), dtype=torch.bfloat16)
-    residual = torch.empty_like(partial)
-    weight = torch.empty((11,), dtype=torch.bfloat16)
-    scratch = (
-        torch.empty((3,), dtype=torch.float32),
-        torch.empty((3,), dtype=torch.float32),
-        torch.empty((3, 11), dtype=torch.float32),
-    )
-    state = SimpleNamespace(
-        world_size=2,
-        device=partial.device,
-        attnres_max_numel=partial.numel(),
-        max_token_num=3,
-    )
-
-    assert triton_ops._all_reduce_residual_attnres_can_run(
-        state,
-        partial,
-        residual,
-        weight,
-        weight,
-        scratch,
-    )
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
@@ -446,7 +394,7 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             sum(int(torch.tensor(shape).prod()) for shape in shapes)
             for shapes in output_shape_cases
         )
-        attnres_max_rows = attnres_config.max_profitable_num_tokens(world_size)
+        attnres_max_rows = 16 if world_size == 8 else 0
         attnres_max_numel = attnres_max_rows * attnres_config.hidden_size
         staged_max_numel = max(staged_max_numel, attnres_max_numel)
         state = create_iris_state(
@@ -540,7 +488,7 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
                 ((16, 7168), (16, 3584)),
                 device,
             )
-        if attnres_config.supports_world_size(world_size):
+        if world_size == 8:
             _check_all_reduce_residual_attnres(state, rank, device)
     finally:
         dist.destroy_process_group()
@@ -644,7 +592,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
     )
 
     config = IRIS_ALL_REDUCE_KERNEL_CONFIG.kimi_k3_attnres
-    max_tokens = config.max_profitable_num_tokens(state.world_size)
+    max_tokens = 16
     num_token_cases = []
     num_tokens = 1
     while num_tokens <= max_tokens:

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -101,12 +101,13 @@ def test_iris_state_uses_protocol_capacities(monkeypatch):
     assert len(created) == 1
 
 
+@pytest.mark.parametrize("world_size", [2, 4, 8])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 def test_producer_direct_admission_supported_world_sizes(
     monkeypatch,
+    world_size,
     dtype,
 ):
-    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
@@ -114,14 +115,13 @@ def test_producer_direct_admission_supported_world_sizes(
         "current_platform",
         lambda: SimpleNamespace(is_cdna4=True),
     )
-    config = iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
-    for world_size in config.supported_world_sizes:
-        state = SimpleNamespace(world_size=world_size, max_bytes=64)
-        assert triton_ops.symm_outputs_can_run(
-            state,
-            ((3, 5), (1, 1)),
-            dtype,
-        )
+    state = SimpleNamespace(world_size=world_size, max_bytes=64)
+
+    assert triton_ops.symm_outputs_can_run(
+        state,
+        ((3, 5), (1, 1)),
+        dtype,
+    )
 
 
 @pytest.mark.parametrize(
@@ -133,7 +133,6 @@ def test_producer_direct_admission_supported_world_sizes(
     ],
 )
 def test_producer_direct_admission_uses_byte_capacity(monkeypatch, dtype, shapes):
-    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
@@ -141,69 +140,43 @@ def test_producer_direct_admission_uses_byte_capacity(monkeypatch, dtype, shapes
         "current_platform",
         lambda: SimpleNamespace(is_cdna4=True),
     )
-    world_size = (
-        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct.supported_world_sizes[-1]
-    )
-    state = SimpleNamespace(world_size=world_size, max_bytes=64)
+    state = SimpleNamespace(world_size=8, max_bytes=64)
 
     assert triton_ops.symm_outputs_can_run(state, shapes, dtype)
 
 
 @pytest.mark.parametrize(
-    ("shapes", "dtype", "op"),
+    ("world_size", "shapes", "dtype", "op"),
     [
-        (((3,),), torch.bfloat16, dist.ReduceOp.SUM),
-        (((3,),), torch.float32, dist.ReduceOp.SUM),
-        (((36,),), torch.bfloat16, dist.ReduceOp.SUM),
-        (((18,),), torch.float32, dist.ReduceOp.SUM),
-        (((4,),), torch.float64, dist.ReduceOp.SUM),
-        (((4,),), torch.bfloat16, dist.ReduceOp.PRODUCT),
+        (1, ((4,),), torch.bfloat16, dist.ReduceOp.SUM),
+        (8, ((3,),), torch.bfloat16, dist.ReduceOp.SUM),
+        (8, ((3,),), torch.float32, dist.ReduceOp.SUM),
+        (8, ((36,),), torch.bfloat16, dist.ReduceOp.SUM),
+        (8, ((18,),), torch.float32, dist.ReduceOp.SUM),
+        (8, ((4,),), torch.float64, dist.ReduceOp.SUM),
+        (8, ((4,),), torch.bfloat16, dist.ReduceOp.PRODUCT),
     ],
 )
 def test_producer_direct_admission_rejects_unsupported_requests(
     monkeypatch,
+    world_size,
     shapes,
     dtype,
     op,
 ):
-    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
         triton_ops,
         "current_platform",
         lambda: SimpleNamespace(is_cdna4=True),
-    )
-    world_size = (
-        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct.supported_world_sizes[-1]
     )
     state = SimpleNamespace(world_size=world_size, max_bytes=64)
 
     assert not triton_ops.symm_outputs_can_run(state, shapes, dtype, op)
 
 
-def test_producer_direct_admission_rejects_unsupported_world_size(monkeypatch):
-    from tokenspeed_kernel.ops.communication import iris as iris_ops
-    from tokenspeed_kernel.ops.communication import triton as triton_ops
-
-    monkeypatch.setattr(
-        triton_ops,
-        "current_platform",
-        lambda: SimpleNamespace(is_cdna4=True),
-    )
-    config = iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
-    world_size = max(config.supported_world_sizes) + 1
-    state = SimpleNamespace(world_size=world_size, max_bytes=64)
-
-    assert not triton_ops.symm_outputs_can_run(
-        state,
-        ((4,),),
-        torch.bfloat16,
-    )
-
-
 def test_producer_direct_admission_is_cdna4_only(monkeypatch):
-    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
@@ -211,10 +184,7 @@ def test_producer_direct_admission_is_cdna4_only(monkeypatch):
         "current_platform",
         lambda: SimpleNamespace(is_cdna4=False),
     )
-    world_size = (
-        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct.supported_world_sizes[-1]
-    )
-    state = SimpleNamespace(world_size=world_size, max_bytes=64)
+    state = SimpleNamespace(world_size=8, max_bytes=64)
 
     assert not triton_ops.symm_outputs_can_run(
         state,
@@ -223,8 +193,16 @@ def test_producer_direct_admission_is_cdna4_only(monkeypatch):
     )
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
-def test_producer_direct_two_stage_threshold(dtype):
+@pytest.mark.parametrize(
+    ("world_size", "dtype", "min_bytes"),
+    [
+        (4, torch.bfloat16, 160 << 10),
+        (4, torch.float32, 160 << 10),
+        (8, torch.bfloat16, 96 << 10),
+        (8, torch.float32, 96 << 10),
+    ],
+)
+def test_producer_direct_two_stage_threshold(world_size, dtype, min_bytes):
     try:
         from tokenspeed_kernel.ops.communication.iris import (
             IRIS_ALL_REDUCE_KERNEL_CONFIG,
@@ -233,27 +211,12 @@ def test_producer_direct_two_stage_threshold(dtype):
         pytest.skip("iris is not installed")
 
     config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
-    for world_size, min_bytes in config.two_stage_min_bytes:
-        alignment = world_size * (config.packed_word_bytes // dtype.itemsize)
-        min_numel = min_bytes // dtype.itemsize
-        assert config.use_two_stage(world_size, min_numel, dtype)
-        assert not config.use_two_stage(
-            world_size,
-            min_numel - alignment,
-            dtype,
-        )
-        assert not config.use_two_stage(world_size, min_numel + 1, dtype)
-
-    one_stage_world_size = next(
-        world_size
-        for world_size in config.supported_world_sizes
-        if config.two_stage_threshold(world_size) is None
-    )
-    assert not config.use_two_stage(
-        one_stage_world_size,
-        config.two_stage_min_bytes[0][1] // dtype.itemsize,
-        dtype,
-    )
+    alignment = world_size * (config.packed_word_bytes // dtype.itemsize)
+    min_numel = min_bytes // dtype.itemsize
+    assert config.use_two_stage(world_size, min_numel, dtype)
+    assert not config.use_two_stage(world_size, min_numel - alignment, dtype)
+    assert not config.use_two_stage(world_size, min_numel + 1, dtype)
+    assert not config.use_two_stage(2, min_numel, dtype)
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
@@ -592,14 +555,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
     )
 
     config = IRIS_ALL_REDUCE_KERNEL_CONFIG.kimi_k3_attnres
-    max_tokens = 16
-    num_token_cases = []
-    num_tokens = 1
-    while num_tokens <= max_tokens:
-        num_token_cases.append(num_tokens)
-        num_tokens *= 2
-
-    for num_tokens in num_token_cases:
+    for num_tokens in (1, 2, 4, 8, 16):
         torch.manual_seed(101 + num_tokens)
         hidden = config.hidden_size
         blocks = (torch.randn(4, num_tokens, hidden, device=device) * 0.1).to(
@@ -640,7 +596,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
             scratch,
             rank=rank,
             group=state.group,
-            local_world_size=state.world_size,
+            local_world_size=8,
         )
         for _ in range(4):
             actual_hidden, actual_residual = allreduce_residual_attnres_combine(
@@ -651,7 +607,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
                 scratch,
                 rank=rank,
                 group=state.group,
-                local_world_size=state.world_size,
+                local_world_size=8,
                 eps=1e-6,
             )
             torch.testing.assert_close(
@@ -671,7 +627,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
                 scratch,
                 rank=rank,
                 group=state.group,
-                local_world_size=state.world_size,
+                local_world_size=8,
                 eps=1e-6,
             )
         graph.replay()

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -384,6 +384,20 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             kernel_config.staged.input_slots,
             staged_max_numel,
         )
+        if state._two_stage_supported:
+            assert state._two_stage_input_buf.numel() == staged_max_numel
+            assert (
+                state._two_stage_scratch_buf.numel()
+                == (staged_max_numel + world_size - 1) // world_size
+            )
+        else:
+            assert state._two_stage_input_buf is None
+            assert state._two_stage_scratch_buf is None
+        output_max_numel = max(
+            producer_direct_max_numel,
+            staged_max_numel if state._two_stage_supported else 0,
+        )
+        assert state._reduced_output_buf.numel() == output_max_numel
         if attnres_max_numel:
             assert state._attnres_input_buf.shape == (
                 2,

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -22,6 +22,7 @@
 import socket
 import sys
 import traceback
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import List, Tuple
 
@@ -206,17 +207,18 @@ def test_producer_direct_two_stage_threshold(world_size, dtype, min_bytes):
     try:
         from tokenspeed_kernel.ops.communication.iris import (
             IRIS_ALL_REDUCE_KERNEL_CONFIG,
+            _use_two_stage_producer_direct,
         )
     except ImportError:
         pytest.skip("iris is not installed")
 
-    config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
+    config = IRIS_ALL_REDUCE_KERNEL_CONFIG
     alignment = world_size * (config.packed_word_bytes // dtype.itemsize)
     min_numel = min_bytes // dtype.itemsize
-    assert config.use_two_stage(world_size, min_numel, dtype)
-    assert not config.use_two_stage(world_size, min_numel - alignment, dtype)
-    assert not config.use_two_stage(world_size, min_numel + 1, dtype)
-    assert not config.use_two_stage(2, min_numel, dtype)
+    assert _use_two_stage_producer_direct(world_size, min_numel, dtype)
+    assert not _use_two_stage_producer_direct(world_size, min_numel - alignment, dtype)
+    assert not _use_two_stage_producer_direct(world_size, min_numel + 1, dtype)
+    assert not _use_two_stage_producer_direct(2, min_numel, dtype)
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
@@ -240,6 +242,28 @@ def test_plain_two_stage_admits_partitionable_shapes(dtype):
     assert not _use_two_stage_plain(8, aligned + 1, dtype)
     # world sizes without a tuned partitioning fall back
     assert not _use_two_stage_plain(2, aligned, dtype)
+
+
+def test_plain_two_stage_is_independent_of_producer_thresholds(monkeypatch):
+    try:
+        from tokenspeed_kernel.ops.communication import iris as iris_ops
+    except ImportError:
+        pytest.skip("iris is not installed")
+
+    config = iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG
+    monkeypatch.setattr(
+        iris_ops,
+        "IRIS_ALL_REDUCE_KERNEL_CONFIG",
+        replace(
+            config,
+            producer_direct=replace(
+                config.producer_direct,
+                two_stage_min_bytes=(),
+            ),
+        ),
+    )
+    assert iris_ops._use_two_stage_plain(8, 8 * 7168, torch.bfloat16)
+    assert not iris_ops._use_two_stage_producer_direct(8, 8 * 7168, torch.bfloat16)
 
 
 @pytest.mark.parametrize("dtype", [torch.float64, torch.complex128, torch.int8])
@@ -372,30 +396,53 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             device=device,
         )
         assert state._input_buf.numel() == producer_direct_max_numel
-        scratch_numel = kernel_config.producer_direct.scratch_numel(
-            max_numel=producer_direct_max_numel,
-            world_size=world_size,
+        producer_direct_two_stage = kernel_config.producer_direct.two_stage_threshold(
+            world_size
+        ) is not None and kernel_config.two_stage.supports_world_size(world_size)
+        scratch_numel = (
+            kernel_config.two_stage.scratch_numel(
+                max_numel=producer_direct_max_numel,
+                world_size=world_size,
+            )
+            if producer_direct_two_stage
+            else 0
         )
         if scratch_numel:
             assert state._producer_direct_scratch_buf.numel() == scratch_numel
         else:
             assert state._producer_direct_scratch_buf is None
+        assert state._producer_direct_ready_flags.shape == (
+            max(
+                kernel_config.producer_direct.one_stage_max_programs,
+                (
+                    kernel_config.two_stage.max_programs
+                    if producer_direct_two_stage
+                    else 0
+                ),
+            ),
+            world_size,
+        )
         assert state._staged_input_buf.shape == (
             kernel_config.staged.input_slots,
             staged_max_numel,
         )
-        if state._two_stage_supported:
-            assert state._two_stage_input_buf.numel() == staged_max_numel
+        if state._staged_two_stage_supported:
+            assert state._staged_two_stage_input_buf.numel() == staged_max_numel
             assert (
-                state._two_stage_scratch_buf.numel()
+                state._staged_two_stage_scratch_buf.numel()
                 == (staged_max_numel + world_size - 1) // world_size
             )
+            assert state._staged_two_stage_ready_flags.shape == (
+                kernel_config.two_stage.max_programs,
+                world_size,
+            )
         else:
-            assert state._two_stage_input_buf is None
-            assert state._two_stage_scratch_buf is None
+            assert state._staged_two_stage_input_buf is None
+            assert state._staged_two_stage_scratch_buf is None
+            assert state._staged_two_stage_ready_flags is None
         output_max_numel = max(
             producer_direct_max_numel,
-            staged_max_numel if state._two_stage_supported else 0,
+            staged_max_numel if state._staged_two_stage_supported else 0,
         )
         assert state._reduced_output_buf.numel() == output_max_numel
         if attnres_max_numel:

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -22,6 +22,7 @@
 import socket
 import sys
 import traceback
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import List, Tuple
 
@@ -68,13 +69,7 @@ def _spawn_and_collect(worker_fn, args, world_size: int) -> None:
         raise RuntimeError("\n".join(f"Rank {r}: {e}" for r, e in error_dict.items()))
 
 
-@pytest.mark.parametrize(
-    ("max_numel", "max_bytes", "expected_numel"),
-    [(16, 64, 32), (16, 0, 16)],
-)
-def test_iris_state_uses_backing_capacity(
-    monkeypatch, max_numel, max_bytes, expected_numel
-):
+def test_iris_state_uses_protocol_capacities(monkeypatch):
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     created = []
@@ -90,25 +85,80 @@ def test_iris_state_uses_backing_capacity(
     state = SimpleNamespace(
         group=object(),
         rank_in_group=0,
-        max_numel=max_numel,
-        max_bytes=max_bytes,
+        max_numel=16,
+        max_bytes=64,
+        attnres_max_numel=55,
+        max_token_num=5,
         device=torch.device("cpu"),
     )
 
     iris_state = triton_ops._get_or_create_iris_state(state, torch.bfloat16)
 
-    assert iris_state.max_numel == expected_numel
+    assert iris_state.staged_max_numel == 16
+    assert iris_state.producer_direct_max_numel == 32
+    assert iris_state.attnres_max_numel == 55
+    assert iris_state.attnres_max_rows == 5
     assert triton_ops._get_or_create_iris_state(state, torch.bfloat16) is iris_state
     assert len(created) == 1
 
 
-@pytest.mark.parametrize("world_size", [2, 4, 8])
+def test_attnres_admission_uses_kernel_config(monkeypatch):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
+    from tokenspeed_kernel.ops.communication import triton as triton_ops
+
+    attnres_config = iris_ops.KimiK3AttnResKernelConfig(
+        hidden_size=11,
+        max_profitable_tokens_by_world_size=((2, 3),),
+        num_subgroups=1,
+        elements_per_thread=1,
+        input_slots=2,
+    )
+    kernel_config = replace(
+        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG,
+        kimi_k3_attnres=attnres_config,
+    )
+    monkeypatch.setattr(
+        iris_ops,
+        "IRIS_ALL_REDUCE_KERNEL_CONFIG",
+        kernel_config,
+    )
+    monkeypatch.setattr(
+        triton_ops,
+        "current_platform",
+        lambda: SimpleNamespace(is_cdna4=True),
+    )
+
+    partial = torch.empty((3, 11), dtype=torch.bfloat16)
+    residual = torch.empty_like(partial)
+    weight = torch.empty((11,), dtype=torch.bfloat16)
+    scratch = (
+        torch.empty((3,), dtype=torch.float32),
+        torch.empty((3,), dtype=torch.float32),
+        torch.empty((3, 11), dtype=torch.float32),
+    )
+    state = SimpleNamespace(
+        world_size=2,
+        device=partial.device,
+        attnres_max_numel=partial.numel(),
+        max_token_num=3,
+    )
+
+    assert triton_ops._all_reduce_residual_attnres_can_run(
+        state,
+        partial,
+        residual,
+        weight,
+        weight,
+        scratch,
+    )
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 def test_producer_direct_admission_supported_world_sizes(
     monkeypatch,
-    world_size,
     dtype,
 ):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
@@ -116,13 +166,14 @@ def test_producer_direct_admission_supported_world_sizes(
         "current_platform",
         lambda: SimpleNamespace(is_cdna4=True),
     )
-    state = SimpleNamespace(world_size=world_size, max_bytes=64)
-
-    assert triton_ops.symm_outputs_can_run(
-        state,
-        ((3, 5), (1, 1)),
-        dtype,
-    )
+    config = iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
+    for world_size in config.supported_world_sizes:
+        state = SimpleNamespace(world_size=world_size, max_bytes=64)
+        assert triton_ops.symm_outputs_can_run(
+            state,
+            ((3, 5), (1, 1)),
+            dtype,
+        )
 
 
 @pytest.mark.parametrize(
@@ -134,6 +185,7 @@ def test_producer_direct_admission_supported_world_sizes(
     ],
 )
 def test_producer_direct_admission_uses_byte_capacity(monkeypatch, dtype, shapes):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
@@ -141,51 +193,59 @@ def test_producer_direct_admission_uses_byte_capacity(monkeypatch, dtype, shapes
         "current_platform",
         lambda: SimpleNamespace(is_cdna4=True),
     )
-    state = SimpleNamespace(world_size=8, max_bytes=64)
+    world_size = (
+        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct.supported_world_sizes[-1]
+    )
+    state = SimpleNamespace(world_size=world_size, max_bytes=64)
 
     assert triton_ops.symm_outputs_can_run(state, shapes, dtype)
 
 
 @pytest.mark.parametrize(
-    ("world_size", "shapes", "dtype", "op"),
+    ("shapes", "dtype", "op"),
     [
-        (1, ((4,),), torch.bfloat16, dist.ReduceOp.SUM),
-        (8, ((3,),), torch.bfloat16, dist.ReduceOp.SUM),
-        (8, ((3,),), torch.float32, dist.ReduceOp.SUM),
-        (8, ((36,),), torch.bfloat16, dist.ReduceOp.SUM),
-        (8, ((18,),), torch.float32, dist.ReduceOp.SUM),
-        (8, ((4,),), torch.float64, dist.ReduceOp.SUM),
-        (8, ((4,),), torch.bfloat16, dist.ReduceOp.PRODUCT),
+        (((3,),), torch.bfloat16, dist.ReduceOp.SUM),
+        (((3,),), torch.float32, dist.ReduceOp.SUM),
+        (((36,),), torch.bfloat16, dist.ReduceOp.SUM),
+        (((18,),), torch.float32, dist.ReduceOp.SUM),
+        (((4,),), torch.float64, dist.ReduceOp.SUM),
+        (((4,),), torch.bfloat16, dist.ReduceOp.PRODUCT),
     ],
 )
 def test_producer_direct_admission_rejects_unsupported_requests(
     monkeypatch,
-    world_size,
     shapes,
     dtype,
     op,
 ):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
         triton_ops,
         "current_platform",
         lambda: SimpleNamespace(is_cdna4=True),
+    )
+    world_size = (
+        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct.supported_world_sizes[-1]
     )
     state = SimpleNamespace(world_size=world_size, max_bytes=64)
 
     assert not triton_ops.symm_outputs_can_run(state, shapes, dtype, op)
 
 
-def test_producer_direct_admission_is_cdna4_only(monkeypatch):
+def test_producer_direct_admission_rejects_unsupported_world_size(monkeypatch):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     monkeypatch.setattr(
         triton_ops,
         "current_platform",
-        lambda: SimpleNamespace(is_cdna4=False),
+        lambda: SimpleNamespace(is_cdna4=True),
     )
-    state = SimpleNamespace(world_size=8, max_bytes=64)
+    config = iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
+    world_size = max(config.supported_world_sizes) + 1
+    state = SimpleNamespace(world_size=world_size, max_bytes=64)
 
     assert not triton_ops.symm_outputs_can_run(
         state,
@@ -194,29 +254,58 @@ def test_producer_direct_admission_is_cdna4_only(monkeypatch):
     )
 
 
-@pytest.mark.parametrize(
-    ("world_size", "dtype", "min_bytes"),
-    [
-        (4, torch.bfloat16, 160 << 10),
-        (4, torch.float32, 160 << 10),
-        (8, torch.bfloat16, 96 << 10),
-        (8, torch.float32, 96 << 10),
-    ],
-)
-def test_producer_direct_two_stage_threshold(world_size, dtype, min_bytes):
+def test_producer_direct_admission_is_cdna4_only(monkeypatch):
+    from tokenspeed_kernel.ops.communication import iris as iris_ops
+    from tokenspeed_kernel.ops.communication import triton as triton_ops
+
+    monkeypatch.setattr(
+        triton_ops,
+        "current_platform",
+        lambda: SimpleNamespace(is_cdna4=False),
+    )
+    world_size = (
+        iris_ops.IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct.supported_world_sizes[-1]
+    )
+    state = SimpleNamespace(world_size=world_size, max_bytes=64)
+
+    assert not triton_ops.symm_outputs_can_run(
+        state,
+        ((4,),),
+        torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_producer_direct_two_stage_threshold(dtype):
     try:
         from tokenspeed_kernel.ops.communication.iris import (
-            _use_two_stage_producer_direct,
+            IRIS_ALL_REDUCE_KERNEL_CONFIG,
         )
     except ImportError:
         pytest.skip("iris is not installed")
 
-    alignment = world_size * (8 // dtype.itemsize)
-    min_numel = min_bytes // dtype.itemsize
-    assert _use_two_stage_producer_direct(world_size, min_numel, dtype)
-    assert not _use_two_stage_producer_direct(world_size, min_numel - alignment, dtype)
-    assert not _use_two_stage_producer_direct(world_size, min_numel + 1, dtype)
-    assert not _use_two_stage_producer_direct(2, min_numel, dtype)
+    config = IRIS_ALL_REDUCE_KERNEL_CONFIG.producer_direct
+    for world_size, min_bytes in config.two_stage_min_bytes:
+        alignment = world_size * (config.packed_word_bytes // dtype.itemsize)
+        min_numel = min_bytes // dtype.itemsize
+        assert config.use_two_stage(world_size, min_numel, dtype)
+        assert not config.use_two_stage(
+            world_size,
+            min_numel - alignment,
+            dtype,
+        )
+        assert not config.use_two_stage(world_size, min_numel + 1, dtype)
+
+    one_stage_world_size = next(
+        world_size
+        for world_size in config.supported_world_sizes
+        if config.two_stage_threshold(world_size) is None
+    )
+    assert not config.use_two_stage(
+        one_stage_world_size,
+        config.two_stage_min_bytes[0][1] // dtype.itemsize,
+        dtype,
+    )
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
@@ -342,22 +431,55 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
     try:
         # Importing inside the worker avoids pulling iris into the parent
         # process (which has no distributed context).
-        from tokenspeed_kernel.ops.communication.iris import create_iris_state
-
-        output_shape_cases = _ar_output_shape_cases()
-        max_numel = max(
-            max(int(torch.tensor(s).prod()) for s in _ar_shape_cases()),
-            max(
-                sum(int(torch.tensor(shape).prod()) for shape in shapes)
-                for shapes in output_shape_cases
-            ),
+        from tokenspeed_kernel.ops.communication.iris import (
+            IRIS_ALL_REDUCE_KERNEL_CONFIG,
+            create_iris_state,
         )
+
+        kernel_config = IRIS_ALL_REDUCE_KERNEL_CONFIG
+        attnres_config = kernel_config.kimi_k3_attnres
+        output_shape_cases = _ar_output_shape_cases()
+        staged_max_numel = max(
+            int(torch.tensor(shape).prod()) for shape in _ar_shape_cases()
+        )
+        producer_direct_max_numel = max(
+            sum(int(torch.tensor(shape).prod()) for shape in shapes)
+            for shapes in output_shape_cases
+        )
+        attnres_max_rows = attnres_config.max_profitable_num_tokens(world_size)
+        attnres_max_numel = attnres_max_rows * attnres_config.hidden_size
+        staged_max_numel = max(staged_max_numel, attnres_max_numel)
         state = create_iris_state(
             group=dist.group.WORLD,
             rank_in_group=rank,
-            max_numel=max_numel,
+            staged_max_numel=staged_max_numel,
+            producer_direct_max_numel=producer_direct_max_numel,
+            attnres_max_numel=attnres_max_numel,
+            attnres_max_rows=attnres_max_rows,
             dtype=torch.bfloat16,
         )
+        assert state._input_buf.numel() == producer_direct_max_numel
+        scratch_numel = kernel_config.producer_direct.scratch_numel(
+            max_numel=producer_direct_max_numel,
+            world_size=world_size,
+        )
+        if scratch_numel:
+            assert state._producer_direct_scratch_buf.numel() == scratch_numel
+        else:
+            assert state._producer_direct_scratch_buf is None
+        assert state._staged_input_buf.shape == (
+            kernel_config.staged.input_slots,
+            staged_max_numel,
+        )
+        if attnres_max_numel:
+            assert state._attnres_input_buf.shape == (
+                attnres_config.input_slots,
+                attnres_max_numel,
+            )
+            assert state._attnres_ready_flags.shape == (
+                attnres_max_rows,
+                world_size,
+            )
         for shape in _ar_shape_cases():
             _check_all_reduce(state, rank, world_size, shape, device)
         for shapes in output_shape_cases:
@@ -372,7 +494,10 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
         fp16_state = create_iris_state(
             group=dist.group.WORLD,
             rank_in_group=rank,
-            max_numel=max_numel,
+            staged_max_numel=0,
+            producer_direct_max_numel=producer_direct_max_numel,
+            attnres_max_numel=0,
+            attnres_max_rows=0,
             dtype=torch.float16,
         )
         _check_all_reduce_symmetric_outputs(
@@ -394,7 +519,10 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
         fp32_state = create_iris_state(
             group=dist.group.WORLD,
             rank_in_group=rank,
-            max_numel=max_numel,
+            staged_max_numel=0,
+            producer_direct_max_numel=producer_direct_max_numel,
+            attnres_max_numel=0,
+            attnres_max_rows=0,
             dtype=torch.float32,
         )
         _check_all_reduce_symmetric_outputs(
@@ -412,7 +540,7 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
                 ((16, 7168), (16, 3584)),
                 device,
             )
-        if world_size == 8:
+        if attnres_config.supports_world_size(world_size):
             _check_all_reduce_residual_attnres(state, rank, device)
     finally:
         dist.destroy_process_group()
@@ -507,6 +635,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
         attnres_partial,
     )
     from tokenspeed_kernel.ops.communication.iris import (
+        IRIS_ALL_REDUCE_KERNEL_CONFIG,
         iris_all_reduce,
     )
     from tokenspeed_kernel.ops.communication.triton import (
@@ -514,9 +643,17 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
         allreduce_residual_attnres_combine_supported,
     )
 
-    for num_tokens in (1, 2, 4, 8, 16):
+    config = IRIS_ALL_REDUCE_KERNEL_CONFIG.kimi_k3_attnres
+    max_tokens = config.max_profitable_num_tokens(state.world_size)
+    num_token_cases = []
+    num_tokens = 1
+    while num_tokens <= max_tokens:
+        num_token_cases.append(num_tokens)
+        num_tokens *= 2
+
+    for num_tokens in num_token_cases:
         torch.manual_seed(101 + num_tokens)
-        hidden = 7168
+        hidden = config.hidden_size
         blocks = (torch.randn(4, num_tokens, hidden, device=device) * 0.1).to(
             torch.bfloat16
         )
@@ -555,7 +692,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
             scratch,
             rank=rank,
             group=state.group,
-            local_world_size=8,
+            local_world_size=state.world_size,
         )
         for _ in range(4):
             actual_hidden, actual_residual = allreduce_residual_attnres_combine(
@@ -566,7 +703,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
                 scratch,
                 rank=rank,
                 group=state.group,
-                local_world_size=8,
+                local_world_size=state.world_size,
                 eps=1e-6,
             )
             torch.testing.assert_close(
@@ -586,7 +723,7 @@ def _check_all_reduce_residual_attnres(state, rank: int, device) -> None:
                 scratch,
                 rank=rank,
                 group=state.group,
-                local_world_size=8,
+                local_world_size=state.world_size,
                 eps=1e-6,
             )
         graph.replay()
@@ -637,7 +774,10 @@ def _ar_subgroup_worker_fn(rank, world_size, port, error_dict):
         state = create_iris_state(
             group=group,
             rank_in_group=group_rank,
-            max_numel=8 * (7168 + 3584),
+            staged_max_numel=4 * 7,
+            producer_direct_max_numel=8 * (7168 + 3584),
+            attnres_max_numel=0,
+            attnres_max_rows=0,
             dtype=torch.bfloat16,
         )
         _check_all_reduce(

--- a/tokenspeed-kernel/test/ops/test_iris_communication.py
+++ b/tokenspeed-kernel/test/ops/test_iris_communication.py
@@ -68,7 +68,7 @@ def _spawn_and_collect(worker_fn, args, world_size: int) -> None:
         raise RuntimeError("\n".join(f"Rank {r}: {e}" for r, e in error_dict.items()))
 
 
-def test_iris_state_uses_protocol_capacities(monkeypatch):
+def test_iris_state_uses_path_capacities(monkeypatch):
     from tokenspeed_kernel.ops.communication import triton as triton_ops
 
     created = []
@@ -357,7 +357,7 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             sum(int(torch.tensor(shape).prod()) for shape in shapes)
             for shapes in output_shape_cases
         )
-        attnres_max_rows = 16 if world_size == 8 else 0
+        attnres_max_rows = 16 if world_size == attnres_config.world_size else 0
         attnres_max_numel = attnres_max_rows * attnres_config.hidden_size
         staged_max_numel = max(staged_max_numel, attnres_max_numel)
         state = create_iris_state(
@@ -368,6 +368,8 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             attnres_max_numel=attnres_max_numel,
             attnres_max_rows=attnres_max_rows,
             dtype=torch.bfloat16,
+            heap_size=None,
+            device=device,
         )
         assert state._input_buf.numel() == producer_direct_max_numel
         scratch_numel = kernel_config.producer_direct.scratch_numel(
@@ -384,7 +386,7 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
         )
         if attnres_max_numel:
             assert state._attnres_input_buf.shape == (
-                attnres_config.input_slots,
+                2,
                 attnres_max_numel,
             )
             assert state._attnres_ready_flags.shape == (
@@ -410,6 +412,8 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             attnres_max_numel=0,
             attnres_max_rows=0,
             dtype=torch.float16,
+            heap_size=None,
+            device=device,
         )
         _check_all_reduce_symmetric_outputs(
             fp16_state,
@@ -435,6 +439,8 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
             attnres_max_numel=0,
             attnres_max_rows=0,
             dtype=torch.float32,
+            heap_size=None,
+            device=device,
         )
         _check_all_reduce_symmetric_outputs(
             fp32_state,
@@ -451,7 +457,7 @@ def _ar_worker_main(rank: int, world_size: int, port: int) -> None:
                 ((16, 7168), (16, 3584)),
                 device,
             )
-        if world_size == 8:
+        if world_size == attnres_config.world_size:
             _check_all_reduce_residual_attnres(state, rank, device)
     finally:
         dist.destroy_process_group()
@@ -683,6 +689,8 @@ def _ar_subgroup_worker_fn(rank, world_size, port, error_dict):
             attnres_max_numel=0,
             attnres_max_rows=0,
             dtype=torch.bfloat16,
+            heap_size=None,
+            device=device,
         )
         _check_all_reduce(
             state,


### PR DESCRIPTION
## Summary

  Previously, IrisAllReduce collapsed the ordinary and producer-direct capacities into one value:

```
  P = max(
      ordinary_all_reduce_max_numel,
      producer_direct_max_bytes / dtype_size,
  )

```

That single capacity then determined the size of otherwise unrelated buffers. Increasing the producer-direct capacity—for example, to accommodate a large MoE output—also enlarged the ordinary all-reduce and fused AttnRes buffers.

Before the ordinary two-stage path was added, the symmetric payload buffers were effectively:

```
  producer-direct input             P
  producer-direct scratch           P
  ordinary one-shot input slots    2P
  AttnRes input slots              2P
                                  ───
                                   6P
```

Current main also contains an ordinary two-stage all-reduce, which requires a symmetric input buffer and a rank-local partition in symmetric scratch. Under the old shared-capacity model, those were also derived from P.

These buffers have different requirements:

- The producer-direct input must hold the complete producer output.
- Producer-direct two-stage scratch holds only the partition reduced by the current rank, approximately Pproducer / world_size. It is unnecessary when producer-direct uses only the one-stage kernel.
- Ordinary one-shot all-reduce uses two alternating input slots to prevent a new invocation from overwriting data that peers may still be reading.
- Ordinary two-stage all-reduce uses one copied input plus approximately Pstaged / world_size of scratch. Its exit barrier makes a second input slot unnecessary.
- Fused Kimi-K3 AttnRes uses two alternating input slots, but its capacity is limited to the token range supported by that fused kernel.
- The reduced output is ordinary device memory rather than symmetric-heap memory. One output buffer is shared and sized to the largest path that uses it.

This PR gives each path an independent capacity:

```
  producer-direct input             Pproducer
  producer-direct scratch           ceil(Pproducer / world_size), when needed

  ordinary one-shot input slots     2 × Pstaged
  ordinary two-stage input          Pstaged, when supported
  ordinary two-stage scratch        ceil(Pstaged / world_size), when supported

  Kimi-K3 AttnRes input slots       2 × Pattnres
```

The symmetric heap retains its 256 MiB minimum. Above that floor, its size is calculated from the buffers and synchronization state actually required, plus the existing 16 MiB headroom. Increasing one path’s capacity therefore no longer enlarges every unrelated buffer.

For a TP8 Kimi-K3 state sized for both an 8,192-token attention all-reduce and an 8,192-token producer-direct MoE all-reduce:

```
  Pproducer = 8192 × (7168 + 3584) × sizeof(BF16) = 168 MiB
  Pstaged   = 8192 × 7168 × sizeof(BF16)          = 112 MiB
  Pattnres  = 16 × 7168 × sizeof(BF16)            = 0.219 MiB
```

```
   Allocation                              Old shared-capacity layout    Independent capacities
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━
   Producer-direct input                                      168 MiB                   168 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Producer-direct scratch                                    168 MiB                    21 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Ordinary one-shot input, two slots                         336 MiB                   224 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   AttnRes input, two slots                                   336 MiB                 0.438 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Ordinary two-stage input                                   168 MiB                   112 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Ordinary two-stage scratch                                  21 MiB                    14 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Synchronization flags                                   ~1.320 MiB                ~0.881 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Automatic symmetric-heap reservation                     1,360 MiB               556.319 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Shared local reduced-output buffer                         168 MiB                   168 MiB
  ──────────────────────────────────────  ────────────────────────────  ────────────────────────
   Total persistent state                                   1,528 MiB               724.319 MiB
```
 
The old heap calculation conservatively charged the ordinary two-stage scratch as another full P, even though its actual allocation was P / world_size.

For the same 8,192-token capacity:

- Symmetric-heap reservation falls from 1,360 MiB to 556.319 MiB, a 59.1% reduction.
- Total persistent all-reduce state falls from 1,528 MiB to 724.319 MiB, a 52.6% reduction.

This makes larger Iris payloads practical where the kernels already support them but the previous shared-capacity model made increasing max_bytes unnecessarily
  expensive.

The PR also puts each kernel’s settings in one place. Buffer allocation and kernel launch now read the same definitions for packed-word geometry, supported group sizes, workgroup shape, program limits, and producer-direct switching thresholds. A kernel-setting change therefore cannot silently diverge from the workspace sizing that supports it.


## Test Plan

The normal staged all-reduce algorithm and existing dispatch thresholds remain unchanged. Tests cover protocol-specific state construction, exact workspace sizing, producer-direct admission and thresholds, supported dtypes and group sizes, and multi-GPU correctness. No performance optimizations in this PR. 