### PR TITLE
perf(v4): restore DSpark decode fast paths

### DIFF
--- a/docs/design/unified_path.md
+++ b/docs/design/unified_path.md
@@ -20,6 +20,16 @@ path nothing exercised routinely.
 
 ## Invariants
 
+### DSpark Markov embedding placement
+
+`--dspark-replicate-markov-embedding` stores the full V4 DSpark Markov
+embedding on every attention TP rank. It trades GPU memory for removal of
+the embedding all-reduce in each proposal position. The normal checkpoint
+weight loader handles replicated and sharded embeddings; target embeddings,
+Markov projections and LM heads retain their existing vocabulary sharding.
+The option is disabled by default and requires the V4 DSpark drafter.
+Eager and captured forwards use the same embedding implementation.
+
 ### One decode metadata path
 
 `AttentionBackend.refresh_decode_metadata(bs, actual_bs, req_pool_indices,
@@ -615,3 +625,29 @@ down to the router and V4).
 * New backends implement `refresh_decode_metadata` + `init_cuda_graph_state`;
   capture is inherited from the base default (idle refresh). Only a
   kernel-imposed capture asymmetry justifies an override.
+# Cache Range Descriptor Staging
+
+Large cache-zero descriptor tables (16,384 to 131,072 rows) reuse at most four
+pinned-host/device buffer pairs per device. A slot stays reserved until its
+zeroing kernel has been submitted, and its CUDA event must complete before
+reuse on any stream. Smaller, oversized, busy, and graph-capture cases retain
+the allocation path. This cache is bounded to 8 MiB each of host and device
+storage per device; it never changes the byte ranges being cleared.
+
+# DSpark Local Sampling Reduction
+
+DSpark uses the registered sampling max/index operator for compact, unpadded
+FP32 vocabulary shards. Both eager execution and graph capture take the same
+path; padded or added-vocabulary shards retain their existing mapping logic.
+The operator returns separate values and indices, avoiding packed-output
+conversion. Finite logits retain exact maxima and lowest-index tie breaking.
+Like the existing CuTe sampling kernel, NaNs are ineligible; an entirely
+invalid row returns negative infinity and index zero. This is not a claim of
+equivalence to PyTorch's NaN propagation.
+
+Hash routing tables are checkpoint weights, immutable between weight loads.
+V4 validates every table value in `post_load_weights`, including on reload,
+before allowing sampling to omit repeated table-value checks. Validation is
+cleared before rechecking so a failed reload cannot retain an earlier success.
+Dynamic token ids and table shape, dtype and device remain checked per call.
+Callers with mutable or unvalidated tables must request table-value checks.

--- a/python/tokenspeed/runtime/configs/model_config.py
+++ b/python/tokenspeed/runtime/configs/model_config.py
@@ -434,6 +434,18 @@ class ModelConfig:
         )
 
         self.hf_text_config = get_hf_text_config(self.hf_config)
+        if is_draft_worker:
+            replicate_markov = getattr(
+                server_args, "dspark_replicate_markov_embedding", False
+            )
+            if replicate_markov and (
+                getattr(server_args, "speculative_algorithm", None) != "DSPARK"
+                or resolve_architecture(self.hf_config) != "DeepseekV4ForCausalLMDSpark"
+            ):
+                raise ValueError(
+                    "--dspark-replicate-markov-embedding requires the V4 DSpark drafter."
+                )
+            self.hf_text_config.dspark_replicate_markov_embedding = replicate_markov
         self.spec_block_size: int | None = None
         if is_draft_worker:
             self.spec_block_size = _apply_block_spec_widths(

--- a/python/tokenspeed/runtime/models/deepseek_v4.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4.py
@@ -1588,6 +1588,8 @@ def dsv4_select_experts(
     hash_indices_table: torch.Tensor | None = None,
     input_ids: torch.Tensor | None = None,
     need_scores: bool = True,
+    *,
+    hash_table_values_validated: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Use an accelerator router when available, otherwise run eager routing."""
     try:
@@ -1599,6 +1601,7 @@ def dsv4_select_experts(
             hash_indices_table,
             input_ids,
             need_scores,
+            hash_table_values_validated=hash_table_values_validated,
         )
     except (NoKernelFoundError, AttributeError, RuntimeError):
         pass
@@ -1886,6 +1889,7 @@ class DeepseekV4MoE(nn.Module):
         self.mapping = mapping
         self.layer_index = layer_index
         self.n_shared_experts = config.n_shared_experts
+        self._hash_table_values_validated = False
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
         self.scoring_func = getattr(config, "scoring_func", "sqrtsoftplus")
         if self.scoring_func != "sqrtsoftplus":
@@ -2021,6 +2025,17 @@ class DeepseekV4MoE(nn.Module):
                 output_format=self.experts.topk_output_format,
             )
 
+    def validate_hash_routing_table(self) -> None:
+        """Validate checkpoint routing values after every weight load."""
+        self._hash_table_values_validated = False
+        table = self.gate.tid2eid
+        if table is None:
+            return
+        experts = self.config.n_routed_experts
+        if not bool(((table >= 0) & (table < experts)).all().item()):
+            raise ValueError(f"hash_indices_table entries must be in [0, {experts})")
+        self._hash_table_values_validated = True
+
     def _select_experts(
         self,
         hidden_states: torch.Tensor,
@@ -2037,6 +2052,7 @@ class DeepseekV4MoE(nn.Module):
             hash_indices_table=self.gate.tid2eid,
             input_ids=input_ids,
             need_scores=need_scores,
+            hash_table_values_validated=self._hash_table_values_validated,
         )
 
     def _make_topk_output(
@@ -3862,7 +3878,9 @@ class DeepseekV4ForCausalLM(BaseCausalLM):
 
     def post_load_weights(self):
         for module in self.modules():
-            if isinstance(module, DeepseekV4Compressor):
+            if isinstance(module, DeepseekV4MoE):
+                module.validate_hash_routing_table()
+            elif isinstance(module, DeepseekV4Compressor):
                 module.process_weights_after_loading()
             elif isinstance(module, DeepseekV4MegaMoEExperts):
                 module.finalize_weights()

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark.py
@@ -341,7 +341,11 @@ class DeepseekV4DSparkModel(nn.Module):
             self.markov_rank,
             params_dtype=torch.float32,
             prefix=add_prefix("markov_embedding", prefix),
-            **target_vocab_parallel_kwargs,
+            **(
+                {"tp_rank": None, "tp_size": None, "tp_group": None}
+                if getattr(config, "dspark_replicate_markov_embedding", False)
+                else target_vocab_parallel_kwargs
+            ),
         )
         self.markov_projection = ParallelLMHead(
             int(config.vocab_size),

--- a/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/heads.py
+++ b/python/tokenspeed/runtime/models/deepseek_v4_dspark_ops/heads.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.sampling import max_and_argmax
 from torch import nn
 
 from tokenspeed.runtime.distributed.comm_ops import all_gather_into_tensor
@@ -28,7 +29,16 @@ def _local_vocab_argmax(
     added_vocab_start = int(shard.added_vocab_start_index)
     rows = local_logits.shape[0]
 
-    if num_org > 0:
+    if (
+        num_org == local_logits.shape[1]
+        and num_org > 0
+        and local_logits.dtype == torch.float32
+        and local_logits.is_contiguous()
+    ):
+        local_max, local_arg = max_and_argmax(
+            local_logits, solution=None, override=None
+        )
+    elif num_org > 0:
         local_max, local_arg = torch.max(local_logits[:, :num_org], dim=-1)
     else:
         local_max = torch.full(

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -272,6 +272,7 @@ class ServerArgs:
     disable_capturable_grammar: bool = False
 
     # Speculative decoding
+    dspark_replicate_markov_embedding: bool = False
     draft_model_path_use_base: bool | None = False
     speculative_config: str | None = None
     speculative_algorithm: str | None = None
@@ -461,6 +462,12 @@ class ServerArgs:
                         self.speculative_num_draft_tokens = num_speculative_tokens + 1
                 else:
                     self.speculative_num_steps = num_speculative_tokens
+
+        if (
+            self.dspark_replicate_markov_embedding
+            and self.speculative_algorithm != "DSPARK"
+        ):
+            raise ValueError("--dspark-replicate-markov-embedding requires DSPARK.")
 
         if self.speculative_num_draft_tokens is None:
             self.speculative_num_draft_tokens = self.speculative_num_steps + 1
@@ -1767,6 +1774,13 @@ class ServerArgs:
         )
 
         # Speculative decoding
+        parser.add_argument(
+            "--dspark-replicate-markov-embedding",
+            action="store_true",
+            default=ServerArgs.dspark_replicate_markov_embedding,
+            help="Replicate the V4 DSpark Markov embedding on each attention TP rank "
+            "to avoid its embedding all-reduce, using additional GPU memory.",
+        )
         parser.add_argument(
             "--draft-model-path-use-base",
             action="store_true",

--- a/test/runtime/test_deepseek_v4_config.py
+++ b/test/runtime/test_deepseek_v4_config.py
@@ -115,6 +115,7 @@ from tokenspeed.runtime.layers.quantization import (
     Fp8Config,
     Mxfp4Config,
 )
+from tokenspeed.runtime.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from tokenspeed.runtime.models import deepseek_v4 as deepseek_v4_model
 from tokenspeed.runtime.models.deepseek_v4 import (
     DeepseekV4ForCausalLM,
@@ -1531,6 +1532,7 @@ class TestDeepseekV4Config(unittest.TestCase):
         server_args = SimpleNamespace(
             mapping=None,
             speculative_algorithm="DSPARK",
+            dspark_replicate_markov_embedding=True,
             enable_prefix_caching=True,
             speculative_num_steps=5,
             speculative_num_draft_tokens=6,
@@ -1569,7 +1571,38 @@ class TestDeepseekV4Config(unittest.TestCase):
             )
         self.assertEqual(model_config.dspark_prefix_replay_tokens, 96)
         self.assertEqual(model_config.num_attention_layers, 2)
+        self.assertTrue(model_config.hf_text_config.dspark_replicate_markov_embedding)
         count_stages.assert_called_once_with("external-draft", revision=None)
+
+    def test_markov_replication_rejects_other_draft_architectures(self):
+        config = SimpleNamespace(architectures=["K3DSparkForCausalLM"])
+        args = SimpleNamespace(
+            mapping=None,
+            speculative_algorithm="DSPARK",
+            dspark_replicate_markov_embedding=True,
+            ext_yaml=None,
+        )
+        with (
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_config",
+                return_value=config,
+            ),
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_generation_config",
+                return_value=SimpleNamespace(eos_token_id=None),
+            ),
+            patch(
+                "tokenspeed.runtime.configs.model_config.get_hf_text_config",
+                return_value=config,
+            ),
+            self.assertRaisesRegex(ValueError, "requires the V4 DSpark drafter"),
+        ):
+            ModelConfig(
+                "unused",
+                model_override_args="{}",
+                is_draft_worker=True,
+                server_args=args,
+            )
 
     def test_model_config_keeps_incompatible_user_quantization_error(self):
         model_config = object.__new__(ModelConfig)
@@ -2447,6 +2480,121 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertEqual(server_args.speculative_algorithm, "DSPARK")
         self.assertEqual(server_args.speculative_num_steps, 5)
         self.assertEqual(server_args.speculative_num_draft_tokens, 6)
+
+    def test_dspark_replicate_markov_embedding_cli(self):
+        parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        common = ["--model=unused", "--disable-kvstore"]
+        self.assertFalse(parser.parse_args(common).dspark_replicate_markov_embedding)
+        for spec in (
+            ["--speculative-algorithm=DSPARK"],
+            ['--speculative-config={"method":"dspark","num_speculative_tokens":5}'],
+        ):
+            with self.subTest(spec=spec):
+                args = ServerArgs.from_cli_args(
+                    parser.parse_args(
+                        common + spec + ["--dspark-replicate-markov-embedding"]
+                    )
+                )
+                self.assertTrue(args.dspark_replicate_markov_embedding)
+                self.assertEqual(args.speculative_algorithm, "DSPARK")
+
+    def test_dspark_replicate_markov_embedding_requires_dspark(self):
+        for algorithm in (None, "MTP", "EAGLE3", "DFLASH"):
+            with (
+                self.subTest(algorithm=algorithm),
+                self.assertRaisesRegex(ValueError, "requires DSPARK"),
+            ):
+                ServerArgs(
+                    model="unused",
+                    speculative_algorithm=algorithm,
+                    dspark_replicate_markov_embedding=True,
+                    disable_kvstore=True,
+                )
+
+    def test_dspark_markov_replication_keeps_other_vocab_heads_sharded(self):
+        module = "tokenspeed.runtime.models.deepseek_v4_dspark"
+        config = SimpleNamespace(
+            dspark_num_stages=1,
+            dspark_block_size=5,
+            dspark_target_layer_ids=(0,),
+            num_hidden_layers=1,
+            hidden_size=8,
+            hc_mult=4,
+            rms_norm_eps=1e-6,
+            hc_eps=1e-6,
+            dspark_noise_token_id=0,
+            dspark_markov_rank=4,
+            vocab_size=128,
+            head_dim=8,
+            num_attention_heads=4,
+            qk_rope_head_dim=4,
+            o_groups=1,
+            o_lora_rank=8,
+            max_position_embeddings=32,
+        )
+        group = object()
+        mapping = SimpleNamespace(
+            attn=SimpleNamespace(tp_rank=2, tp_size=4, tp_group=group)
+        )
+        stage = torch.nn.Module()
+        stage.block = SimpleNamespace(attn_norm=SimpleNamespace(weight=torch.empty(1)))
+        for replicate in (False, True):
+            config.dspark_replicate_markov_embedding = replicate
+            with (
+                self.subTest(replicate=replicate),
+                patch(f"{module}._DSparkStage", return_value=stage),
+                patch(
+                    f"{module}.VocabParallelEmbedding",
+                    side_effect=lambda *a, **kw: torch.nn.Module(),
+                ) as embedding,
+                patch(
+                    f"{module}.ParallelLMHead", return_value=torch.nn.Module()
+                ) as projection,
+                patch(f"{module}.ReplicatedLinear", return_value=torch.nn.Module()),
+                patch(
+                    f"{module}.precompute_dspark_freqs_cis", return_value=torch.empty(1)
+                ),
+            ):
+                DeepseekV4DSparkModel(config, mapping, None, "model")
+                target, markov = embedding.call_args_list
+                self.assertEqual(target.kwargs["tp_size"], 4)
+                self.assertEqual(projection.call_args.kwargs["tp_size"], 4)
+                self.assertEqual(markov.kwargs["tp_size"], None if replicate else 4)
+                self.assertIs(markov.kwargs["tp_group"], None if replicate else group)
+
+    def test_dspark_replicated_markov_weights_match_sharded_lookup(self):
+        vocab_size, rank = 130, 4
+        weights = torch.arange(vocab_size * rank, dtype=torch.float32).view(
+            vocab_size, rank
+        )
+        token_ids = torch.tensor([0, 31, 63, 64, 127, 129])
+        replicated = VocabParallelEmbedding(
+            vocab_size,
+            rank,
+            params_dtype=torch.float32,
+            tp_rank=None,
+            tp_size=None,
+            tp_group=None,
+        )
+        replicated.weight_loader(replicated.weight, weights)
+        partials = []
+        for tp_rank in range(4):
+            sharded = VocabParallelEmbedding(
+                vocab_size,
+                rank,
+                params_dtype=torch.float32,
+                tp_rank=tp_rank,
+                tp_size=4,
+                tp_group=(0, 1, 2, 3),
+            )
+            sharded.weight_loader(sharded.weight, weights)
+            partials.append(sharded(token_ids, reduce_results=False))
+        expected = weights[token_ids]
+        torch.testing.assert_close(replicated(token_ids), expected, rtol=0, atol=0)
+        torch.testing.assert_close(
+            torch.stack(partials).sum(0), expected, rtol=0, atol=0
+        )
 
     def test_dspark_allows_prefix_cache_when_kvstore_is_disabled(self):
         server_args = ServerArgs(
@@ -6525,6 +6673,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             top_k=2,
             renormalize=True,
             correction_bias=bias,
+            hash_table_values_validated=False,
         )
 
         expected_scores = F.softplus(logits).sqrt()
@@ -6535,6 +6684,21 @@ class TestDeepseekV4Config(unittest.TestCase):
         self.assertTrue(torch.allclose(scores, expected_scores))
         self.assertTrue(torch.equal(topk_ids, expected_ids.to(torch.int32)))
         self.assertTrue(torch.allclose(topk_weights, expected_weights))
+
+    def test_hash_table_validation_rechecks_after_loading(self):
+        moe = DeepseekV4MoE.__new__(DeepseekV4MoE)
+        torch.nn.Module.__init__(moe)
+        moe.config = SimpleNamespace(n_routed_experts=4)
+        moe.gate = SimpleNamespace(tid2eid=torch.tensor([[0, 3]], dtype=torch.int32))
+        moe.validate_hash_routing_table()
+        self.assertTrue(moe._hash_table_values_validated)
+        moe.gate.tid2eid[0, 1] = 4
+        with self.assertRaisesRegex(ValueError, "hash_indices_table entries"):
+            moe.validate_hash_routing_table()
+        self.assertFalse(moe._hash_table_values_validated)
+        moe.gate.tid2eid = None
+        moe.validate_hash_routing_table()
+        self.assertFalse(moe._hash_table_values_validated)
 
     def test_deepseek_v4_hash_router_uses_table_ids_and_gate_scores(self):
         logits = torch.tensor(
@@ -6561,6 +6725,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             renormalize=True,
             hash_indices_table=table,
             input_ids=input_ids,
+            hash_table_values_validated=False,
         )
 
         expected_ids = torch.tensor([[3, 1], [2, 3]], dtype=torch.int32)
@@ -6652,6 +6817,7 @@ class TestDeepseekV4Config(unittest.TestCase):
             top_k=6,
             renormalize=True,
             correction_bias=bias,
+            hash_table_values_validated=False,
         )
 
         expected_scores = F.softplus(logits).sqrt()

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/kvcache/triton.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
@@ -400,6 +401,57 @@ def _zero_byte_ranges_kernel(
         )
 
 
+class _ZeroRangeTableStager:
+    """Reuse bounded descriptor storage only after its consuming stream finishes."""
+
+    def __init__(self, capacity: int, min_rows: int) -> None:
+        self.capacity = capacity
+        self.min_rows = min_rows
+        self.lock = threading.Lock()
+        self.slots: dict[torch.device, list[tuple]] = {}
+
+    def acquire(self, ranges: list[tuple[int, int]], device: torch.device):
+        if not self.min_rows <= len(ranges) <= self.capacity:
+            return None
+        with torch.cuda.device(device):
+            if torch.cuda.is_current_stream_capturing():
+                return None
+            stream = torch.cuda.current_stream(device)
+            with self.lock:
+                slots = self.slots.setdefault(device, [])
+                for index, (host, table, event, reserved) in enumerate(slots):
+                    if not reserved and event.query():
+                        break
+                else:
+                    if len(slots) == 4:
+                        return None
+                    index = len(slots)
+                    host = torch.empty(
+                        (self.capacity, 2), dtype=torch.int64, pin_memory=True
+                    )
+                    table = torch.empty_like(host, device=device)
+                    event = torch.cuda.Event()
+                    slots.append((host, table, event, True))
+                slots[index] = (host, table, event, True)
+            try:
+                count = len(ranges)
+                host[:count].copy_(torch.tensor(ranges, dtype=torch.int64))
+                table[:count].copy_(host[:count], non_blocking=True)
+            except Exception:
+                self.release(device, index, stream)
+                raise
+        return table[:count], index, stream
+
+    def release(self, device: torch.device, index: int, stream: torch.cuda.Stream):
+        with self.lock:
+            host, table, event, _ = self.slots[device][index]
+            event.record(stream)
+            self.slots[device][index] = (host, table, event, False)
+
+
+_ZERO_RANGE_TABLE_STAGER = _ZeroRangeTableStager(capacity=131072, min_rows=16384)
+
+
 def zero_byte_ranges(backing: torch.Tensor, ranges: list[tuple[int, int]]) -> None:
     """Zero selected byte ranges in one contiguous cache allocation.
 
@@ -418,11 +470,15 @@ def zero_byte_ranges(backing: torch.Tensor, ranges: list[tuple[int, int]]) -> No
     ):
         raise ValueError("ranges must be non-empty and lie within backing")
 
-    range_table = (
-        torch.tensor(ranges, dtype=torch.int64)
-        .pin_memory()
-        .to(backing.device, non_blocking=True)
-    )
+    staged = _ZERO_RANGE_TABLE_STAGER.acquire(ranges, backing.device)
+    if staged is None:
+        range_table = (
+            torch.tensor(ranges, dtype=torch.int64)
+            .pin_memory()
+            .to(backing.device, non_blocking=True)
+        )
+    else:
+        range_table, slot_index, stream = staged
 
     block_size = 1024
     max_size = max(size for _, size in ranges)
@@ -435,12 +491,16 @@ def zero_byte_ranges(backing: torch.Tensor, ranges: list[tuple[int, int]]) -> No
         len(ranges),
         min(tiles_per_range, triton.cdiv(max_size, block_size)),
     )
-    _zero_byte_ranges_kernel[grid](
-        backing,
-        range_table,
-        BLOCK_SIZE=block_size,
-        num_warps=4,
-    )
+    try:
+        _zero_byte_ranges_kernel[grid](
+            backing,
+            range_table,
+            BLOCK_SIZE=block_size,
+            num_warps=4,
+        )
+    finally:
+        if staged is not None:
+            _ZERO_RANGE_TABLE_STAGER.release(backing.device, slot_index, stream)
 
 
 # -----------------------------------------------------------------------------

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/__init__.py
@@ -360,6 +360,8 @@ def dsv4_select_experts(
     need_scores: bool = True,
     override: str | None = None,
     solution: str | None = None,
+    *,
+    hash_table_values_validated: bool,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Select DeepSeek V4 experts from sqrt-softplus router scores.
 
@@ -377,6 +379,10 @@ def dsv4_select_experts(
             kernels avoid materializing it when false.
         override: Optional exact registered kernel name.
         solution: Optional registered solution name.
+        hash_table_values_validated: Whether all values of an immutable hash
+            table have been checked against the expert count after loading.
+            Pass False for unvalidated or mutable tables. Token ids and table
+            shape, dtype and device are checked regardless of this value.
     Returns:
         FP32 weights, INT32 expert ids, and a tensor shaped [tokens, experts].
         The first two tensors have shape [tokens, top_k]. When need_scores is
@@ -388,6 +394,10 @@ def dsv4_select_experts(
     if not router_logits.is_floating_point():
         raise ValueError("router_logits must be a floating-point tensor")
     tokens, experts = router_logits.shape
+    if not isinstance(hash_table_values_validated, bool):
+        raise TypeError("hash_table_values_validated must be a bool")
+    if hash_table_values_validated and hash_indices_table is None:
+        raise ValueError("hash_table_values_validated requires hash_indices_table")
     if not 0 < top_k <= experts:
         raise ValueError(f"top_k must be in [1, {experts}], got {top_k}")
     if correction_bias is not None and correction_bias.shape != (experts,):
@@ -415,8 +425,9 @@ def dsv4_select_experts(
             raise ValueError("input_ids must be on the same device as router_logits")
         _assert_indices_in_range(input_ids, hash_indices_table.shape[0], "input_ids")
         safe_input_ids = input_ids.clamp(0, hash_indices_table.shape[0] - 1)
-        selected_experts = hash_indices_table[safe_input_ids.reshape(-1).long()]
-        _assert_indices_in_range(selected_experts, experts, "hash_indices_table")
+        if not hash_table_values_validated:
+            selected_experts = hash_indices_table[safe_input_ids.reshape(-1).long()]
+            _assert_indices_in_range(selected_experts, experts, "hash_indices_table")
         input_ids = safe_input_ids
 
     routing_kind = _routing_kind(correction_bias, hash_indices_table)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
@@ -27,7 +27,7 @@ from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
-__all__ = ["argmax"]
+__all__ = ["argmax", "max_and_argmax"]
 
 _SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 _SUPPORTED_OUT_DTYPES = (torch.int32, torch.int64)
@@ -117,6 +117,63 @@ def argmax(
         "sampling", "argmax", logits.dtype, kernel_name=kernel.name, **shape_params
     ):
         return kernel(logits, out=out)
+
+
+def _max_and_argmax_torch(logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    values, indices = torch.where(logits.isnan(), -torch.inf, logits).max(dim=-1)
+    return values.float(), indices
+
+
+def max_and_argmax(
+    logits: torch.Tensor,
+    *,
+    solution: str | None,
+    override: str | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return row-wise sampling maxima and indices without packing the outputs.
+
+    Args:
+        logits: Floating-point logits of shape ``(M, N)``, with ``N > 0``.
+            Supported dtypes are float16, bfloat16 and float32. NaNs and
+            negative infinity are ineligible candidates.
+        solution: Kernel solution to select, or None for automatic selection.
+        override: Exact kernel-name or solution override, or None.
+
+    Returns:
+        Two tensors of shape ``(M,)`` on the input device: float32 maxima
+        and int64 indices. Ties select the lowest index. Rows without an
+        eligible candidate return negative infinity and the in-range index 0,
+        matching the sampling kernel's fallback for invalid rows.
+    """
+    if logits.ndim != 2 or logits.shape[1] == 0:
+        raise ValueError("max_and_argmax requires shape (M, N) with N > 0")
+    if logits.dtype not in _SUPPORTED_DTYPES:
+        raise ValueError(f"Unsupported logits dtype: {logits.dtype}")
+    if not logits.is_cuda or logits.shape[0] == 0:
+        return _max_and_argmax_torch(logits)
+    signature = format_signature(logits=dense_tensor_format(logits.dtype))
+    try:
+        kernel = select_kernel(
+            "sampling",
+            "max_and_argmax",
+            signature,
+            solution=solution,
+            override=override,
+        )
+    except NoKernelFoundError:
+        return _max_and_argmax_torch(logits)
+    shape_params = {"M": logits.shape[0], "N": logits.shape[1]}
+    ShapeCapture.get().record(
+        "sampling", "max_and_argmax", kernel.name, logits.dtype, shape_params
+    )
+    with kernel_scope(
+        "sampling",
+        "max_and_argmax",
+        logits.dtype,
+        kernel_name=kernel.name,
+        **shape_params,
+    ):
+        return kernel(logits)
 
 
 # Backend registration (side-effect imports).

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -389,6 +389,40 @@ def _argmax_cute(
     return out_idx
 
 
+def _max_and_argmax_cute(logits: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        not logits.is_contiguous()
+        or logits.data_ptr() % 16 != 0
+        or not _supports_cute(logits.shape[1], logits.dtype)
+    ):
+        from tokenspeed_kernel.ops.sampling import _max_and_argmax_torch
+
+        return _max_and_argmax_torch(logits)
+    values = torch.empty(logits.shape[0], dtype=torch.float32, device=logits.device)
+    indices = torch.empty(logits.shape[0], dtype=torch.int64, device=logits.device)
+    _invoke_kernel(logits, values, indices)
+    return values, indices
+
+
+if _CUTE_AVAILABLE:
+    register_kernel(
+        "sampling",
+        "max_and_argmax",
+        name="cute_dsl_max_and_argmax",
+        solution="cute_dsl",
+        capability=CapabilityRequirement(
+            min_arch_version=ArchVersion(9, 0),
+            max_arch_version=ArchVersion(11, 9),
+            vendors=frozenset({"nvidia"}),
+        ),
+        signatures=format_signatures(
+            "logits", "dense", {torch.float16, torch.bfloat16, torch.float32}
+        ),
+        priority=Priority.SPECIALIZED,
+        tags={"latency", "determinism"},
+    )(_max_and_argmax_cute)
+
+
 def _argmax_pair_cute(
     logits: torch.Tensor,
     *,

--- a/tokenspeed-kernel/test/ops/test_dsv4_router_validation.py
+++ b/tokenspeed-kernel/test/ops/test_dsv4_router_validation.py
@@ -38,4 +38,53 @@ def test_default_hash_router_rejects_invalid_table_values(invalid: int) -> None:
             renormalize=True,
             hash_indices_table=table,
             input_ids=input_ids,
+            hash_table_values_validated=False,
         )
+
+
+@pytest.mark.parametrize("input_id", [-1, 2])
+def test_validated_hash_router_still_checks_token_ids(input_id: int) -> None:
+    with pytest.raises(ValueError, match="input_ids entries"):
+        dsv4_select_experts(
+            torch.zeros((1, 4)),
+            top_k=2,
+            renormalize=True,
+            hash_indices_table=torch.tensor([[0, 1], [2, 3]], dtype=torch.int32),
+            input_ids=torch.tensor([input_id]),
+            hash_table_values_validated=True,
+        )
+
+
+def test_validated_hash_router_skips_only_table_values(monkeypatch) -> None:
+    import tokenspeed_kernel.ops.moe as moe
+
+    names = []
+    validate = moe._assert_indices_in_range
+
+    def record(indices, limit, name):
+        names.append(name)
+        validate(indices, limit, name)
+
+    class StopBeforeKernel(Exception):
+        pass
+
+    def stop(*args, **kwargs):
+        raise StopBeforeKernel
+
+    monkeypatch.setattr(moe, "_assert_indices_in_range", record)
+    monkeypatch.setattr(moe, "select_kernel", stop)
+    for validated, expected in [
+        (False, ["input_ids", "hash_indices_table"]),
+        (True, ["input_ids"]),
+    ]:
+        names.clear()
+        with pytest.raises(StopBeforeKernel):
+            dsv4_select_experts(
+                torch.zeros((1, 4)),
+                top_k=2,
+                renormalize=True,
+                hash_indices_table=torch.tensor([[0, 1]], dtype=torch.int32),
+                input_ids=torch.tensor([0]),
+                hash_table_values_validated=validated,
+            )
+        assert names == expected

--- a/tokenspeed-kernel/test/ops/test_sampling.py
+++ b/tokenspeed-kernel/test/ops/test_sampling.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import pytest
 import torch
+from tokenspeed_kernel.ops.sampling import max_and_argmax
 from tokenspeed_kernel.ops.sampling.cuda import (
     fused_topk_topp_renorm,
     fused_topk_topp_workspace_size,
@@ -34,6 +35,95 @@ from tokenspeed_kernel.platform import current_platform
 
 # Sentinel matching tokenspeed.runtime.sampling.sampling_params._TOP_K_DISABLED.
 _TOP_K_DISABLED = 1 << 30
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("batch", [0, 1, 4, 16])
+@pytest.mark.parametrize("width", [127, 32320])
+def test_max_and_argmax_values(dtype, batch, width, device):
+    x = torch.randn(batch, width, dtype=dtype, device=device)
+    expected_values, expected_indices = x.max(dim=-1)
+    values, indices = max_and_argmax(x, solution=None, override=None)
+    assert values.dtype == torch.float32
+    assert indices.dtype == torch.int64
+    torch.testing.assert_close(values, expected_values.float(), rtol=0, atol=0)
+    torch.testing.assert_close(indices, expected_indices, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("backend_device", ["cpu", "cuda"])
+def test_max_and_argmax_invalid_rows_and_ties(backend_device):
+    x = torch.full((4, 32320), -torch.inf, device=backend_device)
+    x[0].fill_(torch.nan)
+    x[2, 3] = x[2, 77] = torch.inf
+    x[3, 3] = x[3, 77] = 1
+    x[3, 0] = torch.nan
+    values, indices = max_and_argmax(x, solution=None, override=None)
+    torch.testing.assert_close(
+        values,
+        torch.tensor([-torch.inf, -torch.inf, torch.inf, 1], device=backend_device),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        indices,
+        torch.tensor([0, 0, 3, 3], device=backend_device),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_max_and_argmax_strided_input(device):
+    x = torch.randn(4, 64640, device=device)[:, ::2]
+    values, indices = max_and_argmax(x, solution=None, override=None)
+    expected = x.max(dim=-1)
+    torch.testing.assert_close(values, expected.values, rtol=0, atol=0)
+    torch.testing.assert_close(indices, expected.indices, rtol=0, atol=0)
+
+
+def test_max_and_argmax_uses_cute_kernel(device, monkeypatch):
+    import tokenspeed_kernel.ops.sampling.cute_dsl as sampling_cute
+
+    if not sampling_cute.is_available():
+        pytest.skip("CuTe sampling kernel is unavailable")
+    calls = []
+    invoke = sampling_cute._invoke_kernel
+
+    def record(logits, values, indices):
+        calls.append(logits.shape)
+        return invoke(logits, values, indices)
+
+    monkeypatch.setattr(sampling_cute, "_invoke_kernel", record)
+    x = torch.randn(16, 32320, device=device)
+    values, indices = max_and_argmax(
+        x, solution=None, override="cute_dsl_max_and_argmax"
+    )
+    assert calls == [x.shape]
+    expected = x.max(dim=-1)
+    torch.testing.assert_close(values, expected.values, rtol=0, atol=0)
+    torch.testing.assert_close(indices, expected.indices, rtol=0, atol=0)
+
+
+def test_max_and_argmax_cuda_graph(device):
+    x = torch.randn(4, 32320, device=device)
+    max_and_argmax(x, solution=None, override=None)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        values, indices = max_and_argmax(x, solution=None, override=None)
+    for _ in range(3):
+        x.normal_()
+        graph.replay()
+        expected = x.max(dim=-1)
+        torch.testing.assert_close(values, expected.values, rtol=0, atol=0)
+        torch.testing.assert_close(indices, expected.indices, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "x", [torch.empty(3), torch.empty(2, 0), torch.ones(2, 4, dtype=torch.int64)]
+)
+def test_max_and_argmax_rejects_invalid_inputs(x):
+    with pytest.raises(ValueError):
+        max_and_argmax(x, solution=None, override=None)
+
 
 # The fused top-k + top-p kernel ships only as a CUDA build; on ROCm the
 # Python entry point resolves to a RuntimeError stub. Gate the tests instead

--- a/tokenspeed-kernel/test/ops/test_zero_byte_ranges.py
+++ b/tokenspeed-kernel/test/ops/test_zero_byte_ranges.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+from tokenspeed_kernel.ops.kvcache import triton as kvcache
+
+
+def test_range_staging_size_limits():
+    stager = kvcache._ZeroRangeTableStager(capacity=4, min_rows=2)
+    for count in (0, 1, 5):
+        assert stager.acquire([(0, 1)] * count, torch.device("cuda", 0)) is None
+    assert not stager.slots
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_range_staging_reserved_slots_and_streams(monkeypatch):
+    stager = kvcache._ZeroRangeTableStager(capacity=4, min_rows=1)
+    device = torch.device("cuda", torch.cuda.current_device())
+    acquired = [stager.acquire([(i, 1)], device) for i in range(4)]
+    assert all(item is not None for item in acquired)
+    assert stager.acquire([(8, 1)], device) is None
+    for table, index, stream in acquired:
+        stager.release(device, index, stream)
+    torch.cuda.synchronize()
+    monkeypatch.setattr(kvcache, "_ZERO_RANGE_TABLE_STAGER", stager)
+    buffers = [
+        torch.full((256,), 7, dtype=torch.uint8, device=device) for _ in range(2)
+    ]
+    streams = [torch.cuda.Stream() for _ in buffers]
+    for stream in streams:
+        stream.wait_stream(torch.cuda.current_stream())
+    for step in range(12):
+        for buffer, stream in zip(buffers, streams):
+            with torch.cuda.stream(stream):
+                kvcache.zero_byte_ranges(buffer, [(step * 8, 4), (128 + step * 8, 4)])
+    torch.cuda.synchronize()
+    expected = torch.full((256,), 7, dtype=torch.uint8)
+    for step in range(12):
+        expected[step * 8 : step * 8 + 4] = 0
+        expected[128 + step * 8 : 132 + step * 8] = 0
+    assert all(torch.equal(buffer.cpu(), expected) for buffer in buffers)
+    assert len(stager.slots[device]) == 4
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_range_staging_capture_bypasses_storage():
+    stager = kvcache._ZeroRangeTableStager(capacity=4, min_rows=1)
+    device = torch.device("cuda", torch.cuda.current_device())
+    graph = torch.cuda.CUDAGraph()
+    buffer = torch.zeros(1, device=device)
+    with torch.cuda.graph(graph):
+        assert stager.acquire([(0, 1)], device) is None
+        buffer.add_(1)
+    assert not stager.slots
+    graph.replay()
+    assert buffer.item() == 1

--- a/tokenspeed-kernel/test/test_kernel_api_selection.py
+++ b/tokenspeed-kernel/test/test_kernel_api_selection.py
@@ -3244,6 +3244,7 @@ def _dsv4_select_experts_bias() -> object:
         True,
         correction_bias=correction_bias,
         need_scores=False,
+        hash_table_values_validated=False,
     )
 
 
@@ -3257,6 +3258,7 @@ def _dsv4_select_experts_hash() -> object:
         True,
         hash_indices_table=hash_indices_table,
         input_ids=input_ids,
+        hash_table_values_validated=False,
     )
 
 


### PR DESCRIPTION
## Summary

Restore selected V4 DSpark decode fast paths on top of the normalization fixes in #1404:

- Add `--dspark-replicate-markov-embedding` to avoid the Markov embedding all-reduce. It is disabled by default and leaves the other vocabulary heads sharded.
- Reuse the CuTe sampling reduction through `tokenspeed-kernel` to return local maxima and indices without packed-output conversion. Keep the existing mapping for padded vocabulary shards.
- Validate immutable hash-routing table values after each weight load instead of repeatedly checking them during routing. Per-call token-id and structural checks remain.
- Reuse bounded, four-slot cache-zero descriptor buffers, with CUDA events guarding reuse across streams. Small tables, busy slots and graph capture retain the allocation path.

This does not change mHC normalization, speculative acceptance checks or the scheduler. Sampling follows the existing CuTe invalid-row policy, documented and tested in this change.

## Test Plan

- `pre-commit run --all-files`
- `pytest test/runtime/test_deepseek_v4_config.py -q`
- `pytest tokenspeed-kernel/test/ops/test_sampling.py -k max_and_argmax -q`
- `pytest tokenspeed-kernel/test/ops/test_dsv4_router_validation.py tokenspeed-kernel/test/ops/test_zero_byte_ranges.py -q`
- `pytest tokenspeed-kernel/test/ops/test_mhc_big_fuse.py -q`
- `pytest tokenspeed-kernel/test/test_kernel_api_selection.py -k dsv4 -q`

The above checks passed. End-to-end smoke and a candidate-only concurrency sweep completed with source and artifact consistency checks. Performance validation remains in progress; this draft does not claim full performance recovery or a completed model-quality evaluation.
