### PR TITLE
perf(kimi3): add gfx1250 small-M WMMA and row-CTA decode GEMVs

### DIFF
--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/__init__.py
@@ -3,13 +3,17 @@
 from .linear_attnres_partials_gfx1250 import gluon_linear_attnres_partials_gfx1250
 from .mm import (
     gluon_mm_a16w16_largem_gfx1250,
+    gluon_wmma_tdm_dense_gfx1250,
     triton_mm_a16w16_add3_m16_gfx1250,
     use_gluon_largem_gfx1250,
+    use_gluon_wmma_dense_gfx1250,
 )
 
 __all__ = [
     "gluon_linear_attnres_partials_gfx1250",
     "gluon_mm_a16w16_largem_gfx1250",
+    "gluon_wmma_tdm_dense_gfx1250",
     "triton_mm_a16w16_add3_m16_gfx1250",
     "use_gluon_largem_gfx1250",
+    "use_gluon_wmma_dense_gfx1250",
 ]

--- a/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
+++ b/tokenspeed-kernel-amd/python/tokenspeed_kernel_amd/ops/gfx1250/gemm/fp16/mm.py
@@ -63,10 +63,10 @@ def _wmma_tdm_dense_m16_kernel(
     BLOCK_N: gl.constexpr,
     BLOCK_K: gl.constexpr,
     NUM_BUFFERS: gl.constexpr,
+    K: gl.constexpr,
 ):
-    """Fixed-M/K CDNA5 dense projection candidate."""
+    """Fixed-M CDNA5 dense projection candidate."""
     M: gl.constexpr = 16
-    K: gl.constexpr = 7168
     pid_n = gl.program_id(0)
 
     gl.static_assert(
@@ -75,6 +75,7 @@ def _wmma_tdm_dense_m16_kernel(
     )
     gl.static_assert(0 < ACTUAL_M and ACTUAL_M <= M)
     gl.static_assert(BLOCK_K == 128, "candidate is tuned for 128-wide K tiles")
+    gl.static_assert(K % BLOCK_K == 0, "K must tile exactly into BLOCK_K")
     gl.static_assert(NUM_BUFFERS == 3, "candidate uses a triple-buffer TDM pipeline")
 
     warp_bases: gl.constexpr = [] if BLOCK_N == 16 else [[0, 1], [0, 2]]
@@ -195,10 +196,67 @@ def _launch_wmma_tdm_dense_tiles(
             BLOCK_N=block_n,
             BLOCK_K=block_k,
             NUM_BUFFERS=num_buffers,
+            K=A.shape[1],
             num_warps=num_warps,
             num_stages=1,
             waves_per_eu=1,
         )
+
+
+def use_gluon_wmma_dense_gfx1250(m: int, k: int, n: int) -> bool:
+    """Return whether CDNA5 dense16 WMMA accepts this K3 projection shape.
+
+    M is tiled in 16-row chunks and each chunk re-reads all of B, so the
+    advantage shrinks with every chunk added and rocBLAS wins past the
+    ceiling. Preferring this over the M == 1 row-CTA GEMV is the registry's
+    choice, not this predicate's.
+    """
+
+    return 1 <= m <= 32 and k % 128 == 0 and n % 16 == 0
+
+
+def gluon_wmma_tdm_dense_gfx1250(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    *,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run the CDNA5 dense projection candidate on any accepted shape."""
+    if A.ndim != 2 or B.ndim != 2:
+        raise ValueError("A and B must be 2D")
+    m, k = A.shape
+    n = B.shape[0]
+    if B.shape[1] != k:
+        raise ValueError(f"B must be [N, {k}], got {tuple(B.shape)}")
+    for name, tensor in (("A", A), ("B", B)):
+        if (
+            tensor.dtype != torch.bfloat16
+            or not tensor.is_cuda
+            or not tensor.is_contiguous()
+            or tensor.device != A.device
+        ):
+            raise ValueError(f"{name} must be contiguous GPU BF16 colocated with A")
+    if not use_gluon_wmma_dense_gfx1250(m, k, n):
+        raise ValueError(
+            f"dense16 WMMA needs 1 <= M <= 32, K % 128 == 0 and N % 16 == 0, "
+            f"got M={m}, K={k}, N={n}"
+        )
+
+    if out is None:
+        out = A.new_empty((m, n))
+    elif (
+        tuple(out.shape) != (m, n)
+        or out.dtype != torch.bfloat16
+        or not out.is_cuda
+        or not out.is_contiguous()
+        or out.device != A.device
+    ):
+        raise ValueError(f"out must be contiguous GPU BF16 ({m}, {n}) colocated with A")
+
+    # BLOCK_N selects the WMMA warp bases, so the warp count follows from it.
+    block_n, num_warps = (64, 4) if n % 64 == 0 else (16, 1)
+    _launch_wmma_tdm_dense_tiles(A, B, out, block_n=block_n, num_warps=num_warps)
+    return out
 
 
 def gluon_wmma_tdm_mla_qkv_gate_gfx1250(
@@ -831,7 +889,9 @@ def gluon_mm_a16w16_largem_gfx1250(
 
 __all__ = [
     "use_gluon_largem_gfx1250",
+    "use_gluon_wmma_dense_gfx1250",
     "gluon_mm_a16w16_largem_gfx1250",
+    "gluon_wmma_tdm_dense_gfx1250",
     "gluon_wmma_tdm_kda_qkvfab_gfx1250",
     "gluon_wmma_tdm_mla_qkv_gate_gfx1250",
     "gluon_wmma_tdm_add3_m16_gfx1250",

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/routed_gemv.py
@@ -42,7 +42,7 @@ import threading
 from types import MappingProxyType
 
 import torch
-from tokenspeed_kernel.ops.gemm.triton_gemv import _torch_decode_gemv
+from tokenspeed_kernel.ops.gemm.triton_gemv import _select, _torch_decode_gemv
 from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement, pdl_enabled
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
@@ -904,7 +904,16 @@ ADD3_ROUTE: MappingProxyType[tuple[int, int, int], tuple[int, int, int]] = (
 
 
 def decode_gemv_routed(x: torch.Tensor, weight: torch.Tensor) -> bool:
-    """Whether :data:`MEASURED_ROUTE` covers this call on this platform.
+    """Whether a measured decode kernel covers this call on this platform.
+
+    NVIDIA answers from :data:`MEASURED_ROUTE`. CDNA5 has no such table, so it
+    asks the registry, which holds the row-CTA and dense16 WMMA kernels and
+    honors each spec's own capability gate -- the sm100+ backends above are
+    filtered out there, so this cannot select a kernel ROCm does not have.
+    Which of the two a call lands on is decided by their declared traits.
+
+    CDNA4 is excluded: it has its own tuned M == 1 Triton GEMVs, which a
+    sweep has to rank against these before this may widen.
 
     Args:
         x: ``[M, K]`` activation.
@@ -923,10 +932,19 @@ def decode_gemv_routed(x: torch.Tensor, weight: torch.Tensor) -> bool:
         or x.ndim != 2
     ):
         return False
+
     m, k = x.shape
-    return (m, weight.shape[0], k) in MEASURED_ROUTE and _is_routed_arch(
-        x.device.index or 0
-    )
+    n = weight.shape[0]
+    if (m, n, k) in MEASURED_ROUTE and _is_routed_arch(x.device.index or 0):
+        return True
+
+    from tokenspeed_kernel.platform import current_platform
+
+    # Row-CTA's measured K floor; WMMA's stricter K % 128 == 0 is a trait on
+    # its own spec.
+    if not current_platform().is_cdna5 or k < 256:
+        return False
+    return _select(m, n, k, True) is not _torch_decode_gemv
 
 
 @functools.lru_cache(maxsize=8)

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/triton_gemv.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/gemm/triton_gemv.py
@@ -35,6 +35,7 @@ import functools
 
 import torch
 from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
 from tokenspeed_kernel.registry import Priority, register_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
@@ -140,6 +141,44 @@ def rowcta_gemv(
         num_warps=4,
     )
     return out
+
+
+@register_kernel(
+    "gemm",
+    "decode_gemv",
+    name="gluon_wmma_dense_gfx1250",
+    solution="gluon",
+    capability=CapabilityRequirement(
+        min_arch_version=ArchVersion(12, 5),
+        max_arch_version=ArchVersion(12, 5),
+        vendors=frozenset({"amd"}),
+    ),
+    signatures=_BF16_SIG,
+    traits={
+        "m": frozenset(range(2, 33)),
+        "k_align_128": frozenset({True}),
+        "n_align_16": frozenset({True}),
+    },
+    priority=Priority.SPECIALIZED,
+)
+def wmma_dense_gemv(
+    x: torch.Tensor, weight: torch.Tensor, out: torch.Tensor | None = None
+) -> torch.Tensor:
+    """``x @ weight.T`` for small-M decode activations on CDNA5.
+
+    Args:
+        x: ``[M, K]`` contiguous bf16 activation, K a multiple of 128.
+        weight: ``[N, K]`` contiguous bf16 weight, N a multiple of 16.
+        out: optional ``[M, N]`` destination.
+
+    Returns:
+        ``[M, N]`` output in ``x``'s dtype.
+    """
+    from tokenspeed_kernel_amd.ops.gfx1250.gemm.fp16.mm import (
+        gluon_wmma_tdm_dense_gfx1250,
+    )
+
+    return gluon_wmma_tdm_dense_gfx1250(x, weight, out=out)
 
 
 @register_kernel(

--- a/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
+++ b/tokenspeed-kernel/test/ops/gemm/test_routed_gemv.py
@@ -34,7 +34,10 @@ import sys
 import pytest
 import tokenspeed_kernel.ops.gemm  # noqa: F401  (registration side effects)
 import torch
-from tokenspeed_kernel.ops.gemm.routed_gemv import MEASURED_ROUTE
+from tokenspeed_kernel.ops.gemm.routed_gemv import (
+    MEASURED_ROUTE,
+    decode_gemv_routed,
+)
 from tokenspeed_kernel.ops.gemm.triton_gemv import _select, decode_gemv
 from tokenspeed_kernel.platform import current_platform
 
@@ -342,7 +345,8 @@ def test_route_predicate_admits_the_registered_arch_floor():
 
     x = torch.randn(1, 7168, device="cuda", dtype=torch.bfloat16)
     w = torch.randn(3584, 7168, device="cuda", dtype=torch.bfloat16)
-    nvidia = type("P", (), {"vendor": "nvidia"})()
+    # The predicate also consults the CDNA arm once the route misses.
+    nvidia = type("P", (), {"vendor": "nvidia", "is_cdna5": False})()
     for capability, expected in (((10, 0), True), ((9, 0), False)):
         routed_gemv._is_routed_arch.cache_clear()
         with (
@@ -642,3 +646,65 @@ def test_under_aligned_operands_fall_back_to_torch(monkeypatch, misalign, offset
     )
     got = routed_gemv.skinny_gemv(x, w)
     assert torch.allclose(got.float(), (x @ w.t()).float(), atol=0.5, rtol=2e-2)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not current_platform().is_cdna5,
+    reason="CDNA5 required",
+)
+@pytest.mark.parametrize("m", [1, 2, 16, 17, 32])
+@pytest.mark.parametrize("n,k", [(7168, 1536), (7168, 3584)])
+def test_cdna5_route_admits_decode_shapes(m, n, k):
+    """K3 decode shapes must route on CDNA5, which has no sm100 route table.
+
+    The unquantized Linear path relies on this: o_proj is 93 calls a forward
+    and reached the vendor GEMM. M == 1 lands on row-CTA and the rest on the
+    dense16 WMMA kernel; 17 and 32 cross into a second 16-row chunk, where
+    the launcher masks the tail.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(n, k, device="cuda", dtype=torch.bfloat16)
+
+    assert decode_gemv_routed(x, w)
+
+    got = decode_gemv(x, w).float()
+    ref = (x @ w.t()).float()
+    assert torch.allclose(
+        got, ref, atol=0.5, rtol=2e-2
+    ), f"M={m} N={n} K={k}: max abs err {(got - ref).abs().max().item():.4f}"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or not current_platform().is_cdna5,
+    reason="CDNA5 required",
+)
+def test_cdna5_route_declines_unregistered_calls():
+    """Anything the registry has no specialized kernel for keeps its caller's path."""
+    w_bf16 = torch.randn(7168, 1536, device="cuda", dtype=torch.bfloat16)
+
+    x_fp16 = torch.randn(1, 1536, device="cuda", dtype=torch.float16)
+    assert not decode_gemv_routed(x_fp16, w_bf16.half())
+
+    strided = torch.randn(1, 3072, device="cuda", dtype=torch.bfloat16)[:, ::2]
+    assert not decode_gemv_routed(strided, w_bf16)
+
+    # K=128 is registered but measured slower than the vendor GEMM at wide N.
+    thin = torch.randn(1, 128, device="cuda", dtype=torch.bfloat16)
+    thin_w = torch.randn(8448, 128, device="cuda", dtype=torch.bfloat16)
+    assert not decode_gemv_routed(thin, thin_w)
+
+    # Past the WMMA band nothing is registered: each 16-row chunk re-reads the
+    # whole weight, and by this M rocBLAS is measured faster.
+    wide = torch.randn(64, 1536, device="cuda", dtype=torch.bfloat16)
+    assert not decode_gemv_routed(wide, w_bf16)
+
+    # In-band M, but the WMMA kernel tiles K by 128 and N by its output tile.
+    unaligned_k = torch.randn(16, 1600, device="cuda", dtype=torch.bfloat16)
+    assert not decode_gemv_routed(
+        unaligned_k, torch.randn(7168, 1600, device="cuda", dtype=torch.bfloat16)
+    )
+    unaligned_n = torch.randn(16, 1536, device="cuda", dtype=torch.bfloat16)
+    assert not decode_gemv_routed(
+        unaligned_n, torch.randn(7000, 1536, device="cuda", dtype=torch.bfloat16)
+    )


### PR DESCRIPTION
## Summary
- Register the existing gfx1250 dense16 WMMA kernel for `decode_gemv` at M 2..32, and let M == 1 route to the row-CTA GEMV, so K3 decode projections stop falling through to rocBLAS on CDNA5.
- Unpin `K` on `_wmma_tdm_dense_m16_kernel`. It was fixed at 7168, which excluded the shapes that dominate a decode step: o_proj at K=1536 and latent-up at K=3584.
- Add `gluon_wmma_tdm_dense_gfx1250`, a shape-generic wrapper beside the two shape-locked ones, validating the kernel's actual constraints (M <= 32, `K % 128 == 0`, `N % 16 == 0`) instead of a shape allowlist.
- CDNA5 only, via the spec's own capability gate. CDNA4 has its own tuned M == 1 Triton GEMVs and has not been swept against these.

## Performance
Kernel latency vs. main on gfx1250, cold L2 and CUDA-graph captured. `PR` is whichever kernel the registry selects: row-CTA at M == 1, dense16 WMMA at M 2..32.

o_proj 1536→7168 (93 calls/forward):
| M | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 14.15 | 4.01 | 3.53x |
| 2 | 14.14 | 6.26 | 2.26x |
| 4 | 14.40 | 6.40 | 2.25x |
| 8 | 14.56 | 6.21 | 2.34x |
| 16 | 14.63 | 6.32 | 2.32x |
| 24 | 14.68 | 10.46 | 1.40x |
| 32 | 14.87 | 10.24 | 1.45x |

latent-up 3584→7168:
| M | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 29.97 | 6.76 | 4.43x |
| 2 | 30.15 | 13.01 | 2.32x |
| 4 | 30.08 | 12.46 | 2.42x |
| 8 | 30.44 | 12.80 | 2.38x |
| 16 | 30.15 | 12.99 | 2.32x |
| 24 | 30.18 | 18.46 | 1.64x |
| 32 | 30.15 | 19.23 | 1.57x |

dense-mlp-down 4224→7168 (1 call/forward):
| M | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 34.58 | 7.41 | 4.67x |
| 2 | 34.81 | 14.48 | 2.40x |
| 4 | 34.87 | 14.15 | 2.46x |
| 8 | 35.07 | 14.19 | 2.47x |
| 16 | 35.15 | 14.17 | 2.48x |
| 24 | 35.30 | 21.80 | 1.62x |
| 32 | 35.36 | 22.09 | 1.60x |

shared-down 768→7168:
| M | Main (µs) | PR (µs) | Speedup vs. main |
|--:|----------:|--------:|-----------------:|
| 1 | 8.24 | 3.50 | 2.35x |
| 2 | 8.03 | 4.07 | 1.97x |
| 4 | 8.37 | 4.15 | 2.02x |
| 8 | 8.62 | 4.25 | 2.03x |
| 16 | 8.77 | 4.26 | 2.06x |
| 24 | 8.92 | 6.19 | 1.44x |
| 32 | 8.92 | 7.13 | 1.25x |

M >= 48 is deliberately left unregistered and falls back to rocBLAS. The launcher tiles M in 16-row chunks and re-reads the whole weight per chunk, so the advantage decays at every chunk boundary: measured on o_proj, M=48 is 1.03x and M=64 is 0.80x.

Model throughput on the K3 toy model at TP8, 4K prompt / 1K output, against a matched control measured on the same tree in the same session. At concurrency 1 decode throughput goes from 95.6 to 108.0 tok/s (+13.0%), with decode step p50 falling from 10.47 to 9.28 ms. At concurrency 16 it goes from 735.4 to 758.5 tok/s (+3.1%), with step p50 falling from 20.80 to 20.23 ms. Concurrency 1 gains more because row-CTA at M == 1 is the larger per-call win and o_proj runs 93 times per forward; at concurrency 16 every decode GEMM is M == 16, which lands on the WMMA kernel at ~2.3x.
