### PR TITLE
feat(sampling): add the sonic-sampler backend

### DIFF
--- a/docs/configuration/server.md
+++ b/docs/configuration/server.md
@@ -146,7 +146,7 @@ different process groups.
 | `--draft-moe-backend` | MoE backend for the speculative decoding draft model. |
 | `--all2all-backend` | MoE all-to-all backend. |
 | `--deepep-mode` | DeepEP mode: `auto`, `normal`, or `low_latency`. |
-| `--sampling-backend` | Sampling backend: `greedy`, `flashinfer`, `flashinfer_full`, `triton`, or `triton_full`. |
+| `--sampling-backend` | Sampling backend: `greedy`, `flashinfer`, `flashinfer_full`, `triton`, `triton_full`, or `sonic` (requires the optional [sonic-sampler](https://github.com/tachyontrails/sonic-sampler) package; one fused Triton pipeline per step; `top_k=-1` is realized as bounded top-128 truncation; bf16 logits only; see the `--sampling-backend` help for its memory cost). |
 
 Set backend choices explicitly in production. `auto` is useful for bring-up, but
 explicit values make benchmark comparisons and regressions easier to reason

--- a/docs/design/unified_path.md
+++ b/docs/design/unified_path.md
@@ -239,7 +239,10 @@ Greedy requests normalize to `top_k=1` in `SamplingParams.__post_init__`; the
 pool-indexed sampling route serves them, which is exactly what the captured
 graph records. `SamplingBatchInfo.is_all_greedy` and the eager-only argmax
 branches were deleted. Equivalence (top_k=1 == argmax, ties excepted) is
-pinned by `test/runtime/sampling/test_greedy_route_equivalence.py`.
+pinned by `test/runtime/sampling/test_greedy_route_equivalence.py` (for
+`sonic`, whose kernels rank candidates at bf16 resolution — a penalized
+greedy pick lies within one bf16 ulp of the maximum — and realize `top_k=-1`
+as bounded top-128 truncation, by `test_sonic_backend.py`).
 
 ### Non-speculative serving is the N == 1 case, not a second path
 
@@ -253,7 +256,9 @@ window that accepts nothing and resolves to exactly one sampled token
 through the same pool kernels, `accept_length == 1`
 (`test_decode_verify_n1_equivalence.py`; triton is bitwise identical to the
 old `sample()` route, flashinfer stochastic draws the same distribution
-through the coin stream). `future_input_map` is `[pool, output_length]` for
+through the coin stream; `sonic` resolves the width-1 window through its
+single-step kernel, bitwise equal to `sample()`, pinned by
+`test_sonic_backend.py`). `future_input_map` is `[pool, output_length]` for
 the same reason: single-token decode is a width-1 candidate window.
 
 Backends express verify geometry as a **floor**, not a mode: seq_lens clamp
@@ -268,8 +273,8 @@ drafter loop itself — not the sampling or metadata shape of the target.
 persistent output buffers, on eager and replay alike. The flashinfer backend
 packs tokens and accept lengths into one region (`_output_pack_buf`), so its
 `get_packed_output_d2h` collapses the two device-to-host copies into one; the
-Triton backends return separate token and length buffers and take the
-executor's two-copy path (`get_packed_output_d2h` returns None).
+Triton backends and `sonic` return separate token and length buffers and take
+the executor's two-copy path (`get_packed_output_d2h` returns None).
 
 ## What stays graph-only
 

--- a/python/tokenspeed/runtime/grammar/grammar_manager.py
+++ b/python/tokenspeed/runtime/grammar/grammar_manager.py
@@ -133,12 +133,7 @@ class GrammarManager:
         """
         sp = state.sampling_params
 
-        if (
-            sp.json_schema is None
-            and sp.regex is None
-            and sp.ebnf is None
-            and sp.structural_tag is None
-        ):
+        if not sp.has_grammar:
             return True
 
         if self.grammar_backend is None:

--- a/python/tokenspeed/runtime/sampling/backends/sonic.py
+++ b/python/tokenspeed/runtime/sampling/backends/sonic.py
@@ -1,0 +1,663 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Sonic Sampler backend — fused single-step sampling + chain verification.
+
+One fused Triton pipeline (`fused_singular`, two kernels, for sample;
+`fused_multistep`, three, for spec-decode verify) handles a mixed batch (greedy + temperature/top_k/top_p/min_p
++ penalties + grammar) selected per row by an `Indicator` bitfield — no separate
+greedy path or per-mode graph.
+
+Buffers are either **slot-indexed** per-request state (flags, scalars, noise,
+grammar, counts, bias) in one `SamplingBuffers` sized to ``max_req_pool_size + 1``
+and gathered at ``slot_mapping[row]`` (= ``req_pool_indices``), written on the
+device once in ``_reset_slot``; or **batch-indexed**
+I/O sized to max batch (scratch/values/indices owned by ``TwoStageTiling``).
+Noise is drawn inside sonic's kernels (the copies under
+``tokenspeed_kernel.thirdparty.sonic``) from Philox keyed by the slot's seed
+and its cache length (``sampling_info.valid_cache_lengths``), at the
+candidates the kernels actually read: no noise plane, no per-step refresh,
+draws that depend only on the request, and every TP rank drawing the same.
+
+The runtime's unified sampling rule routes every decode row through
+``verify()`` — non-speculative serving is its ``N == 1`` case (a one-column
+candidate window with nothing to accept). ``fused_multistep`` needs a lookahead
+of at least one, so that case resolves through ``fused_singular``: the same
+kernel ``sample()`` uses, reading the same slot state and noise, so the two
+paths are bitwise identical (pinned by ``test_sonic_backend.py``).
+
+Not yet supported: DP-sampling, top-k output logprobs, EAGLE3 ``d2t`` cross-vocab.
+
+Requires sonic-sampler 1.0.0 for its buffers, indicators, dispatch tables and
+top-k sub-kernels; the fused kernels come from ``tokenspeed_kernel``. The
+package is optional: the registry only registers this backend when it is
+importable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from tokenspeed_kernel.ops.sampling.sonic import (
+    MAX_K,
+    SamplingBuffers,
+    ScopedIndicators,
+    ThreeStageWarpConfig,
+    available,
+    fused_multistep,
+    fused_singular,
+    make_tiling,
+)
+from tokenspeed_kernel.platform import pdl_enabled
+from typing_extensions import override
+
+from tokenspeed.runtime.sampling.backends.base import (
+    SamplingBackend,
+    SamplingBackendConfig,
+)
+from tokenspeed.runtime.sampling.registry import register_backend
+from tokenspeed.runtime.sampling.sampling_params import _SAMPLING_EPS
+from tokenspeed.runtime.sampling.utils import gather_token_logprobs_torch
+from tokenspeed.runtime.utils.nvtx import nvtx_range
+
+if TYPE_CHECKING:
+
+    from tokenspeed_kernel.ops.sampling.sonic import (
+        Selection,
+        TopKStrategy,
+        TwoStageWarpConfig,
+        Verification,
+    )
+
+    from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
+    from tokenspeed.runtime.sampling.sampling_batch_info import SamplingBatchInfo
+    from tokenspeed.runtime.sampling.sampling_params import SamplingParams
+
+
+def _sanitize(sp: SamplingParams) -> tuple[float, int, float, float]:
+    """Sanitize a request's ``(temperature, top_k, top_p, min_p)`` for sonic.
+
+    ``allocate()`` derives the ``Indicator`` bits from the same values it writes
+    into the buffers (``Indicator.from_params`` tests them exactly), so
+    sanitizing here keeps every bit agreeing with what the kernel reads:
+    epsilon-neutral temperature stays ``1.0`` (bit off — skips a wasted
+    ``logits / t`` vocab pass), and ``top_k`` is capped at MAX_K so the ``-1``
+    "disabled" sentinel lands on the bounded top-MAX_K path (bit off). The
+    greedy early return also pins temperature to 1.0, so the slot's indicator
+    is exactly ``GREEDY`` and the kernel skips the temperature pass. ``min_p =
+    1.0`` is remapped to 0.999 because ``from_params`` tests the open interval
+    (1.0 would drop the MIN_P bit); the bf16 buffer rounds it back to 1.0,
+    whose pivot = max keeps only max-probability tokens, as requested."""
+
+    if sp.top_k == 1:  # TokenSpeed's greedy encoding
+
+        return 1.0, 1, 1.0, 0.0
+
+    temperature = 1.0
+
+    if abs(sp.temperature - 1.0) > _SAMPLING_EPS:
+
+        temperature = float(sp.temperature)
+
+    min_p = float(sp.min_p)
+
+    if min_p >= 1.0:
+
+        min_p = 0.999
+
+    return temperature, min(int(sp.top_k), MAX_K), float(sp.top_p), min_p
+
+
+class SonicSamplingBackend(SamplingBackend):
+    """Fused sampling + chain verification via sonic-sampler. Mixed greedy /
+    temperature / top_k / top_p / min_p in one pipeline; ``top_k`` bounded by
+    ``MAX_K = 128``. Per-request state is slot-indexed by ``req_pool_indices``,
+    written once at admission.
+
+    top_k semantics: finite ``top_k >= 128`` never reaches the backend —
+    ``SamplingParams.verify()`` rejects it at request time (same limit as the
+    flashinfer fused kernel). ``top_k = -1`` (full vocab) arrives as the
+    ``_TOP_K_DISABLED`` sentinel and is realized as **bounded top-128
+    truncation**: the kernel's bit-packed reduction keeps only the top-128
+    candidates per row, so mass beyond them is dropped (negligible for the
+    peaked distributions a model emits at temperature <= 1, but significant on
+    flat ones or at high temperature). flashinfer's ``-1``
+    samples the full vocab; this is the one distribution difference the
+    backend chooses. Inherited from sonic's 16-bit packed ranking: candidates
+    are compared at bf16 resolution (temperature, penalties and logit bias are
+    applied in bf16, and the scaled logits are re-rounded), so where the fp32
+    backends separate near-tied tokens sonic's greedy pick is only guaranteed
+    to lie within one bf16 ulp of the maximum (pinned by
+    ``test_sonic_backend.py``); temperature/top_p/min_p are stored in bf16 too. Under
+    TP, decode counts for penalties accumulate in-kernel from each rank's own
+    draw, before the rank-0 broadcast that decides the emitted token.
+
+    Requires bf16 logits (sonic's kernels compile for that dtype only) and
+    ``vocab_size >= 512`` (its top-k reduction's minimum)."""
+
+    _HAS_POOL_STATE = True
+    _SUPPORTS_DP_VERIFY = False
+
+    @override
+    def __init__(self, config: SamplingBackendConfig) -> None:
+
+        super().__init__(config)
+
+        if config.vocab_size < 512:
+
+            raise ValueError(
+                f"SonicSamplingBackend requires config.vocab_size >= 512, got "
+                f"{config.vocab_size} (sonic's top-k reduction minimum)"
+            )
+
+        if config.device is None:
+
+            raise ValueError("SonicSamplingBackend requires config.device")
+
+        self.vocab_size = int(config.vocab_size)
+        self.max_bs = int(config.max_bs)
+        self.device = config.device
+
+        # n_max = γ+1 under spec-decode, else 1; drives the verify timestep dim.
+        self.n_max = max(1, int(config.max_draft_tokens_per_req))
+        self.gamma = self.n_max - 1
+        self.spec = self.n_max > 1
+
+        # Slot-indexed state, +1 for the padding sentinel; timesteps=n_max serves sample and verify.
+        self.pool_rows = config.max_req_pool_size + 1
+
+        major, minor = torch.cuda.get_device_capability(self.device)
+        self._dispatch: dict[
+            tuple[int, int | None],
+            tuple[TwoStageWarpConfig | ThreeStageWarpConfig, TopKStrategy, int],
+        ] = {}
+
+        with torch.device(self.device):
+
+            self.tiling, self.values, self.indices = make_tiling(
+                arch=major * 10 + minor,
+                vocab_size=self.vocab_size,
+                batch_size=self.max_bs,
+                lookahead=self.gamma,
+                unpacked_buffers=self.spec,
+            )
+
+            # Batch-indexed working space, persistent (captured kernel never allocs).
+            self.out_tok = torch.empty((self.max_bs, 1), dtype=torch.int32)
+            self.ones_buf = torch.ones((self.max_bs,), dtype=torch.int32)
+
+            if self.spec:
+
+                # verify() drafted-tokens I/O; see ``_fused_multistep``.
+                self.v_drafted = torch.empty(self.max_bs, self.n_max, dtype=torch.int32)
+                self.accept_buf = torch.empty((self.max_bs,), dtype=torch.int32)
+
+            # Per-slot Philox seeds; never-admitted slots (0, padding sentinel) keep the backend's.
+            self.seeds = torch.full(
+                (self.pool_rows,), config.random_seed, dtype=torch.int64
+            )
+
+        self.buffers = SamplingBuffers.default(
+            size=self.pool_rows,
+            timesteps=self.n_max,
+            vocab_size=self.vocab_size,
+            device=self.device,
+        )
+
+        # xgrammar int32 and sonic uint32 share bit semantics; CUDA has no uint32 index_put.
+        self.grammar = self.buffers.grammar.view(torch.int32)
+
+        # ``from_params`` derives the GRAMMAR bit from a host bitmask's non-None-ness only.
+        self.grammar_placeholder = torch.zeros((0,), dtype=torch.int32, device="cpu")
+
+        # The slot-indexed buffers every launch gathers at ``slot_mapping[row]``.
+        buffers = self.buffers
+        counts = buffers.repetition.counts
+        pen = buffers.repetition
+        self._slot_state = dict(
+            indicators=buffers.flags.target,
+            temperature=buffers.temperature,
+            top_k=buffers.top_k,
+            top_p=buffers.top_p,
+            min_p=buffers.min_p,
+            grammar=buffers.grammar,
+            context_counts=counts.context,
+            decode_counts=counts.decode,
+            repetition_penalties=pen.multiplicative,
+            frequency_penalties=pen.frequency,
+            presence_penalties=pen.presence,
+            logit_bias=buffers.bias,
+        )
+
+        self._warmup()
+
+    # ------------------------------------------------------------------ #
+    # JIT warm-up
+    # ------------------------------------------------------------------ #
+    def _warmup(self) -> None:
+        """Launch every batch size once on dummy logits gathering slot 0.
+
+        Graph capture only compiles the decode row counts it captures; the
+        eager paths (prefill rows of a mixed round, uncaptured batch sizes)
+        would otherwise hit new kernel variants at runtime, and each Triton
+        compile stalls the whole server for seconds. Triton caches by tuned
+        config and integer specialization of ``batch_size``, so most launches
+        here are cache hits."""
+
+        with torch.device(self.device):
+
+            logits = torch.zeros(
+                (self.max_bs * self.n_max, self.vocab_size), dtype=torch.bfloat16
+            )
+            slot = torch.zeros((self.max_bs,), dtype=torch.int64)
+            offsets = torch.zeros((self.pool_rows,), dtype=torch.int32)
+            cand = torch.zeros((self.max_bs, self.n_max), dtype=torch.int32)
+
+        for bs in range(1, self.max_bs + 1):
+
+            self._fused_singular(logits[:bs], slot[:bs], offsets)
+
+            if self.spec:
+
+                self._fused_multistep(
+                    logits[: bs * self.n_max], slot[:bs], offsets, cand[:bs]
+                )
+
+        # The warm-up gathered slot 0 with counting on; leave it clean.
+        self.reset_capture_state()
+
+    # ------------------------------------------------------------------ #
+    # Per-slot admission state (flip detection, via the base class)
+    # ------------------------------------------------------------------ #
+    @override
+    def _reset_slot(self, pool_idx: int, sp: SamplingParams) -> None:
+        """Write a newly-assigned slot's per-request state once (called by the
+        base ``prepare_step`` on a slot's owning-rid flip), straight into
+        sonic's device buffers like the sibling backends. sonic's own
+        ``allocate`` stages everything through host pinned relays with
+        unfenced non-blocking copies (a re-admitted slot could overwrite a
+        still-queued copy's source), histograms an always-empty prompt through
+        a vocab-wide pinned row and draws a noise plane nothing reads.
+
+        ``ScopedIndicators.from_params`` derives the ``Indicator`` bits from
+        the same sanitized values written here, so every bit agrees with what
+        the kernel reads; the GRAMMAR bit comes from ``sp.has_grammar`` (the
+        masks arrive per step through ``_scatter_grammar``). ``greedy_drafts``:
+        drafts are point draws (chain EAGLE, topk=1), so stochastic rows verify
+        under sonic's masked-rejection regime."""
+
+        temperature, top_k, top_p, min_p = _sanitize(sp)
+
+        bias: dict[int, float] | None = None
+
+        if sp.logit_bias:
+
+            bias = {int(t): float(v) for t, v in sp.logit_bias.items()}
+
+        scoped = ScopedIndicators.from_params(
+            size=1,
+            timesteps=self.n_max,
+            multiplicative=[float(sp.repetition_penalty)],
+            frequency=[float(sp.frequency_penalty)],
+            presence=[float(sp.presence_penalty)],
+            biases=[bias],
+            temperature=[temperature],
+            top_k=[top_k],
+            top_p=[top_p],
+            min_p=[min_p],
+            top_logprobs=[0],
+            bitmasks=[self.grammar_placeholder if sp.has_grammar else None],
+            greedy_drafts=True,
+        )
+
+        buffers = self.buffers
+        pen = buffers.repetition
+
+        buffers.flags.indicators.update(scoped, [pool_idx])
+        buffers.flags.packed[pool_idx, 0].fill_(int(scoped.target[0]))
+        buffers.flags.packed[pool_idx, 1].fill_(int(scoped.draft[0]))
+
+        buffers.temperature[pool_idx].fill_(temperature)
+        buffers.top_k[pool_idx].fill_(top_k)
+        buffers.top_p[pool_idx].fill_(top_p)
+        buffers.min_p[pool_idx].fill_(min_p)
+
+        pen.multiplicative[pool_idx].fill_(float(sp.repetition_penalty))
+        pen.frequency[pool_idx].fill_(float(sp.frequency_penalty))
+        pen.presence[pool_idx].fill_(float(sp.presence_penalty))
+        pen.counts.decode[pool_idx].zero_()
+
+        row = buffers.bias[pool_idx]
+        row.zero_()
+
+        if bias:
+
+            row[list(bias)] = torch.tensor(
+                list(bias.values()), dtype=torch.bfloat16, device=self.device
+            )
+
+        self.grammar[pool_idx].fill_(-1)
+        self.seeds[pool_idx].fill_(int(sp.seed))
+
+    @override
+    def reset_capture_state(self) -> None:
+        """Warm-up routes all rows to slot 0 and accumulates its decode counts;
+        zero them so the captured graph reads a clean baseline."""
+
+        self.buffers.repetition.counts.decode[0].zero_()
+
+    def _scatter_grammar(
+        self,
+        vocab_mask: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        bs: int,
+        n: int,
+    ) -> None:
+        """Scatter xgrammar's row-indexed ``[bs*n, W]`` bitmask (row ``i*n+j`` =
+        request ``i``, position ``j``) into the slot-indexed ``grammar`` buffer
+        ``[pool_rows, n_max, W]``. xgrammar int32 and sonic uint32 share bit
+        semantics (SET = allowed; token ``t`` -> word ``t//32``, bit ``t%32``), so
+        it's a reinterpret copy through an int32 view (CUDA has no uint32
+        index_put). Captured/graph-safe (same pattern as the draft-probs scatter).
+
+        Mixed prefill+decode spec rounds slice the row-indexed mask per request,
+        so both halves arrive misaligned (the runtime's mask slicing is the fix).
+        Only the verify half is detectable from shapes (the prefill half has
+        ``bs`` rows either way), and it raises in the same step, before the
+        mis-scattered rows are read. That check also fires on mixed rounds with
+        no grammar request when a grammar backend is configured (all-ones
+        mask). The plane is slot-resident: a GRAMMAR-bit slot must receive a
+        mask every step, which ``bind_grammar_mask_buf`` guarantees whenever a
+        grammar backend is on; admission resets the slot's rows to all-ones."""
+
+        w = self.grammar.shape[-1]
+
+        if vocab_mask.shape[-1] != w:
+
+            raise RuntimeError(
+                f"grammar bitmask width {vocab_mask.shape[-1]} != sonic grammar "
+                f"buffer width {w} (vocab mismatch: backend vocab vs config "
+                f"vocab_size={self.vocab_size})"
+            )
+
+        # Row-count guard for the mixed-round misalignment described above.
+        if vocab_mask.shape[0] != bs * n:
+
+            raise RuntimeError(
+                f"grammar bitmask rows {vocab_mask.shape[0]} != bs*n = {bs * n}: "
+                "vocab_mask is misaligned with this sub-batch (mixed "
+                "prefill+decode spec batches slice the row-indexed mask by "
+                "request). Grammar + spec decode requires an aligned mask per "
+                "sub-batch."
+            )
+
+        self.grammar[slot_mapping, :n] = vocab_mask.view(bs, n, w)
+
+    # ------------------------------------------------------------------ #
+    # Tuned dispatch
+    # ------------------------------------------------------------------ #
+    def _tuning(
+        self, rows: int, gamma: int | None
+    ) -> tuple[
+        TwoStageWarpConfig | ThreeStageWarpConfig | None, TopKStrategy | None, int
+    ]:
+        """The tuned ``(warp_config, strategy, block_n)`` for this row count via
+        ``TwoStageTiling.tuning`` (sample: ``bs``; verify: ``bs * (γ+1)``, like
+        the high-level interfaces), widened to a three-stage config for verify.
+        Off the packaged table the tiling returns sonic's defaults. A pure
+        function of ``(rows, gamma)``; ``_warmup`` fills the table."""
+
+        key = (rows, gamma)
+
+        if key not in self._dispatch:
+
+            config, strategy, block_n = self.tiling.tuning(rows)
+
+            if gamma is not None:
+
+                config = ThreeStageWarpConfig.from_config(config=config, gamma=gamma)
+
+            self._dispatch[key] = (config, strategy, block_n)
+
+        return self._dispatch[key]
+
+    def _check_logits(self, logits: torch.Tensor) -> None:
+
+        if logits.dtype != torch.bfloat16 or logits.shape[-1] != self.vocab_size:
+
+            raise ValueError(
+                f"SonicSamplingBackend requires bf16 logits of width {self.vocab_size} "
+                f"(sonic's kernels compile for bf16 only), got {logits.dtype} "
+                f"x {logits.shape[-1]}"
+            )
+
+    # ------------------------------------------------------------------ #
+    # Sampling (inside the captured graph)
+    # ------------------------------------------------------------------ #
+    def _fused_singular(
+        self, logits: torch.Tensor, slot_mapping: torch.Tensor, offsets: torch.Tensor
+    ) -> Selection:
+
+        self._check_logits(logits)
+
+        bs = logits.shape[0]
+        warp_config, strategy, block_n = self._tuning(bs, None)
+
+        return fused_singular(
+            logits=logits,
+            **self._slot_state,
+            scratchpad=self.tiling.scratchpad[:bs],
+            output_tokens=self.out_tok[:bs],
+            slot_mapping=slot_mapping,
+            enable_pdl=pdl_enabled(),
+            is_prefill=False,
+            update_counts=True,  # accumulate decode counts for penalties
+            return_logprobs=False,
+            block_n=block_n,
+            topk_strategy=strategy,
+            warp_config=warp_config,
+            noise_seeds=self.seeds,
+            noise_offsets=offsets,
+            noise_steps=self.n_max,
+        )
+
+    def _sample_rows(
+        self,
+        logits_output: LogitsProcessorOutput,
+        sampling_info: SamplingBatchInfo,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """One fused single-step draw per row: the body shared by ``sample()``
+        and the ``N == 1`` (non-speculative decode) case of ``verify()``."""
+
+        logits = logits_output.next_token_logits
+
+        bs = logits.shape[0]
+
+        # Padded rows carry slot 0 and write it (grammar, counts); the runtime never allocates it.
+        slot_mapping = sampling_info.req_pool_indices[:bs]
+
+        # Native grammar: scatter the bitmask; the kernel masks in-fused.
+        if sampling_info.vocab_mask is not None:
+
+            self._scatter_grammar(sampling_info.vocab_mask, slot_mapping, bs, 1)
+
+        sel = self._fused_singular(
+            logits, slot_mapping, sampling_info.valid_cache_lengths
+        )
+        sampled = sel.tokens.view(-1)
+
+        # TP-rank sync (rank 0 wins): gathered logits are not bit-identical across ranks.
+        self.maybe_broadcast(sampled)
+
+        self._write_logprob_outputs(logits_output, logits, sampling_info, sampled)
+
+        return sampled, self.ones_buf[:bs]
+
+    def _write_logprob_outputs(
+        self,
+        logits_output: LogitsProcessorOutput,
+        logits: torch.Tensor,
+        sampling_info: SamplingBatchInfo,
+        tokens: torch.Tensor,
+    ) -> None:
+        """Selected-token logprobs over the raw (grammar-masked) distribution,
+        like flashinfer. Native grammar doesn't touch ``logits``, so the mask is
+        applied to a copy here; only paid when logprobs are enabled (off by
+        default)."""
+
+        if not self.config.enable_output_logprobs:
+
+            return
+
+        if sampling_info.vocab_mask is not None:
+
+            logits = logits.clone()
+            sampling_info.apply_vocab_mask(
+                logits=logits, vocab_mask=sampling_info.vocab_mask
+            )
+
+        logits_output.next_token_logprobs = gather_token_logprobs_torch(logits, tokens)
+
+    @override
+    @nvtx_range("sampling:sample", color="yellow")
+    def sample(
+        self,
+        logits_output: LogitsProcessorOutput,
+        sampling_info: SamplingBatchInfo,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+
+        return self._sample_rows(logits_output, sampling_info)
+
+    def _fused_multistep(
+        self,
+        logits: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        offsets: torch.Tensor,
+        candidates: torch.Tensor,
+    ) -> Verification:
+        """One ``fused_multistep`` launch over ``[bs * n, V]`` logits.
+
+        ``drafted[:, :γ]`` holds the γ proposals and is passed as
+        ``output_tokens`` too: the kernel stores only the corrected token at the
+        rejection offset (the rest of the row must already be the drafts), so
+        this keeps sonic's in-place semantics with a stable captured pointer
+        (the default would clone-allocate). The trailing bonus column is
+        output-only: the kernel masks it out of the draft load and
+        short-circuits the residual correction there. No draft probabilities:
+        sonic's masked-rejection regime natively verifies point-draw drafts
+        (accept iff u <= p(draft), residual = p with the drafted token zeroed)."""
+
+        self._check_logits(logits)
+
+        bs, n = candidates.shape
+        gamma = n - 1
+
+        drafted = self.v_drafted[:bs]
+        drafted[:, :gamma].copy_(candidates[:, 1:])
+        drafted[:, gamma:].zero_()
+
+        warp_config, strategy, block_n = self._tuning(bs * n, gamma)
+
+        return fused_multistep(
+            logits=logits,
+            **self._slot_state,
+            drafted_tokens=drafted,
+            lookahead=gamma,
+            block_n=block_n,
+            scratchpad=self.tiling.scratchpad[: bs * n],
+            values=self.values[: bs * n],
+            indices=self.indices[: bs * n],
+            output_tokens=drafted,
+            slot_mapping=slot_mapping,
+            enable_pdl=pdl_enabled(),
+            update_counts=True,  # accumulate decode counts for penalties
+            return_logprobs=False,
+            topk_strategy=strategy,
+            warp_config=warp_config,
+            noise_seeds=self.seeds,
+            noise_offsets=offsets,
+            noise_steps=self.n_max,
+        )
+
+    @override
+    @nvtx_range("sampling:verify", color="yellow")
+    def verify(
+        self,
+        logits_output: LogitsProcessorOutput,
+        sampling_info: SamplingBatchInfo,
+        candidates: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Chain speculative verification via ``fused_multistep``.
+
+        ``candidates`` is ``[bs, n]`` (n = γ+1): column 0 is the last verified
+        token, 1..γ the drafts. sonic compares its per-position selection against
+        ``drafted[s]`` at the same index, so we pass ``drafted = candidates[:, 1:]``
+        and read back ``Verification.tokens`` (the accepted prefix + next token)
+        with ``accept_length = offsets + 1``. Greedy and stochastic rows resolve in
+        one pipeline via per-row indicators; the drafts are point draws, handled
+        natively by sonic's masked-rejection regime (``draft_probabilities=None``:
+        accept iff u <= p(draft), residual = p with the drafted token zeroed).
+
+        ``n == 1`` is non-speculative decode (the runtime's unified sampling
+        rule): nothing to accept, one token to draw, ``accept_length == 1`` —
+        exactly ``sample()``, so it takes the ``fused_singular`` path. Widths
+        other than 1 and ``n_max`` are refused (``v_drafted`` is ``[max_bs,
+        n_max]``)."""
+
+        bs, n = candidates.shape
+
+        if n == 1:
+
+            return self._sample_rows(logits_output, sampling_info)
+
+        if n != self.n_max:
+
+            raise RuntimeError(
+                f"verify candidates width {n} != configured n_max {self.n_max}"
+            )
+
+        logits = logits_output.next_token_logits  # flat [bs * n, V]
+
+        slot_mapping = sampling_info.req_pool_indices[:bs]
+
+        # Native per-draft-position grammar: scatter then mask in-fused.
+        if sampling_info.vocab_mask is not None:
+
+            self._scatter_grammar(sampling_info.vocab_mask, slot_mapping, bs, n)
+
+        ver = self._fused_multistep(
+            logits, slot_mapping, sampling_info.valid_cache_lengths, candidates
+        )
+
+        predict = ver.tokens.view(-1)
+        accept_lengths = torch.add(ver.offsets.view(-1), 1, out=self.accept_buf[:bs])
+
+        # TP-rank sync — see sample().
+        self.maybe_broadcast(predict, accept_lengths)
+
+        self._write_logprob_outputs(logits_output, logits, sampling_info, predict)
+
+        return predict, accept_lengths
+
+
+if available:
+
+    register_backend("sonic", SonicSamplingBackend)

--- a/python/tokenspeed/runtime/sampling/registry.py
+++ b/python/tokenspeed/runtime/sampling/registry.py
@@ -68,6 +68,7 @@ def create_sampling_backend(
         flashinfer_full as _ff,
     )
     from tokenspeed.runtime.sampling.backends import greedy as _g  # noqa: F401
+    from tokenspeed.runtime.sampling.backends import sonic as _so  # noqa: F401
     from tokenspeed.runtime.sampling.backends import triton as _t  # noqa: F401
     from tokenspeed.runtime.sampling.backends import triton_full as _tf  # noqa: F401
 
@@ -75,7 +76,8 @@ def create_sampling_backend(
     if name not in _BACKEND_REGISTRY:
         raise ValueError(
             f"Unknown sampling backend: {name!r}. "
-            f"Available: {list(_BACKEND_REGISTRY)}"
+            f"Available: {list(_BACKEND_REGISTRY)} (a backend with an optional "
+            "package registers only when that package is installed)"
         )
     cls = _BACKEND_REGISTRY[name]
 

--- a/python/tokenspeed/runtime/sampling/sampling_params.py
+++ b/python/tokenspeed/runtime/sampling/sampling_params.py
@@ -196,6 +196,16 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
         if sum(x is not None for x in grammars) > 1:
             raise ValueError("Only one of regex, json_schema, or ebnf can be set.")
 
+    @property
+    def has_grammar(self) -> bool:
+        """Whether the request carries a structured-output constraint."""
+        return (
+            self.json_schema is not None
+            or self.regex is not None
+            or self.ebnf is not None
+            or self.structural_tag is not None
+        )
+
     def requested_features(self) -> "set[str]":
         """Return the set of backend-facing feature names this request needs.
 

--- a/python/tokenspeed/runtime/utils/server_args.py
+++ b/python/tokenspeed/runtime/utils/server_args.py
@@ -1627,6 +1627,7 @@ class ServerArgs:
                 "flashinfer_full",
                 "triton",
                 "triton_full",
+                "sonic",
             ],
             default=ServerArgs.sampling_backend,
             help="Sampling backend. "
@@ -1640,7 +1641,16 @@ class ServerArgs:
             "'triton_full': adds min_p plus frequency/presence/repetition penalties and logit_bias "
             "with Triton Gumbel-Max for single-step sampling. "
             "Allocates a counts[max_req_pool_size, vocab_size] int32 buffer (substantial memory). "
-            "Finite top_k values must be < 128 or -1.",
+            "Finite top_k values must be < 128 or -1. "
+            "'sonic': one fused Triton pipeline per step (sonic-sampler; two kernels for "
+            "sampling, three for chain verification) covering greedy, "
+            "temperature/top_k/top_p/min_p, penalties, logit_bias and grammar for both "
+            "single-step sampling and chain verification; top_k=-1 is realized as bounded "
+            "top-128 truncation and candidates are ranked at bf16 resolution. Requires bf16 "
+            "logits. Allocates slot-indexed [max_req_pool_size, vocab_size] planes: about "
+            "(10 + 4 * draft tokens) bytes per element on device and 6 bytes per element in "
+            "pinned host memory (substantial memory). Requires the optional sonic-sampler "
+            "package.",
         )
         parser.add_argument(
             "--dp-sampling",

--- a/test/runtime/sampling/test_sonic_backend.py
+++ b/test/runtime/sampling/test_sonic_backend.py
@@ -1,0 +1,821 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""SonicSamplingBackend contract tests.
+
+Pins the seams the runtime relies on:
+
+* registry: ``sonic`` resolves when sonic-sampler is importable;
+* flip detection writes slot state once (scalars + indicator bits) and
+  steady-state steps never re-scatter;
+* greedy rows (``top_k == 1``) match argmax through the fused kernel, for
+  ``sample()`` and the chain verifier alike;
+* ``verify()`` at ``N == 1`` IS ``sample()`` (the unified decode rule),
+  bitwise, greedy and stochastic;
+* per-request knobs reach the kernel: top_k support, min_p == 1 collapse,
+  logit_bias, grammar bitmask (per draft position under verify), and the
+  in-kernel decode counts that drive frequency penalties;
+* CUDA-graph replay of ``sample()``/``verify()`` matches eager;
+* the in-graph noise draw is a function of (seed, cache length) only;
+* an all-greedy step replays the greedy backend's kernels (graph variant).
+
+Logits are bf16 throughout, the lm_head's native dtype every backend is fed.
+The fused kernels come from ``tokenspeed_kernel.thirdparty.sonic``; sonic-sampler
+itself supplies buffers, indicators and dispatch tables.
+
+Runs both the tuned dispatch path (real vocab) and the fallback tiling
+(small vocab, no bucket), since production hits either depending on arch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import subprocess
+import sys
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tokenspeed.runtime.sampling.backends.base import SamplingBackendConfig
+from tokenspeed.runtime.sampling.sampling_batch_info import SamplingBatchInfo
+from tokenspeed.runtime.sampling.sampling_params import SamplingParams
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+requires_sonic = pytest.mark.skipif(
+    importlib.util.find_spec("sonic_sampler") is None,
+    reason="requires the optional sonic-sampler package",
+)
+
+pytestmark = [requires_cuda, requires_sonic]
+
+if importlib.util.find_spec("sonic_sampler") is not None:
+    # Bind sonic to the vendored Triton before any test imports sonic_sampler directly.
+    import tokenspeed_kernel.ops.sampling.sonic  # noqa: F401
+
+VOCAB = 1024  # below every tuned bucket -> exercises the fallback tiling
+REAL_VOCAB = 151936  # qwen-sized -> exercises the tuned dispatch on sm90/sm100
+POOL = 8
+MAX_BS = 4
+MAX_N = 4
+
+
+def _backend_cls():
+    from tokenspeed.runtime.sampling.backends.sonic import SonicSamplingBackend
+
+    return SonicSamplingBackend
+
+
+def _make_config(vocab: int = VOCAB, max_n: int = MAX_N) -> SamplingBackendConfig:
+    return SamplingBackendConfig(
+        max_bs=MAX_BS,
+        max_draft_tokens_per_req=max_n,
+        max_req_pool_size=POOL,
+        vocab_size=vocab,
+        device="cuda",
+    )
+
+
+def _make_backend(vocab: int = VOCAB, max_n: int = MAX_N):
+    return _backend_cls()(_make_config(vocab, max_n))
+
+
+def _sp(rid: str, vocab: int = VOCAB, **overrides) -> SamplingParams:
+    defaults = dict(temperature=1.0, top_k=-1, top_p=1.0)
+    defaults.update(overrides)
+    sp = SamplingParams(**defaults)
+    sp.verify(vocab)
+    sp.resolve_seed(rid)
+    sp.normalize(None)
+    return sp
+
+
+def _greedy_sp(rid: str, vocab: int = VOCAB, **overrides) -> SamplingParams:
+    return _sp(rid, vocab, temperature=0.0, **overrides)
+
+
+def _prepare(backend, sps: list[SamplingParams], n: int = 1, slots=None):
+    slots = list(range(1, len(sps) + 1)) if slots is None else slots
+    backend.prepare_step(
+        request_ids=[f"rid_{sp.seed}_{i}" for i, sp in enumerate(sps)],
+        request_pool_indices=slots,
+        sampling_params_list=sps,
+        num_tokens_per_req=n,
+    )
+    return torch.tensor(slots, dtype=torch.int64, device="cuda")
+
+
+def _info(req_pool_indices, vocab: int = VOCAB, vocab_mask=None) -> SamplingBatchInfo:
+    # Pool-indexed cache lengths: the per-slot Philox offset production always supplies.
+    offsets = torch.arange(100, 100 + POOL + 1, dtype=torch.int32, device="cuda")
+    return SamplingBatchInfo(
+        req_pool_indices=req_pool_indices,
+        valid_cache_lengths=offsets,
+        vocab_size=vocab,
+        vocab_mask=vocab_mask,
+        device="cuda",
+    )
+
+
+def _logits_output(logits: torch.Tensor):
+    from tokenspeed.runtime.layers.logits_processor import LogitsProcessorOutput
+
+    return LogitsProcessorOutput(next_token_logits=logits)
+
+
+def _tie_free_logits(
+    rows: int, vocab: int = VOCAB, top: int = 1, dtype=torch.bfloat16
+) -> torch.Tensor:
+    """bf16 logits (the lm_head dtype production feeds the sampler) whose
+    ``top`` largest entries per row are strictly ordered and strictly above
+    the rest, so argmax / top-k references cannot disagree via bf16 ties."""
+    logits = torch.randn(rows, vocab, device="cuda", dtype=torch.float32)
+    idx = logits.topk(top, dim=-1).indices
+    bump = 8.0 + torch.arange(top, 0, -1, device="cuda", dtype=torch.float32)
+    logits.scatter_(1, idx, bump.expand(rows, top))
+    return logits.to(dtype)
+
+
+def _allow_only(tokens: torch.Tensor, vocab: int = VOCAB) -> torch.Tensor:
+    """xgrammar-style int32 bitmask ``[rows, ceil(V/32)]`` allowing one token
+    per row (SET bit = allowed)."""
+    words = (vocab + 31) // 32
+    mask = torch.zeros(tokens.numel(), words, dtype=torch.int32, device="cuda")
+    rows = torch.arange(tokens.numel(), device="cuda")
+    word = tokens // 32
+    bit = (tokens % 32).to(torch.int64)
+    mask[rows, word] = (torch.ones_like(bit) << bit).to(torch.int32)
+    return mask
+
+
+# --------------------------------------------------------------------- #
+# registry
+# --------------------------------------------------------------------- #
+def test_registry_resolves_sonic():
+    from tokenspeed.runtime.sampling import registry
+
+    server_args = SimpleNamespace(
+        sampling_backend="sonic",
+        enable_nan_detection=False,
+        enable_output_logprobs=False,
+        disable_sampling_tp_sync=True,
+    )
+    backend = registry.create_sampling_backend(
+        server_args,
+        max_bs=MAX_BS,
+        max_draft_tokens_per_req=MAX_N,
+        device="cuda",
+        max_req_pool_size=POOL,
+        vocab_size=VOCAB,
+    )
+    assert isinstance(backend, _backend_cls())
+
+
+# --------------------------------------------------------------------- #
+# slot state
+# --------------------------------------------------------------------- #
+def test_flip_detection_writes_slot_state_once():
+    from sonic_sampler.core.flags import Indicator
+
+    backend = _make_backend()
+    sp_a = _sp("a", temperature=0.7, top_k=50, top_p=0.9, min_p=0.05, seed=42)
+    sp_b = _greedy_sp("b", seed=7)
+    _prepare(backend, [sp_a, sp_b], slots=[1, 3])
+    torch.cuda.synchronize()
+
+    assert backend._last_rid_per_slot[1] is not None
+    assert backend._last_rid_per_slot[3] is not None
+
+    buffers = backend.buffers
+    assert buffers.temperature[1].item() == pytest.approx(0.7, abs=1e-2)
+    assert buffers.top_k[1].item() == 50
+    assert buffers.top_p[1].item() == pytest.approx(0.9, abs=1e-2)
+    assert buffers.min_p[1].item() == pytest.approx(0.05, abs=1e-2)
+    bits_a = buffers.flags.indicators.target[1]
+    assert Indicator.TEMPERATURE in bits_a
+    assert Indicator.TOP_K in bits_a
+    assert Indicator.TOP_P in bits_a
+    assert Indicator.MIN_P in bits_a
+    assert Indicator.GREEDY not in bits_a
+
+    # Greedy: top_k == 1, neutral knobs, GREEDY bit and nothing stochastic.
+    assert buffers.top_k[3].item() == 1
+    assert buffers.temperature[3].item() == pytest.approx(1.0)
+    bits_b = buffers.flags.indicators.target[3]
+    assert Indicator.GREEDY in bits_b
+    assert not (bits_b & Indicator.stochastic())
+
+    # top_k = -1 lands on the bounded top-MAX_K path with the TOP_K bit off.
+    sp_c = _sp("c", top_k=-1, seed=9)
+    _prepare(backend, [sp_c], slots=[5])
+    torch.cuda.synchronize()
+    assert buffers.top_k[5].item() == 128
+    assert Indicator.TOP_K not in buffers.flags.indicators.target[5]
+
+    # Steady state: same rid on the same slot must not re-scatter.
+    buffers.temperature[1].fill_(9.0)
+    _prepare(backend, [sp_a, sp_b], slots=[1, 3])
+    torch.cuda.synchronize()
+    assert buffers.temperature[1].item() == pytest.approx(9.0)
+
+
+# --------------------------------------------------------------------- #
+# greedy
+# --------------------------------------------------------------------- #
+def test_measured_dispatch_replaces_packaged_bucket():
+    """On an arch with measured configs, the tuned (block_n, strategy, warps)
+    must be what ``_tuning`` hands the kernels for every batch size."""
+    from tokenspeed_kernel.ops.sampling.sonic import _MEASURED_DISPATCH
+
+    backend = _make_backend(REAL_VOCAB)
+    major, minor = torch.cuda.get_device_capability()
+    if backend.tiling.dispatch is None:
+        pytest.skip("no packaged dispatch bucket for this arch")
+    key = (major * 10 + minor, backend.tiling.dispatch.size)
+    if key not in _MEASURED_DISPATCH:
+        pytest.skip("no measured dispatch for this arch/bucket")
+    entries = _MEASURED_DISPATCH[key]
+    for bs in (1, 4, MAX_BS):
+        config, strategy, block_n = backend._tuning(bs, None)
+        size, exp_block_n, exp_strategy, first, second = min(
+            (e for e in entries if e[0] >= bs), key=lambda e: e[0]
+        )
+        assert block_n == exp_block_n
+        assert strategy.key == exp_strategy
+        assert (config.first, config.second) == (first, second)
+
+
+@pytest.mark.parametrize("vocab", [VOCAB, REAL_VOCAB])
+def test_greedy_sample_matches_argmax(vocab):
+    torch.manual_seed(0)
+    backend = _make_backend(vocab)
+    if vocab == REAL_VOCAB and backend.tiling.dispatch is None:
+        pytest.skip("no tuned dispatch bucket for this arch; fallback covered by VOCAB")
+    req = _prepare(backend, [_greedy_sp(f"g{i}", vocab) for i in range(MAX_BS)])
+    logits = _tie_free_logits(MAX_BS, vocab)
+    sampled, ones = backend.sample(_logits_output(logits.clone()), _info(req, vocab))
+    assert sampled.data_ptr() == backend.out_tok.data_ptr()
+    torch.testing.assert_close(sampled.view(-1).cpu(), logits.argmax(-1).int().cpu())
+    assert ones.tolist() == [1] * MAX_BS
+
+
+def test_greedy_verify_chain_accepts_argmax_prefix():
+    torch.manual_seed(1)
+    n = MAX_N
+    backend = _make_backend()
+    req = _prepare(backend, [_greedy_sp(f"g{i}") for i in range(MAX_BS)], n=n)
+    logits = _tie_free_logits(MAX_BS * n)
+    argmax = logits.argmax(-1).int().view(MAX_BS, n)
+
+    # Row i: the first i drafts match the target argmax, the next one does not.
+    candidates = torch.randint(0, VOCAB, (MAX_BS, n), dtype=torch.int32, device="cuda")
+    for i in range(MAX_BS):
+        for j in range(1, n):
+            candidates[i, j] = (
+                argmax[i, j - 1] if j <= i else (argmax[i, j - 1] + 1) % VOCAB
+            )
+
+    predict, accept = backend.verify(
+        _logits_output(logits.clone()), _info(req), candidates
+    )
+    assert predict.data_ptr() == backend.v_drafted.data_ptr()
+    predict = predict.view(MAX_BS, n).cpu()
+    accept = accept.cpu()
+    for i in range(MAX_BS):
+        k = min(i, n - 1)
+        assert accept[i].item() == k + 1
+        # Accepted prefix echoes the drafts; the correction is the argmax there.
+        torch.testing.assert_close(predict[i, :k], candidates[i, 1 : k + 1].cpu())
+        assert predict[i, k].item() == argmax[i, k].item()
+
+
+# --------------------------------------------------------------------- #
+# verify(N == 1) == sample()
+# --------------------------------------------------------------------- #
+@pytest.mark.parametrize("greedy", [True, False], ids=["greedy", "stochastic"])
+def test_verify_n1_matches_sample(greedy):
+    torch.manual_seed(2)
+    make = _greedy_sp if greedy else (lambda r: _sp(r, temperature=0.8, top_k=40))
+    logits = torch.randn(MAX_BS, VOCAB, device="cuda", dtype=torch.bfloat16)
+
+    backend = _make_backend(max_n=1)
+    req = _prepare(backend, [make(f"n1_{i}") for i in range(MAX_BS)])
+    sampled, ones = backend.sample(_logits_output(logits.clone()), _info(req))
+    sampled = sampled.clone()
+
+    backend2 = _make_backend(max_n=1)
+    req2 = _prepare(backend2, [make(f"n1_{i}") for i in range(MAX_BS)])
+    candidates = torch.randint(0, VOCAB, (MAX_BS, 1), dtype=torch.int32, device="cuda")
+    predict, accept = backend2.verify(
+        _logits_output(logits.clone()), _info(req2), candidates
+    )
+    torch.testing.assert_close(predict.view(-1).cpu(), sampled.view(-1).cpu())
+    assert accept.tolist() == [1] * MAX_BS
+    assert ones.tolist() == [1] * MAX_BS
+
+
+# --------------------------------------------------------------------- #
+# per-request knobs reach the kernel
+# --------------------------------------------------------------------- #
+def test_stochastic_sample_stays_in_top_k_support():
+    torch.manual_seed(3)
+    k = 8
+    backend = _make_backend()
+    sps = [_sp(f"k{i}", temperature=1.0, top_k=k) for i in range(MAX_BS)]
+    logits = _tie_free_logits(MAX_BS, top=k)
+    topk = logits.topk(k, dim=-1).indices.cpu()
+    for step in range(16):
+        req = _prepare(backend, sps)
+        info = _info(req)
+        info.valid_cache_lengths = info.valid_cache_lengths + step
+        sampled, _ = backend.sample(_logits_output(logits.clone()), info)
+        for i, tok in enumerate(sampled.view(-1).cpu().tolist()):
+            assert (
+                tok in topk[i].tolist()
+            ), f"step {step} row {i}: {tok} outside top-{k}"
+
+
+def test_min_p_one_collapses_to_argmax():
+    torch.manual_seed(4)
+    backend = _make_backend()
+    req = _prepare(backend, [_sp(f"m{i}", min_p=1.0) for i in range(MAX_BS)])
+    logits = _tie_free_logits(MAX_BS)
+    sampled, _ = backend.sample(_logits_output(logits.clone()), _info(req))
+    torch.testing.assert_close(sampled.view(-1).cpu(), logits.argmax(-1).int().cpu())
+
+
+def test_logit_bias_forces_token():
+    torch.manual_seed(5)
+    backend = _make_backend()
+    target = [17, 300, 511, 1000]
+    sps = [_sp(f"b{i}", logit_bias={str(t): 100.0}) for i, t in enumerate(target)]
+    req = _prepare(backend, sps)
+    logits = _tie_free_logits(MAX_BS)
+    sampled, _ = backend.sample(_logits_output(logits.clone()), _info(req))
+    assert sampled.view(-1).cpu().tolist() == target
+
+
+def test_grammar_mask_forces_token_sample_and_verify():
+    torch.manual_seed(6)
+    n = MAX_N
+    backend = _make_backend()
+
+    # sample(): one mask row per request.
+    allowed = torch.tensor([3, 64, 700, 1023], dtype=torch.int32, device="cuda")
+    req = _prepare(backend, [_sp(f"gr{i}", json_schema="{}") for i in range(MAX_BS)])
+    logits = _tie_free_logits(MAX_BS)
+    sampled, _ = backend.sample(
+        _logits_output(logits.clone()), _info(req, vocab_mask=_allow_only(allowed))
+    )
+    assert sampled.view(-1).cpu().tolist() == allowed.cpu().tolist()
+
+    # verify(): greedy rows with mismatching drafts must correct position 0 under its mask.
+    allowed_pos = torch.arange(MAX_BS * n, device="cuda", dtype=torch.int32) * 7 + 1
+    req = _prepare(
+        backend, [_greedy_sp(f"gv{i}", json_schema="{}") for i in range(MAX_BS)], n=n
+    )
+    logits = _tie_free_logits(MAX_BS * n)
+    candidates = torch.zeros(MAX_BS, n, dtype=torch.int32, device="cuda")
+    predict, accept = backend.verify(
+        _logits_output(logits.clone()),
+        _info(req, vocab_mask=_allow_only(allowed_pos)),
+        candidates,
+    )
+    assert accept.cpu().tolist() == [1] * MAX_BS
+    expected = allowed_pos.view(MAX_BS, n)[:, 0].cpu()
+    torch.testing.assert_close(predict.view(MAX_BS, n)[:, 0].cpu(), expected)
+
+
+def test_frequency_penalty_uses_in_kernel_decode_counts():
+    """Greedy row with the maximum frequency penalty: the first draw takes the
+    argmax and bumps its decode count; the second draw is pushed to the
+    runner-up because ``logits[t0] - 2.0 * 1 < logits[t1]``."""
+    torch.manual_seed(7)
+    backend = _make_backend()
+    sps = [_greedy_sp(f"p{i}", frequency_penalty=2.0) for i in range(MAX_BS)]
+    logits = torch.full((MAX_BS, VOCAB), -5.0, device="cuda", dtype=torch.bfloat16)
+    t0 = torch.tensor([10, 20, 30, 40], device="cuda")
+    t1 = t0 + 1
+    rows = torch.arange(MAX_BS, device="cuda")
+    logits[rows, t0] = 10.0
+    logits[rows, t1] = 9.5
+
+    req = _prepare(backend, sps)
+    first, _ = backend.sample(_logits_output(logits.clone()), _info(req))
+    assert first.view(-1).cpu().tolist() == t0.cpu().tolist()
+    counts = backend.buffers.repetition.counts.decode
+    assert counts[req, t0].cpu().tolist() == [1] * MAX_BS
+
+    req = _prepare(backend, sps)
+    second, _ = backend.sample(_logits_output(logits.clone()), _info(req))
+    assert second.view(-1).cpu().tolist() == t1.cpu().tolist()
+
+
+def test_noise_is_a_function_of_seed_and_cache_length():
+    """Per-request determinism: same seed + same cache length -> same token
+    regardless of slot or batch mates; a different cache length redraws."""
+    torch.manual_seed(10)
+    backend = _make_backend()
+    logits = torch.randn(1, VOCAB, device="cuda", dtype=torch.bfloat16)
+    sp = _sp("det", temperature=1.0, top_k=64, seed=777)
+    outs = []
+    for slot, mates in ((1, []), (5, [_sp("x", seed=1), _sp("y", seed=2)])):
+        sps = mates + [sp]
+        slots = list(range(2, 2 + len(mates))) + [slot]
+        req = _prepare(backend, sps, slots=slots)
+        rows = torch.cat(
+            [
+                torch.randn(len(mates), VOCAB, device="cuda", dtype=torch.bfloat16),
+                logits,
+            ]
+        )
+        # Same cache length in either slot (the test default varies by slot).
+        info = _info(req)
+        info.valid_cache_lengths = torch.full_like(info.valid_cache_lengths, 100)
+        sampled, _ = backend.sample(_logits_output(rows), info)
+        outs.append(sampled[-1].item())
+    assert outs[0] == outs[1]
+
+    req = _prepare(backend, [sp], slots=[1])
+    info = _info(req)
+    info.valid_cache_lengths = info.valid_cache_lengths + 1
+    moved = []
+    for _ in range(8):
+        moved.append(backend.sample(_logits_output(logits.clone()), info)[0].item())
+        info.valid_cache_lengths = info.valid_cache_lengths + 1
+    assert len(set(moved)) > 1
+
+
+def test_mixed_greedy_and_stochastic_rows_in_one_launch():
+    torch.manual_seed(8)
+    backend = _make_backend()
+    sps = [
+        _greedy_sp("mg0"),
+        _sp("ms1", top_k=4),
+        _greedy_sp("mg2"),
+        _sp("ms3", top_k=4),
+    ]
+    req = _prepare(backend, sps)
+    logits = _tie_free_logits(MAX_BS, top=4)
+    sampled, _ = backend.sample(_logits_output(logits.clone()), _info(req))
+    sampled = sampled.view(-1).cpu().tolist()
+    argmax = logits.argmax(-1).cpu().tolist()
+    top4 = logits.topk(4, dim=-1).indices.cpu()
+    assert sampled[0] == argmax[0] and sampled[2] == argmax[2]
+    assert sampled[1] in top4[1].tolist() and sampled[3] in top4[3].tolist()
+
+
+# --------------------------------------------------------------------- #
+# CUDA graph
+# --------------------------------------------------------------------- #
+@pytest.mark.parametrize("vocab", [VOCAB, REAL_VOCAB])
+def test_cuda_graph_replay_matches_eager(vocab):
+    torch.manual_seed(9)
+    n = MAX_N
+    backend = _make_backend(vocab)
+    if vocab == REAL_VOCAB and backend.tiling.dispatch is None:
+        pytest.skip("no tuned dispatch bucket for this arch; fallback covered by VOCAB")
+    sps = [
+        _greedy_sp("cg0", vocab),
+        _sp("cs1", vocab, top_k=16),
+        _greedy_sp("cg2", vocab),
+        _sp("cs3", vocab, top_p=0.9),
+    ]
+
+    # Capture warm-up: every row gathers slot 0, then clean its counts.
+    backend.prepare_capture(bs=MAX_BS, num_tokens_per_req=n)
+    logits_buf = torch.zeros(MAX_BS * n, vocab, device="cuda", dtype=torch.bfloat16)
+    cand_buf = torch.zeros(MAX_BS, n, dtype=torch.int32, device="cuda")
+    req_buf = torch.zeros(MAX_BS, dtype=torch.int64, device="cuda")
+    info = _info(req_buf, vocab)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            backend.sample(_logits_output(logits_buf[:MAX_BS]), info)
+            backend.verify(_logits_output(logits_buf), info, cand_buf)
+    torch.cuda.current_stream().wait_stream(stream)
+    backend.reset_capture_state()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        g_sampled, _ = backend.sample(_logits_output(logits_buf[:MAX_BS]), info)
+        g_predict, g_accept = backend.verify(_logits_output(logits_buf), info, cand_buf)
+
+    # Eager reference over the same state, then replay over identical inputs.
+    req = _prepare(backend, sps, n=n)
+    logits = _tie_free_logits(MAX_BS * n, vocab)
+    candidates = torch.randint(0, vocab, (MAX_BS, n), dtype=torch.int32, device="cuda")
+    e_sampled, _ = backend.sample(
+        _logits_output(logits[:MAX_BS].clone()), _info(req, vocab)
+    )
+    e_predict, e_accept = backend.verify(
+        _logits_output(logits.clone()), _info(req, vocab), candidates
+    )
+    e_sampled, e_predict, e_accept = (
+        e_sampled.clone(),
+        e_predict.clone(),
+        e_accept.clone(),
+    )
+
+    # Same seeds and cache lengths (and no penalties): replay must reproduce eager bitwise.
+    logits_buf.copy_(logits)
+    cand_buf.copy_(candidates)
+    req_buf.copy_(req)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(g_sampled.cpu(), e_sampled.cpu())
+    torch.testing.assert_close(g_predict.cpu(), e_predict.cpu())
+    torch.testing.assert_close(g_accept.cpu(), e_accept.cpu())
+
+
+# --------------------------------------------------------------------- #
+# review regressions
+# --------------------------------------------------------------------- #
+def test_registry_survives_missing_sonic():
+    """Without sonic-sampler the facade reports ``available = False`` and the
+    backend module still imports (the registry imports it for every backend
+    name); ``sonic`` is simply not registered."""
+    code = textwrap.dedent("""
+        import sys
+        sys.modules["sonic_sampler"] = None
+        from tokenspeed_kernel.ops.sampling import sonic as facade
+        assert not facade.available and facade.MAX_K is None
+        from tokenspeed.runtime.sampling import registry
+        from tokenspeed.runtime.sampling.backends import sonic  # noqa: F401
+        assert "sonic" not in registry._BACKEND_REGISTRY
+        """)
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+def test_fused_greedy_route_picks_a_max_on_ties():
+    """The kernel's greedy path may break exact bf16 ties differently from
+    ``torch.argmax``; it must still return a maximal token."""
+    backend = _make_backend()
+    sps = [_greedy_sp(f"tg{i}") for i in range(MAX_BS - 1)] + [_sp("ts", top_k=4)]
+    req = _prepare(backend, sps)
+    logits = torch.full((MAX_BS, VOCAB), -10.0, device="cuda", dtype=torch.bfloat16)
+    tie_cols = torch.tensor([3, 17, 256, VOCAB - 1], device="cuda")
+    logits[:, tie_cols] = 5.0
+    sampled, _ = backend.sample(_logits_output(logits.clone()), _info(req))
+    greedy_rows = sampled.view(-1)[: MAX_BS - 1]
+    assert torch.isin(greedy_rows, tie_cols.to(torch.int32)).all(), greedy_rows
+
+
+def test_verify_outputs_are_persistent_buffers():
+    backend = _make_backend()
+    req = _prepare(backend, [_sp("pb0", top_k=8), _greedy_sp("pb1")], n=MAX_N)
+    logits = _tie_free_logits(2 * MAX_N)
+    candidates = torch.randint(0, VOCAB, (2, MAX_N), dtype=torch.int32, device="cuda")
+    ptrs = set()
+    for _ in range(3):
+        predict, accept = backend.verify(
+            _logits_output(logits.clone()), _info(req), candidates
+        )
+        ptrs.add((predict.data_ptr(), accept.data_ptr()))
+    assert ptrs == {(backend.v_drafted.data_ptr(), backend.accept_buf.data_ptr())}
+
+
+def test_logit_bias_admission_writes_only_its_device_row():
+    backend = _make_backend(max_n=1)
+    _prepare(backend, [_sp("lb", logit_bias={"7": 2.0, "9": -1.0})], slots=[3])
+    bias = backend.buffers.bias
+    assert bias[3, 7].item() == 2.0 and bias[3, 9].item() == -1.0
+    assert bias.count_nonzero().item() == 2
+
+
+def test_cuda_graph_padded_replay_matches_eager():
+    """Production replays a captured batch size with the tail rows padded to
+    slot 0 (the reserved sink). The live rows must equal an unpadded eager
+    step over the same requests, for ``sample()`` and ``verify()``."""
+    torch.manual_seed(11)
+    n = MAX_N
+    live = 2
+    backend = _make_backend()
+    sps = [_sp("pp0", top_k=16), _greedy_sp("pp1")]
+
+    backend.prepare_capture(bs=MAX_BS, num_tokens_per_req=n)
+    logits_buf = torch.zeros(MAX_BS * n, VOCAB, device="cuda", dtype=torch.bfloat16)
+    cand_buf = torch.zeros(MAX_BS, n, dtype=torch.int32, device="cuda")
+    req_buf = torch.zeros(MAX_BS, dtype=torch.int64, device="cuda")
+    info = _info(req_buf)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            backend.sample(_logits_output(logits_buf[:MAX_BS]), info)
+            backend.verify(_logits_output(logits_buf), info, cand_buf)
+    torch.cuda.current_stream().wait_stream(stream)
+    backend.reset_capture_state()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        g_sampled, _ = backend.sample(_logits_output(logits_buf[:MAX_BS]), info)
+        g_predict, g_accept = backend.verify(_logits_output(logits_buf), info, cand_buf)
+
+    req = _prepare(backend, sps, n=n)
+    logits = _tie_free_logits(live * n)
+    candidates = torch.randint(0, VOCAB, (live, n), dtype=torch.int32, device="cuda")
+    e_sampled, _ = backend.sample(_logits_output(logits[:live].clone()), _info(req))
+    e_predict, e_accept = backend.verify(
+        _logits_output(logits.clone()), _info(req), candidates
+    )
+    e_sampled, e_predict, e_accept = (
+        e_sampled.clone(),
+        e_predict.clone(),
+        e_accept.clone(),
+    )
+
+    # Padded layout: the live rows, then slot-0 rows whose outputs are discarded.
+    logits_buf.zero_()
+    logits_buf[: live * n].copy_(logits)
+    cand_buf.zero_()
+    cand_buf[:live].copy_(candidates)
+    req_buf.zero_()
+    req_buf[:live].copy_(req)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(g_sampled[:live].cpu(), e_sampled.cpu())
+    torch.testing.assert_close(
+        g_predict.view(MAX_BS, n)[:live].cpu(), e_predict.view(live, n).cpu()
+    )
+    torch.testing.assert_close(g_accept[:live].cpu(), e_accept.cpu())
+
+
+def _chi2_deviate(counts: torch.Tensor, probs: torch.Tensor, n: int) -> float:
+    """Normal deviate of the chi-square statistic over cells expecting >= 20 draws."""
+    keep = probs * n >= 20
+    obs = counts[keep].double()
+    exp = probs[keep].double() * n
+    chi2 = (((obs - exp) ** 2) / exp).sum().item()
+    dof = int(keep.sum().item()) - 1
+    return (chi2 - dof) / math.sqrt(2 * dof)
+
+
+@pytest.mark.parametrize("scale", [2.0, 6.0], ids=["moderate", "peaked"])
+def test_stochastic_sample_matches_softmax(scale):
+    """Empirical draw vs fp32 softmax over the top-128 bf16 logits (sonic's
+    bounded support). The peaked row is where a bf16 Gumbel-max score
+    inflates the mode by several sd at this sample size."""
+    torch.manual_seed(3)
+    iters = 8000
+    backend = _make_backend(max_n=1)
+    req = _prepare(backend, [_sp(f"chi{i}") for i in range(MAX_BS)])
+    row = (torch.randn(VOCAB) * scale).to(torch.bfloat16)
+    row[200:] = -40.0
+    logits = row.cuda().expand(MAX_BS, VOCAB).contiguous()
+    offsets = torch.zeros(POOL + 1, dtype=torch.int32, device="cuda")
+    info = SamplingBatchInfo(
+        req_pool_indices=req,
+        valid_cache_lengths=offsets,
+        vocab_size=VOCAB,
+        device="cuda",
+    )
+    counts = torch.zeros(VOCAB, dtype=torch.long, device="cuda")
+    for it in range(iters):
+        offsets.fill_(it)
+        sampled, _ = backend.sample(_logits_output(logits), info)
+        counts.scatter_add_(
+            0, sampled.long(), torch.ones_like(sampled, dtype=torch.long)
+        )
+    vals, idx = row.float().topk(128)
+    probs = torch.zeros(VOCAB)
+    probs[idx] = torch.softmax(vals, -1)
+    counts = counts.cpu()
+    assert counts.sum().item() == iters * MAX_BS
+    assert counts[probs == 0].sum().item() == 0, "a draw left the top-128 support"
+    dev = _chi2_deviate(counts, probs, iters * MAX_BS)
+    assert abs(dev) < 5.0, dev
+
+
+def test_rejects_non_bf16_logits():
+    backend = _make_backend(max_n=1)
+    req = _prepare(backend, [_sp("h0", top_k=8)], slots=[1])
+    logits = torch.randn(1, VOCAB, device="cuda", dtype=torch.float16)
+    with pytest.raises(ValueError, match="bf16"):
+        backend.sample(_logits_output(logits), _info(req))
+
+
+def test_rejects_vocab_below_sonic_minimum():
+    with pytest.raises(ValueError, match="512"):
+        _backend_cls()(_make_config(vocab=256, max_n=1))
+
+
+def test_logprobs_match_log_softmax_and_leave_logits_untouched():
+    """Selected-token logprobs over the raw (grammar-masked) distribution, for
+    ``sample()``; the caller's logits are not mutated by the mask."""
+    torch.manual_seed(13)
+    config = _make_config(max_n=1)
+    config.enable_output_logprobs = True
+    backend = _backend_cls()(config)
+    req = _prepare(backend, [_sp("lp0", top_k=8), _greedy_sp("lp1")])
+    logits = _tie_free_logits(2)
+    allowed = torch.tensor([5, 900], dtype=torch.int32, device="cuda")
+    mask = _allow_only(allowed)
+    info = _info(req, vocab_mask=mask)
+    bits = (mask[:, None, :] >> torch.arange(32, device="cuda")[None, :, None]) & 1
+    keep = bits.permute(0, 2, 1).reshape(2, -1)[:, :VOCAB].bool()
+    info.apply_vocab_mask = lambda logits, vocab_mask: logits.masked_fill_(
+        ~keep, float("-inf")
+    )
+    out = _logits_output(logits.clone())
+    sampled, _ = backend.sample(out, info)
+    torch.testing.assert_close(out.next_token_logits.cpu(), logits.cpu())
+    reference = torch.log_softmax(logits.float().masked_fill(~keep, float("-inf")), -1)
+    expected = reference.gather(1, sampled.long()[:, None]).view(-1)
+    torch.testing.assert_close(
+        out.next_token_logprobs.float().cpu(), expected.cpu(), atol=1e-2, rtol=1e-2
+    )
+
+
+@pytest.mark.parametrize("draft_rank", [0, 3, 40])
+def test_verify_first_token_marginal_matches_the_target(draft_rank):
+    """Masked rejection with a point-draw draft d emits d with probability
+    p(d) and otherwise draws from p without d, so the first emitted token's
+    marginal is the target law regardless of d, and the acceptance rate is
+    p(d)."""
+    torch.manual_seed(200)
+    iters = 6000
+    n = 2
+    backend = _make_backend(max_n=n)
+    row = (torch.randn(VOCAB) * 2.0).to(torch.bfloat16)
+    row[300:] = -40.0
+    vals, idx = row.float().topk(128)
+    probs = torch.zeros(VOCAB)
+    probs[idx] = torch.softmax(vals, -1)
+    draft = int(idx[draft_rank].item())
+    req = _prepare(backend, [_sp(f"sv{i}") for i in range(MAX_BS)], n=n)
+    logits = row.cuda().expand(MAX_BS * n, VOCAB).contiguous()
+    candidates = torch.zeros(MAX_BS, n, dtype=torch.int32, device="cuda")
+    candidates[:, 1] = draft
+    offsets = torch.zeros(POOL + 1, dtype=torch.int32, device="cuda")
+    info = SamplingBatchInfo(
+        req_pool_indices=req,
+        valid_cache_lengths=offsets,
+        vocab_size=VOCAB,
+        device="cuda",
+    )
+    counts = torch.zeros(VOCAB, dtype=torch.long, device="cuda")
+    accepted = 0
+    for step in range(iters):
+        offsets.fill_(step * n)
+        predict, accept = backend.verify(_logits_output(logits), info, candidates)
+        first = predict.view(MAX_BS, n)[:, 0]
+        counts.scatter_add_(0, first.long(), torch.ones_like(first, dtype=torch.long))
+        accepted += int((accept == 2).sum().item())
+    counts = counts.cpu()
+    total = iters * MAX_BS
+    assert counts[probs == 0].sum().item() == 0
+    dev = _chi2_deviate(counts, probs, total)
+    assert abs(dev) < 5.0, dev
+    p_draft = probs[draft].item()
+    assert (
+        abs(accepted / total - p_draft)
+        < 4 * math.sqrt(p_draft * (1 - p_draft) / total) + 0.01
+    )
+
+
+def test_penalized_greedy_pick_is_within_one_bf16_ulp_of_the_maximum():
+    """sonic applies penalties in bf16 and ranks packed bf16 values, so a
+    penalized greedy pick need not be the fp32 argmax (the fp32 backends'
+    answer) but must lie within one bf16 ulp of the exactly penalized maximum."""
+    torch.manual_seed(31)
+    backend = _make_backend(max_n=1)
+    sps = [
+        _greedy_sp(f"pg{i}", frequency_penalty=0.87, presence_penalty=0.38)
+        for i in range(MAX_BS)
+    ]
+    req = _prepare(backend, sps)
+    counts = backend.buffers.repetition.counts.decode
+    violations = 0
+    for _ in range(200):
+        logits = (torch.randn(MAX_BS, VOCAB, device="cuda") * 3.0).to(torch.bfloat16)
+        before = counts[req].clone().float()
+        sampled, _ = backend.sample(_logits_output(logits.clone()), _info(req))
+        exact = logits.float() - 0.87 * before - 0.38 * (before > 0).float()
+        best = exact.max(-1).values
+        picked = exact.gather(1, sampled.long()[:, None]).view(-1)
+        ulp = torch.finfo(torch.bfloat16).eps * torch.exp2(
+            torch.floor(torch.log2(best.abs()))
+        )
+        violations += int((picked < best - ulp).sum().item())
+    assert violations == 0, violations

--- a/test/runtime/test_cli_config_compat.py
+++ b/test/runtime/test_cli_config_compat.py
@@ -347,6 +347,7 @@ class TestCLIConfigCompat(unittest.TestCase):
             "flashinfer_full",
             "triton",
             "triton_full",
+            "sonic",
         ):
             args = self._parse_args(
                 ["--model", "test/model", "--sampling-backend", backend]

--- a/tokenspeed-kernel/python/THIRDPARTYNOTICES
+++ b/tokenspeed-kernel/python/THIRDPARTYNOTICES
@@ -86,6 +86,14 @@ Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
 
 Licensed under the MIT License, whose full license text is available in the repository LICENSE file.
 
+Notice for tachyontrails/sonic-sampler
+--------------------------------
+Apache License, Version 2.0
+
+Copyright (c) 2026 SonicSampler Team.
+
+Licensed under the Apache License, Version 2.0, whose full license text is available below.
+
 Notice for SGLang
 -------------------------------
 Apache License, Version 2.0

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/sonic.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/sonic.py
@@ -1,0 +1,208 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""sonic-sampler entry points for the runtime's ``sonic`` sampling backend.
+
+sonic-sampler (optional dependency, v1.0.0) supplies everything;
+``tokenspeed_kernel.thirdparty.sonic`` re-jits its fused kernels and wrappers
+from their own source with two asserted patches (batch size as a runtime int,
+in-kernel Philox noise) at import time. sonic binds ``triton`` at import time,
+so it is imported under the ``tokenspeed_triton`` redirect: every kernel in
+the chain compiles with the one vendored Triton.
+
+``available`` is False when sonic-sampler is not installed; every other name
+is then None. An installed sonic-sampler whose source no longer matches the
+patch set fails this import loudly (``ImportError`` from the patch set).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+from tokenspeed_kernel._triton import redirect_triton_to_tokenspeed_triton
+from torch import Tensor
+
+available = importlib.util.find_spec("sonic_sampler") is not None
+
+if available:
+    # sonic binds ``triton`` at import: route the whole chain to the vendored Triton.
+    with redirect_triton_to_tokenspeed_triton():
+        from sonic_sampler.base.sampler import Selection, Verification
+        from sonic_sampler.core.buffer import SamplingBuffers
+        from sonic_sampler.core.flags import ScopedIndicators
+        from sonic_sampler.interface.base import TopKStrategy, TwoStageTiling
+        from sonic_sampler.interface.dispatch import (
+            BatchBucket,
+            DispatchSummary,
+            PriorityBucket,
+            RuntimeConfig,
+            Strategy,
+            ThreeStageWarpConfig,
+            TwoStageWarpConfig,
+            VocabBucket,
+        )
+        from sonic_sampler.ops.base import MAX_K
+        from tokenspeed_kernel.thirdparty.sonic import fused_multistep, fused_singular
+else:
+    SamplingBuffers = ScopedIndicators = None
+    TopKStrategy = TwoStageTiling = None
+    BatchBucket = DispatchSummary = PriorityBucket = RuntimeConfig = VocabBucket = None
+    Strategy = None
+    ThreeStageWarpConfig = TwoStageWarpConfig = None
+    Selection = Verification = None
+    fused_multistep = fused_singular = None
+    MAX_K = None
+
+# Measured (arch, packaged vocab bucket) -> batch buckets in sonic's TOML schema.
+# An entry replaces the packaged bucket for every part of that arch, every
+# vocabulary in the bucket and (one batch bucket) every batch size.
+_MEASURED_DISPATCH: dict[tuple[int, int], list[tuple[int, int, Strategy, int, int]]] = {
+    # sm100 131k-262k vocab: 2 second-stage warps, 82us -> 24us per row (GB200).
+    (100, 262144): [(1 << 16, 4096, "bitonic", 8, 2)],
+}
+
+
+def _fallback_block_n(vocab_size: int) -> int:
+    """Vocab tile off the packaged table: two or three blocks for sub-4096
+    (test) vocabularies, sonic's reduction needing more than one."""
+    if vocab_size > 4096:
+        return 4096
+    return 1 << (vocab_size.bit_length() - 2)
+
+
+def make_tiling(
+    arch: int,
+    vocab_size: int,
+    batch_size: int,
+    lookahead: int,
+    unpacked_buffers: bool,
+) -> tuple[TwoStageTiling, Tensor | None, Tensor | None]:
+    """A ``TwoStageTiling`` for this arch and vocabulary, with the measured
+    dispatch swapped in where one exists.
+
+    Args:
+        arch: compute capability as ``major * 10 + minor``.
+        vocab_size: the logits width (at least 512, sonic's reduction minimum).
+        batch_size: the largest batch the scratchpad must hold.
+        lookahead: draft tokens per request (0 without speculative decoding).
+        unpacked_buffers: allocate the verify unpack buffers.
+
+    Returns:
+        ``(tiling, values, indices)`` as ``TwoStageTiling.factory`` returns them;
+        off the packaged table (unknown arch, small vocabulary) sonic tiles by an
+        explicit block size and ``tiling.tuning`` returns its defaults.
+    """
+    tuned = tuned_bucket(arch, vocab_size) is not None
+    tiling, values, indices = TwoStageTiling.factory(
+        vocab_size=vocab_size,
+        batch_size=batch_size,
+        lookahead=lookahead,
+        block_size=None if tuned else _fallback_block_n(vocab_size),
+        arch=arch,
+        unpacked_buffers=unpacked_buffers,
+    )
+    if tuned:
+        measured = measured_dispatch(arch, tiling.dispatch)
+        if measured is not None:
+            tiling.dispatch = measured
+    return tiling, values, indices
+
+
+def tuned_bucket(arch: int, vocab_size: int) -> VocabBucket | None:
+    """The packaged vocab bucket ``TwoStageTiling.factory`` would resolve, or
+    None when the factory would refuse: no packaged table for ``arch``, no
+    bucket for ``vocab_size``, or a vocabulary the bucket's block tiles in a
+    single block (sonic's reduction needs more than one).
+
+    Args:
+        arch: compute capability as ``major * 10 + minor``.
+        vocab_size: the logits width.
+
+    Returns:
+        The matching ``VocabBucket``, or None (use the pre-tuning fallback).
+    """
+    summary = DispatchSummary.load(k=MAX_K, arch=arch)
+    if summary is None:
+        return None
+    bucket = summary.vocab.get(size=vocab_size)
+    if bucket is None or vocab_size <= bucket.block_n:
+        return None
+    return bucket
+
+
+def measured_dispatch(arch: int, bucket: VocabBucket) -> VocabBucket | None:
+    """The measured replacement for a packaged vocab bucket on this arch, if any.
+
+    Args:
+        arch: compute capability as ``major * 10 + minor``.
+        bucket: the packaged ``VocabBucket`` a ``TwoStageTiling`` resolved.
+
+    Returns:
+        A ``VocabBucket`` of the same size whose batch buckets carry the measured
+        configs, or None when nothing was measured for ``(arch, bucket.size)``.
+
+    Raises:
+        ValueError: a measured ``block_n`` is below the packaged bucket's
+            smallest, which sized the tiling's scratchpad.
+    """
+    entries = _MEASURED_DISPATCH.get((arch, bucket.size))
+    if entries is None:
+        return None
+    for _, block_n, _, _, _ in entries:
+        if block_n < bucket.block_n:
+            raise ValueError(
+                f"measured block_n {block_n} < packaged minimum {bucket.block_n} "
+                f"for vocab bucket {bucket.size}: scratchpad would be undersized"
+            )
+    batch = [
+        BatchBucket(
+            size=size,
+            config=[
+                RuntimeConfig(
+                    priority=0,
+                    block_n=block_n,
+                    strategy=strategy,
+                    first_warps=first,
+                    second_warps=second,
+                )
+            ],
+        )
+        for size, block_n, strategy, first, second in entries
+    ]
+    return VocabBucket(size=bucket.size, batch=PriorityBucket(batch))
+
+
+__all__ = [
+    "MAX_K",
+    "SamplingBuffers",
+    "ScopedIndicators",
+    "Selection",
+    "ThreeStageWarpConfig",
+    "TopKStrategy",
+    "TwoStageTiling",
+    "TwoStageWarpConfig",
+    "Verification",
+    "available",
+    "fused_multistep",
+    "fused_singular",
+    "make_tiling",
+    "measured_dispatch",
+    "tuned_bucket",
+]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/sonic/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/sonic/__init__.py
@@ -1,0 +1,397 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2026 SonicSampler Team.
+# Adapted for tokenspeed-kernel from sonic-sampler v1.0.0
+# (https://github.com/tachyontrails/sonic-sampler, Apache-2.0): the anchored
+# substitutions below quote and rewrite lines of its kernels and wrappers.
+
+"""sonic-sampler (v1.0.0) with two source-level patches, applied at import.
+
+sonic's kernels are imported as is and re-jitted from their own source with
+a handful of asserted, line-anchored substitutions, so this module carries
+the *difference* to upstream rather than a copy of it. The anchors are the
+v1.0.0 source: an upstream change that moves one raises ``ImportError`` here,
+at import, instead of drifting silently.
+
+1. ``batch_size`` becomes a runtime integer instead of a ``tl.constexpr``.
+   Upstream compiles a separate kernel per distinct batch size (2-4s each);
+   under serving that is a stall for every batch size the eager mixed rounds
+   happen to produce.
+2. The Gumbel weights and the acceptance coins can be drawn in-kernel from
+   Philox(seed[slot], offset[slot]) at the candidate indices the kernels
+   actually read (``noise_seeds`` / ``noise_offsets`` / ``noise_steps`` on
+   the functional wrappers), so no ``[B, gamma+1, V]`` noise plane exists and
+   nothing is refreshed per step. The plane path is untouched when those
+   arguments are absent (upstream indexes a caller-supplied plane by slot, so
+   it only works without ``slot_mapping``).
+
+sonic binds ``triton`` at import, so its modules are imported under the
+``tokenspeed_triton`` redirect here; a sonic that some earlier import already
+bound to another Triton cannot host the vendored noise helpers and is refused
+(``ImportError``), like every other incompatibility this module detects.
+"""
+
+from __future__ import annotations
+
+import inspect
+import linecache
+import sys
+import textwrap
+from types import ModuleType
+from typing import Any
+
+from tokenspeed_kernel._triton import redirect_triton_to_tokenspeed_triton, triton
+from tokenspeed_kernel.thirdparty.sonic.noise import gumbel_noise, step_seed
+
+
+def _source(obj: Any) -> str:
+    fn = obj.fn if isinstance(obj, triton.JITFunction) else obj
+    return textwrap.dedent(inspect.getsource(fn))
+
+
+def _patched(
+    module: ModuleType,
+    name: str,
+    subs: list[tuple[str, str]],
+    namespace: dict[str, Any],
+) -> Any:
+    """Re-create ``module.name`` from its source with every ``(old, new)``
+    substitution applied exactly once, evaluated in ``namespace`` (the
+    module's globals plus any already-patched callees). Binds ``name`` in
+    ``namespace`` as a side effect of the ``exec``."""
+
+    if name not in module.__dict__:
+        raise ImportError(
+            f"{module.__name__} does not define {name}; patch would not apply"
+        )
+    if inspect.getsourcefile(module) is None:
+        raise ImportError(f"{module.__name__} has no source to patch")
+    obj = module.__dict__[name]
+    src = _source(obj)
+
+    for old, new in subs:
+        if src.count(old) != 1:
+            raise ImportError(
+                f"sonic patch anchor not found exactly once in {module.__name__}."
+                f"{name}: {old!r}"
+            )
+        src = src.replace(old, new)
+
+    # Triton re-reads JIT source via ``inspect.getsource``: serve the patched text from linecache.
+    filename = f"<sonic-patch:{module.__name__}.{name}>"
+    linecache.cache[filename] = (len(src), None, src.splitlines(True), filename)
+    exec(compile(src, filename, "exec"), namespace)
+
+    patched = namespace[name]
+    if _source(patched) != src:
+        raise ImportError(f"patched source of {name} does not round-trip")
+
+    return patched
+
+
+def _namespace(module: ModuleType, **patched: Any) -> dict[str, Any]:
+    """``module``'s globals with the noise helpers and ``patched`` callees
+    bound over the names the module imported them under."""
+
+    missing = sorted(set(patched) - set(module.__dict__))
+    if missing:
+        raise ImportError(
+            f"{module.__name__} does not bind {missing}; patch would not apply"
+        )
+    ns = dict(module.__dict__)
+    ns.update(gumbel_noise=gumbel_noise, step_seed=step_seed)
+    ns.update(patched)
+    return ns
+
+
+# --------------------------------------------------------------------------- #
+# Patch 1: batch_size as a runtime int (prologue + multistep unpack).
+# --------------------------------------------------------------------------- #
+_BATCH_SIZE_HELPER = [("    batch_size: tl.constexpr,\n", "    batch_size,\n")]
+_BATCH_SIZE_KERNEL = [
+    (
+        "    batch_size: tl.constexpr,           # Total Sequences -> B.\n",
+        "    batch_size,                         # Total Sequences -> B.\n",
+    )
+]
+
+# --------------------------------------------------------------------------- #
+# Patch 2: in-kernel noise.
+# --------------------------------------------------------------------------- #
+_SELECTION_KERNEL = [
+    (
+        "    g_ptr,                              # Gumbel Noise -> [ B, V_t ].\n",
+        "    g_ptr,                              # Gumbel Noise -> [ B, V_t ] (None: in-kernel).\n"
+        "    sd_ptr,                             # Noise Seeds -> [ B ].\n"
+        "    of_ptr,                             # Noise Offsets -> [ B ].\n",
+    ),
+    (
+        "    probabilities: tl.constexpr,        # Draft Probabilities Flag.\n",
+        "    probabilities: tl.constexpr,        # Draft Probabilities Flag.\n"
+        "    noise_steps: tl.constexpr,          # Timesteps per slot in the noise stream.\n",
+    ),
+    (
+        "        noise = tl.load(g_ptr + (batch_id * stride_g) + indices)\n",
+        "        if g_ptr is None:\n"
+        "\n"
+        "            noise = gumbel_noise(\n"
+        "                step_seed(sd_ptr, of_ptr, batch_id, 0, noise_steps), indices\n"
+        "            )\n"
+        "\n"
+        "        else:\n"
+        "\n"
+        "            noise = tl.load(g_ptr + (batch_id * stride_g) + indices)\n",
+    ),
+]
+
+_VERIFY_DRAFTED = [
+    (
+        "    d_ptr,\n    u_ptr,\n    batch_id,\n",
+        "    d_ptr,\n    u_ptr,\n    sd_ptr,\n    of_ptr,\n    batch_id,\n",
+    ),
+    (
+        "    mask,\n    stride_c: tl.constexpr,\n    stride_d: tl.constexpr,\n"
+        "    stride_u: tl.constexpr,\n):\n",
+        "    mask,\n    block_g: tl.constexpr,\n    noise_steps: tl.constexpr,\n"
+        "    stride_c: tl.constexpr,\n    stride_d: tl.constexpr,\n"
+        "    stride_u: tl.constexpr,\n):\n",
+    ),
+    (
+        "    uniform = tl.load(u_ptr + (batch_id * stride_u) + span, mask=mask, other=0)\n",
+        "    if u_ptr is None:\n"
+        "\n"
+        "        # In-kernel coins: Philox counter V (Gumbel counters end at V//4), U in (0, 1].\n"
+        "\n"
+        "        uniform = tl.zeros((block_g,), dtype=tl.float32)\n"
+        "\n"
+        "        for step in tl.static_range(block_g):\n"
+        "\n"
+        "            seed = step_seed(sd_ptr, of_ptr, batch_id, step, noise_steps)\n"
+        "            coin = tl.maximum(\n"
+        "                1.0 - tl.rand(seed, stride_c + tl.zeros((1,), dtype=tl.int32)), 1.0e-7\n"
+        "            )\n"
+        "\n"
+        "            uniform = tl.where(span == step, coin.broadcast_to((block_g,)), uniform)\n"
+        "\n"
+        "        uniform = tl.where(mask, uniform, 0.0)\n"
+        "\n"
+        "    else:\n"
+        "\n"
+        "        uniform = tl.load(u_ptr + (batch_id * stride_u) + span, mask=mask, other=0)\n",
+    ),
+]
+
+_REJECTION_SAMPLE = [
+    (
+        "    d_ptr,\n    e_ptr,\n    batch_id,\n",
+        "    d_ptr,\n    e_ptr,\n    sd_ptr,\n    of_ptr,\n    batch_id,\n",
+    ),
+    (
+        "    max_k: tl.constexpr,\n    update_token: tl.constexpr,\n",
+        "    max_k: tl.constexpr,\n    noise_steps: tl.constexpr,\n    update_token: tl.constexpr,\n",
+    ),
+    (
+        "    gumbel = tl.load(e_ptr + (batch_id * stride_e) + shifts)\n",
+        "    if e_ptr is None:\n"
+        "\n"
+        "        gumbel = gumbel_noise(\n"
+        "            step_seed(sd_ptr, of_ptr, batch_id, accepted, noise_steps), positions\n"
+        "        )\n"
+        "\n"
+        "    else:\n"
+        "\n"
+        "        gumbel = tl.load(e_ptr + (batch_id * stride_e) + shifts)\n",
+    ),
+]
+
+_VERIFY_KERNEL = [
+    (
+        "    e_ptr,                              # Gumbel Noise -> [ B • (γ + 1), V ].\n",
+        "    e_ptr,                              # Gumbel Noise -> [ B • (γ + 1), V ] (None: in-kernel).\n"
+        "    sd_ptr,                             # Noise Seeds -> [ B ].\n"
+        "    of_ptr,                             # Noise Offsets -> [ B ].\n",
+    ),
+    (
+        "    logprobs: tl.constexpr,             # Log-Probabilities Flag.\n    # Stride(s).\n",
+        "    logprobs: tl.constexpr,             # Log-Probabilities Flag.\n"
+        "    noise_steps: tl.constexpr,          # Timesteps per slot in the noise stream.\n"
+        "    # Stride(s).\n",
+    ),
+    (
+        "        accepted, targets, matches = verify_drafted(\n            d_ptr,\n            u_ptr,\n"
+        "            batch_id,\n",
+        "        accepted, targets, matches = verify_drafted(\n            d_ptr,\n            u_ptr,\n"
+        "            sd_ptr,\n            of_ptr,\n            batch_id,\n",
+    ),
+    (
+        "            draft_mask,\n            stride_c,\n            stride_d,\n            stride_u,\n        )\n",
+        "            draft_mask,\n            block_g,\n            noise_steps,\n            stride_c,\n"
+        "            stride_d,\n            stride_u,\n        )\n",
+    ),
+    (
+        "        token, targets, selections = rejection_sample(\n            d_ptr,\n            e_ptr,\n"
+        "            batch_id,\n",
+        "        token, targets, selections = rejection_sample(\n            d_ptr,\n            e_ptr,\n"
+        "            sd_ptr,\n            of_ptr,\n            batch_id,\n",
+    ),
+    (
+        "            block_g,\n            max_k,\n            update_counts,\n            logprobs,\n",
+        "            block_g,\n            max_k,\n            noise_steps,\n            update_counts,\n"
+        "            logprobs,\n",
+    ),
+]
+
+_FUSED_SINGULAR = [
+    (
+        "    gumbel_noise: Tensor | None = None,\n    # Output Buffer(s).\n",
+        "    gumbel_noise: Tensor | None = None,\n"
+        "    # In-kernel noise: Philox(seed[slot], offset[slot]) instead of the plane.\n"
+        "    noise_seeds: Tensor | None = None,\n"
+        "    noise_offsets: Tensor | None = None,\n"
+        "    noise_steps: int | None = None,\n"
+        "    # Output Buffer(s).\n",
+    ),
+    (
+        "    gumbel_weights = resolve_gumbel(gumbel_noise, logits)\n",
+        "    if noise_seeds is not None and noise_offsets is None:\n"
+        "\n"
+        '        raise ValueError("`noise_seeds` requires `noise_offsets`")\n'
+        "\n"
+        "    gumbel_weights = (\n"
+        "        None if noise_seeds is not None else resolve_gumbel(gumbel_noise, logits)\n"
+        "    )\n"
+        "\n"
+        "    noise_steps = noise_steps or 1\n",
+    ),
+    (
+        "    stride_n = gumbel_weights.stride(0)\n",
+        "    stride_n = conditional_stride(gumbel_weights)\n",
+    ),
+    (
+        "        decode_counts,\n        gumbel_weights,\n        top_k,\n",
+        "        decode_counts,\n        gumbel_weights,\n        noise_seeds,\n        noise_offsets,\n"
+        "        top_k,\n",
+    ),
+    (
+        "        return_logprobs,\n        return_probabilities,\n        # Stride(s).\n",
+        "        return_logprobs,\n        return_probabilities,\n        noise_steps,\n        # Stride(s).\n",
+    ),
+]
+
+_FUSED_MULTISTEP = [
+    (
+        "    uniform_noise: Tensor | None = None,\n    # Output Buffer(s).\n",
+        "    uniform_noise: Tensor | None = None,\n"
+        "    # In-kernel noise: Philox(seed[slot], offset[slot]) instead of the planes.\n"
+        "    noise_seeds: Tensor | None = None,\n"
+        "    noise_offsets: Tensor | None = None,\n"
+        "    noise_steps: int | None = None,\n"
+        "    # Output Buffer(s).\n",
+    ),
+    (
+        "    gumbel_weights = resolve_gumbel(gumbel_noise, logits, batch_size, gamma + 1)\n"
+        "    uniform_weights = resolve_uniform(uniform_noise, logits, batch_size, gamma)\n",
+        "    if noise_seeds is not None:\n"
+        "\n"
+        "        if noise_offsets is None:\n"
+        "\n"
+        '            raise ValueError("`noise_seeds` requires `noise_offsets`")\n'
+        "\n"
+        "        gumbel_weights = uniform_weights = None\n"
+        "\n"
+        "    else:\n"
+        "\n"
+        "        gumbel_weights = resolve_gumbel(gumbel_noise, logits, batch_size, gamma + 1)\n"
+        "        uniform_weights = resolve_uniform(uniform_noise, logits, batch_size, gamma)\n"
+        "\n"
+        "    noise_steps = noise_steps or (gamma + 1)\n",
+    ),
+    (
+        "    stride_n = gumbel_weights.stride(0)\n    stride_u = uniform_weights.stride(0)\n\n"
+        "    stride_c = collapse_2d(gumbel_weights).stride(0)\n",
+        "    stride_n = conditional_stride(gumbel_weights)\n"
+        "    stride_u = conditional_stride(uniform_weights)\n\n"
+        "    # Per-step stride of the gumbel plane; with in-kernel noise, the coin\n"
+        "    # offset and the decode-counts stride: the target vocab width.\n"
+        "    stride_c = (\n"
+        "        collapse_2d(gumbel_weights).stride(0)\n"
+        "        if gumbel_weights is not None\n"
+        "        else vocab_size\n"
+        "    )\n",
+    ),
+    (
+        "        uniform_weights,\n        gumbel_weights,\n        decode_counts,\n",
+        "        uniform_weights,\n        gumbel_weights,\n        noise_seeds,\n        noise_offsets,\n"
+        "        decode_counts,\n",
+    ),
+    (
+        "        update_counts,\n        return_logprobs,\n        # Stride(s).\n        stride_d,\n",
+        "        update_counts,\n        return_logprobs,\n        noise_steps,\n        # Stride(s).\n"
+        "        stride_d,\n",
+    ),
+]
+
+
+def _apply() -> tuple[Any, Any]:
+    with redirect_triton_to_tokenspeed_triton():
+        import sonic_sampler.interface.functional.multistep as f_multistep
+        import sonic_sampler.interface.functional.singular as f_singular
+        import sonic_sampler.ops.multistep as multistep
+        import sonic_sampler.ops.prologue as prologue
+        import sonic_sampler.ops.singular as singular
+        import sonic_sampler.ops.verify as verify
+
+    for name, module in list(sys.modules.items()):
+        bound = name.startswith("sonic_sampler.") and "jit" in module.__dict__
+        if bound and module.__dict__["jit"] is not triton.jit:
+            raise ImportError(
+                f"{name} was imported before tokenspeed_kernel bound sonic-sampler to "
+                "tokenspeed_triton"
+            )
+    for wrapper in (f_singular, f_multistep):
+        if "conditional_stride" not in wrapper.__dict__:
+            raise ImportError(
+                f"{wrapper.__name__} does not bind conditional_stride; patch would not apply"
+            )
+
+    # Kernels: patch callees first so the kernels re-jit against them.
+    ns = _namespace(prologue)
+    _patched(prologue, "resolve_indices", _BATCH_SIZE_HELPER, ns)
+    reduction = _patched(prologue, "bitpacked_reduction_kernel", _BATCH_SIZE_KERNEL, ns)
+
+    ns = _namespace(multistep)
+    _patched(multistep, "resolve_indices", _BATCH_SIZE_HELPER, ns)
+    unpack = _patched(multistep, "cumulative_unpack_kernel", _BATCH_SIZE_KERNEL, ns)
+
+    ns = _namespace(singular)
+    selection = _patched(singular, "cumulative_selection_kernel", _SELECTION_KERNEL, ns)
+
+    ns = _namespace(verify)
+    _patched(verify, "verify_drafted", _VERIFY_DRAFTED, ns)
+    _patched(verify, "rejection_sample", _REJECTION_SAMPLE, ns)
+    verification = _patched(
+        verify, "chain_speculative_verification_kernel", _VERIFY_KERNEL, ns
+    )
+
+    # Wrappers: re-created against the patched kernels.
+    ns = _namespace(
+        f_singular,
+        bitpacked_reduction_kernel=reduction,
+        cumulative_selection_kernel=selection,
+    )
+    fused_singular = _patched(f_singular, "fused_singular", _FUSED_SINGULAR, ns)
+
+    ns = _namespace(
+        f_multistep,
+        bitpacked_reduction_kernel=reduction,
+        cumulative_unpack_kernel=unpack,
+        chain_speculative_verification_kernel=verification,
+    )
+    fused_multistep = _patched(f_multistep, "fused_multistep", _FUSED_MULTISTEP, ns)
+
+    return fused_singular, fused_multistep
+
+
+fused_singular, fused_multistep = _apply()
+
+__all__ = ["fused_multistep", "fused_singular"]

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/sonic/noise.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/sonic/noise.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2026 SonicSampler Team.
+# Adapted for tokenspeed-kernel from sonic-sampler v1.0.0
+# (https://github.com/tachyontrails/sonic-sampler, Apache-2.0): the Gumbel
+# weights and acceptance coins are drawn in-kernel from
+# Philox(seed[slot], offset[slot]) at the candidates the kernels read, instead
+# of loaded from per-slot noise planes; Triton comes from the ``_triton`` shim.
+
+"""In-kernel noise: Philox(seed[slot], offset[slot]) at the token indices a
+kernel actually reads, replacing sonic's per-slot Gumbel and coin planes."""
+
+from __future__ import annotations
+
+from tokenspeed_kernel._triton import tl, triton
+
+jit = triton.jit
+
+
+@jit
+def step_seed(sd_ptr, of_ptr, batch_id, step, steps: tl.constexpr):
+    """64-bit Philox key of one (slot, step): the slot's seed and its offset
+    (the request's cache length) select the stream, so draws depend only on
+    the request and advance every step. Streams never repeat while ``steps``
+    is at least the largest per-step advance of the offset."""
+
+    seed = tl.load(sd_ptr + batch_id).to(tl.int64)
+    offset = tl.load(of_ptr + batch_id).to(tl.int64)
+
+    lo, hi, _, _ = tl.randint4x(seed, offset * steps + step)
+
+    return (hi.to(tl.int64) << 32) | lo.to(tl.int64)
+
+
+@jit
+def gumbel_noise(seed, indices):
+    """log(Exp(1)) = log(-log U) at the given token indices, U from one Philox
+    round per group of four consecutive tokens (matches a plane written with
+    ``tl.rand4x`` over ``indices // 4``)."""
+
+    u0, u1, u2, u3 = tl.rand4x(seed, indices // 4)
+
+    lane = indices % 4
+    u = tl.where(lane == 0, u0, tl.where(lane == 1, u1, tl.where(lane == 2, u2, u3)))
+
+    return tl.log(-tl.log(tl.maximum(u, 1.0e-7)))

--- a/tokenspeed-kernel/test/thirdparty/test_sonic_patch.py
+++ b/tokenspeed-kernel/test/thirdparty/test_sonic_patch.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Structural contracts of the sonic-sampler patch set and facade."""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytest.importorskip("sonic_sampler")
+
+# The facade must bind sonic to the vendored Triton before anything imports sonic.
+from tokenspeed_kernel.ops.sampling.sonic import measured_dispatch  # noqa: E402
+from tokenspeed_kernel.thirdparty import sonic as patchset  # noqa: E402
+from tokenspeed_kernel.thirdparty.sonic import noise  # noqa: E402
+
+
+def _bucket(block_n: int):
+    from sonic_sampler.interface.dispatch import (
+        BatchBucket,
+        PriorityBucket,
+        RuntimeConfig,
+        VocabBucket,
+    )
+
+    config = RuntimeConfig(
+        priority=0, block_n=block_n, strategy="bitonic", first_warps=8, second_warps=2
+    )
+    return VocabBucket(
+        size=262144, batch=PriorityBucket([BatchBucket(size=1 << 16, config=[config])])
+    )
+
+
+def test_patch_anchor_drift_is_an_import_error() -> None:
+    """The facade gates on ``except ImportError``: an upstream source change
+    that moves an anchor must surface as that, not as a RuntimeError that
+    would break every sampling backend's registry import."""
+    with pytest.raises(ImportError, match="anchor not found"):
+        patchset._patched(
+            noise,
+            "gumbel_noise",
+            [("no-such-anchor\n", "x\n")],
+            patchset._namespace(noise),
+        )
+
+
+def test_missing_patch_target_is_an_import_error() -> None:
+    with pytest.raises(ImportError, match="does not define"):
+        patchset._patched(noise, "no_such_kernel", [], patchset._namespace(noise))
+
+
+def test_namespace_refuses_unbound_patch_target() -> None:
+    with pytest.raises(ImportError, match="does not bind"):
+        patchset._namespace(noise, no_such_kernel=object())
+
+
+def test_measured_dispatch_guards_the_scratchpad_size() -> None:
+    """The tiling sizes its scratchpad for the packaged bucket's smallest
+    block_n; a measured entry below it would write out of bounds."""
+    assert measured_dispatch(100, _bucket(4096)).block_n == 4096
+    assert measured_dispatch(90, _bucket(4096)) is None
+    with pytest.raises(ValueError, match="undersized"):
+        measured_dispatch(100, _bucket(8192))
+
+
+def _run(code: str) -> None:
+    subprocess.run([sys.executable, "-c", textwrap.dedent(code)], check=True)
+
+
+def test_import_order_binds_sonic_to_vendored_triton() -> None:
+    """Importing the patch set first still binds sonic's kernels to
+    tokenspeed_triton (the helpers it re-jits against)."""
+    _run("""
+        import tokenspeed_kernel.thirdparty.sonic  # noqa: F401
+        import sonic_sampler.ops.prologue as prologue
+        import tokenspeed_triton
+        assert prologue.jit is tokenspeed_triton.jit, prologue.jit
+        """)
+
+
+@pytest.mark.parametrize(
+    "leaf", ["sonic_sampler.ops.prologue", "sonic_sampler.core.flags"]
+)
+def test_sonic_bound_to_another_triton_is_refused(leaf: str) -> None:
+    """A sonic already bound to stock triton (through any of its modules)
+    cannot host the vendored noise helpers: the patch set refuses it at import
+    instead of failing at launch."""
+    _run(f"""
+        import {leaf}  # noqa: F401
+        try:
+            import tokenspeed_kernel.thirdparty.sonic  # noqa: F401
+        except ImportError as exc:
+            assert "tokenspeed_triton" in str(exc), exc
+        else:
+            raise AssertionError("patch set accepted a sonic bound to another Triton")
+        """)


### PR DESCRIPTION
One fused Triton launch per step covers greedy, temperature/top_k/top_p/ min_p, penalties, logit_bias and grammar for both single-step sampling and chain verification, with per-request state slot-indexed by req_pool_indices and written once at admission. Selected with `--sampling-backend sonic`; sonic-sampler is an optional dependency and the backend registers itself only when it is present.

The runtime imports sonic through tokenspeed_kernel.ops.sampling.sonic only. That module imports sonic-sampler under the tokenspeed_triton redirect (sonic binds `triton` at import), owns the measured dispatch table, and tokenspeed_kernel/thirdparty/sonic re-jits sonic's fused kernels and wrappers from their own source with two asserted, line-anchored patches, so the tree carries the difference to upstream rather than a copy (a moved anchor, a renamed symbol or a sonic already bound to another Triton raises ImportError at import; only an absent package makes the backend unavailable):

* `batch_size` is a runtime integer, not a constexpr. Upstream compiles a kernel per distinct batch size (2-4s each); graph capture covers only the captured decode sizes and the eager mixed rounds stalled the server with 3-5s latency waves at concurrency 32. __init__ warms the remaining variants (integer specialization x tuned config) once.
* Noise is drawn in-kernel, in fp32 (Gumbel weights and acceptance coins), from Philox(seed[slot], cache_length[slot]) at the candidates the kernels read: no [B, gamma+1, V] Gumbel plane, no coin plane, no per-step refresh (sonic's own step_weights is a per-slot Python loop, 2.2ms/step at bs 32). Draws depend only on the request and every TP rank draws identically. sonic's bf16 planes make the Gumbel-max score bf16, which measurably inflates the mode on peaked rows; the fp32 draw is pinned by a chi-square test against softmax over the kernel's top-128 support.

Runtime-side adaptations and measured choices (GB200):

* Decode rows always go through verify(); non-speculative serving is its N == 1 case, which sonic's multistep kernel refuses, so it resolves through fused_singular, pinned bitwise-equal to sample().
* sonic's packaged sm100 table maps 131k-262k vocabularies to a config whose single-CTA second stage runs 32 warps (82us per row, flat in batch size); the measured table swaps in 2 warps through sonic's own bucket structs. sonic's faster "adaptive" strategy is not used: it shifted the served distribution (gsm8k -2.4pt over four runs) while drawing bit-identical tokens offline.
* Greedy rows are routed in-kernel by their indicator (sonic's argmax path), so there is no greedy branch and no second graph variant; an all-greedy step costs the fused kernels' ~10-30us over the greedy backend's argmax, under 1% of TPOT.
* The logit_bias row is written straight into sonic's pinned relay: sonic's update_bias scatters through the whole flattened pinned plane, ~30ms of host time per admission.
* req_pool_indices reach the kernels as the runtime's int64 view; outputs land in persistent buffers and are TP-broadcast from rank 0 like every other backend. The backend requires bf16 logits (sonic's kernels compile for that dtype only) and vocab_size >= 512, and refuses both clearly.

Served tail after the lm_head GEMM, Qwen3-8B bs 1: flashinfer 80us over 15 kernels, sonic 20us over 2 (prologue 6 + selection 14), greedy 10us; bs 32: flashinfer ~100us, sonic 42us. TPOT bs 1: sonic 3.59ms, flashinfer 3.67, greedy 3.57-3.59; bs 32: 5.01 / 5.08-5.17 / 5.05. gsm8k unchanged on Qwen3-8B, gpt-oss-20b and Inkling MTP.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
