### PR TITLE
refactor(cache): bind attention layers to cache groups from the plan

### DIFF
--- a/docs/design/unified_path.md
+++ b/docs/design/unified_path.md
@@ -63,6 +63,55 @@ unconditionally at wrapper construction, `enforce_eager` included. A decode
 above the ladder runs the same refresh with no graph; it is a first-class
 path, not a fallback.
 
+### Rebinding a cache pool
+
+`set_cache_pool` may run more than once on the same backend tree: a memory
+probe binds a small pool, captures into a throwaway graph pool, then binds
+the real pool. The contract is that a rebound backend is indistinguishable
+from one first bound to that pool:
+
+* Every node first answers `validate_cache_pool` for the whole subtree, and
+  only then do the children and the node publish, without a second
+  validation, so a rejected rebind moves nothing (a router's leaves exist
+  only from its first bind on, so the first bind builds and binds them
+  inside its own publish); `set_cache_pool` is that sequence, shared by
+  every node through `CachePoolBinding` and never overridden; a node does
+  its own work in `_publish_cache_pool` (`set_kv_pool` on the state backends
+  is a retained alias). Atomicity covers rejections only: a failure inside a
+  node's own binding work propagates, and the caller rebuilds the tree. A
+  node rejects a pool that changes the geometry it owns: the router its
+  group geometry (granularities, families, retentions and the row layout the
+  leaves' kernels read), the state backends the state group ids, checkpoint
+  grain and the state layers' ids and shapes, DeepSeek V4 the group ids and
+  row geometry, Inkling the ShortConv geometry. Page counts and transfer
+  policy may change. Paged leaves own kernel geometry only; the router
+  validates group geometry for them.
+* Binding drops every pool-derived latch: pointer tables, scratch and views,
+  per-forward metadata, the paged leaves' graph buffers, Inkling's ShortConv
+  ring and pending remote restores, and side-state verify caches. The state
+  backends keep their pool-independent index buffers, so a same-geometry
+  replacement stays usable without re-initialisation of those buffers (a
+  router in the same tree still needs `init_cuda_graph_state` before any
+  metadata call); the caller still runs `configure_runtime` (with the new
+  pool's specs and page counts), `init_cuda_graph_state`,
+  `init_prefill_graph_state` and `preallocate_verify_workspace` again after
+  a rebind, as after a first bind. A probe pool must still hold `max_bs`
+  state rows: the KDA raw-gate verify scratch is the bound pool's own conv
+  slab. The backend tree covers only itself: the executor's own pool
+  references (`token_to_kv_pool`, its cache runtime contract, the drafter's
+  pool) and the layer-to-group stamps `bind_cache_groups` writes on the
+  model are the caller's to re-publish.
+* A rebind is an operation inside executor construction, owned by the
+  orchestrator a later change adds; nothing in the backend tree guards
+  against a rebind at another time. That orchestrator releases both graph
+  owners' captures first (the captured graphs record the buffers a publish
+  drops, and eager kernels cache pointers they allocated inside a capture,
+  such as flashinfer's trtllm-gen MoE runner and Qwen4-Exp's uniform index
+  bundles), unfreezes the device-global workspace pool the executor froze
+  before capturing, rebinds the trees, re-runs `bind_cache_groups` and the
+  initialisation sequence above, freezes the workspace again and captures
+  again.
+
 ### Padding contract
 
 `bs` is the request count being prepared (the padded graph batch under

--- a/python/tokenspeed/runtime/layers/attention/backends/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/base.py
@@ -75,6 +75,8 @@ class SpeculativeStateBackend(Protocol):
         num_extends: int,
     ) -> None: ...
 
+    def drop_verify_scratch(self) -> None: ...
+
 
 _SpeculativeStateBackendT = TypeVar(
     "_SpeculativeStateBackendT", bound=SpeculativeStateBackend
@@ -111,8 +113,41 @@ class SparseTopKShare:
         self.qsa_metadata = None
 
 
-class AttentionBackend(ABC):
-    """The runner-facing contract; see the module docstring."""
+class CachePoolBinding:
+    """A node's bound cache pool."""
+
+    def _init_pool_binding(self) -> None:
+        self.cache_pool: CachePool | None = None
+
+    def child_backends(self) -> tuple[CachePoolBinding, ...]:
+        """The nodes this one composes (graph support, pointer walk, binding); leaves: ()."""
+        return ()
+
+    def validate_cache_pool(self, cache_pool: CachePool) -> None:
+        """Raise if this node or any child cannot rebind to ``cache_pool``."""
+        for backend in self.child_backends():
+            backend.validate_cache_pool(cache_pool)
+
+    def set_cache_pool(self, cache_pool: CachePool) -> None:
+        """Bind: every node agrees, then the children publish, then this node."""
+        self.validate_cache_pool(cache_pool)
+        self._bind(cache_pool)
+
+    def _bind(self, cache_pool: CachePool) -> None:
+        for backend in self.child_backends():
+            backend._bind(cache_pool)
+        self._publish_cache_pool(cache_pool)
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        """A node's own binding work: read the old pool before super(), use the new one after."""
+        self.cache_pool = cache_pool
+
+
+class AttentionBackend(CachePoolBinding, ABC):
+    """The runner-facing contract; see the module docstring.
+
+    A subclass that skips ``__init__`` calls ``_init_pool_binding()`` itself.
+    """
 
     # Cache families this node consumes from the pool contract (startup
     # validation: every published family must have a consumer); composites
@@ -136,22 +171,24 @@ class AttentionBackend(ABC):
         self.num_qo_heads = spec.num_attention_heads // spec.attn_tp_size
         self.num_kv_heads = max(spec.num_kv_heads // spec.attn_tp_size, 1)
         self.head_dim = spec.head_dim
-        self.cache_pool: CachePool | None = None
-        self._speculative_state_backends: list[SpeculativeStateBackend] = []
+        self._init_pool_binding()
 
     # ------------------------------------------------------------------
     # Structure
     # ------------------------------------------------------------------
 
-    def set_cache_pool(self, cache_pool: CachePool) -> None:
-        """Bind the pool whose buffers this node's kernels read."""
-        self.cache_pool = cache_pool
+    def _init_pool_binding(self) -> None:
+        """The binding lifecycle fields; wrappers that skip __init__ call this."""
+        super()._init_pool_binding()
+        self._speculative_state_backends: list[SpeculativeStateBackend] = []
+        self._sparse_topk = SparseTopKShare()
 
-    def child_backends(self) -> tuple[AttentionBackend, ...]:
-        """Sub-backends this node delegates to (drives the CUDA-graph
-        support resolution and the pointer-identity walk); leaves return
-        ``()``."""
-        return ()
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        """Record the pool and drop the verify caches built on the old one."""
+        super()._publish_cache_pool(cache_pool)
+        for backend in self._speculative_state_backends:
+            backend.drop_verify_scratch()
+        self._sparse_topk.clear()
 
     def configure_runtime(self, **kwargs) -> None:
         """Post-load configuration hook (information unavailable at
@@ -316,10 +353,7 @@ class AttentionBackend(ABC):
         builds a forward's metadata; composites fronting a paged child route
         to the child's, so the model, the indexer and the drafter meet the
         same object whichever level of the tree they hold."""
-        share = self.__dict__.get("_sparse_topk")
-        if share is None:
-            share = self.__dict__["_sparse_topk"] = SparseTopKShare()
-        return share
+        return self._sparse_topk
 
     def update_mamba_state_after_mtp_verify(self, accepted_lengths) -> None:
         """Commit recurrent-state pages after MTP verification; only nodes
@@ -390,12 +424,8 @@ class AttentionBackend(ABC):
         self, backend: SpeculativeStateBackend
     ) -> None:
         """Register a model side-state consumer of MTP verification results."""
-        backends = getattr(self, "_speculative_state_backends", None)
-        if backends is None:
-            backends = []
-            self._speculative_state_backends = backends
-        if backend not in backends:
-            backends.append(backend)
+        if backend not in self._speculative_state_backends:
+            self._speculative_state_backends.append(backend)
 
     def find_speculative_state_backend(
         self, backend_type: type[_SpeculativeStateBackendT]
@@ -404,7 +434,7 @@ class AttentionBackend(ABC):
         return next(
             (
                 backend
-                for backend in getattr(self, "_speculative_state_backends", ())
+                for backend in self._speculative_state_backends
                 if isinstance(backend, backend_type)
             ),
             None,
@@ -414,7 +444,7 @@ class AttentionBackend(ABC):
         self, accepted_lengths: torch.Tensor, *, num_extends: int
     ) -> None:
         """Publish MTP accept/reject results to registered model side-state."""
-        for backend in getattr(self, "_speculative_state_backends", ()):
+        for backend in self._speculative_state_backends:
             backend.commit_after_mtp_verify(accepted_lengths, num_extends=num_extends)
 
     @contextmanager

--- a/python/tokenspeed/runtime/layers/attention/backends/hybrid/linear.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/hybrid/linear.py
@@ -61,6 +61,7 @@ class HybridLinearAttnBackend(AttentionBackend):
         self.full_attn_layers = set(full_attn_layers)
         self.full_attn_backend = full_attn_backend
         self.linear_attn_backend = linear_attn_backend
+        self._init_pool_binding()
 
     # The MLA full-attention sub-backend owns the spec-decode token width and
     # the chunked-prefill machinery. The DeepseekV3-style MLA layer forward
@@ -131,11 +132,6 @@ class HybridLinearAttnBackend(AttentionBackend):
 
     def child_backends(self):
         return (self.full_attn_backend, self.linear_attn_backend)
-
-    def set_cache_pool(self, cache_pool) -> None:
-        self.cache_pool = cache_pool
-        for backend in self.child_backends():
-            backend.set_cache_pool(cache_pool)
 
     def _backend_for_layer(self, layer_id: int) -> AttentionBackend:
         if layer_id in self.full_attn_layers:

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/base.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/base.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from tokenspeed.runtime.layers.attention.backends.base import CachePoolBinding
 from tokenspeed.runtime.layers.attention.backends.support import CudaGraphSupport
 from tokenspeed.runtime.utils.common import ceil_div
 
@@ -53,7 +54,7 @@ if TYPE_CHECKING:
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 
-class PagedAttentionBackend(ABC):
+class PagedAttentionBackend(CachePoolBinding, ABC):
     """One cache group's paged attention kernels and their metadata.
 
     Persistent decode state is leaf-owned: ``init_cuda_graph_state`` allocates
@@ -123,7 +124,7 @@ class PagedAttentionBackend(ABC):
         self.num_qo_heads = spec.num_attention_heads // spec.attn_tp_size
         self.num_kv_heads = max(spec.num_kv_heads // spec.attn_tp_size, 1)
         self.head_dim = spec.head_dim
-        self.cache_pool: CachePool | None = None
+        self._init_pool_binding()
         # Persistent decode buffers (``init_cuda_graph_state``) and the cached
         # per-bs metadata views over them (each leaf's ``_decode_views``).
         self.page_table_buf: torch.Tensor | None = None
@@ -134,13 +135,12 @@ class PagedAttentionBackend(ABC):
     # Static shape / lifecycle
     # ------------------------------------------------------------------
 
-    def set_cache_pool(self, cache_pool: CachePool) -> None:
-        """Remember the pool whose buffers this leaf's kernels read."""
-        self.cache_pool = cache_pool
-
-    def child_backends(self) -> tuple:
-        """Leaves compose nothing (the DSA leaf overrides for its dense child)."""
-        return ()
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        # Graph buffers and views return with init_cuda_graph_state.
+        self.page_table_buf = None
+        self.seq_lens_buf = None
+        self._decode_views_by_bs = {}
 
     def configure_runtime(self, **kwargs) -> None:
         """Post-load configuration hook (e.g. sliding window sizes)."""

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/cache_group_geometry.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/cache_group_geometry.py
@@ -52,12 +52,21 @@ class CacheGroupGeometry:
             ``retention="full_history"`` — the table the router's draft
             write locations ride — or None when the pool publishes no such
             group (a single-group pool's sole group then serves as the
-            history).
+            history). Chosen from the pool at every bind, so it takes no
+            part in geometry equality.
+        row_geometry: ``group_id -> (rows_per_page, entry_stride_tokens)``
+            for every non-state group: the physical row layout the leaves'
+            kernels read, so a rebind keeps it.
+        retentions: ``group_id -> (retention, sliding_window_tokens)`` for
+            every non-state group: the scheduler's retention contract, and the
+            fact ``full_history_group_id`` is chosen from.
     """
 
     granularities: dict[str, int] = field(default_factory=dict)
     families: dict[str, str] = field(default_factory=dict)
-    full_history_group_id: str | None = None
+    full_history_group_id: str | None = field(default=None, compare=False)
+    row_geometry: dict[str, tuple[int | None, int | None]] = field(kw_only=True)
+    retentions: dict[str, tuple[str, int | None]] = field(kw_only=True)
 
     def granularity_of(self, group_id: str) -> int:
         """This group's block granularity; an unknown id is a contract bug.
@@ -104,4 +113,14 @@ def learn_cache_group_geometry(cache_group_specs) -> CacheGroupGeometry:
         full_history_group_id=(
             str(full_history.group_id) if full_history is not None else None
         ),
+        row_geometry={
+            str(spec.group_id): (spec.rows_per_page, spec.entry_stride_tokens)
+            for spec in cache_group_specs
+            if spec.family != "state"
+        },
+        retentions={
+            str(spec.group_id): (str(spec.retention), spec.sliding_window_tokens)
+            for spec in cache_group_specs
+            if spec.family != "state"
+        },
     )

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/dsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/dsa.py
@@ -21,6 +21,7 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 import torch
 from tokenspeed_kernel.ops.attention import (
@@ -50,6 +51,9 @@ from tokenspeed.runtime.layers.attention.kernel_page_sizes import (
 )
 from tokenspeed.runtime.layers.attention.kpool import KPoolRuntime
 from tokenspeed.runtime.layers.attention.registry import register_backend
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 
 
 def _make_dense_leaf(
@@ -189,9 +193,11 @@ class DSABackend(PagedAttentionBackend):
     def child_backends(self):
         return (self._dense_backend,)
 
-    def set_cache_pool(self, cache_pool) -> None:
-        super().set_cache_pool(cache_pool)
-        self._dense_backend.set_cache_pool(cache_pool)
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self._prefill_page_table = None
+        if self.kpool_runtime is not None:
+            self.kpool_runtime.reset_forward(None)
 
     def register_step_counter(self, step_counter):
         self.step_counter = step_counter

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/flashmla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/flashmla.py
@@ -56,6 +56,7 @@ from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.flashinfer_config import get_flashinfer_workspace_size
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 
@@ -185,13 +186,7 @@ class FlashMLABackend(PagedAttentionBackend):
             (max_bs + 1,), dtype=torch.int32, device=config.device
         )
 
-        self.prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
-            self.workspace_buffer, "NHD"
-        )
-        self.prefill_wrapper_paged = BatchMLAPagedAttentionWrapper(
-            self.workspace_buffer,
-            backend="auto",
-        )
+        self._build_prefill_wrappers()
         self.indices_updater_prefill = _PrefillIndicesUpdater(config, spec, self)
 
         # Metadata state. Decode and prefill metadata are split so MIXED batches
@@ -218,6 +213,30 @@ class FlashMLABackend(PagedAttentionBackend):
     # ------------------------------------------------------------------
     # Metadata init
     # ------------------------------------------------------------------
+
+    def _build_prefill_wrappers(self) -> None:
+        self.prefill_wrapper_ragged = BatchPrefillWithRaggedKVCacheWrapper(
+            self.workspace_buffer, "NHD"
+        )
+        self.prefill_wrapper_paged = BatchMLAPagedAttentionWrapper(
+            self.workspace_buffer,
+            backend="auto",
+        )
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        rebinding = self.cache_pool is not None
+        super()._publish_cache_pool(cache_pool)
+        self.forward_decode_metadata = None
+        self.forward_prefill_metadata = None
+        self.chunked_prefill_metadata = None
+        self._decode_tile_metadata = None
+        self._decode_tile_metadata_keepalive = []
+        if rebinding:
+            # The wrappers keep the plan built from the old pool's page table.
+            self._build_prefill_wrappers()
+            self.indices_updater_prefill.prefill_wrapper_ragged = (
+                self.prefill_wrapper_ragged
+            )
 
     def init_forward_metadata(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/mha.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/mha.py
@@ -47,6 +47,7 @@ from tokenspeed.runtime.layers.attention.configs.mha import MHAConfig
 from tokenspeed.runtime.layers.attention.registry import register_backend
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 
@@ -153,6 +154,11 @@ class MHAAttnBackend(PagedAttentionBackend):
 
         self.forward_decode_metadata: MHADecodeMetadata | None = None
         self.forward_extend_metadata: MHAExtendMetadata | None = None
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self.forward_decode_metadata = None
+        self.forward_extend_metadata = None
 
     def support_kv_cache_prewrite(
         self, forward_mode: ForwardMode | None = None

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/mla.py
@@ -50,6 +50,7 @@ from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.utils import get_colorful_logger
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 logger = get_colorful_logger(__name__)
@@ -172,6 +173,14 @@ class MLAAttnBackend(PagedAttentionBackend):
                 sliding_window,
             )
         return answer
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self.forward_decode_metadata = None
+        self.forward_prefill_metadata = None
+        self.chunked_prefill_metadata = None
+        self._block_page_table_buf = None
+        self._block_seq_lens_buf = None
 
     def _should_use_absorbed_cached_extend(
         self, *, max_extend_seq_len: int, max_extend_prefix_len: int

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/msa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/msa.py
@@ -60,6 +60,7 @@ from tokenspeed.runtime.layers.attention.registry import (
 )
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 
@@ -143,6 +144,11 @@ class MSAAttnBackend(PagedAttentionBackend):
             dtype=torch.float32,
             device=self.device,
         )
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self.forward_decode_metadata = None
+        self.forward_extend_metadata = None
 
     @property
     def tokens_per_req(self) -> int:
@@ -516,11 +522,6 @@ class MSAHybridAttnBackend(AttentionBackend):
 
     def child_backends(self) -> tuple[AttentionBackend, ...]:
         return (self.full_router, self.sparse_router)
-
-    def set_cache_pool(self, cache_pool) -> None:
-        self.cache_pool = cache_pool
-        self.full_router.set_cache_pool(cache_pool)
-        self.sparse_router.set_cache_pool(cache_pool)
 
     def support_kv_cache_prewrite(
         self, forward_mode: ForwardMode | None = None

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/router.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/router.py
@@ -127,15 +127,8 @@ class CacheGroupRouter(AttentionBackend):
         self.is_draft = bool(is_draft)
         self.spec_num_tokens = max(int(spec_num_tokens or 1), 1)
         self.device = device
-        self.cache_pool: CachePool | None = None
-        self._speculative_state_backends = []
-        self._stacks: GroupTableStacks | None = None
-        # Published write locations: the decode slot (graph-recorded views,
-        # refreshed in place) and the extend slot (fresh per round).
-        self.decode_write_locations: RouterDecodeWriteLocations | None = None
-        self._decode_views: dict[tuple[int, int], RouterDecodeWriteLocations] = {}
-        self._decode_request_offset = 0
-        self._extend_write_locations: dict[str, torch.Tensor] | None = None
+        self._init_pool_binding()
+        self._forget_bound_pool_state()
 
     def bind(
         self,
@@ -147,21 +140,10 @@ class CacheGroupRouter(AttentionBackend):
         ``set_cache_pool`` is the production caller; unit fixtures bind
         hand-built leaves directly.
         """
-        if not leaves:
-            raise ValueError(
-                f"{type(self).__name__}: the bound pool view has no paged "
-                "(history-family) cache groups to route"
-            )
-        for gid in leaves:
-            if geometry.families.get(gid, "history") != "history":
-                raise ValueError(
-                    f"cache group {gid!r} is family {geometry.families[gid]!r}; "
-                    "the router serves paged history groups only"
-                )
+        self._check_routable(geometry, tuple(leaves))
         self._geometry = geometry
         self.leaves = dict(sorted(leaves.items()))
-        self._stacks = None
-        self._decode_views = {}
+        self._forget_bound_pool_state()
 
     # ------------------------------------------------------------------
     # Structure
@@ -174,20 +156,72 @@ class CacheGroupRouter(AttentionBackend):
     def child_backends(self) -> tuple[PagedAttentionBackend, ...]:
         return tuple(self.leaves.values())
 
-    def set_cache_pool(self, cache_pool: CachePool) -> None:
-        """Bind the pool: learn the group geometry from its published specs
-        and build one leaf per paged group of this view (``paged_group_ids``)."""
-        self.cache_pool = cache_pool
+    def _forget_bound_pool_state(self) -> None:
+        """The table stacks and write locations built for a bound pool; init rebuilds them."""
+        self._stacks: GroupTableStacks | None = None
+        self._decode_views: dict[tuple[int, int], RouterDecodeWriteLocations] = {}
+        # Published write locations: the decode slot (graph-recorded views,
+        # refreshed in place) and the extend slot (fresh per round).
+        self.decode_write_locations: RouterDecodeWriteLocations | None = None
+        self._extend_write_locations: dict[str, torch.Tensor] | None = None
+        self._decode_request_offset = 0
+
+    def _check_routable(
+        self, geometry: CacheGroupGeometry, group_ids: tuple[str, ...]
+    ) -> None:
+        if not group_ids:
+            raise ValueError(
+                f"{type(self).__name__}: the bound pool view has no paged "
+                "(history-family) cache groups to route"
+            )
+        for gid in group_ids:
+            if geometry.families.get(gid, "history") != "history":
+                raise ValueError(
+                    f"cache group {gid!r} is family {geometry.families[gid]!r}; "
+                    "the router serves paged history groups only"
+                )
+
+    @staticmethod
+    def _derive(cache_pool: CachePool) -> tuple[CacheGroupGeometry, tuple[str, ...]]:
+        """The geometry and paged group ids ``cache_pool`` publishes."""
         geometry = learn_cache_group_geometry(cache_pool.arena.cache_group_specs)
-        self.bind(
-            geometry,
-            {
-                gid: self._leaf_factory(gid, geometry.granularity_of(gid))
-                for gid in cache_pool.paged_group_ids
-            },
-        )
-        for leaf in self.leaves.values():
-            leaf.set_cache_pool(cache_pool)
+        return geometry, tuple(sorted(cache_pool.paged_group_ids))
+
+    def _learn(
+        self, cache_pool: CachePool
+    ) -> tuple[CacheGroupGeometry, tuple[str, ...]]:
+        """The geometry and paged group ids of ``cache_pool``, or raise on a change."""
+        geometry, group_ids = self._derive(cache_pool)
+        self._check_routable(geometry, group_ids)
+        if self._geometry is not None and (
+            geometry != self._geometry or group_ids != tuple(self.leaves)
+        ):
+            raise RuntimeError(
+                "CacheGroupRouter cannot rebind a pool of a different geometry"
+            )
+        return geometry, group_ids
+
+    def validate_cache_pool(self, cache_pool: CachePool) -> None:
+        super().validate_cache_pool(cache_pool)
+        self._learn(cache_pool)
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        """A first bind builds and binds the leaves; every bind drops the tables."""
+        geometry, group_ids = self._derive(cache_pool)
+        if self._geometry is not None:
+            self._geometry = geometry
+            self._forget_bound_pool_state()
+        else:
+            self.bind(
+                geometry,
+                {
+                    gid: self._leaf_factory(gid, geometry.granularity_of(gid))
+                    for gid in group_ids
+                },
+            )
+            for leaf in self.leaves.values():
+                leaf.set_cache_pool(cache_pool)
+        super()._publish_cache_pool(cache_pool)
 
     def configure_runtime(self, **kwargs) -> None:
         for leaf in self.leaves.values():

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/tokenspeed_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/tokenspeed_mla.py
@@ -64,6 +64,7 @@ from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.utils.env import global_server_args_dict
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 logger = logging.getLogger(__name__)
@@ -181,6 +182,14 @@ class CuteDSLMLABackend(PagedAttentionBackend):
         self._block_page_table_buf: torch.Tensor | None = None
         self._block_seq_lens_buf: torch.Tensor | None = None
         self._logged_block_layouts: set[tuple[int, int, bool]] = set()
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self.forward_decode_metadata = None
+        self.forward_prefill_metadata = None
+        self.chunked_prefill_metadata = None
+        self._block_page_table_buf = None
+        self._block_seq_lens_buf = None
 
     def _cutedsl_workspace(self, q_len_capacity: int) -> torch.Tensor:
         """Per-use view of the shared block, sized by the closed-form bound."""

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/trtllm.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/trtllm.py
@@ -58,6 +58,7 @@ from tokenspeed.runtime.layers.common import fp8_cast_contiguous
 from tokenspeed.runtime.utils.env import envs
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 
@@ -137,8 +138,16 @@ class TRTLLMMHAAttnBackend(PagedAttentionBackend):
         # Padded decode requests have seq_len=1; with q_len=spec_num_tokens
         # they'd hit an empty causal span and the kernel returns NaN.
         self.spec_cache_seqlens_buf: torch.Tensor | None = None
+        # Pure aranges per bs: pool-independent, so a rebind keeps them.
         self._cu_seqlens_by_bs: dict[int, torch.Tensor] = {}
         self._verify_views_by_bs: dict[int, TRTLLMMHAMetadata] = {}
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self.forward_prefill_metadata = None
+        self.forward_decode_metadata = None
+        self.spec_cache_seqlens_buf = None
+        self._verify_views_by_bs = {}
 
     def support_kv_cache_prewrite(
         self, forward_mode: ForwardMode | None = None

--- a/python/tokenspeed/runtime/layers/attention/backends/paged/trtllm_mla.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/paged/trtllm_mla.py
@@ -53,6 +53,7 @@ from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.utils.env import envs
 
 if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 # Block constraint from flashinfer: block_num % (128 / page_size) == 0
@@ -172,6 +173,12 @@ class TRTLLMMLABackend(PagedAttentionBackend):
         self.chunked_prefill_metadata: TRTLLMMLAChunkedPrefillMetadata | None = None
 
     # ---- Metadata initialization ----
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self.forward_decode_metadata = None
+        self.forward_prefill_metadata = None
+        self.chunked_prefill_metadata = None
 
     def init_forward_metadata(
         self,

--- a/python/tokenspeed/runtime/layers/attention/backends/specific/deepseek_v4.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/specific/deepseek_v4.py
@@ -13,7 +13,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, NamedTuple
 
 import torch
 from tokenspeed_kernel import (
@@ -68,6 +69,9 @@ from tokenspeed.runtime.layers.attention.kv_cache.recipes.spec import (
 from tokenspeed.runtime.layers.attention.registry import register_backend
 from tokenspeed.runtime.utils.env import global_server_args_dict
 from tokenspeed.runtime.utils.nvtx import nvtx_range
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 
 DEEPSEEK_V4_DEFAULT_PREFILL_CHUNK_SIZE = 4
 
@@ -219,6 +223,15 @@ def _refresh_decode_indexer_schedule_metadata(
             refreshed_keys.add(key)
 
 
+class _CacheGroupContract(NamedTuple):
+    specs: tuple[CacheGroupSpec, ...]
+    group_ids: tuple[str, ...]
+    group_kinds: dict[str, tuple[int, str, str]]
+    row_geometry: dict[str, tuple[int, int]]
+    raw_tokens_per_page: dict[str, int]
+    max_page_ids: dict[str, int]
+
+
 class DeepseekV4AttentionBackend(AttentionBackend):
     """Metadata owner for the model-local DeepSeek V4 attention path."""
 
@@ -264,9 +277,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
         # The persistent decode buffers + per-shape views; allocated by
         # init_cuda_graph_state (unconditionally at wrapper construction).
         self.graph: DeepseekV4GraphBuffers | None = None
-        self._expected_cache_group_ids: tuple[str, ...] | None = None
-        self._cache_group_raw_tokens_per_page: dict[str, int] = {}
-        self._cache_group_max_page_ids: dict[str, int] = {}
+        self._init_cache_group_latches()
         self._cuda_graph_active_page_validity: torch.Tensor | None = None
         self._prefill_workspace_buffer: torch.Tensor | None = None
         self._prefill_workspace_rows = 0
@@ -301,11 +312,11 @@ class DeepseekV4AttentionBackend(AttentionBackend):
             self.step_counter.record_cache()
         return hidden_states
 
-    def _configure_cache_group_contract(
-        self,
-        cache_group_specs=(),
-        cache_group_page_counts=None,
-    ) -> tuple[CacheGroupSpec, ...]:
+    @staticmethod
+    def _derive_cache_group_contract(
+        cache_group_specs: Sequence[CacheGroupSpec],
+        cache_group_page_counts: Mapping[str, int] | None,
+    ) -> _CacheGroupContract:
         specs = tuple(cache_group_specs or ())
         group_ids = tuple(spec.group_id for spec in specs)
         if any(not isinstance(group_id, str) or not group_id for group_id in group_ids):
@@ -320,6 +331,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                 raise RuntimeError(
                     "DeepSeek V4 cache page counts require matching group specs"
                 )
+            row_geometry: dict[str, tuple[int, int]] = {}
             raw_tokens_per_page: dict[str, int] = {}
             max_page_ids: dict[str, int] = {}
         else:
@@ -341,6 +353,7 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                     "DeepSeek V4 cache groups must reserve page 0 and at least one "
                     f"live page: {invalid_counts!r}"
                 )
+            row_geometry = {}
             raw_tokens_per_page = {}
             for spec, group_id in zip(specs, group_ids, strict=True):
                 raw_tokens = int(spec.rows_per_page) * int(spec.entry_stride_tokens)
@@ -350,24 +363,116 @@ class DeepseekV4AttentionBackend(AttentionBackend):
                         f"group={group_id!r} rows_per_page={spec.rows_per_page} "
                         f"entry_stride_tokens={spec.entry_stride_tokens}"
                     )
+                row_geometry[group_id] = (
+                    int(spec.rows_per_page),
+                    int(spec.entry_stride_tokens),
+                )
                 raw_tokens_per_page[group_id] = raw_tokens
             max_page_ids = {
                 group_id: int(page_counts[group_id]) - 1 for group_id in group_ids
             }
 
-        if self._expected_cache_group_ids is not None:
-            if (
-                self._expected_cache_group_ids != group_ids
-                or self._cache_group_raw_tokens_per_page != raw_tokens_per_page
-                or self._cache_group_max_page_ids != max_page_ids
-            ):
-                raise RuntimeError(
-                    "DeepSeek V4 cache group contract changed after initialization"
-                )
+        group_kinds = {
+            str(spec.group_id): (
+                int(spec.block_granularity),
+                str(spec.family),
+                str(spec.retention),
+            )
+            for spec in specs
+        }
+        return _CacheGroupContract(
+            specs,
+            group_ids,
+            group_kinds,
+            row_geometry,
+            raw_tokens_per_page,
+            max_page_ids,
+        )
+
+    def _configure_cache_group_contract(
+        self,
+        cache_group_specs: Sequence[CacheGroupSpec],
+        cache_group_page_counts: Mapping[str, int] | None,
+    ) -> tuple[CacheGroupSpec, ...]:
+        contract = self._derive_cache_group_contract(
+            cache_group_specs, cache_group_page_counts
+        )
+        (
+            specs,
+            group_ids,
+            group_kinds,
+            row_geometry,
+            raw_tokens_per_page,
+            max_page_ids,
+        ) = contract
+        if self._expected_cache_group_ids is not None and (
+            self._expected_cache_group_ids != group_ids
+            or self._cache_group_kinds != group_kinds
+            or self._cache_group_row_geometry != row_geometry
+            or self._cache_group_raw_tokens_per_page != raw_tokens_per_page
+            or self._cache_group_max_page_ids != max_page_ids
+        ):
+            raise RuntimeError(
+                "DeepSeek V4 cache group contract changed after initialization"
+            )
         self._expected_cache_group_ids = group_ids
+        self._cache_group_kinds = group_kinds
+        self._cache_group_row_geometry = row_geometry
         self._cache_group_raw_tokens_per_page = raw_tokens_per_page
         self._cache_group_max_page_ids = max_page_ids
         return specs
+
+    def _init_cache_group_latches(self) -> None:
+        """The contract latched from the bound pool; a fixture built with __new__ calls this."""
+        self._expected_cache_group_ids: tuple[str, ...] | None = None
+        self._cache_group_kinds: dict[str, tuple[int, str, str]] = {}
+        self._cache_group_row_geometry: dict[str, tuple[int, int]] = {}
+        self._cache_group_raw_tokens_per_page: dict[str, int] = {}
+        self._cache_group_max_page_ids: dict[str, int] = {}
+
+    def _rebind_contract(self, cache_pool: CachePool) -> _CacheGroupContract:
+        """The contract ``cache_pool`` publishes, or raise on a geometry change."""
+        contract = self._derive_cache_group_contract(
+            tuple(cache_pool.arena.cache_group_specs),
+            cache_pool.arena.cache_group_page_counts,
+        )
+        if self.cache_pool is not None and (
+            sorted(contract.group_ids) != sorted(self._expected_cache_group_ids or ())
+            or contract.group_kinds != self._cache_group_kinds
+            or contract.row_geometry != self._cache_group_row_geometry
+        ):
+            raise RuntimeError("DeepSeek V4 cache group geometry changed on rebind")
+        return contract
+
+    def validate_cache_pool(self, cache_pool: CachePool) -> None:
+        super().validate_cache_pool(cache_pool)
+        self._rebind_contract(cache_pool)
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        # Page counts may change between binds: relatch the contract.
+        contract = self._rebind_contract(cache_pool)
+        super()._publish_cache_pool(cache_pool)
+        self._expected_cache_group_ids = contract.group_ids
+        self._cache_group_kinds = contract.group_kinds
+        self._cache_group_row_geometry = contract.row_geometry
+        self._cache_group_raw_tokens_per_page = contract.raw_tokens_per_page
+        self._cache_group_max_page_ids = contract.max_page_ids
+        # Sized from the old pool's page counts; init_cuda_graph_state rebuilds them.
+        self.graph = None
+        self._cuda_graph_active_page_validity = None
+        self._decode_q_padding_workspace = None
+        self._decode_q_padding_workspace_layout = None
+        self.draft_rounds = None
+        self.forward_metadata = None
+        self.forward_prefill_metadata = None
+        self.forward_decode_metadata = None
+        self.slot_mappings = DeepseekV4ForwardSlotMappings()
+        self._swa_window_size = 0
+        self._swa_block_size = 0
+        self._prefill_workspace_buffer = None
+        self._prefill_workspace_rows = 0
+        self._prefill_workspace_head_dim = 0
+        self._prefill_dense_compressed_indices_buffer = None
 
     def configure_runtime(self, **kwargs) -> None:
         self._configure_cache_group_contract(

--- a/python/tokenspeed/runtime/layers/attention/backends/specific/inkling.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/specific/inkling.py
@@ -45,8 +45,10 @@ and overwritten.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import torch
 from tokenspeed_kernel import (
@@ -65,6 +67,11 @@ from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
 from tokenspeed.runtime.layers.attention.backends.base import (
     AttentionBackend,
 )
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
+
+logger = logging.getLogger(__name__)
 
 # Matches the runtime causal_conv1d kernels' padded-slot sentinel.
 PAD_SLOT_ID = -1
@@ -150,6 +157,45 @@ class InklingConvStatePool:
         return self.conv_state.nbytes + self.remote_restore_pending.nbytes
 
 
+_ConvGeometry = tuple[int, tuple[tuple[str, int], ...], tuple[str, ...]]
+
+
+class InklingConvColumns(TypedDict):
+    block_tokens: int
+    group_block_tokens: dict[str, int]
+    pd_endpoint_snapshots: bool
+
+
+def conv_columns_for_pool(pool: CachePool) -> InklingConvColumns:
+    """The paged ShortConv geometry a backend derives from its bound pool."""
+    prefix_granularity = pool.arena.plan.prefix_granularity
+    # The checkpoint grain belongs to the conv groups' own specs; P is only
+    # the fallback when a group is absent from the plan.
+    specs_by_id = {spec.group_id: spec for spec in pool.arena.cache_group_specs}
+
+    def conv_grain(group_id: str) -> int:
+        spec = specs_by_id.get(group_id)
+        return spec.block_granularity if spec is not None else prefix_granularity
+
+    conv_columns: InklingConvColumns = {
+        "block_tokens": conv_grain("kvconv"),
+        "group_block_tokens": {
+            "kvconv": conv_grain("kvconv"),
+            "hiddenconv": conv_grain("hiddenconv"),
+        },
+        "pd_endpoint_snapshots": all(
+            spec.transfer_policy == "latest_snapshot"
+            for spec in pool.arena.cache_group_specs
+            if spec.group_id in ("kvconv", "hiddenconv")
+        )
+        and any(
+            spec.group_id in ("kvconv", "hiddenconv")
+            for spec in pool.arena.cache_group_specs
+        ),
+    }
+    return conv_columns
+
+
 class InklingAttnBackend(AttentionBackend):
     """Thin wrapper over the dense MHA backend adding conv metadata.
 
@@ -164,16 +210,16 @@ class InklingAttnBackend(AttentionBackend):
         inner: AttentionBackend,
         conv_pool: InklingConvStatePool,
         *,
-        conv_columns: dict,
         spec_num_tokens: int = 1,
         enable_layerwise_cache_ready: bool = False,
-    ):
+    ) -> None:
         # Deliberately skip AttentionBackend.__init__: the wrapper mirrors inner via __getattr__.
         self.inner = inner
         self.conv_pool = conv_pool
-        # Paged conv geometry (see _inkling_conv_columns). Mandatory: the
+        # Paged conv geometry (see conv_columns_for_pool). Mandatory: the
         # sconv state always has its paged bridges; there is no rolling mode.
-        self.conv_columns = conv_columns
+        self.conv_columns: InklingConvColumns
+        self._conv_geometry_latched: _ConvGeometry | None = None
         # The conv groups are state-family: the inner router builds leaves
         # for history groups only, so it never sees them; this wrapper reads
         # them straight out of block_tables.
@@ -188,6 +234,35 @@ class InklingAttnBackend(AttentionBackend):
         # Spec decoding: >1 means decode rounds carry this many tokens/request (verify / catch-up).
         self.conv_spec_num_tokens = max(1, int(spec_num_tokens))
         self.enable_layerwise_cache_ready = enable_layerwise_cache_ready
+        self._reset_graph_state()
+        self._init_pool_binding()
+        # Registered lazily by the model's four ShortConv sites. The buffers
+        # are fixed LCM field views; target verify publishes them only after
+        # accepted-length selection.
+        self._checkpoint_streams: dict[
+            tuple[int, int, int, str], tuple[torch.Tensor, ...]
+        ] = {}
+
+    @property
+    def _inner_max_context_len(self) -> int:
+        # Router and bare leaf both expose it (a property raising
+        # AttributeError here would fall through to __getattr__ and surface
+        # as a confusing "inner has no _inner_max_context_len").
+        return self.inner.max_context_len
+
+    def __getattr__(self, name: str) -> Any:
+        # Guard `inner` so a half-constructed wrapper raises AttributeError instead of recursing.
+        if name == "inner":
+            raise AttributeError(name)
+        if name == "conv_columns":
+            raise AttributeError("conv_columns is learnt by set_cache_pool")
+        return getattr(self.inner, name)
+
+    def child_backends(self) -> tuple[AttentionBackend, ...]:
+        return (self.inner,)
+
+    def _reset_graph_state(self) -> None:
+        """Forget every graph and breakable-prefill buffer; the next init rebuilds them."""
         # Persistent spec conv metadata buffers for CUDA graphs; sized in init_cuda_graph_state.
         self._graph_spec_qsl: torch.Tensor | None = None
         self._graph_spec_seq_idx: torch.Tensor | None = None
@@ -206,36 +281,48 @@ class InklingAttnBackend(AttentionBackend):
         self._pfg_cache_indices: torch.Tensor | None = None
         self._pfg_has_initial_state: torch.Tensor | None = None
         self._pfg_max_bs = 0
-        # Registered lazily by the model's four ShortConv sites. The buffers
-        # are fixed LCM field views; target verify publishes them only after
-        # accepted-length selection.
-        self._checkpoint_streams: dict[
-            tuple[int, int, int, str], tuple[torch.Tensor, ...]
-        ] = {}
+        self._graph_col_tables: dict[str, torch.Tensor] | None = None
+        self._graph_seq_lens: torch.Tensor | None = None
+        self._rel_qsl_cache: dict[int, torch.Tensor] = {}
+        self._rel_qsl_retired: list[torch.Tensor] = []
 
-    @property
-    def _inner_max_context_len(self) -> int:
-        # Router and bare leaf both expose it (a property raising
-        # AttributeError here would fall through to __getattr__ and surface
-        # as a confusing "inner has no _inner_max_context_len").
-        return self.inner.max_context_len
+    @staticmethod
+    def _conv_geometry(pool: CachePool) -> _ConvGeometry:
+        """The ShortConv geometry a rebind keeps; ``pd_endpoint_snapshots`` is policy."""
+        columns = conv_columns_for_pool(pool)
+        published = {spec.group_id for spec in pool.arena.cache_group_specs}
+        return (
+            columns["block_tokens"],
+            tuple(sorted(columns["group_block_tokens"].items())),
+            tuple(gid for gid in ("hiddenconv", "kvconv") if gid in published),
+        )
 
-    def __getattr__(self, name):
-        # Guard `inner` so a half-constructed wrapper raises AttributeError instead of recursing.
-        if name == "inner":
-            raise AttributeError(name)
-        return getattr(self.inner, name)
+    def validate_cache_pool(self, cache_pool: CachePool) -> None:
+        super().validate_cache_pool(cache_pool)
+        if self.cache_pool is None:
+            return
+        if self._conv_geometry(cache_pool) != self._conv_geometry_latched:
+            raise RuntimeError("Inkling ShortConv geometry changed on rebind")
 
-    def child_backends(self):
-        return (self.inner,)
-
-    def set_cache_pool(self, cache_pool) -> None:
-        # Explicit forward: the base class DEFINES set_cache_pool (it only
-        # stores the pool), so the __getattr__ fallback never fires -- without
-        # this the inner router would keep zero leaves and die at
-        # init_cuda_graph_state.
-        self.cache_pool = cache_pool
-        self.inner.set_cache_pool(cache_pool)
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        rebinding = self.cache_pool is not None
+        super()._publish_cache_pool(cache_pool)
+        # The recorded checkpoint streams are views into the old pool.
+        self._checkpoint_streams.clear()
+        self.conv_prefill_metadata = None
+        self.conv_decode_metadata = None
+        self._reset_graph_state()
+        if rebinding:
+            # The ring rows and pending restores belonged to the old pool's requests.
+            self.conv_pool.conv_state.zero_()
+            self.conv_pool.remote_restore_pending.zero_()
+        self.conv_columns = conv_columns_for_pool(cache_pool)
+        self._conv_geometry_latched = self._conv_geometry(cache_pool)
+        logger.info(
+            "Inkling ShortConv boundary checkpoints: P=%d, groups=%s",
+            cache_pool.arena.plan.prefix_granularity,
+            tuple(self.conv_columns["group_block_tokens"]),
+        )
 
     @property
     def supports_layer_sliding_window(self):
@@ -528,7 +615,7 @@ class InklingAttnBackend(AttentionBackend):
             col_block_table={g: t[:bs] for g, t in self._graph_col_tables.items()},
             remote_restore_mask=(
                 self._graph_remote_restore_mask[:bs]
-                if self.conv_columns.get("pd_endpoint_snapshots", False)
+                if self.conv_columns["pd_endpoint_snapshots"]
                 else None
             ),
         )
@@ -606,10 +693,7 @@ class InklingAttnBackend(AttentionBackend):
         Grown buffers are retained (never freed): their static contents stay
         correct for any graph that recorded them.
         """
-        cache = getattr(self, "_rel_qsl_cache", None)
-        if cache is None:
-            cache = self._rel_qsl_cache = {}
-            self._rel_qsl_retired = []
+        cache = self._rel_qsl_cache
         buf = cache.get(max_seqlen_q)
         if buf is None or buf.shape[0] < bs + 1:
             if buf is not None:
@@ -838,6 +922,7 @@ class InklingAttnBackend(AttentionBackend):
                 extends beyond it run eager and skip the static route).
             max_bs: Request capacity; also the PAD request row index.
         """
+        self.inner.init_prefill_graph_state(max_num_tokens, max_bs)
         geo = self.conv_columns
         device = self.conv_pool.conv_state.device
         self._pfg_max_bs = min(max_bs, self.conv_pool.num_slots - 2)
@@ -954,7 +1039,7 @@ class InklingAttnBackend(AttentionBackend):
             # k-token spec chunk (target verify / draft window).
             self.conv_decode_metadata = self._spec_conv_metadata(bs)
             return
-        if self.conv_columns.get("pd_endpoint_snapshots", False):
+        if self.conv_columns["pd_endpoint_snapshots"]:
             self._graph_remote_restore_mask[:bs].zero_()
         self.conv_decode_metadata = self._graph_decode_conv_metadata(bs)
 
@@ -1007,7 +1092,7 @@ class InklingAttnBackend(AttentionBackend):
             # Rebuild so the eager post-verify hook (outside the graph) sees this round's bs and mode.
             self.conv_decode_metadata = self._spec_conv_metadata(bs)
             return
-        if self.conv_columns.get("pd_endpoint_snapshots", False):
+        if self.conv_columns["pd_endpoint_snapshots"]:
             self._consume_remote_restore_mask(
                 self._graph_cache_indices[:bs],
                 out=self._graph_remote_restore_mask[:bs],

--- a/python/tokenspeed/runtime/layers/attention/backends/specific/qwen4_exp.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/specific/qwen4_exp.py
@@ -26,6 +26,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 import torch
+from typing_extensions import override
 
 from tokenspeed.runtime.layers.attention.backends.base import CudaGraphSupport
 from tokenspeed.runtime.layers.attention.backends.state.mamba import (
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
         AttnConfig,
         SoftmaxAttnConfig,
     )
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.attention.qsa.indexer import QSAIndexer
     from tokenspeed.runtime.layers.qwen4_exp_ple import Qwen4ExpPLELayer
 
@@ -77,6 +79,13 @@ class Qwen4ExpMambaAttnBackend(MambaAttnBackend):
     ) -> int:
         self._ensure_ple_verify_scratch(max_bs, draft_token_num)
         return sum(tensor.nbytes for tensor in self._ple_verify_scratch.values())
+
+    @override
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self._ple_verify_scratch = {}
+        for layer in self._ple_layers:
+            layer.drop_verify_scratch()
 
     def _ensure_ple_verify_scratch(self, max_bs: int, draft_token_num: int) -> None:
         """Allocate graph-stable PLE context and convolution rollback rows."""

--- a/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/kda.py
@@ -24,6 +24,7 @@ See ``KdaAttnBackend`` for what separates the family from GDN."""
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import torch
@@ -64,6 +65,7 @@ if TYPE_CHECKING:
         AttnConfig,
         SoftmaxAttnConfig,
     )
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 
 
 KDA_PREFILL_BACKENDS = ("auto", "fla", "flashkda", "cutedsl_kda")
@@ -118,15 +120,7 @@ class KdaAttnBackend(MambaAttnBackend):
         self._batched_replay_kernel = None
         self._replay_uses_raw_gate = False
         self._verify_split_producers = False
-        self._verify_producer_stream: torch.cuda.Stream | None = None
-        self._verify_producer_forks: dict[int, StreamFork] = {}
-        self._replay_payloads: tuple[torch.Tensor, ...] | None = None
-        self._replay_weights: dict[int, tuple] = {}
-        self._replay_descriptors = None
-        self._replay_group_indices = None
-        self._batched_replay_launch = None
-        self._batched_replay_ready = False
-        self._replay_descriptor_bound: set[int] = set()
+        self._reset_replay_state()
         self.kda_backend = (kda_backend or "auto").strip().lower()
         if self.kda_backend not in KDA_PREFILL_BACKENDS:
             raise ValueError(
@@ -139,13 +133,66 @@ class KdaAttnBackend(MambaAttnBackend):
             self.kda_backend,
         )
 
+    def _reset_replay_state(self) -> None:
+        self._verify_producer_stream: torch.cuda.Stream | None = None
+        self._verify_producer_forks: dict[int, StreamFork] = {}
+        self._replay_payloads: tuple[torch.Tensor, ...] | None = None
+        self._replay_weights: dict[
+            int,
+            tuple[
+                torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int, int, float
+            ],
+        ] = {}
+        self._replay_descriptors: torch.Tensor | None = None
+        self._replay_group_indices: torch.Tensor | None = None
+        self._batched_replay_launch: (
+            Callable[[torch.Tensor, torch.Tensor, torch.Tensor], None] | None
+        ) = None
+        self._batched_replay_ready = False
+        self._replay_descriptor_bound: set[int] = set()
+        self._descriptor_row_by_layer: dict[int, int] = {}
+        self._replay_group_ids: tuple[str, ...] = ()
+        self._replay_group_rows: dict[str, int] = {}
+
+    @staticmethod
+    def _replay_shape(kv_pool: CachePool) -> dict[str, int]:
+        first_layer = min(kv_pool.state_group_by_layer)
+        num_heads, head_dim = kv_pool.get_component(
+            first_layer, "recurrent_state"
+        ).shape[1:3]
+        return {"num_heads": num_heads, "head_dim": head_dim}
+
+    @staticmethod
+    def _layer_pools_are_uniform(kv_pool: CachePool) -> bool:
+        shapes = {
+            (
+                tuple(kv_pool.get_component(layer_id, "conv_state").shape[1:]),
+                tuple(kv_pool.get_component(layer_id, "recurrent_state").shape[1:]),
+            )
+            for layer_id in kv_pool.state_group_by_layer
+        }
+        return len(shapes) == 1
+
     @override
-    def set_kv_pool(self, kv_pool) -> None:
-        super().set_kv_pool(kv_pool)
-        first_layer = self._state_layer_ids()[0]
-        _, first_state = self._state_components(first_layer)
-        num_heads, head_dim = first_state.shape[1:3]
-        shape = {"num_heads": num_heads, "head_dim": head_dim}
+    def validate_cache_pool(self, cache_pool: CachePool) -> None:
+        super().validate_cache_pool(cache_pool)
+        replay_active = kda_replay_commit_supported(
+            self.dtype,
+            recurrent_layout=self.kda_recurrent_layout,
+            **self._replay_shape(cache_pool),
+        )
+        if (
+            replay_active
+            and self.speculative_num_draft_tokens > 1
+            and not self._layer_pools_are_uniform(cache_pool)
+        ):
+            raise RuntimeError("batched KDA replay requires uniform layer pools")
+
+    @override
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        super()._publish_cache_pool(cache_pool)
+        self._reset_replay_state()
+        shape = self._replay_shape(cache_pool)
         self._replay_active = kda_replay_commit_supported(
             self.dtype,
             recurrent_layout=self.kda_recurrent_layout,
@@ -199,15 +246,6 @@ class KdaAttnBackend(MambaAttnBackend):
                         for layer_id in layer_ids
                     }
                 hv, head_dim = first_ssm.shape[1:3]
-                for layer_id in layer_ids[1:]:
-                    conv, ssm = self._state_components(layer_id)
-                    if (
-                        conv.shape[1:] != first_conv.shape[1:]
-                        or ssm.shape[1:] != first_ssm.shape[1:]
-                    ):
-                        raise RuntimeError(
-                            "batched KDA replay requires uniform layer pools"
-                        )
                 payload_shape = (len(layer_ids), rows)
                 self._replay_payloads = (
                     torch.empty(
@@ -233,10 +271,6 @@ class KdaAttnBackend(MambaAttnBackend):
                 )
                 self._replay_descriptors = addresses
                 self._replay_group_indices = group_indices
-                self._replay_descriptor_bound.clear()
-                self._replay_weights.clear()
-                self._batched_replay_launch = None
-                self._batched_replay_ready = False
 
     def _replay_payload(self, layer_id: int) -> tuple[torch.Tensor, ...]:
         """Return one layer row from the stacked replay workspaces."""
@@ -370,10 +404,15 @@ class KdaAttnBackend(MambaAttnBackend):
                     f"preallocated scratch holds {capacity}"
                 )
             return
-        self._verify_scratch = {}
+        scratch = {}
         for layer_id in self._state_layer_ids():
             conv, _ = self._state_components(layer_id)
-            self._verify_scratch[layer_id] = (
+            if self._replay_uses_raw_gate and conv.shape[0] < rows:
+                raise RuntimeError(
+                    f"KDA verify needs {rows} transient conv rows but the "
+                    f"bound pool's conv slab holds {conv.shape[0]}"
+                )
+            scratch[layer_id] = (
                 (
                     conv
                     if self._replay_uses_raw_gate
@@ -383,6 +422,7 @@ class KdaAttnBackend(MambaAttnBackend):
                 ),
                 None,
             )
+        self._verify_scratch = scratch
 
     @override
     def preallocate_verify_workspace(self, max_bs: int, draft_token_num: int) -> int:

--- a/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/mamba.py
@@ -69,10 +69,13 @@ from tokenspeed.runtime.layers.attention.linear.gdn import fused_gdn_gating
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from tokenspeed_kernel.ops.metadata import PrepTape
+
     from tokenspeed.runtime.layers.attention.configs.base import (
         AttnConfig,
         SoftmaxAttnConfig,
     )
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
     from tokenspeed.runtime.layers.paged_attention import PagedAttention
 
 # Default cache group id carrying GDN/Mamba state pages.
@@ -336,6 +339,11 @@ class _GDNReplayWorkspace:
     state_dtype: torch.dtype
 
 
+_StateLayerGeometry = tuple[
+    tuple[int, tuple[int, ...], torch.dtype, tuple[int, ...], torch.dtype], ...
+]
+
+
 class MambaAttnBackend(AttentionBackend):
     """Attention backend for Mamba/GDN linear attention layers."""
 
@@ -350,30 +358,50 @@ class MambaAttnBackend(AttentionBackend):
     def __init__(self, config: AttnConfig, spec: SoftmaxAttnConfig):
         super().__init__(config, spec)
         self.pad_slot_id = -1
-        self.forward_metadata: MambaForwardMetadata = None
-        self.query_start_loc_list = []
-        self.cached_cuda_graph_decode_query_start_loc: torch.Tensor = None
-        self.cached_cuda_graph_verify_query_start_loc: torch.Tensor = None
+        self.forward_metadata: MambaForwardMetadata | None = None
+        self._reset_graph_state()
         self.speculative_num_draft_tokens = config.speculative_num_draft_tokens
-        self.kv_pool = None
         self.state_paging_active = False
         self._checkpoint_granularity = 1
         self._state_group_ids: tuple[str, ...] = ()
+        self._state_layer_geometry: _StateLayerGeometry = ()
+        linear_attn = config.component(LinearAttnConfig)
+        self.replay_ssm = linear_attn is not None and bool(linear_attn.replay_ssm)
+        self._gdn_replay: _GDNReplayWorkspace | None = None
+        self._verify_scratch = None
+        self._verify_commit_ctx = None
+        self._verify_copy_tables: dict[str, torch.Tensor | int | None] | None = None
+        self._replay_state_tapes: dict[int, PrepTape] = {}
+
+    @property
+    def kv_pool(self) -> CachePool | None:
+        return self.cache_pool
+
+    def _reset_graph_state(self) -> None:
+        """Index buffers init_cuda_graph_state rebuilds; a rebind keeps them."""
+        self.query_start_loc_list: list[torch.Tensor] = []
+        self.cached_cuda_graph_decode_query_start_loc: torch.Tensor | None = None
+        self.cached_cuda_graph_verify_query_start_loc: torch.Tensor | None = None
         # CUDA-graph buffers: one persistent dual-index (state_in/state_out)
         # [bs] buffer per state group for every bs up to max_decode_bs (the
         # runner sizes them, never the capture ladder). Values are keyed by
         # group ID and indexed by ``bs - 1``.
         self.state_in_by_group: dict[str, list[torch.Tensor]] = {}
         self.state_out_by_group: dict[str, list[torch.Tensor]] = {}
-        linear_attn = config.component(LinearAttnConfig)
-        self.replay_ssm = linear_attn is not None and bool(linear_attn.replay_ssm)
-        self._gdn_replay: _GDNReplayWorkspace | None = None
-        self._verify_scratch = None
-        self._verify_commit_ctx = None
+        self._verify_seed_dst_cache: dict[tuple[int, int, int], torch.Tensor] = {}
+        self._verify_grid_cache: dict[tuple[int, int], torch.Tensor] = {}
+        self._verify_base_cache: dict[tuple[int, int], torch.Tensor] = {}
+        self._qsl_dirty: list[bool] = []
+        self._qsl_last_mode: list[tuple[ForwardMode, bool] | None] = []
 
-    def set_kv_pool(self, kv_pool) -> None:
+    def set_kv_pool(self, kv_pool: CachePool) -> None:
         """Bind a unified pool that publishes state groups and component views."""
-        self.kv_pool = kv_pool
+        self.set_cache_pool(kv_pool)
+
+    def _state_geometry(
+        self, kv_pool: CachePool
+    ) -> tuple[tuple[str, ...], int, _StateLayerGeometry]:
+        """State group ids, checkpoint grain and per-layer state geometry, or raise."""
         contract = kv_pool.arena.runtime_contract
         if contract is None:
             raise RuntimeError(
@@ -392,8 +420,6 @@ class MambaAttnBackend(AttentionBackend):
             raise RuntimeError(
                 "MambaAttnBackend requires state_group_by_layer and get_component()"
             )
-        self._state_group_ids = state_group_ids
-        self.state_paging_active = True
         checkpoint_granularities = {
             spec.checkpoint_granularity
             for spec in contract.group_specs
@@ -404,7 +430,59 @@ class MambaAttnBackend(AttentionBackend):
                 "MambaAttnBackend requires one shared state-group "
                 f"checkpoint_granularity, got {sorted(checkpoint_granularities, key=str)}"
             )
-        self._checkpoint_granularity = int(checkpoint_granularities.pop())
+        checkpoint_granularity = int(checkpoint_granularities.pop())
+        layer_geometry = tuple(
+            (
+                layer,
+                tuple(conv.shape[1:]),
+                conv.dtype,
+                tuple(recurrent.shape[1:]),
+                recurrent.dtype,
+            )
+            for layer in sorted(kv_pool.state_group_by_layer)
+            for conv, recurrent in (
+                (
+                    kv_pool.get_component(layer, "conv_state"),
+                    kv_pool.get_component(layer, "recurrent_state"),
+                ),
+            )
+        )
+        geometry = (
+            tuple(sorted(state_group_ids)),
+            checkpoint_granularity,
+            layer_geometry,
+        )
+        if self.kv_pool is not None and geometry != (
+            tuple(sorted(self._state_group_ids)),
+            self._checkpoint_granularity,
+            self._state_layer_geometry,
+        ):
+            raise RuntimeError(
+                "MambaAttnBackend cannot rebind a pool of a different state geometry"
+            )
+        return geometry
+
+    def validate_cache_pool(self, cache_pool: CachePool) -> None:
+        super().validate_cache_pool(cache_pool)
+        self._state_geometry(cache_pool)
+
+    def _publish_cache_pool(self, cache_pool: CachePool) -> None:
+        """Latch the state geometry; init and preallocate rebuild the rest."""
+        state_group_ids, checkpoint_granularity, layer_geometry = self._state_geometry(
+            cache_pool
+        )
+        super()._publish_cache_pool(cache_pool)
+        self._state_group_ids = state_group_ids
+        self.state_paging_active = True
+        self._checkpoint_granularity = checkpoint_granularity
+        self._state_layer_geometry = layer_geometry
+        # init_cuda_graph_state and preallocate_verify_workspace rebuild these for the new pool.
+        self._verify_scratch = None
+        self._verify_copy_tables = None
+        self._verify_commit_ctx = None
+        self._gdn_replay = None
+        self._replay_state_tapes = {}
+        self.forward_metadata = None
 
     @staticmethod
     def _decode_state_block_bounds(
@@ -524,12 +602,12 @@ class MambaAttnBackend(AttentionBackend):
             rows_needed
         ):
             return
-        self._verify_scratch = {}
+        scratch = {}
         self._verify_copy_tables = None
         layer_ids = tuple(self._state_layer_ids())
         for layer_id in layer_ids:
             conv, ssm = self._state_components(layer_id)
-            self._verify_scratch[layer_id] = (
+            scratch[layer_id] = (
                 torch.zeros(
                     (rows_needed, *conv.shape[1:]),
                     dtype=conv.dtype,
@@ -576,6 +654,7 @@ class MambaAttnBackend(AttentionBackend):
                     ),
                     state_dtype=ssm.dtype,
                 )
+        self._verify_scratch = scratch
 
     def preallocate_verify_workspace(self, max_bs: int, draft_token_num: int) -> int:
         """Allocate graph-stable verify state and return its byte size."""
@@ -600,12 +679,12 @@ class MambaAttnBackend(AttentionBackend):
         """Allocate model-owned verify state and return its byte size."""
         return 0
 
-    def _verify_copy_tables_get(self) -> dict:
+    def _verify_copy_tables_get(self) -> dict[str, torch.Tensor | int | None]:
         """Pointer tables for the batched verify state copies and replay:
         per-layer base addresses, row strides, and state-group selectors.
         Rebuilt only when the scratch is reallocated so CUDA graph capture
         can record stable tensors."""
-        tables = getattr(self, "_verify_copy_tables", None)
+        tables = self._verify_copy_tables
         if tables is not None:
             return tables
         layer_ids = list(self._state_layer_ids())
@@ -678,9 +757,7 @@ class MambaAttnBackend(AttentionBackend):
         """Memoized layer-major ``[L*bs]`` scratch init-row ids (row
         ``req*(T+1)`` per request, tiled per layer). Graph replay must see the
         identical tensor, mirroring ``_verify_scratch_grid``."""
-        cache = getattr(self, "_verify_seed_dst_cache", None)
-        if cache is None:
-            cache = self._verify_seed_dst_cache = {}
+        cache = self._verify_seed_dst_cache
         tables = self._verify_copy_tables_get()
         key = (bs, draft_token_num, tables["num_layers"])
         rows = cache.get(key)
@@ -727,9 +804,7 @@ class MambaAttnBackend(AttentionBackend):
         the seeded init window, rows ``req*(T+1)+1+t`` the per-position
         outputs. Memoized per (bs, T): CUDA-graph capture records the tensor's
         storage, so replays must present the identical tensor."""
-        cache = getattr(self, "_verify_grid_cache", None)
-        if cache is None:
-            cache = self._verify_grid_cache = {}
+        cache = self._verify_grid_cache
         grid = cache.get((bs, draft_token_num))
         if grid is not None:
             return grid
@@ -978,6 +1053,8 @@ class MambaAttnBackend(AttentionBackend):
     # ---- CUDA graph state ----
 
     def init_cuda_graph_state(self, max_bs: int, **kwargs):
+        """Rebuild the index buffers before any graph that reads them is captured."""
+        self._reset_graph_state()
         for i in range(max_bs):
             self.query_start_loc_list.append(
                 torch.empty((i + 2,), dtype=torch.int32, device=self.device)
@@ -1237,9 +1314,7 @@ class MambaAttnBackend(AttentionBackend):
         if use_tape:
             from tokenspeed_kernel.ops.metadata import PrepTape, Reg
 
-            tapes = getattr(self, "_replay_state_tapes", None)
-            if tapes is None:
-                tapes = self._replay_state_tapes = {}
+            tapes = self._replay_state_tapes
             tape = tapes.get(bs)
             if tape is None:
                 tape = PrepTape(self.device)

--- a/python/tokenspeed/runtime/layers/attention/backends/state/qsa.py
+++ b/python/tokenspeed/runtime/layers/attention/backends/state/qsa.py
@@ -67,6 +67,10 @@ class QSABackend:
                 raise RuntimeError("QSA backend cannot be rebound to another model")
         self._indexers = bound
 
+    def drop_verify_scratch(self) -> None:
+        for indexer in self._indexers:
+            indexer.drop_verify_scratch()
+
     def commit_after_mtp_verify(
         self,
         accepted_lengths: torch.Tensor,

--- a/python/tokenspeed/runtime/layers/attention/qsa/indexer.py
+++ b/python/tokenspeed/runtime/layers/attention/qsa/indexer.py
@@ -166,6 +166,12 @@ class QSAIndexer(nn.Module):
             persistent=False,
         )
 
+    def drop_verify_scratch(self) -> None:
+        """Forget the verify views and their pool; a rebind reissues them."""
+        self._verify_scratch.clear()
+        self._active_verify_width = None
+        self._last_pool = None
+
     @staticmethod
     def _full_backend(ctx: ForwardContext) -> CacheGroupRouter:
         """The cache-group router serving the model's paged groups (the

--- a/python/tokenspeed/runtime/layers/attention/registry.py
+++ b/python/tokenspeed/runtime/layers/attention/registry.py
@@ -627,16 +627,14 @@ def _create_hybrid_linear_attn_backend(
     model_config: ModelConfig,
     config: AttnConfig,
     *,
-    pool,
     full_attn_backend_name: str | None = None,
     is_kda: bool = False,
 ) -> AttentionBackend:
-    """Create a hybrid backend for a linear-attention model over one pool.
+    """Create a hybrid backend for a linear-attention model.
 
     GDN (Qwen3.5, MHA base) or, when ``is_kda`` is set, KDA (Kimi-K3,
-    MLA base; GLM-5.3-Flash, DSA base). ``pool`` is the model's layer-mapped
-    view over the one shared cache pool; both sub-backends consume its
-    per-group tables.
+    MLA base; GLM-5.3-Flash, DSA base). Both sub-backends bind to the one
+    shared cache pool through the wrapper's ``set_cache_pool``.
     """
     from tokenspeed.runtime.layers.attention.backends.hybrid.linear import (
         HybridLinearAttnBackend,
@@ -703,8 +701,6 @@ def _create_hybrid_linear_attn_backend(
 
     # Recurrent state lives in the LCM arena and is addressed by the
     # per-group block tables, so no separate request-indexed Mamba pool exists.
-    linear_attn_backend.set_kv_pool(pool)
-
     backend = HybridLinearAttnBackend(
         full_attn_backend, linear_attn_backend, full_attn_layers
     )
@@ -724,7 +720,6 @@ def _wrap_inkling_backend(
     *,
     num_layers,
     is_draft,
-    conv_columns,
     enable_layerwise_cache_ready=False,
 ):
     """Wrap a dense backend with the engine-side Inkling sconv state pool.
@@ -764,49 +759,10 @@ def _wrap_inkling_backend(
     backend = InklingAttnBackend(
         inner,
         conv_pool,
-        conv_columns=conv_columns,
         spec_num_tokens=spec_tokens,
         enable_layerwise_cache_ready=enable_layerwise_cache_ready,
     )
     return backend
-
-
-def _inkling_conv_columns(pool, text_config):
-    """Return the ShortConv checkpoint groups backed by the cache plan."""
-    layer_labels = text_config.cache_layer_types
-    prefix_granularity = pool.arena.plan.prefix_granularity
-    # The checkpoint grain belongs to the conv groups' own specs; P is only
-    # the fallback when a group is absent from the plan.
-    specs_by_id = {spec.group_id: spec for spec in pool.arena.cache_group_specs}
-
-    def conv_grain(group_id):
-        spec = specs_by_id.get(group_id)
-        return spec.block_granularity if spec is not None else prefix_granularity
-
-    conv_columns = {
-        "block_tokens": conv_grain("kvconv"),
-        "conv_group_of_layer": ("kvconv",) * len(layer_labels),
-        "hidden_group_of_layer": ("hiddenconv",) * len(layer_labels),
-        "group_block_tokens": {
-            "kvconv": conv_grain("kvconv"),
-            "hiddenconv": conv_grain("hiddenconv"),
-        },
-        "pd_endpoint_snapshots": all(
-            spec.transfer_policy == "latest_snapshot"
-            for spec in pool.arena.cache_group_specs
-            if spec.group_id in ("kvconv", "hiddenconv")
-        )
-        and any(
-            spec.group_id in ("kvconv", "hiddenconv")
-            for spec in pool.arena.cache_group_specs
-        ),
-    }
-    logger.info(
-        "Inkling ShortConv boundary checkpoints: P=%d, groups=%s",
-        prefix_granularity,
-        tuple(conv_columns["group_block_tokens"]),
-    )
-    return conv_columns
 
 
 def _create_target_components(
@@ -837,7 +793,6 @@ def _create_target_components(
             server_args,
             model_config,
             config,
-            pool=pool,
             full_attn_backend_name=full_attn_backend_name,
             is_kda=is_kda,
         )
@@ -854,7 +809,6 @@ def _create_target_components(
         config,
         num_layers=text_config.num_hidden_layers,
         is_draft=False,
-        conv_columns=_inkling_conv_columns(pool, text_config),
         enable_layerwise_cache_ready=(
             server_args.disaggregation_mode == "prefill"
             and server_args.disaggregation_layerwise_interval > 0
@@ -908,7 +862,6 @@ def _create_draft_components(
             server_args,
             model_config,
             config,
-            pool=draft_pool,
             full_attn_backend_name=full_attn_backend_name,
             is_kda=is_kda,
         )
@@ -926,7 +879,6 @@ def _create_draft_components(
             config,
             num_layers=num_layers,
             is_draft=True,
-            conv_columns=_inkling_conv_columns(draft_pool, text_config),
         )
     return backend, draft_pool
 

--- a/python/tokenspeed/runtime/layers/qwen4_exp_ple.py
+++ b/python/tokenspeed/runtime/layers/qwen4_exp_ple.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import torch
 import torch.nn.functional as F
@@ -59,6 +60,9 @@ from tokenspeed.runtime.layers.vocab_parallel_embedding import (
     get_masked_input_and_mask,
 )
 from tokenspeed.runtime.utils import add_prefix
+
+if TYPE_CHECKING:
+    from tokenspeed.runtime.layers.attention.kv_cache.base import CachePool
 
 _IndexBundle = tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
 # Uniform-batch index bundles captured into a CUDA graph. During capture the
@@ -452,6 +456,7 @@ class Qwen4ExpPLELayer(nn.Module):
             tuple[int, int], tuple[torch.Tensor, torch.Tensor]
         ] = {}
         self._active_verify_key: tuple[int, int] | None = None
+        self._last_pool: CachePool | None = None
 
     def _load_kv_proj_shard(
         self,
@@ -849,6 +854,12 @@ class Qwen4ExpPLELayer(nn.Module):
         scratch = (external[0][:rows], external[1][:rows])
         self._verify_scratch[key] = scratch
         return scratch
+
+    def drop_verify_scratch(self) -> None:
+        """Forget the workspace views; the backend reissues them for a rebound pool."""
+        self._verify_scratch.clear()
+        self._active_verify_key = None
+        self._last_pool = None
 
     def commit_verified(
         self,

--- a/test/runtime/cache_pool_test_utils.py
+++ b/test/runtime/cache_pool_test_utils.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import inspect
+from collections.abc import Iterator
+
 import torch
 
 from tokenspeed.runtime.layers.attention.kv_cache.arena import CacheArena
@@ -279,3 +282,96 @@ def make_mla_memory_plan(
         max_padding_fraction=1.0,
     )
     return layout.bind(size // prefix_granularity)
+
+
+def binding_state(node: object) -> dict[str, object]:
+    """Every attribute of ``node``, reduced to what a fresh-vs-rebound comparison sees."""
+    return {name: _reduced(value, set()) for name, value in vars(node).items()}
+
+
+def _reduced(value: object, seen: set[int]) -> object:
+    if isinstance(value, torch.Tensor):
+        return (
+            "tensor",
+            tuple(value.shape),
+            value.stride(),
+            value.dtype,
+            str(value.device),
+        )
+    if isinstance(value, dict):
+        return (
+            "dict",
+            tuple(
+                (str(key), _reduced(item, seen))
+                for key, item in sorted(value.items(), key=lambda kv: str(kv[0]))
+            ),
+        )
+    if isinstance(value, (list, tuple)):
+        return (type(value).__name__, tuple(_reduced(item, seen) for item in value))
+    if isinstance(value, (set, frozenset)):
+        return (type(value).__name__, sorted(map(str, value)))
+    if isinstance(value, (bool, int, float, str, type(None))):
+        return value
+    if isinstance(value, (torch.dtype, torch.device)):
+        return str(value)
+    if (
+        hasattr(value, "__dict__")
+        and not isinstance(value, type)
+        and not callable(value)
+    ):
+        if id(value) in seen:
+            return type(value).__name__
+        seen.add(id(value))
+        return (
+            type(value).__name__,
+            tuple(
+                (name, _reduced(item, seen))
+                for name, item in sorted(vars(value).items())
+            ),
+        )
+    return type(value).__name__
+
+
+def storages_of(*tensors: torch.Tensor) -> set[int]:
+    """The untyped storages behind ``tensors``, so views at any offset are recognised."""
+    return {tensor.untyped_storage().data_ptr() for tensor in tensors}
+
+
+def reachable_tensors(node: object) -> list[torch.Tensor]:
+    """Every tensor reachable from ``node``'s attributes, for an alias set taken before a rebind."""
+    return [
+        tensor for value in vars(node).values() for tensor in _tensors(value, set())
+    ]
+
+
+def assert_no_alias(node: object, storages: set[int]) -> None:
+    """Fail if any tensor reachable from ``node``'s attributes lives in ``storages``."""
+    for name, value in vars(node).items():
+        for tensor in _tensors(value, set()):
+            assert (
+                tensor.untyped_storage().data_ptr() not in storages
+            ), f"{name} still aliases the old pool"
+
+
+def _tensors(value: object, seen: set[int]) -> Iterator[torch.Tensor]:
+    if isinstance(value, torch.Tensor):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _tensors(item, seen)
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        for item in value:
+            yield from _tensors(item, seen)
+    elif inspect.isfunction(value) and value.__closure__:
+        for cell in value.__closure__:
+            yield from _tensors(cell.cell_contents, seen)
+    elif isinstance(value, torch.nn.Module) or (
+        hasattr(value, "__dict__")
+        and not isinstance(value, type)
+        and not callable(value)
+    ):
+        if id(value) in seen:
+            return
+        seen.add(id(value))
+        for item in vars(value).values():
+            yield from _tensors(item, seen)

--- a/test/runtime/test_cache_group_router.py
+++ b/test/runtime/test_cache_group_router.py
@@ -7,8 +7,10 @@ check the fused triton fills against the same torch reference.
 
 from __future__ import annotations
 
+import ast
 import os
 import sys
+import textwrap
 import unittest
 from types import SimpleNamespace
 
@@ -16,6 +18,12 @@ import torch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
+from runtime.cache_pool_test_utils import (
+    assert_no_alias,
+    binding_state,
+    reachable_tensors,
+    storages_of,
+)
 
 register_cuda_ci(est_time=10, suite="runtime-1gpu")
 
@@ -301,6 +309,8 @@ def _geometry():
         granularities={FULL: 4, SWA: 4, "linear_attention_0": 8},
         families={FULL: "history", SWA: "history", "linear_attention_0": "state"},
         full_history_group_id=FULL,
+        row_geometry={FULL: (4, 1), SWA: (4, 1)},
+        retentions={FULL: ("full_history", None), SWA: ("sliding_window", 4)},
     )
 
 
@@ -865,6 +875,430 @@ class CacheGroupRouterTest(unittest.TestCase):
         kept = (share.prefill, share.decode)
         router.advance_draft_forward_metadata(torch.ones(2, dtype=torch.int32))
         self.assertEqual((share.prefill, share.decode), kept)
+
+
+def _spec(
+    group_id,
+    family="history",
+    granularity=4,
+    retention="full_history",
+    rows_per_page=None,
+    entry_stride_tokens=None,
+    sliding_window_tokens=None,
+):
+    return SimpleNamespace(
+        group_id=group_id,
+        family=family,
+        retention=retention,
+        block_granularity=granularity,
+        rows_per_page=rows_per_page,
+        entry_stride_tokens=entry_stride_tokens,
+        sliding_window_tokens=sliding_window_tokens,
+    )
+
+
+def _pool(*specs, paged=(FULL, SWA)):
+    return SimpleNamespace(
+        arena=SimpleNamespace(cache_group_specs=tuple(specs)),
+        paged_group_ids=tuple(paged),
+    )
+
+
+class CacheGroupRouterRebindTest(unittest.TestCase):
+    """A same-geometry rebind must keep the leaves it already initialised."""
+
+    def _router(self):
+        built = []
+
+        def factory(group_id, granularity):
+            leaf = _StubLeaf(granularity)
+            built.append(group_id)
+            return leaf
+
+        router = CacheGroupRouter(
+            factory, is_draft=False, spec_num_tokens=1, device="cpu"
+        )
+        return router, built
+
+    def test_same_geometry_rebind_keeps_leaves_and_their_state(self):
+        router, built = self._router()
+        specs = (_spec(FULL), _spec(SWA), _spec("linear_attention_0", "state", 8))
+        router.set_cache_pool(_pool(*specs))
+        self.assertEqual(sorted(built), sorted([FULL, SWA]))
+        first = dict(router.leaves)
+        counter = object()
+        router.register_step_counter(counter)
+        router._stacks = object()
+        router.decode_write_locations = object()
+
+        bigger = _pool(*specs)  # a different pool object, the same published geometry
+        router.set_cache_pool(bigger)
+
+        self.assertEqual(len(built), 2, "leaves must not be rebuilt")
+        self.assertIsNone(router._stacks)
+        self.assertIsNone(router.decode_write_locations)
+        self.assertIsNone(router._extend_write_locations)
+        self.assertEqual(router._decode_views, {})
+        self.assertEqual(router._decode_request_offset, 0)
+        for gid, leaf in router.leaves.items():
+            self.assertIs(leaf, first[gid])
+            self.assertIs(leaf.step_counter, counter)
+            self.assertIs(leaf.cache_pool, bigger)
+        self.assertIs(router.cache_pool, bigger)
+
+    def test_changed_geometry_rebind_is_rejected(self):
+        router, built = self._router()
+        original = _pool(_spec(FULL), _spec(SWA))
+        router.set_cache_pool(original)
+        first = dict(router.leaves)
+
+        with self.assertRaises(RuntimeError):
+            router.set_cache_pool(_pool(_spec(FULL, granularity=8), _spec(SWA)))
+
+        self.assertEqual(len(built), 2)
+        self.assertEqual(router.leaves, first)
+        self.assertIs(router.cache_pool, original)
+        router.set_cache_pool(original)
+        self.assertEqual(router.leaves, first)
+
+    def test_same_span_but_different_row_geometry_is_rejected(self):
+        """Equal products do not make two published row geometries identical."""
+        router, _ = self._router()
+        original = _pool(
+            _spec(FULL, granularity=4, rows_per_page=4, entry_stride_tokens=1),
+            paged=(FULL,),
+        )
+        changed = _pool(
+            _spec(FULL, granularity=4, rows_per_page=2, entry_stride_tokens=2),
+            paged=(FULL,),
+        )
+        router.set_cache_pool(original)
+
+        with self.assertRaisesRegex(RuntimeError, "different geometry"):
+            router.set_cache_pool(changed)
+
+        self.assertIs(router.cache_pool, original)
+
+    def test_reordered_full_history_groups_match_a_fresh_bind(self):
+        """Spec declaration order is not published geometry."""
+        probe_specs = (_spec(FULL), _spec("full_history_1"))
+        real_specs = tuple(reversed(probe_specs))
+        rebound, _ = self._router()
+        rebound.set_cache_pool(_pool(*probe_specs, paged=(FULL, "full_history_1")))
+
+        rebound.set_cache_pool(_pool(*real_specs, paged=("full_history_1", FULL)))
+
+        fresh, _ = self._router()
+        fresh.set_cache_pool(_pool(*real_specs, paged=("full_history_1", FULL)))
+        self.assertEqual(rebound.geometry, fresh.geometry)
+        self.assertEqual(
+            rebound.geometry.full_history_group_id,
+            fresh.geometry.full_history_group_id,
+        )
+
+    def test_rebind_rejects_a_changed_sliding_window(self):
+        """The window length is part of the scheduler's retention contract."""
+        router, _ = self._router()
+        original = _pool(
+            _spec(FULL, retention="full_history"),
+            _spec(SWA, retention="sliding_window", sliding_window_tokens=128),
+        )
+        changed = _pool(
+            _spec(FULL, retention="full_history"),
+            _spec(SWA, retention="sliding_window", sliding_window_tokens=256),
+        )
+        router.set_cache_pool(original)
+
+        with self.assertRaisesRegex(RuntimeError, "different geometry"):
+            router.set_cache_pool(changed)
+
+        self.assertIs(router.cache_pool, original)
+
+    def test_rebind_rejects_a_changed_group_retention_contract(self):
+        """A group's allocation/retention meaning is part of its published contract."""
+        router, _ = self._router()
+        original = _pool(
+            _spec(FULL, retention="full_history"),
+            _spec(SWA, retention="sliding_window", sliding_window_tokens=128),
+        )
+        changed = _pool(
+            _spec(FULL, retention="full_history"),
+            _spec(SWA, retention="full_history"),
+        )
+        router.set_cache_pool(original)
+
+        with self.assertRaisesRegex(RuntimeError, "different geometry"):
+            router.set_cache_pool(changed)
+
+        self.assertIs(router.cache_pool, original)
+
+    def test_the_alias_gate_sees_through_modules(self):
+        """Registered side backends are nn.Modules; a view they keep must be found."""
+        slab = torch.zeros(4, 4)
+
+        class _Side(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self._verify_scratch = slab[1:3]
+
+        node = SimpleNamespace(_speculative_state_backends=[_Side()])
+        self.assertEqual(len(reachable_tensors(node)), 1)
+        with self.assertRaisesRegex(AssertionError, "_speculative_state_backends"):
+            assert_no_alias(node, storages_of(slab))
+
+    def test_a_rebound_router_matches_a_fresh_one_field_by_field(self):
+        specs = (_spec(FULL), _spec(SWA))
+        rebound, _ = self._router()
+        rebound.set_cache_pool(_pool(*specs))
+        rebound.init_cuda_graph_state(2)
+        old_tensors = [
+            t
+            for node in (rebound, *rebound.leaves.values())
+            for t in reachable_tensors(node)
+        ]
+        old = storages_of(*old_tensors)
+        # A served round's per-forward state, which the rebind must forget.
+        rebound._decode_views[(1, 1)] = object()
+        rebound.decode_write_locations = object()
+        rebound._extend_write_locations = {FULL: torch.zeros(1)}
+        rebound._decode_request_offset = 3
+        rebound.set_cache_pool(_pool(*specs))
+        rebound.init_cuda_graph_state(2)
+        fresh, _ = self._router()
+        fresh.set_cache_pool(_pool(*specs))
+        fresh.init_cuda_graph_state(2)
+
+        self.assertEqual(binding_state(rebound), binding_state(fresh))
+        for node in (rebound, *rebound.leaves.values()):
+            assert_no_alias(node, old)
+        self.assertGreaterEqual(len(old_tensors), 2 * len(rebound.leaves))
+
+    def test_metadata_before_the_re_init_fails_loudly(self):
+        router, _ = self._router()
+        specs = (_spec(FULL), _spec(SWA))
+        router.set_cache_pool(_pool(*specs))
+        router.init_cuda_graph_state(2)
+
+        router.set_cache_pool(_pool(*specs))
+
+        with self.assertRaisesRegex(RuntimeError, "init_cuda_graph_state must run"):
+            router.stacks
+
+    def test_rebound_leaves_are_as_unbound_as_fresh_ones(self):
+        """Graph buffers and views only come back with init_cuda_graph_state."""
+        router, _ = self._router()
+        specs = (_spec(FULL), _spec(SWA))
+        router.set_cache_pool(_pool(*specs))
+        router.init_cuda_graph_state(2)
+        for leaf in router.leaves.values():
+            leaf._decode_views_by_bs[1] = object()
+
+        router.set_cache_pool(_pool(*specs))
+
+        for leaf in router.leaves.values():
+            self.assertIsNone(leaf.page_table_buf)
+            self.assertIsNone(leaf.seq_lens_buf)
+            self.assertEqual(leaf._decode_views_by_bs, {})
+
+
+class PagedLeafRebindTest(unittest.TestCase):
+    """Every leaf forgets the per-forward and per-graph state it annotates as optional.
+
+    The gate reads ``self.<name>: <Type> | None = None`` annotations in ``__init__``
+    whose name mentions ``metadata`` or ends in ``_buf``; state declared another way
+    (DSA's page-table alias, FlashMLA's keepalive list) gets its own test below.
+    """
+
+    def _optional_slots(self, backend_cls):
+        import inspect
+
+        init = ast.parse(textwrap.dedent(inspect.getsource(backend_cls.__init__)))
+        slots = []
+        for node in ast.walk(init):
+            if (
+                isinstance(node, ast.AnnAssign)
+                and isinstance(node.target, ast.Attribute)
+                and isinstance(node.target.value, ast.Name)
+                and node.target.value.id == "self"
+                and ast.unparse(node.annotation).endswith("| None")
+            ):
+                slots.append(node.target.attr)
+        return slots
+
+    def _check(self, backend_cls, expected, **publish_reads):
+        slots = self._optional_slots(backend_cls)
+        self.assertTrue(slots)
+        self.assertEqual(sorted(slots), sorted(expected))
+        leaf = backend_cls.__new__(backend_cls)
+        leaf._init_pool_binding()
+        leaf.cache_pool = object()
+        for name, value in publish_reads.items():
+            setattr(leaf, name, value)
+        stale = object()
+        for name in slots:
+            setattr(leaf, name, stale)
+        pool = object()
+
+        leaf.set_cache_pool(pool)
+
+        self.assertIs(leaf.cache_pool, pool)
+        for name in slots:
+            self.assertIsNone(getattr(leaf, name), name)
+
+    def test_mha_leaf_forgets_the_previous_forward(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.mha import (
+            MHAAttnBackend,
+        )
+
+        self._check(
+            MHAAttnBackend, ["forward_decode_metadata", "forward_extend_metadata"]
+        )
+
+    def test_msa_leaf_forgets_the_previous_forward(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.msa import (
+            MSAAttnBackend,
+        )
+
+        self._check(
+            MSAAttnBackend, ["forward_decode_metadata", "forward_extend_metadata"]
+        )
+
+    def test_mla_leaf_forgets_the_previous_forward(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.mla import (
+            MLAAttnBackend,
+        )
+
+        self._check(
+            MLAAttnBackend,
+            [
+                "forward_decode_metadata",
+                "forward_prefill_metadata",
+                "chunked_prefill_metadata",
+                "_block_page_table_buf",
+                "_block_seq_lens_buf",
+            ],
+        )
+
+    def test_trtllm_mha_leaf_forgets_the_previous_forward(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.trtllm import (
+            TRTLLMMHAAttnBackend,
+        )
+
+        self._check(
+            TRTLLMMHAAttnBackend,
+            [
+                "forward_prefill_metadata",
+                "forward_decode_metadata",
+                "spec_cache_seqlens_buf",
+            ],
+        )
+
+    def test_trtllm_mla_leaf_forgets_the_previous_forward(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.trtllm_mla import (
+            TRTLLMMLABackend,
+        )
+
+        self._check(
+            TRTLLMMLABackend,
+            [
+                "forward_decode_metadata",
+                "forward_prefill_metadata",
+                "chunked_prefill_metadata",
+            ],
+        )
+
+    @unittest.skipUnless(
+        torch.version.hip is None, "FlashInfer wrappers are NVIDIA-only"
+    )
+    def test_flashmla_leaf_forgets_the_previous_forward(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.flashmla import (
+            FlashMLABackend,
+        )
+
+        self._check(
+            FlashMLABackend,
+            [
+                "forward_decode_metadata",
+                "forward_prefill_metadata",
+                "chunked_prefill_metadata",
+                "_decode_tile_metadata",
+            ],
+            workspace_buffer=torch.empty(1 << 20, dtype=torch.uint8, device="cuda"),
+            indices_updater_prefill=SimpleNamespace(prefill_wrapper_ragged=None),
+        )
+
+    def test_trtllm_leaf_forgets_the_verify_views(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.trtllm import (
+            TRTLLMMHAAttnBackend,
+        )
+
+        leaf = TRTLLMMHAAttnBackend.__new__(TRTLLMMHAAttnBackend)
+        leaf._init_pool_binding()
+        leaf._verify_views_by_bs = {1: object()}
+        leaf.set_cache_pool(object())
+        self.assertEqual(leaf._verify_views_by_bs, {})
+
+    @unittest.skipUnless(
+        torch.version.hip is None, "FlashInfer wrappers are NVIDIA-only"
+    )
+    def test_flashmla_leaf_forgets_the_tile_keepalives(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.flashmla import (
+            FlashMLABackend,
+        )
+
+        leaf = FlashMLABackend.__new__(FlashMLABackend)
+        leaf._init_pool_binding()
+        leaf.cache_pool = object()
+        leaf._decode_tile_metadata_keepalive = [object()]
+        leaf.workspace_buffer = torch.empty(1 << 20, dtype=torch.uint8, device="cuda")
+        leaf.prefill_wrapper_ragged = leaf.prefill_wrapper_paged = object()
+        leaf.indices_updater_prefill = SimpleNamespace(prefill_wrapper_ragged=object())
+        leaf.set_cache_pool(object())
+        self.assertEqual(leaf._decode_tile_metadata_keepalive, [])
+        self.assertIsNot(leaf.prefill_wrapper_paged, leaf.prefill_wrapper_ragged)
+        self.assertIs(
+            leaf.indices_updater_prefill.prefill_wrapper_ragged,
+            leaf.prefill_wrapper_ragged,
+        )
+
+    def test_cutedsl_mla_leaf_forgets_the_previous_forward(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.tokenspeed_mla import (
+            CuteDSLMLABackend,
+        )
+
+        self._check(
+            CuteDSLMLABackend,
+            [
+                "forward_decode_metadata",
+                "forward_prefill_metadata",
+                "chunked_prefill_metadata",
+                "_block_page_table_buf",
+                "_block_seq_lens_buf",
+            ],
+        )
+
+    def test_dsa_forgets_the_prefill_page_table_alias(self):
+        from tokenspeed.runtime.layers.attention.backends.paged.dsa import DSABackend
+
+        backend = DSABackend.__new__(DSABackend)
+        backend._init_pool_binding()
+        backend._dense_backend = SimpleNamespace(
+            validate_cache_pool=lambda pool: None,
+            set_cache_pool=lambda pool: None,
+            _bind=lambda pool: None,
+        )
+        backend._prefill_page_table = object()
+        backend.kpool_runtime = SimpleNamespace(prefill_plan=object())
+        backend.kpool_runtime.reset_forward = lambda req_pool_indices: setattr(
+            backend.kpool_runtime, "prefill_plan", None
+        )
+        pool = object()
+
+        backend.set_cache_pool(pool)
+
+        self.assertIs(backend.cache_pool, pool)
+        self.assertIsNone(backend._prefill_page_table)
+        self.assertIsNone(backend.kpool_runtime.prefill_plan)
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -11,6 +11,8 @@ from types import MethodType, SimpleNamespace
 from typing import ClassVar
 from unittest.mock import Mock, patch
 
+import pytest
+
 # CI Registration (parsed via AST, runtime no-op)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from ci_system.ci_register import register_cuda_ci
@@ -4178,6 +4180,8 @@ class TestDeepseekV4Config(unittest.TestCase):
                     retention="sliding_window",
                     rows_per_page=64,
                     entry_stride_tokens=1,
+                    block_granularity=(64) * (1),
+                    family="history",
                 ),
             ),
             cache_group_page_counts={V4_SWA_KV_GROUP_ID: 128},
@@ -6791,3 +6795,184 @@ def test_v4_pd_recipe_and_readiness_follow_cache_producers():
     for mode in (ForwardMode.EXTEND, ForwardMode.DECODE, ForwardMode.IDLE):
         assert backend.record_layer_cache_ready(output, mode) is output
     assert records == [True]
+
+
+def _cache_pool_with_page_counts(page_counts, rows_per_page, entry_stride_tokens):
+    specs = [
+        SimpleNamespace(
+            group_id=group_id,
+            rows_per_page=rows_per_page,
+            entry_stride_tokens=entry_stride_tokens,
+            block_granularity=rows_per_page * entry_stride_tokens,
+            family="history",
+            retention="full_history",
+        )
+        for group_id in page_counts
+    ]
+    return SimpleNamespace(
+        arena=SimpleNamespace(
+            cache_group_specs=specs, cache_group_page_counts=page_counts
+        )
+    )
+
+
+def _unbound_deepseek_v4_backend():
+    from tokenspeed.runtime.layers.attention.backends.specific.deepseek_v4 import (
+        DeepseekV4AttentionBackend,
+    )
+
+    backend = DeepseekV4AttentionBackend.__new__(DeepseekV4AttentionBackend)
+    backend._init_pool_binding()
+    backend._init_cache_group_latches()
+    return backend
+
+
+class DeepseekV4RebindTest(unittest.TestCase):
+    def test_rebinding_the_pool_relatches_the_cache_group_contract(self):
+        """A probe pool and the real pool share geometry but not page counts."""
+        probe = _cache_pool_with_page_counts({"swa": 4, "compressed_4": 4}, 4, 1)
+        real = _cache_pool_with_page_counts({"swa": 64, "compressed_4": 16}, 4, 1)
+        rebound = _unbound_deepseek_v4_backend()
+        rebound.set_cache_pool(probe)
+        rebound.set_cache_pool(real)
+        fresh = _unbound_deepseek_v4_backend()
+        fresh.set_cache_pool(real)
+
+        assert rebound._cache_group_max_page_ids == {"swa": 63, "compressed_4": 15}
+        assert rebound._expected_cache_group_ids == fresh._expected_cache_group_ids
+        assert (
+            rebound._cache_group_raw_tokens_per_page
+            == fresh._cache_group_raw_tokens_per_page
+        )
+        assert rebound._cache_group_max_page_ids == fresh._cache_group_max_page_ids
+
+    def test_rebinding_the_pool_drops_the_runtime_state_built_for_the_old_pool(self):
+        from tokenspeed.runtime.layers.attention.backends.specific.deepseek_v4 import (
+            DeepseekV4ForwardSlotMappings,
+        )
+
+        backend = _unbound_deepseek_v4_backend()
+        backend.set_cache_pool(
+            _cache_pool_with_page_counts({"swa": 4, "compressed_4": 4}, 4, 1)
+        )
+        stale = object()
+        for name in (
+            "graph",
+            "_cuda_graph_active_page_validity",
+            "_decode_q_padding_workspace",
+            "_decode_q_padding_workspace_layout",
+            "draft_rounds",
+            "forward_metadata",
+            "forward_prefill_metadata",
+            "forward_decode_metadata",
+            "slot_mappings",
+            "_prefill_workspace_buffer",
+            "_prefill_dense_compressed_indices_buffer",
+        ):
+            setattr(backend, name, stale)
+        backend._swa_window_size = backend._swa_block_size = 5
+        backend._prefill_workspace_rows = backend._prefill_workspace_head_dim = 7
+
+        backend.set_cache_pool(
+            _cache_pool_with_page_counts({"swa": 64, "compressed_4": 16}, 4, 1)
+        )
+        for name in (
+            "graph",
+            "_cuda_graph_active_page_validity",
+            "_decode_q_padding_workspace",
+            "_decode_q_padding_workspace_layout",
+            "draft_rounds",
+            "forward_metadata",
+            "forward_prefill_metadata",
+            "forward_decode_metadata",
+            "_prefill_workspace_buffer",
+            "_prefill_dense_compressed_indices_buffer",
+        ):
+            assert getattr(backend, name) is None, name
+        assert isinstance(backend.slot_mappings, DeepseekV4ForwardSlotMappings)
+        assert (backend._swa_window_size, backend._swa_block_size) == (0, 0)
+        assert (
+            backend._prefill_workspace_rows,
+            backend._prefill_workspace_head_dim,
+        ) == (0, 0)
+
+    def test_configure_runtime_before_the_first_bind_still_allows_the_first_bind(self):
+        backend = _unbound_deepseek_v4_backend()
+        pool = _cache_pool_with_page_counts({"swa": 4, "compressed_4": 4}, 4, 1)
+        backend.configure_runtime(
+            cache_group_specs=pool.arena.cache_group_specs,
+            cache_group_page_counts=pool.arena.cache_group_page_counts,
+        )
+
+        backend.set_cache_pool(pool)
+
+        assert backend.cache_pool is pool
+
+    def test_rebinding_a_pool_of_different_geometry_is_rejected(self):
+        backend = _unbound_deepseek_v4_backend()
+        original = _cache_pool_with_page_counts({"swa": 4, "compressed_4": 4}, 4, 1)
+        backend.set_cache_pool(original)
+        with pytest.raises(RuntimeError, match="geometry changed on rebind"):
+            backend.set_cache_pool(
+                _cache_pool_with_page_counts({"swa": 4, "compressed_8": 4}, 4, 1)
+            )
+
+        assert backend.cache_pool is original
+        assert backend._expected_cache_group_ids == ("swa", "compressed_4")
+        backend.set_cache_pool(original)
+
+    def test_rebinding_a_pool_with_the_same_token_span_but_other_rows_is_rejected(self):
+        backend = _unbound_deepseek_v4_backend()
+        backend.set_cache_pool(_cache_pool_with_page_counts({"swa": 4}, 4, 1))
+        with pytest.raises(RuntimeError, match="geometry changed on rebind"):
+            backend.set_cache_pool(_cache_pool_with_page_counts({"swa": 4}, 2, 2))
+
+    def test_rebinding_accepts_reordered_equal_cache_groups(self):
+        """Declaration order is not part of the published group geometry."""
+        probe = _cache_pool_with_page_counts({"swa": 4, "compressed_4": 4}, 4, 1)
+        reordered = _cache_pool_with_page_counts({"compressed_4": 16, "swa": 64}, 4, 1)
+        rebound = _unbound_deepseek_v4_backend()
+        rebound.set_cache_pool(probe)
+
+        rebound.set_cache_pool(reordered)
+
+        fresh = _unbound_deepseek_v4_backend()
+        fresh.set_cache_pool(reordered)
+        self.assertEqual(rebound._cache_group_kinds, fresh._cache_group_kinds)
+        self.assertEqual(
+            rebound._cache_group_row_geometry, fresh._cache_group_row_geometry
+        )
+        self.assertEqual(
+            rebound._cache_group_max_page_ids, fresh._cache_group_max_page_ids
+        )
+
+    def test_rebinding_a_pool_with_other_block_granularity_is_rejected(self):
+        """Block granularity is published geometry even when row layout is unchanged."""
+        original = _cache_pool_with_page_counts({"swa": 4}, 4, 1)
+        replacement = _cache_pool_with_page_counts({"swa": 4}, 4, 1)
+        original.arena.cache_group_specs[0].block_granularity = 4
+        replacement.arena.cache_group_specs[0].block_granularity = 8
+        backend = _unbound_deepseek_v4_backend()
+        backend.set_cache_pool(original)
+
+        with pytest.raises(RuntimeError, match="geometry changed on rebind"):
+            backend.set_cache_pool(replacement)
+
+        assert backend.cache_pool is original
+
+    def test_configure_runtime_after_a_rebind_checks_the_relatched_contract(self):
+        backend = _unbound_deepseek_v4_backend()
+        backend.set_cache_pool(
+            _cache_pool_with_page_counts({"swa": 4, "compressed_4": 4}, 4, 1)
+        )
+        real = _cache_pool_with_page_counts({"swa": 64, "compressed_4": 16}, 4, 1)
+        backend.set_cache_pool(real)
+        backend.configure_runtime(
+            cache_group_specs=real.arena.cache_group_specs,
+            cache_group_page_counts=real.arena.cache_group_page_counts,
+        )
+        with pytest.raises(RuntimeError, match="contract changed after initialization"):
+            backend.configure_runtime(
+                cache_group_specs=real.arena.cache_group_specs,
+                cache_group_page_counts={"swa": 32, "compressed_4": 16},
+            )

--- a/test/runtime/test_draft_advance_seqlens.py
+++ b/test/runtime/test_draft_advance_seqlens.py
@@ -158,12 +158,19 @@ def test_msa_hybrid_fans_pool_binding_out_to_both_routers():
         def __init__(self):
             self.cache_pool = None
 
+        def validate_cache_pool(self, cache_pool):
+            del cache_pool
+
         def set_cache_pool(self, cache_pool):
             self.cache_pool = cache_pool
+
+        def _bind(self, cache_pool):
+            self.set_cache_pool(cache_pool)
 
     dense = ChildRouter()
     sparse = ChildRouter()
     backend = object.__new__(MSAHybridAttnBackend)
+    backend._init_pool_binding()
     backend.full_router = dense
     backend.sparse_router = sparse
     pool = object()
@@ -211,6 +218,8 @@ def test_router_fans_advance_out_to_every_leaf():
             granularities={"full_attention": 64},
             families={"full_attention": "history"},
             full_history_group_id="full_attention",
+            row_geometry={"full_attention": (64, 1)},
+            retentions={"full_attention": ("full_history", None)},
         ),
         {"full_attention": leaf},
     )

--- a/test/runtime/test_draft_page_table_scrub.py
+++ b/test/runtime/test_draft_page_table_scrub.py
@@ -61,6 +61,8 @@ def _draft_router(rows: int = 8) -> CacheGroupRouter:
             granularities={FULL: 128},
             families={FULL: "history"},
             full_history_group_id=FULL,
+            row_geometry={FULL: (128, 1)},
+            retentions={FULL: ("full_history", None)},
         ),
         {FULL: _Leaf()},
     )

--- a/test/runtime/test_gdn_state_paging.py
+++ b/test/runtime/test_gdn_state_paging.py
@@ -270,7 +270,7 @@ class CacheContractMetadataTest(unittest.TestCase):
         )
         stub_pool = _ContractPool(
             self.P,
-            {0: ("linear_attention", object(), object())},
+            {0: ("linear_attention", torch.zeros(2, 3), torch.zeros(2, 5))},
         )
         backend.set_kv_pool(stub_pool)
         self.assertTrue(backend.state_paging_active)

--- a/test/runtime/test_group_aware_mha.py
+++ b/test/runtime/test_group_aware_mha.py
@@ -87,6 +87,8 @@ class RouterOverMhaLeavesTest(unittest.TestCase):
                 granularities={gid: 4 for gid in group_ids},
                 families={gid: "history" for gid in group_ids},
                 full_history_group_id=FULL,
+                row_geometry={gid: (4, 1) for gid in group_ids},
+                retentions={gid: ("full_history", None) for gid in group_ids},
             ),
             leaves,
         )

--- a/test/runtime/test_group_write_locations.py
+++ b/test/runtime/test_group_write_locations.py
@@ -145,6 +145,8 @@ class MtpReanchorTest(unittest.TestCase):
             granularities={FULL: 4, SWA: 4},
             families={FULL: "history", SWA: "history"},
             full_history_group_id=FULL,
+            row_geometry={FULL: (4, 1), SWA: (4, 1)},
+            retentions={FULL: ("full_history", None), SWA: ("sliding_window", 4)},
         )
         router.bind(geometry, leaves)
         router.init_cuda_graph_state(4)

--- a/test/runtime/test_inkling_activation_parity.py
+++ b/test/runtime/test_inkling_activation_parity.py
@@ -230,6 +230,8 @@ class _Harness:
                     if "full_attention" in self.attn_groups
                     else self.attn_groups[0]
                 ),
+                row_geometry={gid: (PAGE_SIZE, 1) for gid in self.attn_groups},
+                retentions={gid: ("full_history", None) for gid in self.attn_groups},
             ),
             leaves,
         )
@@ -266,14 +268,15 @@ class _Harness:
         num_conv_pages = 1024 // conv_block_tokens
         conv_columns = {
             "block_tokens": conv_block_tokens,
-            "conv_group_of_layer": ("kvconv",) * text.num_hidden_layers,
-            "hidden_group_of_layer": ("hiddenconv",) * text.num_hidden_layers,
             "group_block_tokens": {
                 "kvconv": conv_block_tokens,
                 "hiddenconv": conv_block_tokens,
             },
+            "pd_endpoint_snapshots": False,
         }
-        self.backend = InklingAttnBackend(inner, conv_pool, conv_columns=conv_columns)
+        self.backend = InklingAttnBackend(inner, conv_pool)
+        # The leaves bind directly below; supply the geometry a wrapper bind learns.
+        self.backend.conv_columns = conv_columns
         self.pool_view = _ConvCheckpointPool(
             self.kv_pool,
             layer_kv_widths=[
@@ -451,6 +454,88 @@ class TestInklingActivationParity(unittest.TestCase):
                 report += self._compare(f"decode{step}", got, ref, slice(-1, None))
         # Print the full per-layer report on success for eyeballing.
         print("\n".join(report))
+
+
+class InklingRebindTest(unittest.TestCase):
+    def test_rebinding_the_pool_forgets_recorded_checkpoint_streams(self):
+        """Checkpoint streams are pool views and the ring held the old pool's requests."""
+        from tokenspeed.runtime.layers.attention.backends.specific.inkling import (
+            InklingAttnBackend,
+            InklingConvStatePool,
+            conv_columns_for_pool,
+        )
+
+        def pool(block_granularity, transfer_policy):
+            spec = SimpleNamespace(
+                group_id="kvconv",
+                block_granularity=block_granularity,
+                transfer_policy=transfer_policy,
+            )
+            plan = SimpleNamespace(prefix_granularity=1)
+            return SimpleNamespace(
+                arena=SimpleNamespace(plan=plan, cache_group_specs=(spec,))
+            )
+
+        backend = InklingAttnBackend.__new__(InklingAttnBackend)
+        backend._init_pool_binding()
+        backend._checkpoint_streams = {}
+        backend.inner = SimpleNamespace(
+            set_cache_pool=lambda pool: None,
+            validate_cache_pool=lambda pool: None,
+            _bind=lambda pool: None,
+        )
+        backend.conv_pool = InklingConvStatePool(
+            num_layers=2,
+            num_slots=4,
+            conv_dim=4,
+            ring_size=2,
+            dtype=torch.float32,
+            device="cpu",
+        )
+        backend.conv_columns = conv_columns_for_pool(pool(64, "latest_snapshot"))
+        backend.set_cache_pool(pool(64, "latest_snapshot"))
+        stream = dict(layer_id=0, channel_offset=0, dim=4, group_id="kvconv")
+        backend.register_shortconv_checkpoint_stream(
+            **stream, buffers=(torch.zeros(4),)
+        )
+
+        backend.conv_prefill_metadata = backend.conv_decode_metadata = object()
+        backend._pfg_col_tables = backend._graph_col_tables = {"kvconv": object()}
+        backend._graph_seq_lens = object()
+        backend._rel_qsl_cache = {8: object()}
+        backend._rel_qsl_retired = [object()]
+        backend.conv_pool.conv_state[0, 3].fill_(17)
+        backend.mark_remote_cache_ready(3)
+        backend.set_cache_pool(pool(64, "latest_snapshot"))
+        assert not backend.conv_pool.conv_state.any()
+        assert not backend.conv_pool.remote_restore_pending.any()
+        assert backend.conv_prefill_metadata is None
+        assert backend.conv_decode_metadata is None
+        assert backend._pfg_col_tables is None
+        assert backend._graph_col_tables is None
+        assert backend._graph_seq_lens is None
+        assert backend._rel_qsl_cache == {} and backend._rel_qsl_retired == []
+        rebound = (torch.zeros(4),)
+        backend.register_shortconv_checkpoint_stream(**stream, buffers=rebound)
+        assert backend._checkpoint_streams[(0, 0, 4, "kvconv")] is rebound
+        # hiddenconv has no spec in this fixture, so its grain is the plan's P.
+        assert backend.conv_columns["group_block_tokens"] == {
+            "kvconv": 64,
+            "hiddenconv": 1,
+        }
+
+        backend.set_cache_pool(pool(64, transfer_policy="none"))
+        assert backend.conv_columns["pd_endpoint_snapshots"] is False
+        with self.assertRaisesRegex(RuntimeError, "geometry changed on rebind"):
+            backend.set_cache_pool(pool(32, "latest_snapshot"))
+        # A pool publishing no conv groups falls back to P for every grain: still not this geometry.
+        bare = SimpleNamespace(
+            arena=SimpleNamespace(
+                plan=SimpleNamespace(prefix_granularity=64), cache_group_specs=()
+            )
+        )
+        with self.assertRaisesRegex(RuntimeError, "geometry changed on rebind"):
+            backend.set_cache_pool(bare)
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_inkling_mtp_conv_state.py
+++ b/test/runtime/test_inkling_mtp_conv_state.py
@@ -85,7 +85,11 @@ class TestInklingCacheContract(unittest.TestCase):
         )
 
         backend = InklingAttnBackend.__new__(InklingAttnBackend)
-        backend.conv_columns = {"block_tokens": 128}
+        backend.conv_columns = {
+            "block_tokens": 128,
+            "group_block_tokens": {"kvconv": 128, "hiddenconv": 128},
+            "pd_endpoint_snapshots": False,
+        }
 
         def metadata(*, seq_len: int, page: int, restore: bool = False):
             return InklingConvMetadata(

--- a/test/runtime/test_kimi_k3_kda_eager_commit.py
+++ b/test/runtime/test_kimi_k3_kda_eager_commit.py
@@ -7,6 +7,11 @@ import torch
 if not torch.cuda.is_available():
     pytest.skip("CUDA required", allow_module_level=True)
 
+from test.runtime.cache_pool_test_utils import (
+    assert_no_alias,
+    binding_state,
+    storages_of,
+)
 from test.runtime.conftest import KIMI_STATE_GROUPS as _STATE_GROUPS
 from test.runtime.conftest import block_tables_for as _tables_for
 from test.runtime.conftest import kimi_recipe as _kimi_recipe
@@ -14,6 +19,9 @@ from test.runtime.conftest import make_kimi_pool as _make_kimi_pool
 from types import MethodType, SimpleNamespace  # noqa: E402
 
 from tokenspeed.runtime.execution.forward_batch_info import ForwardMode
+from tokenspeed.runtime.layers.attention.backends.hybrid.linear import (
+    HybridLinearAttnBackend,
+)
 from tokenspeed.runtime.layers.attention.backends.state.kda import KdaAttnBackend
 from tokenspeed.runtime.layers.attention.backends.state.mamba import (
     MambaAttnBackend,
@@ -57,6 +65,7 @@ class _Harness:
             # Stub component(): this backend construction never queries components.
             component=lambda cls: None,
         )
+        self.config = config
         self.backend = KdaAttnBackend(config, spec)
         self.backend.set_kv_pool(self.pool)
         # The persistent decode buffers exist from construction, as at the
@@ -623,9 +632,8 @@ def test_verify_scratch_cannot_grow_after_preallocation():
     harness = _Harness(eager_replay=True)
     harness.backend.preallocate_verify_workspace(harness.backend.max_bs, T)
     capacity = next(iter(harness.backend._verify_scratch.values()))[0].shape[0]
-    harness.backend.query_start_loc_list.extend([None] * (capacity + 1))
     with pytest.raises(RuntimeError, match="preallocated scratch holds"):
-        harness.backend._ensure_verify_scratch(1, T)
+        harness.backend._ensure_verify_scratch(capacity + 1, T)
 
 
 def test_no_store_fused_verify_matches_decomposed_outputs():
@@ -658,3 +666,231 @@ def test_no_store_fused_verify_matches_decomposed_outputs():
     wrong = decomposed.forward(inputs, len(rpis))[0]
     with pytest.raises(AssertionError):
         torch.testing.assert_close(fused_out[0], wrong, atol=2e-2, rtol=2e-2)
+
+
+def test_rebinding_the_pool_reissues_the_raw_gate_scratch(monkeypatch):
+    """Raw-gate scratch is issued against the bound pool; a rebind must not keep the old one."""
+    monkeypatch.setattr(
+        "tokenspeed.runtime.layers.attention.backends.state.kda.kda_batched_replay_uses_raw_gate",
+        lambda dtype, **kwargs: True,
+    )
+    harness = _Harness(eager_replay=True)
+    assert harness.backend._replay_uses_raw_gate
+    harness.backend.preallocate_verify_workspace(harness.config.max_bs, T)
+    old_pool = storages_of(
+        *(
+            harness.backend._state_components(layer_id)[component]
+            for layer_id in harness.layer_ids
+            for component in (0, 1)
+        )
+    )
+    replacement = _make_kimi_pool(DEV, usable_pages=24)
+
+    harness.backend.set_kv_pool(replacement)
+    assert harness.backend._verify_scratch is None
+    harness.backend.preallocate_verify_workspace(harness.config.max_bs, T)
+    assert_no_alias(harness.backend, old_pool)
+    for layer_id in harness.layer_ids:
+        rows = harness.backend._verify_scratch[layer_id][0]
+        assert rows.device == replacement.get_component(layer_id, "conv_state").device
+        assert rows.shape[0] >= harness.config.max_bs
+
+
+def test_rebinding_the_pool_commits_like_a_fresh_bind():
+    """Verify/commit after a rebind lands in the new pool exactly as a fresh bind's does."""
+    rebound = _Harness(eager_replay=True)
+    fresh = _Harness(eager_replay=True)
+    rpis = [0, 1]
+    pages = {
+        group_id: [2 + group * len(rpis) + i for i in range(len(rpis))]
+        for group, group_id in enumerate(_STATE_GROUPS)
+    }
+    seq_lens = [8 + T] * len(rpis)
+    rebound.round(rpis, pages, seq_lens, 100, [1, T])
+
+    replacement = _make_kimi_pool(DEV, usable_pages=24)
+    rebound.backend.set_kv_pool(replacement)
+    rebound.backend.init_cuda_graph_state(rebound.config.max_bs)
+    rebound.pool = replacement
+    rebound.contract = replacement.arena.runtime_contract
+    for round_index, accepted in enumerate(([0, T], [T, 2])):
+        for harness in (rebound, fresh):
+            harness.round(rpis, pages, seq_lens, 200 + round_index, accepted)
+        _assert_committed_pages_equal(rebound, fresh, pages)
+        seq_lens = [length + count for length, count in zip(seq_lens, accepted)]
+    layer_id = fresh.layer_ids[0]
+    page = pages[fresh.pool.state_group_by_layer[layer_id]][0]
+    for harness in (rebound, fresh):
+        for component in ("conv_state", "recurrent_state"):
+            assert harness.pool.get_component(layer_id, component)[page].abs().sum() > 0
+
+
+def test_reordered_state_groups_are_the_same_geometry():
+    """Group ids name the groups; the contract's enumeration order is not geometry."""
+    harness = _Harness(eager_replay=False)
+    specs = harness.pool.arena.runtime_contract.group_specs
+    reordered = SimpleNamespace(
+        arena=SimpleNamespace(
+            cache_group_specs=harness.pool.arena.cache_group_specs,
+            runtime_contract=SimpleNamespace(group_specs=tuple(reversed(specs))),
+        ),
+        paged_group_ids=harness.pool.paged_group_ids,
+        state_group_by_layer=harness.pool.state_group_by_layer,
+        get_component=harness.pool.get_component,
+    )
+
+    harness.backend.validate_cache_pool(reordered)
+
+
+def test_a_rejected_hybrid_rebind_moves_no_child():
+    """The router accepts a pool the state backend rejects; two-phase binding must move nothing."""
+    from tokenspeed.runtime.layers.attention.backends.paged.router import (
+        CacheGroupRouter,
+    )
+
+    harness = _Harness(eager_replay=False)
+    leaves = []
+
+    def leaf_factory(group_id, granularity):
+        leaf = SimpleNamespace(group_id=group_id, cache_pool=None)
+        leaf.validate_cache_pool = lambda pool: None
+        leaf.set_cache_pool = leaf._bind = lambda pool: setattr(
+            leaf, "cache_pool", pool
+        )
+        leaves.append(leaf)
+        return leaf
+
+    router = CacheGroupRouter(
+        leaf_factory, is_draft=False, spec_num_tokens=T, device=DEV
+    )
+    hybrid = HybridLinearAttnBackend(router, harness.backend, [])
+    hybrid.set_cache_pool(harness.pool)
+    assert leaves and all(leaf.cache_pool is harness.pool for leaf in leaves)
+
+    def retyped(layer, name):
+        component = harness.pool.get_component(layer, name)
+        if name == "conv_state":
+            return component.to(
+                torch.float32 if component.dtype != torch.float32 else torch.float16
+            )
+        return component
+
+    retyped_pool = SimpleNamespace(
+        arena=harness.pool.arena,
+        paged_group_ids=harness.pool.paged_group_ids,
+        state_group_by_layer=harness.pool.state_group_by_layer,
+        get_component=retyped,
+    )
+    router.validate_cache_pool(retyped_pool)
+    with pytest.raises(RuntimeError, match="different state geometry"):
+        hybrid.set_cache_pool(retyped_pool)
+
+    assert hybrid.cache_pool is harness.pool
+    assert router.cache_pool is harness.pool
+    assert all(leaf.cache_pool is harness.pool for leaf in leaves)
+    assert harness.backend.kv_pool is harness.pool
+
+
+def test_a_rejected_hybrid_rebind_publishes_nothing():
+    harness = _Harness(eager_replay=False)
+    full = SimpleNamespace(device=DEV, cache_pool=harness.pool)
+    full.set_cache_pool = full._bind = lambda pool: setattr(full, "cache_pool", pool)
+    full.validate_cache_pool = lambda pool: None
+    hybrid = HybridLinearAttnBackend(full, harness.backend, [])
+    hybrid.set_cache_pool(harness.pool)
+
+    contract = harness.pool.arena.runtime_contract
+    coarser = SimpleNamespace(
+        arena=SimpleNamespace(
+            runtime_contract=SimpleNamespace(
+                group_specs=tuple(
+                    (
+                        SimpleNamespace(
+                            group_id=spec.group_id,
+                            family=spec.family,
+                            checkpoint_granularity=2 * spec.checkpoint_granularity,
+                        )
+                        if spec.family == "state"
+                        else spec
+                    )
+                    for spec in contract.group_specs
+                )
+            )
+        ),
+        state_group_by_layer=harness.pool.state_group_by_layer,
+        get_component=harness.pool.get_component,
+    )
+    with pytest.raises(RuntimeError, match="different state geometry"):
+        hybrid.set_cache_pool(coarser)
+
+    assert hybrid.cache_pool is harness.pool
+    assert harness.backend.kv_pool is harness.pool
+
+
+def test_a_rebound_backend_matches_a_fresh_one_field_by_field():
+    """After the documented re-initialisation, no attribute tells a rebind from a fresh bind."""
+    rebound = _Harness(eager_replay=True)
+    fresh = _Harness(eager_replay=True)
+    pages = {group: [2] for group in _STATE_GROUPS}
+    rebound.round([0], pages, [8 + T], 100, [1])
+    old_slabs = storages_of(
+        *(
+            rebound.backend._state_components(layer_id)[component]
+            for layer_id in rebound.backend._state_layer_ids()
+            for component in (0, 1)
+        )
+    )
+
+    rebound.backend.set_kv_pool(_make_kimi_pool(DEV, usable_pages=24))
+    for harness in (rebound, fresh):
+        harness.backend.init_cuda_graph_state(harness.config.max_bs)
+        harness.backend.preallocate_verify_workspace(harness.config.max_bs, T)
+
+    assert binding_state(rebound.backend) == binding_state(fresh.backend)
+    assert_no_alias(rebound.backend, old_slabs)
+
+
+def test_a_pool_too_small_for_the_raw_gate_scratch_is_refused(monkeypatch):
+    """The raw-gate scratch is the pool's own conv slab, so a probe pool must hold max_bs rows."""
+    monkeypatch.setattr(
+        "tokenspeed.runtime.layers.attention.backends.state.kda.kda_batched_replay_uses_raw_gate",
+        lambda dtype, **kwargs: True,
+    )
+    harness = _Harness(eager_replay=True)
+    assert harness.backend._replay_uses_raw_gate
+    harness.backend.set_kv_pool(_make_kimi_pool(DEV, usable_pages=4))
+
+    with pytest.raises(RuntimeError, match="transient conv rows"):
+        harness.backend.preallocate_verify_workspace(harness.config.max_bs, T)
+
+
+def test_hybrid_rebinding_reaches_the_state_child():
+    harness = _Harness(eager_replay=False)
+    full = SimpleNamespace(device=DEV, cache_pool=None)
+    full.set_cache_pool = full._bind = lambda pool: setattr(full, "cache_pool", pool)
+    full.validate_cache_pool = lambda pool: None
+    full.init_prefill_graph_state = lambda max_num_tokens, max_bs: None
+    hybrid = HybridLinearAttnBackend(full, harness.backend, [])
+    side_state = SimpleNamespace(
+        dropped=False, commit_after_mtp_verify=lambda *a, **k: None
+    )
+    side_state.drop_verify_scratch = lambda: setattr(side_state, "dropped", True)
+    hybrid.register_speculative_state_backend(side_state)
+    share = harness.backend.sparse_topk
+    share.prefill = share.decode = object()
+
+    old_slabs = storages_of(
+        *(
+            harness.backend._state_components(layer_id)[component]
+            for layer_id in harness.backend._state_layer_ids()
+            for component in (0, 1)
+        )
+    )
+    replacement = _make_kimi_pool(DEV, usable_pages=24)
+    hybrid.set_cache_pool(replacement)
+    assert full.cache_pool is replacement
+    assert harness.backend.kv_pool is replacement
+    assert side_state.dropped
+    assert share.prefill is None and share.decode is None
+    assert_no_alias(hybrid, old_slabs)
+    assert_no_alias(harness.backend, old_slabs)

--- a/test/runtime/test_qsa_backend.py
+++ b/test/runtime/test_qsa_backend.py
@@ -20,11 +20,25 @@
 
 from __future__ import annotations
 
+import os
+import sys
+
 import pytest
 import torch
 
-from tokenspeed.runtime.layers.attention.backends.base import AttentionBackend
-from tokenspeed.runtime.layers.attention.backends.state.qsa import bind_qsa_indexers
+# Executed as a script by run_ci_suite: the test dir must be importable.
+_TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _TEST_DIR)
+from ci_system.ci_register import register_cuda_ci  # noqa: E402
+
+from tokenspeed.runtime.layers.attention.backends.base import (  # noqa: E402
+    AttentionBackend,
+)
+from tokenspeed.runtime.layers.attention.backends.state.qsa import (  # noqa: E402
+    bind_qsa_indexers,
+)
+
+register_cuda_ci(est_time=30, suite="runtime-1gpu")
 
 
 class _TestAttentionBackend:
@@ -38,6 +52,7 @@ class _TestAttentionBackend:
 
     def __init__(self, *, is_draft: bool) -> None:
         self.is_draft = is_draft
+        self._speculative_state_backends: list = []
 
 
 class _TestIndexer:
@@ -78,7 +93,7 @@ def test_qsa_backend_draft_never_commits_target_acceptance() -> None:
     )
 
     assert qsa_backend is None
-    assert not hasattr(attn_backend, "_speculative_state_backends")
+    assert attn_backend._speculative_state_backends == []
     assert indexer.commits == []
 
 
@@ -88,3 +103,7 @@ def test_qsa_backend_rejects_rebinding_to_another_model() -> None:
 
     with pytest.raises(RuntimeError, match="cannot be rebound"):
         bind_qsa_indexers(attn_backend, [_TestIndexer()])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/runtime/test_qwen35_gdn_replay.py
+++ b/test/runtime/test_qwen35_gdn_replay.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -411,6 +412,152 @@ def test_qwen_replay_commits_all_layers_with_one_kernel_call(monkeypatch):
             atol=1e-6,
             rtol=1e-5,
         )
+
+
+@pytest.mark.parametrize("replay", [False, True])
+def test_rebinding_the_pool_retargets_the_verify_copy_tables(replay):
+    """The copy tables hold the pool's data_ptrs, so a rebind must rebuild them."""
+    backend, _ = _make_backend(*_initial_pools(), replay=replay)
+    backend.preallocate_verify_workspace(BATCH, DRAFT_TOKENS)
+    stale = backend._verify_copy_tables_get()
+
+    replacement = _ContractPool(4, {0: ("linear_attention", *_initial_pools(seed=29))})
+    backend.forward_metadata = object()
+    backend._replay_state_tapes = {1: object()}
+    backend.set_kv_pool(replacement)
+    assert backend._gdn_replay is None
+    assert backend._replay_state_tapes == {}
+    assert backend.forward_metadata is None
+    backend.init_cuda_graph_state(BATCH)
+    assert len(backend.query_start_loc_list) == BATCH
+    backend.preallocate_verify_workspace(BATCH, DRAFT_TOKENS)
+    assert (backend._gdn_replay is not None) == replay
+    tables = backend._verify_copy_tables_get()
+    conv, ssm = backend._state_components(0)
+    assert tables["conv_comp"][0].item() == conv.data_ptr()
+    assert tables["ssm_comp"][0].item() == ssm.data_ptr()
+    assert tables["conv_comp"][0].item() != stale["conv_comp"][0].item()
+
+
+def test_rebinding_a_pool_with_other_state_component_shapes_is_rejected():
+    backend, original = _make_backend(*_initial_pools(), replay=False)
+    conv, _ = _initial_pools(seed=29)
+    recurrent = torch.zeros(
+        8,
+        NUM_V_HEADS * 2,
+        HEAD_V_DIM // 2,
+        HEAD_K_DIM,
+        device=DEVICE,
+        dtype=torch.float32,
+    )
+    with pytest.raises(RuntimeError, match="different state geometry"):
+        backend.set_kv_pool(
+            _ContractPool(4, {0: ("linear_attention", conv, recurrent)})
+        )
+    assert backend.kv_pool is original
+
+
+def test_rebinding_rejects_geometry_change_in_a_nonfirst_state_layer():
+    """Geometry validation must cover every layer, not only min(layer_id)."""
+    conv, recurrent = _initial_pools(seed=37)
+    original = _ContractPool(
+        4,
+        {
+            0: ("linear_attention", conv.clone(), recurrent.clone()),
+            1: ("linear_attention", conv.clone(), recurrent.clone()),
+        },
+    )
+    backend = MambaAttnBackend(*_config(replay=False))
+    backend.set_kv_pool(original)
+
+    changed_recurrent = torch.zeros(
+        recurrent.shape[0],
+        recurrent.shape[1] * 2,
+        recurrent.shape[2] // 2,
+        recurrent.shape[3],
+        device=DEVICE,
+        dtype=recurrent.dtype,
+    )
+    changed = _ContractPool(
+        4,
+        {
+            0: ("linear_attention", conv.clone(), recurrent.clone()),
+            1: ("linear_attention", conv.clone(), changed_recurrent),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="different state geometry"):
+        backend.set_kv_pool(changed)
+
+    assert backend.kv_pool is original
+
+
+def test_rebinding_a_pool_whose_state_layers_moved_is_rejected():
+    """Equal shapes on shifted layer ids are a different geometry."""
+    conv, recurrent = _initial_pools(seed=41)
+
+    def pool(*layers):
+        return _ContractPool(
+            4,
+            {
+                layer: ("linear_attention", conv.clone(), recurrent.clone())
+                for layer in layers
+            },
+        )
+
+    original = pool(0, 1)
+    backend = MambaAttnBackend(*_config(replay=False))
+    backend.set_kv_pool(original)
+
+    with pytest.raises(RuntimeError, match="different state geometry"):
+        backend.set_kv_pool(pool(1, 2))
+
+    assert backend.kv_pool is original
+
+
+def test_rebinding_a_pool_of_different_state_geometry_is_rejected():
+    backend, original = _make_backend(*_initial_pools(), replay=False)
+    backend.set_cache_pool(original)
+    with pytest.raises(RuntimeError, match="different state geometry"):
+        backend.set_cache_pool(
+            _ContractPool(8, {0: ("linear_attention", *_initial_pools())})
+        )
+
+    assert backend.kv_pool is original
+    assert backend.cache_pool is original
+    assert backend._checkpoint_granularity == 4
+
+
+def test_rebinding_a_state_backend_drops_registered_side_state_scratch():
+    backend, _ = _make_backend(*_initial_pools(), replay=False)
+    side = SimpleNamespace(dropped=False, commit_after_mtp_verify=lambda *a, **k: None)
+    side.drop_verify_scratch = lambda: setattr(side, "dropped", True)
+    backend.register_speculative_state_backend(side)
+
+    backend.set_cache_pool(
+        _ContractPool(4, {0: ("linear_attention", *_initial_pools(seed=31))})
+    )
+    assert side.dropped
+
+
+def test_rebinding_the_pool_drops_the_ple_verify_scratch():
+    """The PLE scratch is cut from the bound arena's fields, so a rebind must reissue it."""
+    from tokenspeed.runtime.layers.attention.backends.specific.qwen4_exp import (
+        Qwen4ExpMambaAttnBackend,
+    )
+
+    backend = Qwen4ExpMambaAttnBackend.__new__(Qwen4ExpMambaAttnBackend)
+    backend._init_pool_binding()
+    layer = SimpleNamespace(dropped=False)
+    layer.drop_verify_scratch = lambda: setattr(layer, "dropped", True)
+    backend._ple_layers = (layer,)
+    backend._ple_verify_scratch = {"context": torch.zeros(2)}
+
+    pool = _ContractPool(4, {0: ("linear_attention", *_initial_pools())})
+    backend.set_kv_pool(pool)
+    assert backend.kv_pool is pool
+    assert backend._ple_verify_scratch == {}
+    assert layer.dropped
 
 
 if __name__ == "__main__":

--- a/test/runtime/test_qwen4_exp.py
+++ b/test/runtime/test_qwen4_exp.py
@@ -440,6 +440,13 @@ def _qsa_router(
             granularities=dict(_QSA_GROUP_GRANULARITIES),
             families={gid: "history" for gid in _QSA_GROUP_GRANULARITIES},
             full_history_group_id=FULL_ATTENTION,
+            row_geometry={
+                gid: (granularity, 1)
+                for gid, granularity in _QSA_GROUP_GRANULARITIES.items()
+            },
+            retentions={
+                gid: ("full_history", None) for gid in _QSA_GROUP_GRANULARITIES
+            },
         ),
         {
             gid: leaf_factory(gid, granularity)
@@ -1274,7 +1281,7 @@ def test_qwen4_exp_ple_verify_workspace_shares_context_rows() -> None:
         qwen4_exp_ple_conv_field(2): torch.empty((3, 16, 9), dtype=torch.bfloat16),
     }
     backend = object.__new__(Qwen4ExpMambaAttnBackend)
-    backend.kv_pool = SimpleNamespace(
+    backend.cache_pool = SimpleNamespace(
         arena=SimpleNamespace(
             plan=SimpleNamespace(fields=fields),
             field=cache_fields.__getitem__,
@@ -1366,18 +1373,6 @@ def test_qwen4_exp_selects_model_specific_gdn_backend(monkeypatch) -> None:
         ),
         attention_arch=object(),
     )
-    state_group = SimpleNamespace(
-        group_id=LINEAR_ATTENTION,
-        family="state",
-        checkpoint_granularity=128,
-    )
-    pool = SimpleNamespace(
-        arena=SimpleNamespace(
-            runtime_contract=SimpleNamespace(group_specs=(state_group,))
-        ),
-        state_group_by_layer={0: LINEAR_ATTENTION},
-        get_component=lambda layer_id, name: None,
-    )
     monkeypatch.setattr(
         attention_registry,
         "_create_attn_backend_with_name",
@@ -1388,7 +1383,6 @@ def test_qwen4_exp_selects_model_specific_gdn_backend(monkeypatch) -> None:
         SimpleNamespace(speculative_algorithm=None, kda_backend="auto"),
         model_config,
         config,
-        pool=pool,
     )
 
     assert isinstance(

--- a/test/runtime/test_unified_decode_path.py
+++ b/test/runtime/test_unified_decode_path.py
@@ -97,6 +97,8 @@ class _RouterCase(_TorchCase):
                 granularities={FULL: 2},
                 families={FULL: "history"},
                 full_history_group_id=FULL,
+                row_geometry={FULL: (2, 1)},
+                retentions={FULL: ("full_history", None)},
             ),
             {FULL: leaf},
         )


### PR DESCRIPTION
Rebinding a cache pool is part of the memory-probe plan (#1380, split into
three PRs; this is the first): the executor will bind a small probe pool,
capture graphs to measure, release them, and bind the real pool. Today
set_cache_pool is a plain assignment on most backends and each family
latches pool-derived state (pointer tables, page-table buffers, replay
descriptors, verify scratch, conv-column geometry) that a second bind
would leave stale.

This PR makes a second bind behave like a first bind:

- One entry, CachePoolBinding.set_cache_pool: validate the pool against
  the geometry latched on the first bind (recursively over children),
  bind the children, then publish. Each node's _publish_cache_pool drops
  its own pool-derived latches; the 19 backends implement it.
- A pool with a different published geometry is rejected before anything
  moves: paged group ids/granularity/family/retention/row geometry
  (router), state group ids, checkpoint grain and per-layer state shapes
  and dtypes (Mamba/KDA), group kinds and page counts (DeepSeek V4),
  ShortConv columns (Inkling). Page counts and transfer policy may change.
- First-bind behaviour is unchanged; the graph owners, the executor and
  the device build are untouched. A rebind is a construction-time
  operation owned by the orchestrator the third PR adds; the backend tree
  carries no lifecycle state.

Tests: per family, a rebound backend matches a fresh one field by field
and keeps no view into the old pool (storage-level alias gate), geometry
changes are refused, and an AST gate pins that every paged leaf resets
each optional per-forward slot. docs/design/unified_path.md gains a
"Rebinding a cache pool" section with the contract and the orchestrator's
obligations.

Validation on GB200 (1 GPU): 20 pool-binding test files, 503 passed on the
branch vs 461 on main with no branch-only failure (the 5 failures are
pre-existing on main); 38 rebind tests fail on main and pass here;
Qwen3-8B boots and serves a completion.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
