### PR TITLE
fix(grammar): add GLM45 reasoning structural-tag mapping

### DIFF
--- a/python/tokenspeed/runtime/grammar/reasoning_structural_tag.py
+++ b/python/tokenspeed/runtime/grammar/reasoning_structural_tag.py
@@ -61,6 +61,7 @@ _REASONING_PARSER_TO_XGRAMMAR_MODEL: dict[str, str] = {
     "minimax": "minimax",
     "qwen3": "qwen_3",
     "qwen3_thinking": "qwen_3",
+    "glm45": "glm_4_7",
 }
 
 


### PR DESCRIPTION
## Summary

Fix structured-output generation with the `glm45` reasoning parser.

`glm45` was missing from the reasoning structural-tag model mapping, so `structural_tag_for_reasoning_response()` returned no boundary information and `json_schema` constraints were applied from token 0.

For GLM-4.5+/5.x templates that begin generation in a reasoning channel, this constrained the model before it could emit the reasoning terminator. The JSON answer was then consumed as `reasoning_content`, leaving an empty response body
for `parse_json_schema_response`.

As a result, structured tool calls such as `tool_choice="required"` or named tool choices could be lost even though the model generated the expected payload.

## Fix

Map the glm45 reasoning parser to xgrammar's glm_4_7 builtin:

```bash
"glm45": "glm_4_7",
```

GLM45 and GLM47 use the same [reasoning_tag, response] channel layout expected by the xgrammar builtin.

With this mapping, structured-output constraints remain inactive during the reasoning channel and are enabled only after generation transitions into the response channel.