### PR TITLE
perf(amd): schedule causal prefill workgroups longest-first

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
@@ -61,6 +61,7 @@ class AttentionConfig:
     HAS_LSE: gl.constexpr
     WINDOW_LEFT: gl.constexpr
     TDM_WARP_HINT: gl.constexpr
+    REVERSE_Q_BLOCKS: gl.constexpr
     q_strides: InputStrides
     k_strides: InputStrides
     v_strides: InputStrides
@@ -90,6 +91,7 @@ class AttentionConfig:
         HAS_LSE,
         WINDOW_LEFT,
         TDM_WARP_HINT,
+        REVERSE_Q_BLOCKS,
         q_strides,
         k_strides,
         v_strides,
@@ -136,6 +138,7 @@ class AttentionConfig:
         self.HAS_LSE = gl.constexpr(HAS_LSE)
         self.WINDOW_LEFT = gl.constexpr(WINDOW_LEFT)
         self.TDM_WARP_HINT = gl.constexpr(TDM_WARP_HINT)
+        self.REVERSE_Q_BLOCKS = gl.constexpr(REVERSE_Q_BLOCKS)
         self.q_strides = q_strides
         self.k_strides = k_strides
         self.v_strides = v_strides
@@ -232,6 +235,8 @@ class AttentionProgram:
         batch = gl.program_id(0)
         q_head = gl.program_id(1)
         q_block = gl.program_id(2)
+        if cfg.REVERSE_Q_BLOCKS:
+            q_block = gl.num_programs(axis=2) - 1 - q_block
         kv_head = q_head // (cfg.N_HEADS // cfg.N_KV_HEADS)
         seq_base = gl.load(cu_seqlens_ptr + batch)
         seq_end = gl.load(cu_seqlens_ptr + batch + 1)
@@ -658,6 +663,7 @@ def _mha_prefill_gfx1250(
     HAS_LSE: gl.constexpr,
     WINDOW_LEFT: gl.constexpr,
     TDM_WARP_HINT: gl.constexpr,
+    REVERSE_Q_BLOCKS: gl.constexpr,
     NUM_WARPS: gl.constexpr,
     NUM_BUFFERS: gl.constexpr,
 ):
@@ -675,6 +681,7 @@ def _mha_prefill_gfx1250(
         HAS_LSE,
         WINDOW_LEFT,
         TDM_WARP_HINT,
+        REVERSE_Q_BLOCKS,
         InputStrides(Q_STRIDE_T, Q_STRIDE_H, Q_STRIDE_D),
         InputStrides(K_STRIDE_T, K_STRIDE_H, K_STRIDE_D),
         InputStrides(V_STRIDE_T, V_STRIDE_H, V_STRIDE_D),
@@ -748,6 +755,17 @@ def _select_tdm_warp_hint(
         and window_left < 0
         and workgroups >= _GFX1250_NUM_CUS
     )
+
+
+def _select_reverse_q_blocks(
+    *,
+    block_m: int,
+    max_seqlen: int,
+    window_left: int,
+    workgroups: int,
+) -> bool:
+    """Schedule long causal workgroups first to minimize the dispatch tail."""
+    return window_left < 0 and workgroups >= _GFX1250_NUM_CUS and max_seqlen > block_m
 
 
 def _select_m_tile(
@@ -876,6 +894,12 @@ def gluon_mha_prefill_gfx1250(
         window_left=config.window_left,
         workgroups=math.prod(config.grid),
     )
+    reverse_q_blocks = _select_reverse_q_blocks(
+        block_m=config.block_m,
+        max_seqlen=config.max_seqlen,
+        window_left=config.window_left,
+        workgroups=math.prod(config.grid),
+    )
 
     _mha_prefill_gfx1250[config.grid](
         q,
@@ -905,6 +929,7 @@ def gluon_mha_prefill_gfx1250(
         return_lse,
         config.window_left,
         tdm_warp_hint,
+        reverse_q_blocks,
         config.num_warps,
         config.num_buffers,
         num_warps=config.num_warps,

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/attention/mha/prefill.py
@@ -840,6 +840,15 @@ def triton_cdiv(x: int, y: int) -> int:
     return (x + y - 1) // y
 
 
+def _count_live_workgroups(
+    *, cu_seqlens_cpu: list[int], n_heads: int, block_m: int
+) -> int:
+    return n_heads * sum(
+        triton_cdiv(seq_end - seq_start, block_m)
+        for seq_start, seq_end in zip(cu_seqlens_cpu, cu_seqlens_cpu[1:])
+    )
+
+
 def gluon_mha_prefill_gfx1250(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -898,7 +907,11 @@ def gluon_mha_prefill_gfx1250(
         block_m=config.block_m,
         max_seqlen=config.max_seqlen,
         window_left=config.window_left,
-        workgroups=math.prod(config.grid),
+        workgroups=_count_live_workgroups(
+            cu_seqlens_cpu=cu_seqlens_cpu,
+            n_heads=config.n_heads,
+            block_m=config.block_m,
+        ),
     )
 
     _mha_prefill_gfx1250[config.grid](

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
@@ -184,6 +184,33 @@ def test_select_reverse_q_blocks():
         assert not prefill._select_reverse_q_blocks(**(kwargs | override))
 
 
+def test_mha_prefill_reverse_counts_live_ragged_workgroups():
+    device, dtype = "cuda", torch.bfloat16
+    seqlens = [4096] + [1] * 31
+    n_q_heads, n_kv_heads, head_dim = 1, 1, 64
+    q, k, v, cu, cu_cpu, max_seqlen = _inputs(
+        seqlens, n_q_heads, n_kv_heads, head_dim, device, dtype
+    )
+    assert len(seqlens) * n_q_heads * prefill.triton_cdiv(max_seqlen, 256) == 512
+
+    original_order = prefill._select_reverse_q_blocks
+    observed_workgroups = []
+
+    def capture_workgroups(**kwargs):
+        observed_workgroups.append(kwargs["workgroups"])
+        return False
+
+    prefill._select_reverse_q_blocks = capture_workgroups
+    try:
+        out = prefill.gluon_mha_prefill_gfx1250(q, k, v, cu, cu_cpu, max_seqlen)
+    finally:
+        prefill._select_reverse_q_blocks = original_order
+
+    assert observed_workgroups == [47]
+    assert out.shape == q.shape
+    assert not torch.isnan(out).any()
+
+
 def test_mha_prefill_tdm_warp_hint_remainder():
     device, dtype = "cuda", torch.bfloat16
     n_q_heads, n_kv_heads, head_dim = 8, 2, 128

--- a/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
+++ b/tokenspeed-kernel/test/ops/attention/test_gluon_mha_prefill_gfx1250.py
@@ -167,6 +167,23 @@ def test_select_tdm_warp_hint():
         assert not prefill._select_tdm_warp_hint(**(kwargs | override))
 
 
+def test_select_reverse_q_blocks():
+    kwargs = {
+        "block_m": 256,
+        "max_seqlen": 4096,
+        "window_left": -1,
+        "workgroups": 256,
+    }
+    assert prefill._select_reverse_q_blocks(**kwargs)
+
+    for override in (
+        {"max_seqlen": 256},
+        {"window_left": 64},
+        {"workgroups": 255},
+    ):
+        assert not prefill._select_reverse_q_blocks(**(kwargs | override))
+
+
 def test_mha_prefill_tdm_warp_hint_remainder():
     device, dtype = "cuda", torch.bfloat16
     n_q_heads, n_kv_heads, head_dim = 8, 2, 128
@@ -198,6 +215,43 @@ def test_mha_prefill_tdm_warp_hint_remainder():
     finally:
         prefill.get_config = original_config
         prefill._select_tdm_warp_hint = original_hint
+
+    assert torch.equal(out, control)
+    expected = _reference(q, k, v, cu_cpu, n_q_heads, n_kv_heads, head_dim)
+    torch.testing.assert_close(out.float(), expected, rtol=8e-2, atol=8e-2)
+
+
+def test_mha_prefill_reverse_q_blocks_ragged():
+    device, dtype = "cuda", torch.bfloat16
+    n_q_heads, n_kv_heads, head_dim = 8, 2, 128
+    q, k, v, cu, cu_cpu, max_seqlen = _inputs(
+        [300, 513], n_q_heads, n_kv_heads, head_dim, device, dtype
+    )
+
+    original_config = prefill.get_config
+    original_order = prefill._select_reverse_q_blocks
+
+    def forced_config(**kwargs):
+        cfg = original_config(**kwargs)
+        return cfg._replace(
+            block_m=256,
+            num_warps=8,
+            grid=(
+                cfg.batch_size,
+                cfg.n_heads,
+                (cfg.max_seqlen + 255) // 256,
+            ),
+        )
+
+    prefill.get_config = forced_config
+    try:
+        prefill._select_reverse_q_blocks = lambda **_kwargs: False
+        control = prefill.gluon_mha_prefill_gfx1250(q, k, v, cu, cu_cpu, max_seqlen)
+        prefill._select_reverse_q_blocks = lambda **_kwargs: True
+        out = prefill.gluon_mha_prefill_gfx1250(q, k, v, cu, cu_cpu, max_seqlen)
+    finally:
+        prefill.get_config = original_config
+        prefill._select_reverse_q_blocks = original_order
 
     assert torch.equal(out, control)
     expected = _reference(q, k, v, cu_cpu, n_q_heads, n_kv_heads, head_dim)


### PR DESCRIPTION
## Summary

Schedules sufficiently occupied gfx1250 full-causal MHA prefill workgroups in descending q-block order.

Causal work per q block grows monotonically: on the 256x64 tile, the first block visits 4 KV tiles while the last block of a 4096-token sequence visits 64. Ascending order leaves expensive workgroups in the dispatch tail. Mapping early physical IDs to late logical q blocks lets the hardware schedule long work first and backfill CUs with shorter workgroups.

This changes only workgroup order. Per-workgroup attention math, memory accesses, K/V buffering, and output locations are unchanged.

The policy requires:

- full causal attention;
- at least 256 live workgroups, computed from the packed sequence lengths;
- more than one q tile.

Sliding-window, single-tile, and underfilled launches retain ascending order.

## Performance

gfx1250 at 2400 MHz. Every row passed the causal reference before timing and received a CLEAN exclusive-run verdict.

Five order-balanced trials on BF16, 4x4096, GQA 8/1, D128, 512 workgroups:

| order | mean TFLOP/s |
|---|---:|
| ascending | 1,357.0 |
| descending | 1,670.2 |

Gain: **+23.08%**.

Additional screens:

| case | ascending | descending | change |
|---|---:|---:|---:|
| S8192, 2 workgroups/CU | 1,472 | 1,852 | +25.8% |
| 3 workgroups/CU | 1,471 | 1,628 | +10.7% |
| H32/Hkv8, 8 workgroups/CU | 1,622 | 1,659 | +2.3% |
| 1 workgroup/CU | 1,045 | 1,052 | +0.7% |
| ragged 851/914/1053 | 620 | 675 | +8.9% |
| D64 | 878 | 1,076 | +22.6% |
| FP16 | 1,334 | 1,630 | +22.2% |
| FP8 E4M3 | 2,014 | 2,541 | +26.2% |
| FP8 E5M2 | 2,012 | 2,541 | +26.3% |
| sinks + LSE | 1,357 | 1,667 | +22.8% |

Measured exclusions: window 1024 was neutral, window 64 regressed 2.2%, and a 128-workgroup underfill regressed 3.7%.

Codegen remains spill-free at 467 VGPRs with the same 256 WMMAs, waits, barriers, and memory instructions.

## Test Plan

- `pre-commit run --all-files`
- gfx1250 direct hardware matrix: 15/15 passed
- narrow and wide tiles, D64/D128, full/sliding attention
- bit-identical ascending/descending outputs on ragged remainder tiles
- adversarial ragged occupancy gate: 512 rectangular groups / 47 live groups
- BF16, FP16, FP8 E4M3/E5M2, GQA/MHA, sinks, and LSE performance correctness gates