### PR TITLE
perf(amd): schedule gfx1250 MHA prefill for ILP

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
@@ -704,6 +704,16 @@ class LaunchConfig(NamedTuple):
     grid: tuple[int, ...]
 
 
+def _select_llvm_fn_attrs(*, head_dim: int, max_seqlen: int, window_left: int) -> str:
+    """Use max-ILP where it reduces scheduler overhead without regressions.
+
+    It wins for full D=128 attention once fixed scheduling overhead is amortized.
+    D=64, very short sequences, and medium/large sliding windows regress.
+    """
+    use_max_ilp = head_dim == 128 and max_seqlen >= 512 and window_left < 0
+    return "amdgpu-sched-strategy=max-ilp" if use_max_ilp else ""
+
+
 def _select_m_tile(
     *, batch_size: int, n_heads: int, max_seqlen: int
 ) -> tuple[int, int]:
@@ -855,6 +865,11 @@ def gluon_mha_prefill_gfx1250(
         config.num_buffers,
         num_warps=config.num_warps,
         waves_per_eu=config.waves_per_eu,
+        llvm_fn_attrs=_select_llvm_fn_attrs(
+            head_dim=config.head_dim,
+            max_seqlen=config.max_seqlen,
+            window_left=config.window_left,
+        ),
     )
     if return_lse:
         return output, lse

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
@@ -82,8 +82,11 @@ def test_mha_prefill_tile_shapes(block_m, num_warps, head_dim, window_left):
     """
     device, dtype = "cuda", torch.bfloat16
     n_q_heads, n_kv_heads = 4, 1
+    # D=128 full attention crosses the max-ILP scheduler's minimum sequence
+    # length, so this matrix compiles both scheduler policies as well.
+    seqlen = 512 if head_dim == 128 and window_left < 0 else 320
     q, k, v, cu, cu_cpu, max_seqlen = _inputs(
-        [320], n_q_heads, n_kv_heads, head_dim, device, dtype
+        [seqlen], n_q_heads, n_kv_heads, head_dim, device, dtype
     )
 
     original = prefill.get_config
@@ -120,6 +123,28 @@ def test_mha_prefill_tile_shapes(block_m, num_warps, head_dim, window_left):
     assert not torch.isnan(out).any()
     expected = _reference(q, k, v, cu_cpu, n_q_heads, n_kv_heads, head_dim, window_left)
     torch.testing.assert_close(out.float(), expected, rtol=8e-2, atol=8e-2)
+
+
+def test_select_llvm_fn_attrs():
+    max_ilp = "amdgpu-sched-strategy=max-ilp"
+
+    assert (
+        prefill._select_llvm_fn_attrs(head_dim=128, max_seqlen=512, window_left=-1)
+        == max_ilp
+    )
+
+    # Each guard has a measured regression when max-ILP is used.
+    assert (
+        prefill._select_llvm_fn_attrs(head_dim=64, max_seqlen=512, window_left=-1) == ""
+    )
+    assert (
+        prefill._select_llvm_fn_attrs(head_dim=128, max_seqlen=256, window_left=-1)
+        == ""
+    )
+    assert (
+        prefill._select_llvm_fn_attrs(head_dim=128, max_seqlen=4096, window_left=512)
+        == ""
+    )
 
 
 def test_select_m_tile_gates():


### PR DESCRIPTION
## Summary

Uses LLVM's `max-ilp` scheduler for full D=128 gfx1250 MHA prefill when `max_seqlen >= 512`.

The default schedule already has no spills. `max-ilp` improves the instruction schedule:

| metric | default | max-ILP |
|---|---:|---:|
| VGPRs | 488 | 466 |
| VGPR bank switches | 824 | 638 |
| ALU waits | 126 | 98 |
| static instructions | 5,177 | 4,928 |

The policy is deliberately narrow. D=64, sequences shorter than 512, and sliding-window attention stay on the default scheduler because those paths measured neutral to slower.

## Test Plan

gfx1250 at a pinned 2400 MHz. Five order-balanced trials were run under one outer GPU lock; all ten runs had 0.00% clock spread and passed the causal PyTorch reference before timing.

| scheduler | mean TFLOP/s | gain |
|---|---:|---:|
| default | 1,510.4 | - |
| max-ILP | 1,559.8 | **+3.27%** |

All ten gfx1250 test cases pass on hardware: narrow and wide tiles, D=64 and D=128, full and sliding window, plus scheduler and tile-selection guards. `pre-commit run --all-files` passes.
