### PR TITLE
perf(amd): remove the small-route expert block barrier

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/fp16/moe_align_device.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx950/moe/fp16/moe_align_device.py
@@ -244,12 +244,8 @@ def _prepare_small_kernel(
         gl.store(
             sei_ptr + block_ids,
             gl.full([BLOCK_NB], -1, gl.int32, layout=LE),
-            mask=block_ids < nb_max,
+            mask=(block_ids >= num_blocks) & (block_ids < nb_max),
         )
-
-    # The sentinel fill is owned by one wave; synchronize before other waves
-    # overwrite live block ranges with expert IDs.
-    gl.barrier()
 
     for block_offset in gl.static_range(0, MAX_BLOCKS_PER_EXPERT):
         gl.store(
@@ -361,7 +357,7 @@ def moe_align_block_size_device(
             sentinel,
             BLOCK_G=triton.next_power_of_2(N),
             BLOCK_E=BLOCK_E,
-            BLOCK_NB=64,
+            BLOCK_NB=256,
             # N is the flattened route count (token rows * top-k), not a GEMM dimension.
             # block_m is routed rows per expert block; this matches the worst
             # case, where all routes hit one expert.

--- a/tokenspeed-kernel/test/ops/moe/test_gluon_bf16_moe_gfx950.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gluon_bf16_moe_gfx950.py
@@ -259,10 +259,10 @@ def test_small_route_boundary_alignment_contract(case: str) -> None:
 
 
 def test_small_route_production_alignment_graph_replay() -> None:
-    """Graph replay preserves cross-wave block-table initialization ordering."""
+    """Graph replay updates the live block prefix and padded suffix."""
     num_tokens, num_experts, top_k, block_m = 64, 288, 8, 16
     flat_slots = torch.arange(num_tokens * top_k, device="cuda", dtype=torch.int32)
-    topk_ids = ((flat_slots.remainder(3) + 1) * 64).reshape(num_tokens, top_k)
+    topk_ids = torch.zeros((num_tokens, top_k), device="cuda", dtype=torch.int32)
     topk_weights = (flat_slots.float() + 0.25).reshape(num_tokens, top_k)
 
     moe_align_block_size_device(
@@ -295,7 +295,7 @@ def test_small_route_production_alignment_graph_replay() -> None:
     )
     first_experts = outputs[1].clone()
 
-    topk_ids.copy_((((flat_slots + 1).remainder(3) + 1) * 64 + 1).reshape_as(topk_ids))
+    topk_ids.copy_((flat_slots * 37).remainder(num_experts).reshape_as(topk_ids))
     topk_weights.copy_(torch.flip(topk_weights, dims=(0, 1)))
     for _ in range(32):
         graph.replay()
@@ -309,6 +309,20 @@ def test_small_route_production_alignment_graph_replay() -> None:
         expert_start=0,
     )
     assert not torch.equal(outputs[1], first_experts)
+
+    topk_ids.zero_()
+    for _ in range(32):
+        graph.replay()
+    torch.cuda.synchronize()
+    _assert_production_alignment_contract(
+        topk_ids,
+        topk_weights,
+        outputs,
+        num_experts=num_experts,
+        block_m=block_m,
+        expert_start=0,
+    )
+    torch.testing.assert_close(outputs[1], first_experts, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("num_tokens", [1, 8, 32, 64, 256])


### PR DESCRIPTION
Initialize only the unused suffix of the sorted expert-block table. The per-expert writes cover the disjoint live prefix, so the two global-memory write phases no longer require a workgroup barrier. Use a 256-entry tile so all four waves cooperate on the suffix initialization.

The output layout, routing order, packed route IDs, weights, and large-route path are unchanged. Strengthen the graph-replay contract test by growing and then shrinking the live block prefix, which verifies that the moving suffix cannot retain stale expert IDs.

MI350X physical GPU 4, 64 rows, top-k 8, 288 experts, block 16, captured graph replay. Three alternating parent/candidate fresh-process pairs, 31 timing samples per process and 20 warmups:

- one call, 200 replays/sample: 9.969 -> 9.809 us/call (-1.61%); median paired change -2.40%, range -2.81% to -0.46%
- 42 calls, 20 replays/sample: 380.981 -> 371.521 us/graph (-2.48%), or 9.071 -> 8.846 us/call; median paired change -2.55%, range -2.64% to -2.21%
- all 42 distinct canonical outputs matched the parent exactly

The generated production kernel removes the explicit source barrier and one corresponding hardware barrier; compiler-generated reduction barriers remain.

Tests:
- focused alignment and changed-boundary replay tests: 7 passed
- full BF16 expert module: 18 passed
- downstream FP8 expert-path tests: 12 passed, 7 deselected
- pre-commit run --all-files: passed
