### PR TITLE
fix(amd): select gfx1250 TDM index width from the index domain

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/_common.py
@@ -337,6 +337,7 @@ class MoEConfig:
 
     acc_layout: gl.constexpr
 
+    # TDM descriptor row-index width, not the width of pointer arithmetic.
     index_type: gl.constexpr
 
     @gluon.constexpr_function
@@ -538,7 +539,7 @@ def create_descriptor(
             GatherIndx_ptr + offs_m_gather,
             mask=start_m + offs_m_gather < M,
             other=0,
-        ).to(gl.int32)
+        ).to(cfg.index_type)
 
         x_desc = gl.amd.cdna5.tdm.make_tensor_descriptor(
             base=x_ptr,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/decode.py
@@ -106,6 +106,7 @@ def _matmul_decode(
     XCD_SWIZZLE: gl.constexpr,
     SWIZZLE_MX_SCALE: gl.constexpr,
     EVEN_K: gl.constexpr,
+    INDEX_TYPE: gl.constexpr,
     UPCAST_INDICES: gl.constexpr = False,
     NUM_BUFFERS: gl.constexpr = 2,
     SCALE_BLOCK: gl.constexpr = 32,
@@ -135,16 +136,8 @@ def _matmul_decode(
     DTYPE_X: gl.constexpr = get_scaled_dot_format_string(X.dtype.element_ty)
     DTYPE_W: gl.constexpr = get_scaled_dot_format_string(W.dtype.element_ty)
 
-    if GatherIndx is not None:
-        # In triton_kernels, when indices exceed int32 range, they are upcasted to int64. TDM Gather doesn't
-        # support int64 indices. Only int16 or int32 are supported. In that case, we need to fall back to
-        # AsyncCopy. Fortunately in the GPT-OSS example, we don't need to upcast.
-        gl.static_assert(
-            not UPCAST_INDICES,
-            "TDM Gather doesn't support int64 indices. Only int16 or int32 are supported.",
-        )
-
-    index_type: gl.constexpr = gl.int64 if UPCAST_INDICES else gl.int32
+    # Width of pointer arithmetic only; TDM row indices use INDEX_TYPE.
+    address_index_type: gl.constexpr = gl.int64 if UPCAST_INDICES else gl.int32
     USE_GATHER: gl.constexpr = GatherIndx is not None
 
     SCALE_PRESHUFFLE: gl.constexpr = (
@@ -168,7 +161,7 @@ def _matmul_decode(
         WITH_X_MX_SCALE=WITH_X_MX_SCALE,
         WITH_W_MX_SCALE=WITH_W_MX_SCALE,
         SCALE_PRESHUFFLE=SCALE_PRESHUFFLE,
-        index_type=index_type,
+        index_type=INDEX_TYPE,
         NUM_SUBTILES=NUM_SUBTILES,
         EVEN_K=EVEN_K,
         USE_GATHER=USE_GATHER,
@@ -218,9 +211,9 @@ def _matmul_decode(
 
     eM = gl.multiple_of(gl.load(XSliceSizes + expt_id), X_SLICE_SIZES_DIVISIBILITY)
 
-    expt_id, off_m = expt_id.to(cfg.index_type), off_m.to(cfg.index_type)
-    start_m = start_m.to(cfg.index_type)
-    pid_n, pid_k = pid_n.to(cfg.index_type), pid_k.to(cfg.index_type)
+    expt_id, off_m = expt_id.to(address_index_type), off_m.to(address_index_type)
+    start_m = start_m.to(address_index_type)
+    pid_n, pid_k = pid_n.to(address_index_type), pid_k.to(address_index_type)
 
     X_ptr = X
     if not cfg.USE_GATHER:
@@ -367,7 +360,9 @@ def _matmul_decode(
             layout=SCATTER_SHARED_LAYOUT,
         )
 
-        col_offset = (OUT_BLOCK_N * _enforce_wave_uniform_i32(pid_n)).to(cfg.index_type)
+        col_offset = (OUT_BLOCK_N * _enforce_wave_uniform_i32(pid_n)).to(
+            address_index_type
+        )
         y_desc = gl.amd.cdna5.tdm.update_tensor_descriptor(
             y_desc, add_offsets=[0, col_offset], clamp_bounds=True
         )
@@ -384,8 +379,8 @@ def _matmul_decode(
         Y_ptr += start_m * stride_y_m
 
         y_offs = (
-            offs_y_m.to(cfg.index_type)[:, None] * stride_y_m
-            + offs_y_n.to(cfg.index_type)[None, :] * stride_y_n
+            offs_y_m.to(address_index_type)[:, None] * stride_y_m
+            + offs_y_n.to(address_index_type)[None, :] * stride_y_n
         )
         y_mask = mask_m[:, None] & mask_n[None, :]
         gl.amd.cdna5.buffer_store(out, Y_ptr, y_offs, mask=y_mask)

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/moe/mxfp4/fused.py
@@ -807,6 +807,7 @@ def _matmul(
     XCD_SWIZZLE: gl.constexpr,
     SWIZZLE_MX_SCALE: gl.constexpr,
     EVEN_K: gl.constexpr,
+    INDEX_TYPE: gl.constexpr,
     UPCAST_INDICES: gl.constexpr = False,
     NUM_BUFFERS: gl.constexpr = 2,
     SCALE_BLOCK: gl.constexpr = 32,
@@ -820,16 +821,8 @@ def _matmul(
     DTYPE_X: gl.constexpr = get_scaled_dot_format_string(X.dtype.element_ty)
     DTYPE_W: gl.constexpr = get_scaled_dot_format_string(W.dtype.element_ty)
 
-    if GatherIndx is not None:
-        # In triton_kernels, when indices exceed int32 range, they are upcasted to int64. TDM Gather doesn't
-        # support int64 indices. Only int16 or int32 are supported. In that case, we need to fall back to
-        # AsyncCopy. Fortunately in the GPT-OSS example, we don't need to upcast.
-        gl.static_assert(
-            not UPCAST_INDICES,
-            "TDM Gather doesn't support int64 indices. Only int16 or int32 are supported.",
-        )
-
-    index_type: gl.constexpr = gl.int64 if UPCAST_INDICES else gl.int32
+    # Width of pointer arithmetic only; TDM row indices use INDEX_TYPE.
+    address_index_type: gl.constexpr = gl.int64 if UPCAST_INDICES else gl.int32
     USE_GATHER: gl.constexpr = GatherIndx is not None
 
     SCALE_PRESHUFFLE: gl.constexpr = (
@@ -859,7 +852,7 @@ def _matmul(
         WITH_X_MX_SCALE=WITH_X_MX_SCALE,
         WITH_W_MX_SCALE=WITH_W_MX_SCALE,
         SCALE_PRESHUFFLE=SCALE_PRESHUFFLE,
-        index_type=index_type,
+        index_type=INDEX_TYPE,
         NUM_SUBTILES=NUM_SUBTILES,
         EVEN_K=EVEN_K,
         USE_GATHER=USE_GATHER,
@@ -929,9 +922,9 @@ def _matmul(
     else:
         eM = M
 
-    expt_id, off_m = expt_id.to(cfg.index_type), off_m.to(cfg.index_type)
-    start_m, start_z = start_m.to(cfg.index_type), start_z.to(cfg.index_type)
-    pid_n, pid_k = pid_n.to(cfg.index_type), pid_k.to(cfg.index_type)
+    expt_id, off_m = expt_id.to(address_index_type), off_m.to(address_index_type)
+    start_m, start_z = start_m.to(address_index_type), start_z.to(address_index_type)
+    pid_n, pid_k = pid_n.to(address_index_type), pid_k.to(address_index_type)
 
     X_ptr = X + start_z * stride_x_z
     if not cfg.USE_GATHER:
@@ -941,7 +934,7 @@ def _matmul(
     w_offs = pid_n * BLOCK_N * stride_w_n
 
     if cfg.WITH_X_MX_SCALE:
-        XMxScale_ptr = XMxScale + start_z.to(cfg.index_type) * stride_x_mx_z
+        XMxScale_ptr = XMxScale + start_z.to(address_index_type) * stride_x_mx_z
         if not cfg.USE_GATHER:
             XMxScale_ptr += start_m * stride_x_mx_m
     else:
@@ -982,7 +975,7 @@ def _matmul(
         start_m,
     )
 
-    Y_ptr = Y + start_z_out.to(cfg.index_type) * stride_y_z
+    Y_ptr = Y + start_z_out.to(address_index_type) * stride_y_z
 
     if SCHEDULE == "sliceNK":
         pgm = MoESliceNKProgram.initialize(
@@ -1105,7 +1098,9 @@ def _matmul(
             layout=SCATTER_SHARED_LAYOUT,
         )
 
-        col_offset = (OUT_BLOCK_N * _enforce_wave_uniform_i32(pid_n)).to(cfg.index_type)
+        col_offset = (OUT_BLOCK_N * _enforce_wave_uniform_i32(pid_n)).to(
+            address_index_type
+        )
         y_desc = gl.amd.cdna5.tdm.update_tensor_descriptor(
             y_desc, add_offsets=[0, col_offset], clamp_bounds=True
         )
@@ -1122,8 +1117,8 @@ def _matmul(
         Y_ptr += start_m * stride_y_m
 
         y_offs = (
-            offs_y_m.to(cfg.index_type)[:, None] * stride_y_m
-            + offs_y_n.to(cfg.index_type)[None, :] * stride_y_n
+            offs_y_m.to(address_index_type)[:, None] * stride_y_m
+            + offs_y_n.to(address_index_type)[None, :] * stride_y_n
         )
         y_mask = mask_m[:, None] & mask_n[None, :]
         gl.amd.cdna5.buffer_store(out, Y_ptr, y_offs, mask=y_mask)
@@ -1251,6 +1246,50 @@ def _resolve_block_m(
     return max(16, min(triton.next_power_of_2(rows_per_expert), 128))
 
 
+# TDM zero-extends 16-bit indices when packing them (TDMUtility.cpp), so gl.int16
+# names the width only and the field spans the full unsigned range.
+_UINT16_MAX = (1 << 16) - 1
+
+
+def select_tdm_index_width_bits(
+    *,
+    gather_input_rows: int | None,
+    scatter_writeback_rows: int | None,
+) -> int:
+    """Return the narrowest TDM index width, in bits, that fits every index.
+    Both directions share one index field, so the width must hold the largest
+    value either emits.
+
+    The two largest values differ by one. A gather emits row ordinals, so its
+    largest is ``gather_input_rows - 1``. A scatter's masked-off lanes emit
+    ``scatter_writeback_rows`` itself, one row past the last.
+    """
+    if gather_input_rows is None and scatter_writeback_rows is None:
+        return 32
+    if gather_input_rows is not None and gather_input_rows - 1 > _UINT16_MAX:
+        return 32
+    if scatter_writeback_rows is not None and scatter_writeback_rows > _UINT16_MAX:
+        return 32
+    return 16
+
+
+def get_tdm_index_type(
+    a: Tensor,
+    gather_indx: torch.Tensor | None,
+    scatter_indx: torch.Tensor | None,
+) -> gl.dtype:
+    """Pick the TDM gather/scatter index type for this launch."""
+    gather_input_rows = None if gather_indx is None else int(a.shape_max[-2])
+    scatter_writeback_rows = (
+        None if scatter_indx is None else int(scatter_indx.shape[0])
+    )
+    width_bits = select_tdm_index_width_bits(
+        gather_input_rows=gather_input_rows,
+        scatter_writeback_rows=scatter_writeback_rows,
+    )
+    return gl.int16 if width_bits == 16 else gl.int32
+
+
 def matmul(
     a,
     b,
@@ -1359,6 +1398,8 @@ def matmul(
             b = b_torch
         b_dtype = FP4 if b_torch.dtype == torch.uint8 else b_torch.dtype
         b = wrap_torch_tensor(b, dtype=b_dtype)
+
+    index_type = get_tdm_index_type(a, gather_indx, scatter_indx)
 
     a_scale = _as_tensor(precision_config.a_mx_scale)
     b_scale = _as_tensor(precision_config.b_mx_scale)
@@ -1485,6 +1526,7 @@ def matmul(
         SWIZZLE_MX_SCALE=swizzle_mx_scale,
         EVEN_K=(K % opt_flags.block_k == 0),
         UPCAST_INDICES=should_upcast_indices(a, b, out_matmul),
+        INDEX_TYPE=index_type,
         NUM_BUFFERS=num_buffers,
         SCALE_BLOCK=scale_block,
         SCHEDULE=schedule,

--- a/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
+++ b/tokenspeed-kernel/test/ops/moe/test_gfx1250_mxfp4_index_contract.py
@@ -36,7 +36,7 @@ if not is_amd():
     )
 
 from tokenspeed_kernel_amd._triton import gl  # noqa: E402
-from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4 import _common  # noqa: E402
+from tokenspeed_kernel_amd.ops.gfx1250.moe.mxfp4 import _common, fused  # noqa: E402
 
 # Read sources from the tree the import resolved to, not the repo layout.
 MXFP4_ROOT = Path(_common.__file__).parent
@@ -118,3 +118,60 @@ def test_consumers_slice_the_dimension_that_leaves_rows_distributed(
     assert index_ownership(base, slice_dim) == IndexOwnership(
         warps=num_warps, rows_covered=num_indices
     )
+
+
+# ---------------------------------------------------------------------------
+# Index width: how many row indices one TDM instruction carries
+# ---------------------------------------------------------------------------
+
+
+# A gather's largest index is source rows minus one, so 65536 rows still fit.
+@pytest.mark.parametrize(
+    ("gather_input_rows", "expected_bits"),
+    [(1, 16), (65_536, 16), (65_537, 32)],
+)
+def test_gather_narrows_up_to_the_last_representable_source_row(
+    gather_input_rows: int, expected_bits: int
+) -> None:
+    bits = fused.select_tdm_index_width_bits(
+        gather_input_rows=gather_input_rows, scatter_writeback_rows=None
+    )
+    assert bits == expected_bits
+
+
+# Masked-off scatter lanes store the row count itself as an out-of-bounds
+# sentinel, so the count must fit, not the count minus one.
+@pytest.mark.parametrize(
+    ("scatter_writeback_rows", "expected_bits"),
+    [(1, 16), (65_535, 16), (65_536, 32)],
+)
+def test_scatter_reserves_room_for_the_masked_off_sentinel(
+    scatter_writeback_rows: int, expected_bits: int
+) -> None:
+    bits = fused.select_tdm_index_width_bits(
+        gather_input_rows=None, scatter_writeback_rows=scatter_writeback_rows
+    )
+    assert bits == expected_bits
+
+
+@pytest.mark.parametrize(
+    ("gather_input_rows", "scatter_writeback_rows", "expected_bits"),
+    [
+        (65_536, 65_535, 16),
+        (65_537, 65_535, 32),
+        (65_536, 65_536, 32),
+        (65_537, 65_536, 32),
+        # No index is emitted at all, so keep the conservative width.
+        (None, None, 32),
+    ],
+)
+def test_either_direction_alone_can_force_the_wide_index(
+    gather_input_rows: int | None,
+    scatter_writeback_rows: int | None,
+    expected_bits: int,
+) -> None:
+    bits = fused.select_tdm_index_width_bits(
+        gather_input_rows=gather_input_rows,
+        scatter_writeback_rows=scatter_writeback_rows,
+    )
+    assert bits == expected_bits


### PR DESCRIPTION
The gfx1250 TDM gather/scatter index element type alone determines how many row indices one instruction carries: 
 - 16 at 16 bits
 - 8 at 32 bits

The MXFP4 MoE kernels tied that type to `UPCAST_INDICES`, which describes pointer-address width, and `create_descriptor` additionally hard-coded `.to(gl.int32)` on the loaded gather indices. Every launch therefore asked the hardware for the wide index form and moved identical data in twice as many instructions; at BLOCK_M = 16 that is two half-packed instructions where one fully packed instruction would do.

This PR separate the two widths. `address_index_type` keeps the previous rule for pointer arithmetic, and a new `INDEX_TYPE` constexpr carries the descriptor index type.