### PR TITLE
perf(amd): specialize gfx1250 prefill TDM producer warps

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
@@ -60,6 +60,7 @@ class AttentionConfig:
     HAS_SINK: gl.constexpr
     HAS_LSE: gl.constexpr
     WINDOW_LEFT: gl.constexpr
+    TDM_WARP_HINT: gl.constexpr
     q_strides: InputStrides
     k_strides: InputStrides
     v_strides: InputStrides
@@ -88,6 +89,7 @@ class AttentionConfig:
         HAS_SINK,
         HAS_LSE,
         WINDOW_LEFT,
+        TDM_WARP_HINT,
         q_strides,
         k_strides,
         v_strides,
@@ -133,6 +135,7 @@ class AttentionConfig:
         self.HAS_SINK = gl.constexpr(HAS_SINK)
         self.HAS_LSE = gl.constexpr(HAS_LSE)
         self.WINDOW_LEFT = gl.constexpr(WINDOW_LEFT)
+        self.TDM_WARP_HINT = gl.constexpr(TDM_WARP_HINT)
         self.q_strides = q_strides
         self.k_strides = k_strides
         self.v_strides = v_strides
@@ -318,14 +321,22 @@ class AttentionProgram:
 
     @gluon.jit
     def tdm_load_global_to_shared_k(self, kv_start, buffer_index):
+        warp_used_hint: gl.constexpr = 0x0F if self.cfg.TDM_WARP_HINT else None
         cdna5.tdm.async_load(
-            self.k_desc, [kv_start, 0], self.k_buffer.index(buffer_index)
+            self.k_desc,
+            [kv_start, 0],
+            self.k_buffer.index(buffer_index),
+            warp_used_hint=warp_used_hint,
         )
 
     @gluon.jit
     def tdm_load_global_to_shared_v(self, kv_start, buffer_index):
+        warp_used_hint: gl.constexpr = 0x0F if self.cfg.TDM_WARP_HINT else None
         cdna5.tdm.async_load(
-            self.v_desc, [kv_start, 0], self.v_buffer.index(buffer_index)
+            self.v_desc,
+            [kv_start, 0],
+            self.v_buffer.index(buffer_index),
+            warp_used_hint=warp_used_hint,
         )
 
     @gluon.jit
@@ -646,6 +657,7 @@ def _mha_prefill_gfx1250(
     HAS_SINK: gl.constexpr,
     HAS_LSE: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
+    TDM_WARP_HINT: gl.constexpr,
     NUM_WARPS: gl.constexpr,
     NUM_BUFFERS: gl.constexpr,
 ):
@@ -662,6 +674,7 @@ def _mha_prefill_gfx1250(
         HAS_SINK,
         HAS_LSE,
         WINDOW_LEFT,
+        TDM_WARP_HINT,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
         InputStrides(V_STRIDE_T, V_STRIDE_H, V_STRIDE_D),
@@ -712,6 +725,29 @@ def _select_llvm_fn_attrs(*, head_dim: int, max_seqlen: int, window_left: int) -
     """
     use_max_ilp = head_dim == 128 and max_seqlen >= 512 and window_left < 0
     return "amdgpu-sched-strategy=max-ilp" if use_max_ilp else ""
+
+
+def _select_tdm_warp_hint(
+    *,
+    block_m: int,
+    block_n: int,
+    num_warps: int,
+    window_left: int,
+    workgroups: int,
+) -> bool:
+    """Use four TDM producer warps for the fully occupied eight-warp tile.
+
+    Without the hint all eight warps participate in each descriptor load.
+    Sliding-window and underfilled launches do not amortize this specialization
+    and retain the original all-warp behavior.
+    """
+    return (
+        block_m == 256
+        and block_n == 64
+        and num_warps == 8
+        and window_left < 0
+        and workgroups >= _GFX1250_NUM_CUS
+    )
 
 
 def _select_m_tile(
@@ -833,6 +869,13 @@ def gluon_mha_prefill_gfx1250(
     )
     sink_arg = sinks if sinks is not None else q
     lse_arg = lse if lse is not None else q
+    tdm_warp_hint = _select_tdm_warp_hint(
+        block_m=config.block_m,
+        block_n=config.block_n,
+        num_warps=config.num_warps,
+        window_left=config.window_left,
+        workgroups=math.prod(config.grid),
+    )
 
     _mha_prefill_gfx1250[config.grid](
         q,
@@ -861,6 +904,7 @@ def gluon_mha_prefill_gfx1250(
         sinks is not None,
         return_lse,
         config.window_left,
+        tdm_warp_hint,
         config.num_warps,
         config.num_buffers,
         num_warps=config.num_warps,

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
@@ -147,6 +147,63 @@ def test_select_llvm_fn_attrs():
     )
 
 
+def test_select_tdm_warp_hint():
+    kwargs = {
+        "block_m": 256,
+        "block_n": 64,
+        "num_warps": 8,
+        "window_left": -1,
+        "workgroups": 256,
+    }
+    assert prefill._select_tdm_warp_hint(**kwargs)
+
+    for override in (
+        {"block_m": 128},
+        {"block_n": 128},
+        {"num_warps": 4},
+        {"window_left": 64},
+        {"workgroups": 255},
+    ):
+        assert not prefill._select_tdm_warp_hint(**(kwargs | override))
+
+
+def test_mha_prefill_tdm_warp_hint_remainder():
+    device, dtype = "cuda", torch.bfloat16
+    n_q_heads, n_kv_heads, head_dim = 8, 2, 128
+    q, k, v, cu, cu_cpu, max_seqlen = _inputs(
+        [300, 513], n_q_heads, n_kv_heads, head_dim, device, dtype
+    )
+
+    original_config = prefill.get_config
+    original_hint = prefill._select_tdm_warp_hint
+
+    def forced_config(**kwargs):
+        cfg = original_config(**kwargs)
+        return cfg._replace(
+            block_m=256,
+            num_warps=8,
+            grid=(
+                cfg.batch_size,
+                cfg.n_heads,
+                (cfg.max_seqlen + 255) // 256,
+            ),
+        )
+
+    prefill.get_config = forced_config
+    try:
+        prefill._select_tdm_warp_hint = lambda **_kwargs: False
+        control = prefill.gluon_mha_prefill_gfx1250(q, k, v, cu, cu_cpu, max_seqlen)
+        prefill._select_tdm_warp_hint = lambda **_kwargs: True
+        out = prefill.gluon_mha_prefill_gfx1250(q, k, v, cu, cu_cpu, max_seqlen)
+    finally:
+        prefill.get_config = original_config
+        prefill._select_tdm_warp_hint = original_hint
+
+    assert torch.equal(out, control)
+    expected = _reference(q, k, v, cu_cpu, n_q_heads, n_kv_heads, head_dim)
+    torch.testing.assert_close(out.float(), expected, rtol=8e-2, atol=8e-2)
+
+
 def test_select_m_tile_gates():
     """Both gates on the wide tile are load-bearing.
 


### PR DESCRIPTION
## Summary

- specialize the gfx1250 MHA prefill 256x64/8-warp path so four warps participate in each existing K/V TDM descriptor load
- preserve separate K/V counter events, issue order, and wait distances
- enable only for full attention with at least 256 workgroups; narrow, underfilled, and sliding-window paths remain unchanged
- add selector-boundary and forced eight-warp ragged-remainder tests

## Performance

All reported values are correctness-gated, exclusive `gpu-measure` runs at a verified 2400 MHz.

Five-run order-balanced acceptance case (4x4096, Hq=8, Hkv=1, D=128 BF16, 512 workgroups):

| path | mean TFLOP/s |
|---|---:|
| all eight warps participate | 1,283.4 |
| four TDM producer warps | 1,359.6 |

**+5.94%**

Additional CLEAN paired checks:

| case | control | optimized | change |
|---|---:|---:|---:|
| 4x4096, H32/Hkv8 | 1,565 | 1,617 | +3.3% |
| minimum 256-workgroup grid | 712 | 734 | +3.1% |
| ragged 851/914/1053 | 605 | 623 | +3.0% |
| FP16 D128 | 1,264 | 1,337 | +5.8% |
| sinks + LSE | 1,302 | 1,362 | +4.6% |
| BF16 D64 | 845 | 880 | +4.1% |
| FP8 E4M3 | 1,937 | 2,009 | +3.7% |
| FP8 E5M2 | 1,929 | 2,025 | +5.0% |

Sliding-window cases regressed and are intentionally excluded by the selector.

## Validation

- targeted gfx1250 suite: narrow/wide, D64/D128, full/sliding, selector boundaries, and forced ragged 300/513 remainder path all pass
- forced eight-warp hinted and unhinted outputs are bit-identical
- same-input BF16, FP8 E4M3, and FP8 E5M2 checks are bit-identical (`max_diff=0`)
- repository pre-commit checks pass for both changed files
