### PR TITLE
perf(moe): add gfx1250 fused softmax top-k

### DIFF
--- a/python/tokenspeed/runtime/layers/moe/topk.py
+++ b/python/tokenspeed/runtime/layers/moe/topk.py
@@ -292,7 +292,7 @@ class TopKConfig:
     routed_scaling_factor: float | None = None
     output_format: TopKOutputFormat | None = None
     zero_expert_num: int | None = 0
-    topk_indices_dtype: torch.dtype | None = torch.int32
+    topk_indices_dtype: torch.dtype = torch.int32
     # Weights dtype for the biased-grouped path; bf16 lets consumers skip a cast.
     topk_weights_dtype: torch.dtype = torch.float32
     # Shared-expert sink (Inkling)
@@ -352,7 +352,7 @@ class TopK(torch.nn.Module):
         routed_scaling_factor: float | None = None,
         output_format: TopKOutputFormat | None = None,
         zero_expert_num: int | None = 0,
-        topk_indices_dtype=torch.int32,
+        topk_indices_dtype: torch.dtype = torch.int32,
         topk_weights_dtype: torch.dtype = torch.float32,
         num_sink_experts: int = 0,
         sink_global_scale: torch.Tensor | None = None,
@@ -600,10 +600,12 @@ def select_experts(
         topk_weights, topk_ids = moe_softmax_topk(
             router_logits,
             top_k,
+            topk_indices_dtype=topk_config.topk_indices_dtype,
             renormalize=renormalize,
             routed_scaling_factor=(
                 1.0 if routed_scaling_factor is None else routed_scaling_factor
             ),
+            solution=None,
         )
         topk_ids = topk_ids_logical_to_physical(
             topk_ids,

--- a/python/tokenspeed/runtime/models/gpt_oss.py
+++ b/python/tokenspeed/runtime/models/gpt_oss.py
@@ -291,16 +291,6 @@ class GptOssAttention(nn.Module):
         return self.forward_core(s)
 
 
-def routing_function(hidden_states, gating_output, topk, renormalize):
-
-    experts = torch.topk(gating_output, k=topk, dim=-1, sorted=True)
-    expert_weights = torch.nn.functional.softmax(
-        experts.values.to(torch.float32), dim=1
-    )
-    expert_indices = experts.indices.to(torch.int32)
-    return expert_weights, expert_indices
-
-
 class GptOssSparseMoeBlock(nn.Module):
     def __init__(
         self,
@@ -366,9 +356,12 @@ class GptOssSparseMoeBlock(nn.Module):
             params_dtype=config.dtype,
         )
 
+        # Declare model semantics only; the kernel package selects the
+        # platform- and shape-specific softmax top-k implementation.
         self.topk = TopK(
             top_k=top_k,
-            custom_routing_function=routing_function,
+            renormalize=True,
+            custom_routing_function=None,
             output_format=self.experts.topk_output_format,
             topk_indices_dtype=(
                 torch.int64 if get_all2all_backend().is_deepep() else torch.int32

--- a/test/runtime/layers/test_moe_topk.py
+++ b/test/runtime/layers/test_moe_topk.py
@@ -31,20 +31,28 @@ def test_topk_call_can_override_configured_output_format() -> None:
 def test_plain_route_uses_kernel_package_softmax_topk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls: list[tuple[int, bool, float]] = []
+    calls: list[tuple[int, torch.dtype, bool, float, str | None]] = []
 
     def fake_softmax_topk(
         router_logits: torch.Tensor,
         topk: int,
         *,
+        topk_indices_dtype: torch.dtype,
         renormalize: bool,
         routed_scaling_factor: float,
-        enable_pdl: bool,
+        solution: str | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        del enable_pdl
-        calls.append((topk, renormalize, routed_scaling_factor))
+        calls.append(
+            (
+                topk,
+                topk_indices_dtype,
+                renormalize,
+                routed_scaling_factor,
+                solution,
+            )
+        )
         shape = (router_logits.shape[0], topk)
-        return torch.ones(shape), torch.zeros(shape, dtype=torch.int64)
+        return torch.ones(shape), torch.zeros(shape, dtype=topk_indices_dtype)
 
     monkeypatch.setattr(topk_module, "moe_softmax_topk", fake_softmax_topk)
     output = select_experts(
@@ -54,11 +62,13 @@ def test_plain_route_uses_kernel_package_softmax_topk(
             top_k=2,
             renormalize=True,
             routed_scaling_factor=2.5,
+            topk_indices_dtype=torch.int32,
         ),
     )
 
-    assert calls == [(2, True, 2.5)]
+    assert calls == [(2, torch.int32, True, 2.5, None)]
     assert output.topk_weights.shape == output.topk_ids.shape == (2, 2)
+    assert output.topk_ids.dtype == torch.int32
 
 
 @pytest.mark.parametrize("renormalize", [False, True])

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/softmax_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/softmax_topk.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 
 import torch
-from tokenspeed_kernel.platform import Platform, pdl_enabled
+from tokenspeed_kernel.platform import pdl_enabled
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import (
@@ -45,7 +45,6 @@ def _triton_eligible(router_logits: torch.Tensor, topk: int) -> bool:
         and router_logits.stride(1) == 1
         and router_logits.shape[1] <= _TRITON_MAX_EXPERTS
         and topk <= _TRITON_MAX_TOPK
-        and Platform.get().is_nvidia
     )
 
 
@@ -53,6 +52,7 @@ def moe_softmax_topk(
     router_logits: torch.Tensor,
     topk: int,
     *,
+    topk_indices_dtype: torch.dtype,
     renormalize: bool = True,
     routed_scaling_factor: float = 1.0,
     solution: str | None = None,
@@ -60,10 +60,11 @@ def moe_softmax_topk(
     """Select experts using softmax routing in one fused launch when supported.
 
     Args:
-        router_logits: Router logits shaped ``[tokens, experts]``. CUDA FP16,
-            BF16, and FP32 inputs with a contiguous expert dimension use the
-            fused NVIDIA Triton kernel; other inputs use the PyTorch fallback.
+        router_logits: Router logits shaped ``[tokens, experts]``. Inputs
+            matching a registered Triton implementation use it; others use
+            the PyTorch fallback.
         topk: Number of experts selected per token.
+        topk_indices_dtype: Integer dtype for returned expert ids.
         renormalize: Normalize the selected weights to sum to one. When false,
             return probabilities from the softmax over all experts.
         routed_scaling_factor: Scale applied to every selected route weight.
@@ -72,8 +73,7 @@ def moe_softmax_topk(
 
     Returns:
         ``(topk_weights, topk_ids)`` shaped ``[tokens, topk]``. Weights are
-        FP32 and ids are INT64, matching ``torch.topk`` and DeepEP's routing
-        metadata contract.
+        FP32 and ids use ``topk_indices_dtype``.
     """
     if router_logits.ndim != 2:
         raise ValueError("router_logits must have shape [tokens, experts]")
@@ -82,11 +82,17 @@ def moe_softmax_topk(
         raise ValueError("router_logits must have a floating-point dtype")
     if not 0 < topk <= experts:
         raise ValueError(f"topk must be in [1, {experts}], got {topk}")
+    if topk_indices_dtype not in (torch.int32, torch.int64):
+        raise ValueError("topk_indices_dtype must be torch.int32 or torch.int64")
     if tokens == 0:
         shape = (0, topk)
         return (
             torch.empty(shape, device=router_logits.device, dtype=torch.float32),
-            torch.empty(shape, device=router_logits.device, dtype=torch.int64),
+            torch.empty(
+                shape,
+                device=router_logits.device,
+                dtype=topk_indices_dtype,
+            ),
         )
 
     if solution is None and not _triton_eligible(router_logits, topk):
@@ -96,6 +102,7 @@ def moe_softmax_topk(
         return torch_softmax_topk(
             router_logits=router_logits,
             topk=topk,
+            topk_indices_dtype=topk_indices_dtype,
             renormalize=renormalize,
             routed_scaling_factor=routed_scaling_factor,
             enable_pdl=enable_pdl,
@@ -107,11 +114,13 @@ def moe_softmax_topk(
         format_signature(
             router_logits=dense_tensor_format(router_logits.dtype),
         ),
+        traits={"tokens": int(tokens), "experts": int(experts), "topk": int(topk)},
         solution=solution,
     )
     return kernel(
         router_logits=router_logits,
         topk=topk,
+        topk_indices_dtype=topk_indices_dtype,
         renormalize=renormalize,
         routed_scaling_factor=routed_scaling_factor,
         enable_pdl=enable_pdl,
@@ -131,19 +140,22 @@ def torch_softmax_topk(
     *,
     router_logits: torch.Tensor,
     topk: int,
+    topk_indices_dtype: torch.dtype,
     renormalize: bool,
     routed_scaling_factor: float,
     enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """PyTorch reference for ordinary softmax top-k routing."""
     del enable_pdl
-    scores = torch.softmax(router_logits.float(), dim=-1)
-    topk_weights, topk_ids = torch.topk(scores, topk, dim=-1)
+    logits = router_logits.float()
+    topk_logits, topk_ids = torch.topk(logits, topk, dim=-1, sorted=True)
     if renormalize:
-        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+        topk_weights = torch.softmax(topk_logits, dim=-1)
+    else:
+        topk_weights = torch.softmax(logits, dim=-1).gather(-1, topk_ids)
     if routed_scaling_factor != 1.0:
         topk_weights = topk_weights * routed_scaling_factor
-    return topk_weights, topk_ids
+    return topk_weights, topk_ids.to(topk_indices_dtype)
 
 
 __all__ = ["moe_softmax_topk", "torch_softmax_topk"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/softmax_topk.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton/softmax_topk.py
@@ -18,13 +18,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Single-launch softmax top-k routing for NVIDIA GPUs."""
+"""Single-launch softmax top-k routing for NVIDIA and gfx1250 GPUs."""
 
 from __future__ import annotations
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
-from tokenspeed_kernel.platform import CapabilityRequirement, Platform
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement, Platform
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import format_signatures
 
@@ -120,6 +120,22 @@ def _softmax_topk_kernel(
 @register_kernel(
     "moe",
     "softmax_topk",
+    name="triton_softmax_topk_gfx1250",
+    solution="triton",
+    capability=CapabilityRequirement(
+        min_arch_version=ArchVersion(12, 5),
+        max_arch_version=ArchVersion(12, 5),
+        vendors=frozenset({"amd"}),
+    ),
+    signatures=format_signatures(
+        "router_logits", "dense", {torch.float16, torch.bfloat16, torch.float32}
+    ),
+    priority=Priority.PERFORMANT,
+    tags={"gfx1250", "routing", "latency"},
+)
+@register_kernel(
+    "moe",
+    "softmax_topk",
     name="triton_softmax_topk",
     solution="triton",
     capability=CapabilityRequirement(vendors=frozenset({"nvidia"})),
@@ -133,11 +149,25 @@ def triton_softmax_topk(
     *,
     router_logits: torch.Tensor,
     topk: int,
+    topk_indices_dtype: torch.dtype,
     renormalize: bool,
     routed_scaling_factor: float,
     enable_pdl: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Fused softmax, top-k selection, normalization, and route scaling."""
+    """Fuse softmax, top-k selection, normalization, and route scaling.
+
+    Args:
+        router_logits: Router logits shaped ``[tokens, experts]``.
+        topk: Number of experts selected per token.
+        topk_indices_dtype: Integer dtype for returned expert ids.
+        renormalize: Whether to normalize selected weights to sum to one.
+        routed_scaling_factor: Scale applied to selected route weights.
+        enable_pdl: Whether supported NVIDIA launches may use PDL.
+
+    Returns:
+        FP32 route weights and INT32 or INT64 expert ids, each shaped
+        ``[tokens, topk]``.
+    """
     if (
         router_logits.ndim != 2
         or not router_logits.is_cuda
@@ -155,11 +185,15 @@ def triton_softmax_topk(
         raise ValueError(
             f"Triton softmax-topk supports at most 1024 experts, got {experts}"
         )
+    if topk_indices_dtype not in (torch.int32, torch.int64):
+        raise ValueError("topk_indices_dtype must be torch.int32 or torch.int64")
 
     weights = torch.empty(
         (tokens, topk), dtype=torch.float32, device=router_logits.device
     )
-    ids = torch.empty((tokens, topk), dtype=torch.int64, device=router_logits.device)
+    ids = torch.empty(
+        (tokens, topk), dtype=topk_indices_dtype, device=router_logits.device
+    )
     if tokens == 0:
         return weights, ids
 

--- a/tokenspeed-kernel/test/ops/moe/test_softmax_topk.py
+++ b/tokenspeed-kernel/test/ops/moe/test_softmax_topk.py
@@ -29,15 +29,17 @@ from tokenspeed_kernel.ops.moe.triton.softmax_topk import triton_softmax_topk
 from tokenspeed_kernel.platform import Platform
 
 
-def test_torch_reference_runs_on_cpu():
+def test_torch_reference_runs_on_cpu() -> None:
     # FP64 is intentionally outside the fused signature and exercises the
     # portable fallback while preserving the previous runtime behavior.
     logits = torch.tensor([[0.0, 2.0, 1.0, -1.0]], dtype=torch.float64)
     weights, ids = moe_softmax_topk(
         logits,
         2,
+        topk_indices_dtype=torch.int64,
         renormalize=True,
         routed_scaling_factor=2.0,
+        solution=None,
     )
     assert torch.equal(ids, torch.tensor([[1, 2]], dtype=torch.int64))
     torch.testing.assert_close(
@@ -46,9 +48,10 @@ def test_torch_reference_runs_on_cpu():
     )
 
 
-needs_nvidia = pytest.mark.skipif(
-    not torch.cuda.is_available() or not Platform.get().is_nvidia,
-    reason="fused softmax-topk needs NVIDIA CUDA",
+needs_fused_softmax_topk = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not (Platform.get().is_nvidia or Platform.get().is_cdna5),
+    reason="fused softmax-topk requires NVIDIA or gfx1250",
 )
 
 
@@ -87,7 +90,7 @@ def _assert_valid_topk(
     )
 
 
-@needs_nvidia
+@needs_fused_softmax_topk
 @pytest.mark.parametrize("renormalize", [False, True])
 @pytest.mark.parametrize(
     "tokens,experts,topk,dtype",
@@ -105,47 +108,84 @@ def test_triton_matches_softmax_topk(
     topk: int,
     dtype: torch.dtype,
     renormalize: bool,
-):
+) -> None:
     torch.manual_seed(tokens * 1000 + experts)
     logits = torch.randn(tokens, experts, device="cuda", dtype=dtype)
     scale = 2.5
     weights, ids = triton_softmax_topk(
         router_logits=logits,
         topk=topk,
+        topk_indices_dtype=torch.int64,
         renormalize=renormalize,
         routed_scaling_factor=scale,
+        enable_pdl=False,
     )
     _assert_valid_topk(logits, weights, ids, topk, renormalize, scale)
 
 
-@needs_nvidia
-def test_lowest_id_tie_break_and_strided_rows():
+@needs_fused_softmax_topk
+def test_lowest_id_tie_break_and_strided_rows() -> None:
     storage = torch.zeros((6, 272), dtype=torch.bfloat16, device="cuda")
     logits = storage[::2, :256]
     assert not logits.is_contiguous() and logits.stride(1) == 1
-    weights, ids = moe_softmax_topk(logits, 8, renormalize=True)
+    weights, ids = moe_softmax_topk(
+        router_logits=logits,
+        topk=8,
+        topk_indices_dtype=torch.int64,
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        solution=None,
+    )
     expected_ids = torch.arange(8, dtype=torch.int64, device="cuda")
     assert torch.equal(ids, expected_ids.expand(3, 8))
     torch.testing.assert_close(weights, torch.full_like(weights, 1.0 / 8.0))
 
 
-@needs_nvidia
-def test_public_entry_point_is_cuda_graph_capturable():
+@needs_fused_softmax_topk
+def test_public_entry_point_is_cuda_graph_capturable() -> None:
     logits = torch.randn(1, 256, dtype=torch.bfloat16, device="cuda")
     # Compile before capture; production warms the kernels before capturing a
     # decode graph as well.
-    moe_softmax_topk(logits, 8, renormalize=True)
+    moe_softmax_topk(
+        router_logits=logits,
+        topk=8,
+        topk_indices_dtype=torch.int64,
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        solution=None,
+    )
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
-        weights, ids = moe_softmax_topk(logits, 8, renormalize=True)
+        weights, ids = moe_softmax_topk(
+            router_logits=logits,
+            topk=8,
+            topk_indices_dtype=torch.int64,
+            renormalize=True,
+            routed_scaling_factor=1.0,
+            solution=None,
+        )
     graph.replay()
     torch.cuda.synchronize()
-    _assert_valid_topk(logits, weights, ids, 8, True, 1.0)
+    _assert_valid_topk(
+        logits,
+        weights,
+        ids,
+        8,
+        True,
+        1.0,
+    )
 
 
-@needs_nvidia
-def test_empty_batch():
+@needs_fused_softmax_topk
+def test_empty_batch() -> None:
     logits = torch.empty((0, 256), dtype=torch.bfloat16, device="cuda")
-    weights, ids = moe_softmax_topk(logits, 8)
+    weights, ids = moe_softmax_topk(
+        router_logits=logits,
+        topk=8,
+        topk_indices_dtype=torch.int64,
+        renormalize=True,
+        routed_scaling_factor=1.0,
+        solution=None,
+    )
     assert weights.shape == ids.shape == (0, 8)
     assert weights.dtype == torch.float32 and ids.dtype == torch.int64

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -65,7 +65,9 @@ import tokenspeed_kernel.ops.moe.gluon.fp8 as _moe_gluon_fp8
 import tokenspeed_kernel.ops.moe.gluon.sigmoid_topk as _moe_gluon_sigmoid_topk
 import tokenspeed_kernel.ops.moe.latent_decode as _moe_latent_decode
 import tokenspeed_kernel.ops.moe.sigmoid_topk as _moe_sigmoid_topk
+import tokenspeed_kernel.ops.moe.softmax_topk as _moe_softmax_topk
 import tokenspeed_kernel.ops.moe.triton as _moe_triton
+import tokenspeed_kernel.ops.moe.triton.softmax_topk as _moe_triton_softmax_topk
 import tokenspeed_kernel.ops.quantization as _quantization_pkg
 import tokenspeed_kernel.ops.quantization.flashinfer as _quantization_flashinfer
 import tokenspeed_kernel.ops.quantization.triton as _quantization_triton
@@ -190,11 +192,13 @@ _RELOAD_MODULES = [
     _moe_gluon_fp8,
     _moe_gluon_mxfp4,
     _moe_sigmoid_topk,
+    _moe_softmax_topk,
     _moe_gluon_sigmoid_topk,
     _moe_gluon,
     _moe_triton_bf16,
     _moe_triton_decode_sigmoid_topk,
     _moe_triton_mxfp4,
+    _moe_triton_softmax_topk,
     _moe_triton,
     _moe_pkg,
     # Quantization registration modules.
@@ -2629,6 +2633,56 @@ def test_gfx1250_sigmoid_topk_selects_by_token_count(
     assert batched.name == "gluon_sigmoid_bias_topk_gfx1250"
     assert other_shape.name == "torch_sigmoid_bias_topk"
     assert reduced_precision.name == "torch_sigmoid_bias_topk"
+
+
+def test_amd_softmax_topk_selects_triton_on_gfx1250(
+    mi350_platform: PlatformInfo,
+    mi450_platform: PlatformInfo,
+) -> None:
+    registry = KernelRegistry.get()
+    triton_spec = registry.get_by_name("triton_softmax_topk_gfx1250")
+    torch_spec = registry.get_by_name("torch_softmax_topk")
+    if triton_spec is None or torch_spec is None:
+        pytest.skip("softmax top-k kernels are unavailable")
+
+    bf16_signature = format_signature(
+        router_logits=dense_tensor_format(torch.bfloat16),
+    )
+    fp32_signature = format_signature(
+        router_logits=dense_tensor_format(torch.float32),
+    )
+    real_platform = Platform.get()
+    try:
+        Platform.override(mi350_platform)
+        registry.clear_cache()
+        gfx950 = select_kernel(
+            "moe",
+            "softmax_topk",
+            bf16_signature,
+            traits={"tokens": 1, "experts": 128, "topk": 4},
+        )
+
+        Platform.override(mi450_platform)
+        registry.clear_cache()
+        standard_shape = select_kernel(
+            "moe",
+            "softmax_topk",
+            bf16_signature,
+            traits={"tokens": 1, "experts": 128, "topk": 4},
+        )
+        general_shape = select_kernel(
+            "moe",
+            "softmax_topk",
+            fp32_signature,
+            traits={"tokens": 2, "experts": 896, "topk": 16},
+        )
+    finally:
+        Platform.override(real_platform)
+        registry.clear_cache()
+
+    assert gfx950.name == "torch_softmax_topk"
+    assert standard_shape.name == "triton_softmax_topk_gfx1250"
+    assert general_shape.name == "triton_softmax_topk_gfx1250"
 
 
 def test_gluon_mxfp4_plan_selects_dynamic_apply_on_cdna4(


### PR DESCRIPTION
## Summary
- Extend the existing fused softmax top-k route to gfx1250.
- Route GPT-OSS through the generic `TopK` layer so kernel selection stays in `tokenspeed-kernel`.
- Support INT32 and INT64 expert IDs and share test coverage across NVIDIA and gfx1250.

## Performance
GPT-OSS decode routing on gfx1250 (`M=1, E=128, topk=4`, BF16).

| Scope | Main (µs) | PR (µs) | Speedup vs. main |
|---|---:|---:|---:|
| Routing | 18.64 | 16.55 | 1.13x |
| MoE block | 307.18 | 293.46 | 1.05x |

Routing drops from five GPU dispatches to one, while the measured MoE block drops from 11 dispatches to seven. Route IDs and MoE outputs match the existing path.
