### PR TITLE
perf(mla): add opt-in packed Q decode for FP8 and FP16

### DIFF
--- a/tokenspeed-mla/README.md
+++ b/tokenspeed-mla/README.md
@@ -55,6 +55,7 @@ python ./tokenspeed-mla/python/tokenspeed_mla/fmha.py \
 ```
 
 ### Decode Performance
+
 ![Decode Latency Comparison for num_heads=16](https://raw.githubusercontent.com/lightseekorg/tokenspeed/main/tokenspeed-mla/assets/latency_comparison_numHead16.png)
 ![Decode Latency Comparison for num_heads=32](https://raw.githubusercontent.com/lightseekorg/tokenspeed/main/tokenspeed-mla/assets/latency_comparison_numHead32.png)
 
@@ -81,8 +82,52 @@ decode scenarios, especially token-by-token agent traffic. Example:
 `M` (`H_eff=128`) and the remaining two query groups are scheduled on the
 scheduler second dimension (`q_seqlen_eff=2`).
 
+The public `tokenspeed_mla_decode` also accepts `enable_packed_q=True` to
+opt into continuous query/head packing on the FP8 and FP16/BF16 M128 paths, adapted from
+FlashInfer PR #4178. The default is **False**, preserving the folded-query
+implementation. M64 and token-gapped Q/output views continue to
+use that implementation even when the option is enabled.
+
+Packed rows are ordered as `query_token * num_heads + head`. Each 2-CTA
+group owns 128 consecutive rows, including across query boundaries. Thus
+H96/Sq4 uses three query tiles instead of four, and H96/Sq8 uses six
+instead of eight. Only the final tile may contain padding. This is a tensor
+view transformation, with no additional packing kernel. The kernel uses
+per-row causal positions and predicates partial output/LSE rows.
+
+For packed queries, auto split-KV uses `ceil(H * q_len / 128)` query tiles,
+and workspace needs `B * 128 * ceil(H * q_len / 128) * split_kv * 513 * 4`
+bytes for D512/FP32 partials, or zero when split-KV is one. Callers enabling
+this option must provide sufficient workspace. Output shape, output dtype
+(BF16 for FP8; input dtype for FP16/BF16), and base-2 LSE semantics are unchanged.
+The FP16/BF16 implementation retains its existing split-KV heuristic, reducer
+capacity and PDL waits. The option is part of the
+compile cache key. Existing direct kernel callers retain the old layout;
+opting in through the public wrapper keeps tiling and workspace consistent.
+
+Sliding-window and DCP masking remain supported; window boundaries use the
+packed row's original query-token position.
+
+Regression coverage is in [tests/test_mla_decode.py](tests/test_mla_decode.py).
+It checks packed-query geometry, split-KV workspace sizing, FP8/FP16/BF16
+outputs and LSE, reducer variants, CUDA-graph replay, sliding windows and DCP.
+From the repository root, select this checkout's sources explicitly:
+
+```bash
+PYTHONPATH=tokenspeed-mla/python python -m pytest -q tokenspeed-mla/tests/test_mla_decode.py
+```
+
+GPU cases require Blackwell SM100/SM103 and are skipped on other devices.
+Add `-k 'not TestGPU'` to run only CPU checks, or `-k TestGPU` for GPU checks.
+
 Other optimizations include:
 
+- FP8 split-KV candidates are normalized to nonempty K partitions before
+  workspace allocation and kernel launch. The reducer uses a 32/64-split
+  capacity for the M128/M64 paths and selects 1/2/4 disjoint D512 output bands
+  when the real output rows do not fill the GPU. These changes adapt the
+  split-KV and reducer optimizations from FlashInfer PR #4178 to TokenSpeed's
+  folded-query layout; both reducer settings are included in the compile cache.
 - Using 2CTA UTCMMA instruction to reduce shared memory usage.
 - Try to use as less mbarrier as possible.
 - Split kv loading warp to get more latency hiding ability. After loading K, V is already in the L2 cache. Loading K of next tile will not have to wait for the completion of V loading.

--- a/tokenspeed-mla/THIRDPARTYNOTICES
+++ b/tokenspeed-mla/THIRDPARTYNOTICES
@@ -22,6 +22,27 @@ Copyright contributors to the FlashInfer project
 Licensed under the Apache License, Version 2.0, whose full license text is
 available below.
 
+The nonempty split-KV selection and adaptive D512 reducer topology in
+python/tokenspeed_mla/mla_decode.py are adapted from FlashInfer PR #4178
+(commit 4890932dd0e479758c5bf7dbd607504da55f8077),
+flashinfer/cute_dsl/attention/monolithic/mla_decode.py.
+Copyright (c) 2026 by FlashInfer team. Licensed under Apache License, Version 2.0.
+
+The corresponding output-band indexing in python/tokenspeed_mla/mla_decode_fp8.py
+is adapted to TokenSpeed's folded-query layout from that commit's
+flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py.
+Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+These portions are covered by the BSD 3-Clause License reproduced below.
+
+The opt-in continuous query/head tiling helper in
+python/tokenspeed_mla/mla_helpers.py and the packed Q, mask, workspace and
+reducer indexing in python/tokenspeed_mla/mla_decode_fp8.py and
+python/tokenspeed_mla/mla_decode_fp16.py are adapted from
+the same PR's mla_helpers.py and mla_decode_fp8.py, retaining TokenSpeed's
+existing four-dimensional loader, pipeline and base-2 LSE interfaces.
+Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+These portions are covered by the BSD 3-Clause License reproduced below.
+
 ================================================================================
                               BSD 3-Clause License
 ================================================================================

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode.py
@@ -40,6 +40,8 @@ from tokenspeed_mla.mla_decode_fp16 import (
     BlackwellMultiHeadLatentAttentionForwardFP16,
 )
 from tokenspeed_mla.mla_helpers import (
+    ceil_div,
+    compute_q_tile_layout,
     get_mla_decode_fold_sq_factor,
     select_mla_decode_tilers,
 )
@@ -48,6 +50,31 @@ from tokenspeed_mla.utils import (
     get_num_sm,
     torch_to_cutlass_dtype,
 )
+
+
+def _get_reducer_d_tiles(
+    batch_size: int,
+    seq_len_q: int,
+    num_heads: int,
+    num_sms: int,
+    split_kv: int,
+) -> int:
+    """Return 1/2/4 D512 bands for the real output rows and split count.
+
+    Adapted from FlashInfer PR #4178: minimize waves per output band, keeping
+    the smaller grid on ties. Full row grids avoid duplicating LSE reduction.
+    """
+    rows = batch_size * seq_len_q * num_heads
+    if rows <= 0 or num_sms <= 0 or rows >= num_sms or split_kv <= 1:
+        return 1
+    best = 1
+    best_waves = ceil_div(rows, num_sms)
+    for bands in (2, 4):
+        if bands <= split_kv:
+            waves = ceil_div(rows * bands, num_sms)
+            if waves * best < best_waves * bands:
+                best, best_waves = bands, waves
+    return best
 
 
 @functools.cache
@@ -61,7 +88,11 @@ def _get_split_kv_and_workspace_size(
     torch_dtype: torch.dtype,
     mma_qk_tiler_mn: tuple[int, int],
 ) -> Tuple[int, int]:
-    """Cache split_kv and workspace_size since they are deterministic for the same params."""
+    """Return cached split count and workspace bytes for the effective Q layout.
+
+    FP8 normalizes uniform K partitions before sizing the workspace so the
+    launch grid, scratch strides and reducer use the same nonempty split count.
+    """
     is_fp8 = torch_dtype == torch.float8_e4m3fn
     if is_fp8 and mma_qk_tiler_mn[0] == 64:
         # M64 launches one CTA per M tile. Reuse the FP8 kernel's wave-aware
@@ -75,18 +106,20 @@ def _get_split_kv_and_workspace_size(
             max_active_blocks,
             1,
         )
-        workspace_size = BlackwellMultiHeadLatentAttentionForwardFP8.get_workspace_size(
-            H, q_len, kv_lora_rank, B, split_kv, cutlass.Float32
-        )
     else:
         split_kv = BlackwellMultiHeadLatentAttentionForwardFP16.get_split_kv_simplified(
             B, q_len, max_active_blocks
         )
-        workspace_size = (
-            BlackwellMultiHeadLatentAttentionForwardFP16.get_workspace_size(
-                H, q_len, kv_lora_rank, B, split_kv, cutlass.Float32
-            )
-        )
+    if is_fp8:
+        # The occupancy candidate may contain empty final partitions (e.g.
+        # 32 splits for only 8 K tiles). Preserve the uniform chunk width while
+        # removing those partitions, as in FlashInfer PR #4178.
+        k_tiles = ceil_div(max_seq_len, mma_qk_tiler_mn[1])
+        tiles_per_split = ceil_div(k_tiles, split_kv)
+        split_kv = ceil_div(k_tiles, tiles_per_split)
+    workspace_size = BlackwellMultiHeadLatentAttentionForwardFP16.get_workspace_size(
+        H, q_len, kv_lora_rank, B, split_kv, cutlass.Float32
+    )
     return split_kv, workspace_size
 
 
@@ -163,6 +196,9 @@ def _get_compiled_mla_kernel(
     use_pdl: bool = False,
     return_lse: bool = False,  # DCP: enable LSE output
     compute_capability: tuple[int, int] = (0, 0),
+    reducer_d_tiles: int = 1,
+    reducer_max_splits: int = 256,
+    pack_q: bool = False,
 ) -> Callable:
     """Compile and cache an MLA decode kernel.
 
@@ -209,9 +245,12 @@ def _get_compiled_mla_kernel(
     kernel_kwargs["num_heads"] = num_heads
     kernel_kwargs["seq_len_q"] = seq_len_q
     kernel_kwargs["window_left"] = window_left
+    kernel_kwargs["pack_q"] = pack_q
     if is_fp8:
         # DCP (cp_world) strided global-coordinate causal masking is fp8-only.
         kernel_kwargs["cp_world"] = cp_world
+        kernel_kwargs["reducer_d_tiles"] = reducer_d_tiles
+        kernel_kwargs["reducer_max_splits"] = reducer_max_splits
     kernel_obj = KernelClass(**kernel_kwargs)
 
     # All dimensions as sym_int — this matches the original kernel's use of
@@ -376,6 +415,7 @@ def tokenspeed_mla_decode(
     ] = None,  # per-request global causal bound; None = local (non-DCP)
     cp_world: int = 1,  # decode-context-parallel world size (1 = no DCP)
     cp_rank: int = 0,  # this rank's index in [0, cp_world); subtracted from causal_seqs
+    enable_packed_q: bool = False,
 ) -> torch.Tensor:
     """CuTe DSL MLA decode kernel for Blackwell SM100.
 
@@ -415,7 +455,7 @@ def tokenspeed_mla_decode(
         Otherwise,the sequence length is fixed for all the requests in the batch.
     causal_mask : bool
         Whether to enable causal masking in the CuTe DSL kernel.
-        Currently this is effective for the FP8 kernel path.
+        Supported by both the FP8 and FP16/BF16 kernel paths.
     window_left : int
         Sliding-window span, or -1 (default) for full history. When
         non-negative, query row ``i`` of the ``q_len`` block attends to keys
@@ -457,6 +497,12 @@ def tokenspeed_mla_decode(
         bound is ``ceil((causal_seqs - cp_rank) / cp_world)``; the wrapper folds
         ``cp_rank`` in for you, so callers pass the same global ``causal_seqs`` on
         every rank. Must be 0 when ``cp_world == 1``.
+    enable_packed_q : bool
+        Opt into continuous query/head packing on FP8 and FP16/BF16 M128
+        kernels. Default False preserves the existing folded-query path.
+        M64 and token-gapped Q/output views retain that path even when True.
+        Packed split-KV workspace uses ``B * 128 * ceil(H*q_len/128) *
+        split_kv * (kv_lora_rank + 1) * 4`` bytes (zero for split_kv=1).
 
     Returns
     -------
@@ -526,14 +572,23 @@ def tokenspeed_mla_decode(
         is_fp8=is_fp8,
         compute_capability=compute_capability,
     )
-    # Fold only by a factor that exactly divides q_len; otherwise leave q_len
-    # on the scheduler dimension.
     mma_m_tile = mma_qk_tiler_mn[0]
-    fold_sq_factor = get_mla_decode_fold_sq_factor(H, q_len, mma_m_tile)
-
-    # Effective dimensions used by split_kv/workspace accounting.
-    H_eff = H * fold_sq_factor
-    q_len_eff = q_len // fold_sq_factor
+    # A flat view requires adjacent query tokens to continue the head rows.
+    # Keep the existing path for token-gapped views and M64 kernels.
+    pack_q = (
+        enable_packed_q
+        and mma_m_tile == 128
+        and query.stride(1) == H * query.stride(2)
+        and (out is None or out.stride(1) == H * out.stride(2))
+    )
+    if pack_q:
+        _, q_len_eff, _ = compute_q_tile_layout(H, q_len, mma_m_tile)
+        H_eff = mma_m_tile
+        fold_sq_factor = 1
+    else:
+        fold_sq_factor = get_mla_decode_fold_sq_factor(H, q_len, mma_m_tile)
+        H_eff = H * fold_sq_factor
+        q_len_eff = q_len // fold_sq_factor
 
     # Cached split_kv and workspace_size computation
     max_active_blocks = get_num_sm(query.device)
@@ -662,6 +717,15 @@ def tokenspeed_mla_decode(
         use_pdl=enable_pdl,
         return_lse=return_lse,
         compute_capability=compute_capability,
+        reducer_d_tiles=(
+            _get_reducer_d_tiles(B, q_len, H, max_active_blocks, split_kv)
+            if is_fp8
+            else 1
+        ),
+        # Public FP8 auto-splitting is bounded by 64 (M64) or 32 (M128).
+        # Both values are in the compile cache key, including across batches.
+        reducer_max_splits=(64 if mma_m_tile == 64 else 32) if is_fp8 else 256,
+        pack_q=pack_q,
     )
 
     # DCP: allocate real LSE tensor when return_lse=True (DCP path). torch.zeros

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp16.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp16.py
@@ -68,12 +68,13 @@ from cutlass.cutlass_dsl import BaseDSL
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 
 try:
-    from .mla_helpers import (
+    from tokenspeed_mla.mla_helpers import (
         LOG2_E,
         MAX_SPLITS,
         MLAStaticTileScheduler,
         MLAStaticTileSchedulerParams,
         ceil_div,
+        compute_q_tile_layout,
         create_mla_static_tile_scheduler,
         create_mla_static_tile_scheduler_params,
         get_mla_decode_fold_sq_factor,
@@ -85,6 +86,7 @@ except ImportError:
         MLAStaticTileScheduler,
         MLAStaticTileSchedulerParams,
         ceil_div,
+        compute_q_tile_layout,
         create_mla_static_tile_scheduler,
         create_mla_static_tile_scheduler_params,
         get_mla_decode_fold_sq_factor,
@@ -176,6 +178,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         num_heads: int = 128,
         seq_len_q: int = 1,
         window_left: int = -1,
+        pack_q: bool = False,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -205,6 +208,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             the whole block plus ``window_left`` tokens of history, which is
             the mask a block drafter's ``sliding_attention`` layers declare.
         :type window_left: int
+        :param pack_q: Pack consecutive query/head rows into M128 tiles. The
+            caller must size split-KV workspace for (128, ceil(H*Sq/128)).
+            False preserves the folded layout for existing direct callers.
+        :type pack_q: bool
         """
 
         self.latent_dim = 512
@@ -220,6 +227,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         self.is_var_seq = is_var_seq
         self.is_var_split_kv = is_var_split_kv
         self.fold_sq_factor = fold_sq_factor
+        self.pack_q = pack_q
+        if pack_q and (mma_qk_tiler_mn[0] != 128 or fold_sq_factor != 1):
+            raise ValueError("Packed Q requires M128 and fold_sq_factor=1")
+        if pack_q:
+            self.total_q_rows, self.num_q_tiles, self.tail_q_rows = (
+                compute_q_tile_layout(num_heads, seq_len_q, mma_qk_tiler_mn[0])
+            )
         self.is_causal = is_causal
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
@@ -442,9 +456,48 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             else None
         )
 
+        o_reduction = o
+        lse_reduction = lse
+        if cutlass.const_expr(self.pack_q):
+            # Keep the original loader's four modes; query tiles now select
+            # consecutive head rows across query-token boundaries.
+            def _flatten_q(t):
+                return cute.make_tensor(
+                    t.iterator,
+                    cute.make_layout(
+                        (self.total_q_rows, t.shape[1], 1, t.shape[3]),
+                        stride=(t.stride[0], t.stride[1], t.stride[3], t.stride[3]),
+                    ),
+                )
+
+            q_latent = _flatten_q(q_latent)
+            q_rope = _flatten_q(q_rope)
+            m_tile = self.mma_qk_tiler_mn[0]
+            num_q_tiles = cute.ceil_div(o.shape[0] * o.shape[2], m_tile)
+            o = cute.make_tensor(
+                o.iterator,
+                cute.make_layout(
+                    (m_tile, o.shape[1], num_q_tiles, o.shape[3]),
+                    stride=(
+                        o.stride[0],
+                        o.stride[1],
+                        m_tile * o.stride[0],
+                        o.stride[3],
+                    ),
+                ),
+            )
+            if cutlass.const_expr(not self.skip_lse):
+                lse = cute.make_tensor(
+                    lse.iterator,
+                    cute.make_layout(
+                        (m_tile, num_q_tiles, lse.shape[2]),
+                        stride=(lse.stride[0], m_tile * lse.stride[0], lse.stride[2]),
+                    ),
+                )
+
         # Fold a query-token group into heads when fold_sq_factor > 1:
         # [H, D, S_q, B] -> [H*F, D, S_q/F, B], F=fold_sq_factor.
-        if cutlass.const_expr(self.fold_sq_factor > 1):
+        elif cutlass.const_expr(self.fold_sq_factor > 1):
 
             def _fold_sq_4d(t):
                 fold_groups = t.shape[2] // self.fold_sq_factor
@@ -484,11 +537,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     ),
                 )
 
+        if cutlass.const_expr(not self.pack_q):
+            o_reduction = o
+            lse_reduction = lse
+
         acc_o, acc_lse = self.initialize_workspace(
-            q_latent.shape[0],
-            q_latent.shape[1],
-            q_latent.shape[2],
-            q_latent.shape[3],
+            o.shape[0],
+            o.shape[1],
+            o.shape[2],
+            o.shape[3],
             split_kv,
             self.acc_dtype,
             workspace,
@@ -778,15 +835,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         )
         if cutlass.const_expr(acc_o is not None):
             self.reduction_kernel(
-                o,
-                lse,
+                o_reduction,
+                lse_reduction,
                 acc_o,
                 acc_lse,
                 split_kv,
                 cache_seqs,
                 block_split_kvs,
             ).launch(
-                grid=(q_latent.shape[0], q_latent.shape[2], q_latent.shape[3]),
+                grid=(
+                    o_reduction.shape[0],
+                    o_reduction.shape[2],
+                    o_reduction.shape[3],
+                ),
                 block=[self.threads_per_warp * self.num_compute_warps, 1, 1],
                 smem=MAX_SPLITS * self.acc_dtype.width // 8,
                 stream=stream,
@@ -1375,7 +1436,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         mO=mO,
                         K=cache_seqs[blk_coord[2]],
                         L=mCL.shape[1],
-                        H=mQL.shape[0],
+                        H=(
+                            cutlass.min(
+                                self.mma_qk_tiler[0],
+                                self.total_q_rows - blk_coord[1] * self.mma_qk_tiler[0],
+                            )
+                            if cutlass.const_expr(self.pack_q)
+                            else mQL.shape[0]
+                        ),
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
                         tiled_mma_pv=tiled_mma_pv,
@@ -1432,6 +1500,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         bidx, bidy, bidz = cute.arch.block_idx()
         tidx, _, _ = cute.arch.thread_idx()
         blk_coord = (bidx, bidy, bidz)
+        # Outputs retain [H, D, Sq, B]; partials use packed M128 query tiles.
+        acc_row = blk_coord[0]
+        acc_tile = blk_coord[1]
+        if cutlass.const_expr(self.pack_q):
+            flat_row = bidy * self.num_heads + bidx
+            acc_row = flat_row % self.mma_qk_tiler[0]
+            acc_tile = flat_row // self.mma_qk_tiler[0]
         local_split_kv = (
             block_split_kvs[blk_coord[2]] if self.is_var_split_kv else split_kv
         )
@@ -1461,7 +1536,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         # before consuming the intermediate workspace.
         cute.arch.griddepcontrol_wait()
 
-        gLSE = mAccLSE[blk_coord[0], None, blk_coord[1], blk_coord[2]]
+        gLSE = mAccLSE[acc_row, None, acc_tile, blk_coord[2]]
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         if warp_idx == 0:
             # calculate the global lse and exp ^ (local_lse - global_lse)
@@ -1511,7 +1586,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         elements_per_thread = cute.ceil_div(
             self.latent_dim, self.threads_per_warp * self.num_compute_warps
         )
-        gAccO = mAccO[blk_coord[0], None, None, blk_coord[1], blk_coord[2]]
+        gAccO = mAccO[acc_row, None, None, acc_tile, blk_coord[2]]
         rAccO = cute.make_rmem_tensor(
             cute.make_layout(elements_per_thread), self.acc_dtype
         )
@@ -1793,12 +1868,12 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             tSgKR,
         )
 
-        tQLgQL = tQLgQL_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
-        tQRgQR = tQRgQR_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
+        q_group = 0 if cutlass.const_expr(self.pack_q) else common_params.blk_coord[1]
+        qk_params.q_m_tile = (
+            common_params.blk_coord[1] if cutlass.const_expr(self.pack_q) else 0
+        )
+        tQLgQL = tQLgQL_mkl[None, None, None, q_group, common_params.blk_coord[2]]
+        tQRgQR = tQRgQR_mkl[None, None, None, q_group, common_params.blk_coord[2]]
 
         # Flatten divide and partition global tensors for V TMA load
         page_tile_size = min(self.page_size, self.mma_pv_tiler[2])
@@ -1948,7 +2023,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 # load q latent
                 cute.copy(
                     qk_params.tma_atom_q_latent,
-                    qk_params.tQLgQL[None, 0, i],
+                    qk_params.tQLgQL[None, qk_params.q_m_tile, i],
                     qk_params.tQsQ[None, (i, 0)],
                     tma_bar_ptr=tma_bar_ptr,
                 )
@@ -1956,7 +2031,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 # load q rope
                 cute.copy(
                     qk_params.tma_atom_q_rope,
-                    qk_params.tQRgQR[None, 0, i],
+                    qk_params.tQRgQR[None, qk_params.q_m_tile, i],
                     qk_params.tQsQ_rope[None, i],
                     tma_bar_ptr=tma_bar_ptr,
                 )
@@ -2779,7 +2854,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         # Spec-decoding (MTP) causal mask: row r's effective K
                         # bound is K - (S_q - 1) + q_tok(r). With fold factor F
                         # the M tile is [F sub_q_tok][num_heads heads].
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            q_tok = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             qk_row = tTR_tS[i][0]
                             q_tok = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
@@ -2801,10 +2882,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     )
                     if cutlass.const_expr(self.window_left >= 0):
                         # Row q_tok's window opens at
-                        # K - seq_len_q - window_left + q_tok, so a key at or
+                        # K - seq_len_q - window_left + q_tok, so a key strictly
                         # before that is out of view however the upper bound
                         # was computed.
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            win_row = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             win_row = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
                                 + (
@@ -2859,7 +2946,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                     qk_col = tTR_tS[i][1]
                     if cutlass.const_expr(self.is_causal):
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            q_tok = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             qk_row = tTR_tS[i][0]
                             q_tok = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
@@ -2881,10 +2974,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                     )
                     if cutlass.const_expr(self.window_left >= 0):
                         # Row q_tok's window opens at
-                        # K - seq_len_q - window_left + q_tok, so a key at or
+                        # K - seq_len_q - window_left + q_tok, so a key strictly
                         # before that is out of view however the upper bound
                         # was computed.
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            win_row = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             win_row = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
                                 + (

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_decode_fp8.py
@@ -67,12 +67,13 @@ from cutlass.cutlass_dsl import BaseDSL
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 
 try:
-    from .mla_helpers import (
+    from tokenspeed_mla.mla_helpers import (
         LOG2_E,
         MAX_SPLITS,
         MLAStaticTileScheduler,
         MLAStaticTileSchedulerParams,
         ceil_div,
+        compute_q_tile_layout,
         create_mla_static_tile_scheduler,
         create_mla_static_tile_scheduler_params,
         get_mla_decode_fold_sq_factor,
@@ -84,6 +85,7 @@ except ImportError:
         MLAStaticTileScheduler,
         MLAStaticTileSchedulerParams,
         ceil_div,
+        compute_q_tile_layout,
         create_mla_static_tile_scheduler,
         create_mla_static_tile_scheduler_params,
         get_mla_decode_fold_sq_factor,
@@ -221,6 +223,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         seq_len_q: int = 1,
         window_left: int = -1,
         cp_world: int = 1,  # DCP world size; >1 enables strided global-coord causal masking
+        reducer_d_tiles: int = 1,
+        reducer_max_splits: int = MAX_SPLITS,
+        pack_q: bool = False,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -250,9 +255,24 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             the whole block plus ``window_left`` tokens of history, which is
             the mask a block drafter's ``sliding_attention`` layers declare.
         :type window_left: int
+        :param reducer_d_tiles: Number of disjoint D512 output bands (1, 2 or 4)
+        :type reducer_d_tiles: int
+        :param reducer_max_splits: Static reducer capacity; must cover every split
+        :type reducer_max_splits: int
+        :param pack_q: Pack consecutive query/head rows into M128 tiles. The
+            caller must size split-KV workspace for (128, ceil(H*Sq/128)).
+            False preserves the folded layout for existing direct callers.
+        :type pack_q: bool
         """
 
         self.latent_dim = 512
+        if reducer_d_tiles not in (1, 2, 4):
+            raise ValueError("reducer_d_tiles must be 1, 2 or 4")
+        if reducer_max_splits not in (32, 64, MAX_SPLITS):
+            raise ValueError("reducer_max_splits must be 32, 64 or MAX_SPLITS")
+        self.reducer_d_tiles = reducer_d_tiles
+        self.reducer_d_tile = self.latent_dim // reducer_d_tiles
+        self.reducer_max_splits = reducer_max_splits
         self.rope_dim = 64
         self.acc_dtype = acc_dtype
         self.lse_dtype = lse_dtype
@@ -265,6 +285,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         self.is_var_seq = is_var_seq
         self.is_var_split_kv = is_var_split_kv
         self.fold_sq_factor = fold_sq_factor
+        self.pack_q = pack_q
+        if pack_q and (mma_qk_tiler_mn[0] != 128 or fold_sq_factor != 1):
+            raise ValueError("Packed Q requires M128 and fold_sq_factor=1")
+        if pack_q:
+            self.total_q_rows, self.num_q_tiles, self.tail_q_rows = (
+                compute_q_tile_layout(num_heads, seq_len_q, mma_qk_tiler_mn[0])
+            )
         self.is_causal = is_causal
         # Original (pre-fold) num_heads and seq_len_q used for per-row causal
         # q_token_index computation. When fold_sq_factor > 1, each S_q group folds
@@ -532,11 +559,50 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             else None
         )
 
+        o_reduction = o
+        lse_reduction = lse
+        if cutlass.const_expr(self.pack_q):
+            # Bound Q's TMA row extent by the real rows; only the final tile
+            # can be partial. Keep a singleton S mode for the existing loader.
+            def _flatten_q(t):
+                return cute.make_tensor(
+                    t.iterator,
+                    cute.make_layout(
+                        (self.total_q_rows, t.shape[1], 1, t.shape[3]),
+                        stride=(t.stride[0], t.stride[1], t.stride[3], t.stride[3]),
+                    ),
+                )
+
+            q_latent = _flatten_q(q_latent)
+            q_rope = _flatten_q(q_rope)
+            m_tile = self.mma_qk_tiler_mn[0]
+            num_q_tiles = cute.ceil_div(o.shape[0] * o.shape[2], m_tile)
+            o = cute.make_tensor(
+                o.iterator,
+                cute.make_layout(
+                    (m_tile, o.shape[1], num_q_tiles, o.shape[3]),
+                    stride=(
+                        o.stride[0],
+                        o.stride[1],
+                        m_tile * o.stride[0],
+                        o.stride[3],
+                    ),
+                ),
+            )
+            if cutlass.const_expr(not self.skip_lse):
+                lse = cute.make_tensor(
+                    lse.iterator,
+                    cute.make_layout(
+                        (m_tile, num_q_tiles, lse.shape[2]),
+                        stride=(lse.stride[0], m_tile * lse.stride[0], lse.stride[2]),
+                    ),
+                )
+
         # When num_heads < M tile (128), fold fold_sq_factor query tokens into
         # the head dimension to better fill MMA M dimension per S_q group.
         # E.g., H=64, S_q=4, fold_sq_factor=2 → M_eff=128, S_q_eff=2.
         # This works because MLA shares KV across all heads/queries independently.
-        if cutlass.const_expr(self.fold_sq_factor > 1):
+        elif cutlass.const_expr(self.fold_sq_factor > 1):
 
             def _fold_sq_4d(t):
                 # [H, D, S_q, B] → [H*F, D, S_q/F, B], where F=fold_sq_factor.
@@ -578,11 +644,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     ),
                 )
 
+        if cutlass.const_expr(not self.pack_q):
+            o_reduction = o
+            lse_reduction = lse
+
         acc_o, acc_lse = self.initialize_workspace(
-            q_latent.shape[0],
-            q_latent.shape[1],
-            q_latent.shape[2],
-            q_latent.shape[3],
+            o.shape[0],
+            o.shape[1],
+            o.shape[2],
+            o.shape[3],
             split_kv,
             self.acc_dtype,
             workspace,
@@ -990,17 +1060,21 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         )
         if cutlass.const_expr(acc_o is not None):
             self.reduction_kernel(
-                o,
-                lse,
+                o_reduction,
+                lse_reduction,
                 acc_o,
                 acc_lse,
                 split_kv,
                 cache_seqs,
                 block_split_kvs,
             ).launch(
-                grid=(q_latent.shape[0], q_latent.shape[2], q_latent.shape[3]),
+                grid=(
+                    o_reduction.shape[0] * self.reducer_d_tiles,
+                    o_reduction.shape[2],
+                    o_reduction.shape[3],
+                ),
                 block=[self.threads_per_warp * self.num_compute_warps, 1, 1],
-                smem=MAX_SPLITS * self.acc_dtype.width // 8,
+                smem=self.reducer_max_splits * self.acc_dtype.width // 8,
                 stream=stream,
                 min_blocks_per_mp=1,
                 use_pdl=use_pdl,
@@ -1644,7 +1718,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         K=cache_seqs[blk_coord[2]],
                         K_causal=causal_seqs[blk_coord[2]],
                         L=mCL.shape[1],
-                        H=mQL.shape[0],
+                        H=(
+                            cutlass.min(
+                                self.mma_qk_tiler[0],
+                                self.total_q_rows - blk_coord[1] * self.mma_qk_tiler[0],
+                            )
+                            if cutlass.const_expr(self.pack_q)
+                            else mQL.shape[0]
+                        ),
                         tmem_ptr=tmem_ptr,
                         tidx=tidx,
                         tiled_mma_pv=tiled_mma_pv,
@@ -1702,7 +1783,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         """
         bidx, bidy, bidz = cute.arch.block_idx()
         tidx, _, _ = cute.arch.thread_idx()
-        blk_coord = (bidx, bidy, bidz)
+        # Output coordinates retain the original query/head layout for packed Q.
+        # Each CTA writes a disjoint D band; only band zero writes the LSE.
+        d_tile_idx = bidx % self.reducer_d_tiles
+        blk_coord = (bidx // self.reducer_d_tiles, bidy, bidz)
+        acc_row = blk_coord[0]
+        acc_tile = blk_coord[1]
+        if cutlass.const_expr(self.pack_q):
+            flat_row = bidy * self.num_heads + blk_coord[0]
+            acc_row = flat_row % self.mma_qk_tiler[0]
+            acc_tile = flat_row // self.mma_qk_tiler[0]
         local_split_kv = (
             block_split_kvs[blk_coord[2]] if self.is_var_split_kv else split_kv
         )
@@ -1724,17 +1814,21 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
 
         # Alloc shared memory
         smem = utils.SmemAllocator()
-        storage = smem.allocate(MAX_SPLITS * self.acc_dtype.width // 8, 16)
+        storage = smem.allocate(self.reducer_max_splits * self.acc_dtype.width // 8, 16)
         lse_scale_ptr = cute.recast_ptr(storage, dtype=self.acc_dtype)
-        smem_lse_scale = cute.make_tensor(lse_scale_ptr, cute.make_layout(MAX_SPLITS))
+        smem_lse_scale = cute.make_tensor(
+            lse_scale_ptr, cute.make_layout(self.reducer_max_splits)
+        )
 
         cute.arch.griddepcontrol_wait()
 
-        gLSE = mAccLSE[blk_coord[0], None, blk_coord[1], blk_coord[2]]
+        gLSE = mAccLSE[acc_row, None, acc_tile, blk_coord[2]]
         warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
         if warp_idx == 0:
             # calculate the global lse and exp ^ (local_lse - global_lse)
-            lse_per_thread = cute.ceil_div(MAX_SPLITS, self.threads_per_warp)
+            lse_per_thread = cute.ceil_div(
+                self.reducer_max_splits, self.threads_per_warp
+            )
 
             local_lse = cute.make_rmem_tensor(
                 cute.make_layout(lse_per_thread), self.lse_dtype
@@ -1764,7 +1858,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 or sum_lse != sum_lse  # noqa: SIM201
                 else self.lse_dtype.inf
             )
-            if tidx == 0:
+            if tidx == 0 and d_tile_idx == 0:
                 if cutlass.const_expr(not self.skip_lse):
                     mLSE[blk_coord[0], blk_coord[1], blk_coord[2]] = global_lse
             # store the scale to shared memory
@@ -1778,9 +1872,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         pipeline.sync(barrier_id=4)
 
         elements_per_thread = cute.ceil_div(
-            self.latent_dim, self.threads_per_warp * self.num_compute_warps
+            self.reducer_d_tile, self.threads_per_warp * self.num_compute_warps
         )
-        gAccO = mAccO[blk_coord[0], None, None, blk_coord[1], blk_coord[2]]
+        gAccO = mAccO[acc_row, None, None, acc_tile, blk_coord[2]]
         rAccO = cute.make_rmem_tensor(
             cute.make_layout(elements_per_thread), self.acc_dtype
         )
@@ -1788,11 +1882,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         rAccO.fill(0.0)
         for i in range(local_split_kv):
             for j in cutlass.range_constexpr(elements_per_thread):
-                element_idx = tidx + j * self.threads_per_warp * self.num_compute_warps
+                element_idx = (
+                    d_tile_idx * self.reducer_d_tile
+                    + tidx
+                    + j * self.threads_per_warp * self.num_compute_warps
+                )
                 rAccO[j] += gAccO[i, element_idx] * smem_lse_scale[i]
         rO.store(rAccO.load().to(self.o_dtype))
         for j in cutlass.range_constexpr(elements_per_thread):
-            element_idx = tidx + j * self.threads_per_warp * self.num_compute_warps
+            element_idx = (
+                d_tile_idx * self.reducer_d_tile
+                + tidx
+                + j * self.threads_per_warp * self.num_compute_warps
+            )
             mO[blk_coord[0], element_idx, blk_coord[1], blk_coord[2]] = rO[j]
         cute.arch.griddepcontrol_launch_dependents()
         return
@@ -1924,12 +2026,10 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             cute.group_modes(tSgQR, 0, 3),
         )
 
-        tQLgQL = tQLgQL_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
-        tQRgQR = tQRgQR_mkl[
-            None, None, None, common_params.blk_coord[1], common_params.blk_coord[2]
-        ]
+        q_group = 0 if cutlass.const_expr(self.pack_q) else common_params.blk_coord[1]
+        q_m_tile = common_params.blk_coord[1] if cutlass.const_expr(self.pack_q) else 0
+        tQLgQL = tQLgQL_mkl[None, None, None, q_group, common_params.blk_coord[2]]
+        tQRgQR = tQRgQR_mkl[None, None, None, q_group, common_params.blk_coord[2]]
 
         # Issue Q TMA copies
         load_q_pipeline = common_params.load_q_pipeline
@@ -1938,14 +2038,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         for i in cutlass.range_constexpr(self.iterations_qk_latent):
             cute.copy(
                 q_params.tma_atom_q_latent,
-                tQLgQL[None, 0, i],
+                tQLgQL[None, q_m_tile, i],
                 tQsQ[None, (i, 0)],
                 tma_bar_ptr=tma_bar_ptr,
             )
         for i in cutlass.range_constexpr(self.iterations_qk_rope):
             cute.copy(
                 q_params.tma_atom_q_rope,
-                tQRgQR[None, 0, i],
+                tQRgQR[None, q_m_tile, i],
                 tQsQ_rope[None, i],
                 tma_bar_ptr=tma_bar_ptr,
             )
@@ -3247,7 +3347,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 if apply_mask:
                     qk_col = tTR_tS[i][1]
                     if cutlass.const_expr(self.is_causal):
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            q_tok = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             qk_row = tTR_tS[i][0]
                             q_tok = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
@@ -3284,10 +3390,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     )
                     if cutlass.const_expr(self.window_left >= 0):
                         # Row q_tok's window opens at
-                        # K - seq_len_q - window_left + q_tok, so a key at or
+                        # K - seq_len_q - window_left + q_tok, so a key strictly
                         # before that is out of view however the upper bound
                         # was computed.
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            win_row = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             win_row = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
                                 + (
@@ -3341,7 +3453,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             if apply_mask:
                 for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
                     if cutlass.const_expr(self.is_causal):
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            q_tok = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             q_tok = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
                                 + (
@@ -3383,10 +3501,16 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                     )
                     if cutlass.const_expr(self.window_left >= 0):
                         # Row q_tok's window opens at
-                        # K - seq_len_q - window_left + q_tok, so a key at or
+                        # K - seq_len_q - window_left + q_tok, so a key strictly
                         # before that is out of view however the upper bound
                         # was computed.
-                        if cutlass.const_expr(self.fold_sq_factor > 1):
+                        if cutlass.const_expr(self.pack_q):
+                            win_row = (
+                                common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                                + common_params.blk_coord[0] * cta_m_rows
+                                + tTR_tS[i][0]
+                            ) // self.num_heads
+                        elif cutlass.const_expr(self.fold_sq_factor > 1):
                             win_row = (
                                 common_params.blk_coord[1] * self.fold_sq_factor
                                 + (

--- a/tokenspeed-mla/python/tokenspeed_mla/mla_helpers.py
+++ b/tokenspeed-mla/python/tokenspeed_mla/mla_helpers.py
@@ -48,6 +48,24 @@ def select_mla_decode_tilers(
     return default_qk, default_pv
 
 
+def compute_q_tile_layout(
+    num_heads: int, seq_len_q: int, m_tile: int
+) -> tuple[int, int, int]:
+    """Return total rows, tile count and valid rows in the final query tile.
+
+    ``num_heads`` is the positive head count per query, ``seq_len_q`` is the
+    positive query length, and ``m_tile`` is the positive MMA row capacity.
+    Heads must fit within one MMA tile. Following FlashInfer PR #4178,
+    consecutive rows represent ``query_token * num_heads + head`` and may
+    cross query boundaries. The returned tail is in ``[1, m_tile]``.
+    """
+    if min(num_heads, seq_len_q, m_tile) <= 0 or num_heads > m_tile:
+        raise ValueError("Require positive H, Sq and M, with H <= M")
+    total_rows = num_heads * seq_len_q
+    num_tiles = (total_rows + m_tile - 1) // m_tile
+    return total_rows, num_tiles, total_rows - (num_tiles - 1) * m_tile
+
+
 def get_mla_decode_fold_sq_factor(
     num_heads: int, seq_len_q: int, mma_m_tile: int = 128
 ) -> int:

--- a/tokenspeed-mla/tests/test_mla_decode.py
+++ b/tokenspeed-mla/tests/test_mla_decode.py
@@ -1,0 +1,735 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""MLA decode regression tests; GPU checks are grouped in TestGPU."""
+
+import inspect
+import itertools
+import math
+import multiprocessing
+import traceback
+from dataclasses import dataclass
+
+import pytest
+import torch
+from tokenspeed_mla.mla_helpers import compute_q_tile_layout
+
+
+@dataclass(frozen=True)
+class _Case:
+    batch: int
+    kv_len: int
+    heads: int
+    q_len: int
+
+    def __post_init__(self):
+        if min(self.batch, self.kv_len, self.heads, self.q_len) <= 0:
+            raise ValueError("B, K, H and Q must be positive")
+        if self.heads > 128 or self.q_len > self.kv_len:
+            raise ValueError("Require H <= 128 and Q <= K")
+
+    @property
+    def name(self):
+        return f"B{self.batch}_K{self.kv_len}_H{self.heads}_Q{self.q_len}"
+
+
+def _make_inputs(case, dtype_name, variable_kv, device):
+    """Return deterministic Q, paged KV, page tables and request-local KV lengths."""
+    page_size = 64
+
+    generator = torch.Generator(device=device).manual_seed(42)
+    dtype = {
+        "fp8": torch.float8_e4m3fn,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }[dtype_name]
+    source_dtype = torch.float16 if dtype_name == "fp16" else torch.bfloat16
+    pages = math.ceil(case.kv_len / page_size)
+    query = torch.randn(
+        case.batch,
+        case.q_len,
+        case.heads,
+        576,
+        generator=generator,
+        device=device,
+        dtype=source_dtype,
+    ).to(dtype)
+    kv = torch.randn(
+        case.batch * pages,
+        page_size,
+        576,
+        generator=generator,
+        device=device,
+        dtype=source_dtype,
+    ).to(dtype)
+    # Unique shuffled physical pages avoid accidental cross-request sharing.
+    # CuTe TMA page-table rows must have an even number of int32 indices at P64.
+    table_width = math.ceil(pages / (128 // page_size)) * (128 // page_size)
+    tables = torch.zeros(case.batch, table_width, device=device, dtype=torch.int32)
+    tables[:, :pages] = torch.randperm(
+        case.batch * pages, generator=generator, device=device, dtype=torch.int32
+    ).reshape(case.batch, pages)
+    lengths = [
+        (
+            max(case.q_len, case.kv_len - (b * 37) % max(1, case.kv_len // 2))
+            if variable_kv
+            else case.kv_len
+        )
+        for b in range(case.batch)
+    ]
+    seq_lens = torch.tensor(lengths, device=device, dtype=torch.int32)
+    return query, kv, tables, seq_lens
+
+
+def _reference_mla(query, kv, tables, seq_lens, request_indices):
+    """Return FP32 outputs for selected requests using dequantized inputs.
+
+    Each query token sees K-Q+token+1 keys (bottom-right causal alignment).
+    Gather one request at a time to bound long-context reference memory.
+    """
+    q_len, heads = query.shape[1:3]
+    page_size = kv.shape[1]
+    outputs = []
+    for batch_idx in request_indices:
+        length = int(seq_lens[batch_idx])
+        page_ids = tables[batch_idx, : math.ceil(length / page_size)].long()
+        # CPU advanced indexing does not implement FP8; gather its byte view.
+        cache = kv.view(torch.uint8)[page_ids].view(kv.dtype)
+        cache = cache.reshape(-1, 576)[:length].float()
+        q = query[batch_idx].float().reshape(q_len * heads, 576)
+        logits = (q @ cache.T).reshape(q_len, heads, length) * 192**-0.5
+        visible = length - q_len + torch.arange(q_len, device=q.device) + 1
+        mask = torch.arange(length, device=q.device)[None, :] < visible[:, None]
+        logits.masked_fill_(~mask[:, None, :], float("-inf"))
+        probs = torch.softmax(logits, dim=-1)
+        outputs.append(probs @ cache[:, :512])
+    return torch.stack(outputs)
+
+
+def _check_output(actual, expected, dtype):
+    """Check output dtype and values against FP32 reference."""
+    output_dtype = torch.float16 if dtype == "fp16" else torch.bfloat16
+    if actual.dtype != output_dtype:
+        raise AssertionError(f"Expected {output_dtype} output, got {actual.dtype}")
+    actual = actual.float()
+    # Match PR #4178's FP8 elementwise tolerance. Quantized softmax weights
+    # can produce larger absolute errors on rows with cancellation; retain
+    # the stricter global relative-RMSE guard below, including at long K.
+    tolerance = 0.1 if dtype == "fp8" else 0.01
+    torch.testing.assert_close(actual, expected, atol=tolerance, rtol=tolerance)
+    delta = actual - expected
+    relative_rmse = (
+        delta.square().mean().sqrt() / expected.square().mean().sqrt().clamp_min(1e-8)
+    ).item()
+    # An absolute tolerance alone could accept all-zero outputs at long K.
+    if relative_rmse > (0.05 if dtype == "fp8" else 0.01):
+        raise AssertionError(f"Relative RMSE too large: {relative_rmse:.6f}")
+
+
+@pytest.mark.parametrize(
+    "batch,q_len,heads,splits,expected",
+    [
+        (1, 1, 6, 32, 4),
+        (1, 1, 48, 32, 2),
+        (1, 1, 96, 32, 4),
+        (1, 8, 96, 8, 1),
+        (4, 1, 48, 32, 1),
+        (1, 1, 6, 2, 2),
+        (1, 1, 6, 1, 1),
+    ],
+)
+def test_reducer_parallelism_uses_real_rows_and_available_splits(
+    batch, q_len, heads, splits, expected
+):
+    decode = pytest.importorskip("tokenspeed_mla.mla_decode")
+    assert decode._get_reducer_d_tiles(batch, q_len, heads, 148, splits) == expected
+
+
+@pytest.mark.parametrize(
+    "kv_len,tile_m,expected_splits",
+    [
+        (128, 128, 1),
+        (384, 128, 3),
+        (1024, 128, 8),
+        (4096, 128, 32),
+        (16512, 64, 43),
+    ],
+)
+def test_fp8_workspace_counts_only_nonempty_partitions(kv_len, tile_m, expected_splits):
+    decode = pytest.importorskip("tokenspeed_mla.mla_decode")
+    splits, workspace = decode._get_split_kv_and_workspace_size(
+        1, 1, 48, 512, 148, kv_len, torch.float8_e4m3fn, (tile_m, 128)
+    )
+    assert splits == expected_splits
+    assert workspace == (0 if splits == 1 else 48 * splits * 513 * 4)
+    k_tiles = (kv_len + 127) // 128
+    tiles_per_split = (k_tiles + splits - 1) // splits
+    assert (splits - 1) * tiles_per_split < k_tiles <= splits * tiles_per_split
+
+
+def test_bf16_split_selection_is_unchanged():
+    decode = pytest.importorskip("tokenspeed_mla.mla_decode")
+    splits, workspace = decode._get_split_kv_and_workspace_size(
+        1, 1, 96, 512, 148, 128, torch.bfloat16, (128, 128)
+    )
+    assert splits == 32
+    assert workspace == 96 * 32 * 513 * 4
+
+
+@pytest.mark.parametrize("dtype", ["fp8", "bf16"])
+def test_input_pages_are_unique_and_tma_aligned(dtype):
+    case = _Case(4, 129, 12, 8)
+    q, kv, tables, lengths = _make_inputs(case, dtype, True, "cpu")
+    q_again, kv_again, _, _ = _make_inputs(case, dtype, True, "cpu")
+    assert torch.equal(q.view(torch.uint8), q_again.view(torch.uint8))
+    assert torch.equal(kv.view(torch.uint8), kv_again.view(torch.uint8))
+    assert tables.shape == (4, 4)  # Three used pages and one padded table index.
+    assert torch.unique(tables[:, :3]).numel() == 12
+    assert lengths.max() == 129
+    assert lengths.min() >= case.q_len
+    assert torch.unique(lengths).numel() > 1
+
+
+def test_reference_uses_page_table_lengths_and_bottom_right_causality():
+    # Zero logits make attention a simple prefix mean. Logical tokens are
+    # [1, 3, 7] and [9, 11], with deliberately permuted physical pages.
+    q = torch.zeros(2, 2, 1, 576)
+    kv = torch.full((4, 2, 576), 1000.0)
+    kv[2, 0].fill_(1)
+    kv[2, 1].fill_(3)
+    kv[0, 0].fill_(7)
+    kv[3, 0].fill_(9)
+    kv[3, 1].fill_(11)
+    tables = torch.tensor([[2, 0], [3, 1]], dtype=torch.int32)
+    lengths = torch.tensor([3, 2], dtype=torch.int32)
+    output = _reference_mla(q, kv, tables, lengths, [0, 1])
+    expected = torch.tensor([[2, 11 / 3], [9, 10]])[:, :, None, None].expand(
+        2, 2, 1, 512
+    )
+    torch.testing.assert_close(output, expected)
+
+
+def test_reference_dequantizes_fp8_before_arithmetic():
+    q, kv, tables, lengths = _make_inputs(_Case(2, 67, 6, 4), "fp8", False, "cpu")
+    output = _reference_mla(q, kv, tables, lengths, [0, 1])
+    expected = _reference_mla(q.float(), kv.float(), tables, lengths, [0, 1])
+    torch.testing.assert_close(output, expected)
+
+
+@pytest.mark.parametrize("dtype", ["fp8", "fp16", "bf16"])
+def test_input_and_output_dtype_contract(dtype):
+    q, kv, tables, lengths = _make_inputs(_Case(1, 67, 6, 4), dtype, False, "cpu")
+    expected_dtype = {
+        "fp8": torch.float8_e4m3fn,
+        "fp16": torch.float16,
+        "bf16": torch.bfloat16,
+    }[dtype]
+    assert q.dtype == kv.dtype == expected_dtype
+    expected = _reference_mla(q, kv, tables, lengths, [0])
+    output_dtype = torch.float16 if dtype == "fp16" else torch.bfloat16
+    _check_output(expected.to(output_dtype), expected, dtype)
+    wrong_dtype = torch.bfloat16 if dtype == "fp16" else torch.float16
+    with pytest.raises(AssertionError, match="output"):
+        _check_output(expected.to(wrong_dtype), expected, dtype)
+
+
+@pytest.mark.parametrize("value", [0.0, float("nan")])
+def test_accuracy_check_rejects_empty_graph_and_zero_long_context_outputs(value):
+    expected = torch.full((1, 1, 1, 512), 0.001)
+    actual = torch.full(expected.shape, value, dtype=torch.bfloat16)
+    with pytest.raises(AssertionError):
+        _check_output(actual, expected, "fp8")
+
+
+@pytest.mark.parametrize(
+    "heads,queries,expected",
+    [
+        (96, 4, (384, 3, 128)),
+        (96, 8, (768, 6, 128)),
+        (96, 3, (288, 3, 32)),
+        (48, 3, (144, 2, 16)),
+        (12, 11, (132, 2, 4)),
+        (128, 3, (384, 3, 128)),
+    ],
+)
+def test_packed_tile_geometry(heads, queries, expected):
+    assert compute_q_tile_layout(heads, queries, 128) == expected
+
+
+@pytest.mark.parametrize("args", [(0, 4, 128), (96, 0, 128), (129, 4, 128), (96, 4, 0)])
+def test_invalid_packed_geometry(args):
+    with pytest.raises(ValueError):
+        compute_q_tile_layout(*args)
+
+
+@pytest.mark.parametrize("batch,expected_splits", [(1, 24), (4, 6)])
+def test_packed_workspace_matches_launch_geometry(batch, expected_splits):
+    import tokenspeed_mla.mla_decode as decode
+
+    _, tiles, _ = compute_q_tile_layout(96, 4, 128)
+    splits, workspace = decode._get_split_kv_and_workspace_size(
+        batch, tiles, 128, 512, 148, 65536, torch.float8_e4m3fn, (128, 128)
+    )
+    assert splits == expected_splits
+    assert workspace == batch * 128 * tiles * splits * 513 * 4
+
+
+def test_packed_q_is_opt_in():
+    import tokenspeed_mla.mla_decode as decode
+    from tokenspeed_mla.mla_decode_fp16 import (
+        BlackwellMultiHeadLatentAttentionForwardFP16,
+    )
+
+    assert (
+        inspect.signature(decode.tokenspeed_mla_decode)
+        .parameters["enable_packed_q"]
+        .default
+        is False
+    )
+    assert (
+        inspect.signature(BlackwellMultiHeadLatentAttentionForwardFP16)
+        .parameters["pack_q"]
+        .default
+        is False
+    )
+    assert (
+        inspect.signature(decode._get_compiled_mla_kernel).parameters["pack_q"].default
+        is False
+    )
+
+
+def _check_fp8_gpu(case, variable_kv):
+    from tokenspeed_mla import tokenspeed_mla_decode
+
+    q, kv, tables, lengths = _make_inputs(case, "fp8", variable_kv, "cuda")
+    workspace = torch.zeros(256 * 1024**2, dtype=torch.int8, device="cuda")
+    out = torch.empty(
+        case.batch,
+        case.q_len,
+        case.heads,
+        512,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    indices = (
+        list(range(case.batch))
+        if case.batch <= 4
+        else sorted({0, case.batch // 2, case.batch - 1})
+    )
+    expected = _reference_mla(q, kv, tables, lengths, indices)
+    kwargs = dict(
+        query=q,
+        kv_cache=kv,
+        workspace_buffer=workspace,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        block_tables=tables,
+        seq_lens=lengths,
+        max_seq_len=case.kv_len,
+        softmax_scale=192**-0.5,
+        output_scale=1.0,
+        out=out,
+        is_var_seq=variable_kv,
+        causal_mask=True,
+        window_left=-1,
+        enable_pdl=False,
+        return_lse=False,
+        causal_seqs=None,
+        cp_world=1,
+        cp_rank=0,
+        enable_packed_q=False,
+    )
+    tokenspeed_mla_decode(**kwargs)
+    torch.cuda.synchronize()
+    _check_output(out[indices], expected, "fp8")
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        tokenspeed_mla_decode(**kwargs)
+    out.fill_(float("nan"))
+    for _ in range(3):
+        graph.replay()
+    torch.cuda.synchronize()
+    _check_output(out[indices], expected, "fp8")
+
+
+def _check_packed_gpu():
+    import tokenspeed_mla.mla_decode as decode
+
+    torch.backends.cuda.matmul.allow_tf32 = False
+    workspace = torch.zeros(32 * 1024**2, dtype=torch.int8, device="cuda")
+    original_compile = decode._get_compiled_mla_kernel
+    selections = []
+
+    def record_compile(*args, **kwargs):
+        selections.append(kwargs["pack_q"])
+        return original_compile(*args, **kwargs)
+
+    decode._get_compiled_mla_kernel = record_compile
+    cases = [
+        # Cross-query masks straddle a K128 boundary, with split-KV.
+        (_Case(1, 129, 96, 4), "fp8", False, False, False, True),
+        (_Case(4, 257, 96, 8), "fp8", True, True, False, True),
+        # Partial final rows, no reducer, and multiple persistent work items.
+        (_Case(32, 128, 96, 3), "fp8", False, False, False, True),
+        (_Case(1, 257, 48, 3), "fp8", False, True, False, True),
+        # FP16/BF16 share packing, including tails, folding and PDL.
+        (_Case(1, 129, 96, 4), "bf16", False, False, False, True),
+        (_Case(1, 129, 96, 4), "fp16", False, False, False, True),
+        (_Case(4, 257, 96, 8), "fp16", True, True, False, True),
+        (_Case(32, 128, 96, 3), "fp16", False, False, False, True),
+        (_Case(1, 129, 48, 4), "fp16", False, False, False, True),
+        # Existing M64 and token-gapped M128 paths stay selected.
+        (_Case(1, 129, 12, 4), "fp8", False, False, False, False),
+        (_Case(1, 129, 96, 4), "fp8", False, False, True, False),
+        (_Case(1, 129, 96, 4), "fp16", False, False, True, False),
+    ]
+    for case, dtype, variable_kv, pdl, token_gap, expected_packed in cases:
+        q, kv, tables, lengths = _make_inputs(case, dtype, variable_kv, "cuda")
+        if token_gap:
+            storage = torch.empty(
+                (case.batch, case.q_len * 2, case.heads, 576),
+                device="cuda",
+                dtype=q.dtype,
+            )
+            view = storage[:, ::2]
+            view.copy_(q)
+            q = view
+        indices = list(range(case.batch))
+        expected = _reference_mla(q, kv, tables, lengths, indices)
+        # Guard the final output allocation against tail-row writes.
+        storage = torch.full(
+            (case.batch * case.q_len * case.heads * 512 + 1024,),
+            123.0,
+            dtype=torch.float16 if dtype == "fp16" else torch.bfloat16,
+            device="cuda",
+        )
+        out = storage[512:-512].view(case.batch, case.q_len, case.heads, 512)
+        kwargs = dict(
+            query=q,
+            kv_cache=kv,
+            workspace_buffer=workspace,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            block_tables=tables,
+            seq_lens=lengths,
+            max_seq_len=case.kv_len,
+            softmax_scale=192**-0.5,
+            is_var_seq=variable_kv,
+            enable_pdl=pdl,
+            out=out,
+            return_lse=True,
+        )
+        default_out, default_lse = decode.tokenspeed_mla_decode(**kwargs)
+        assert selections[-1] is False
+        default_out = default_out.clone()
+        default_lse = default_lse.clone()
+        _check_output(default_out, expected, dtype)
+        disabled_out, disabled_lse = decode.tokenspeed_mla_decode(
+            **kwargs, enable_packed_q=False
+        )
+        torch.testing.assert_close(disabled_out, default_out, atol=0, rtol=0)
+        torch.testing.assert_close(disabled_lse, default_lse, atol=0, rtol=0)
+        result, lse = decode.tokenspeed_mla_decode(**kwargs, enable_packed_q=True)
+        assert selections[-1] is expected_packed
+        torch.cuda.synchronize()
+        _check_output(result, expected, dtype)
+        if dtype != "fp8":
+            torch.testing.assert_close(lse, default_lse, atol=2e-5, rtol=1e-5)
+        if not expected_packed:
+            torch.testing.assert_close(result, default_out, atol=0, rtol=0)
+        # Uniform attention exposes off-by-one causal boundaries in LSE.
+        q.zero_()
+        expected = _reference_mla(q, kv, tables, lengths, indices)
+        visible = (
+            lengths[:, None]
+            - case.q_len
+            + torch.arange(1, case.q_len + 1, device="cuda")[None, :]
+        )
+        expected_lse = visible.float().log2()[:, :, None].expand(-1, -1, case.heads)
+        result, lse = decode.tokenspeed_mla_decode(**kwargs, enable_packed_q=True)
+        torch.cuda.synchronize()
+        torch.testing.assert_close(lse, expected_lse, atol=2e-5, rtol=1e-5)
+        _check_output(result, expected, dtype)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=stream):
+            result, lse = decode.tokenspeed_mla_decode(**kwargs, enable_packed_q=True)
+        result.fill_(float("nan"))
+        lse.fill_(float("nan"))
+        for _ in range(3):
+            graph.replay()
+        torch.cuda.synchronize()
+        _check_output(result, expected, dtype)
+        torch.testing.assert_close(lse, expected_lse, atol=2e-5, rtol=1e-5)
+        assert torch.all(storage[:512] == 123) and torch.all(storage[-512:] == 123)
+        print(
+            f"Packed Q verified: {case.name} dtype={dtype} packed={expected_packed}",
+            flush=True,
+        )
+
+
+def _check_packed_masks_gpu():
+    from tokenspeed_mla import tokenspeed_mla_decode
+
+    torch.backends.cuda.matmul.allow_tf32 = False
+    workspace = torch.zeros(32 * 1024**2, dtype=torch.int8, device="cuda")
+    # Narrow and multi-tile windows exercise the unsplit epilogue and reducer.
+    # H96/Q3 also puts both the window boundary and output in a partial tile.
+    case = _Case(2, 769, 96, 3)
+    for dtype in ("fp8", "fp16", "bf16"):
+        q, kv, tables, lengths = _make_inputs(case, dtype, True, "cuda")
+        for window in (2, 256):
+            for causal in (False, True):
+                expected = torch.empty(
+                    case.batch, case.q_len, case.heads, 512, device="cuda"
+                )
+                expected_lse = torch.empty(
+                    case.batch, case.q_len, case.heads, device="cuda"
+                )
+                visible = torch.empty_like(expected_lse)
+                for batch in range(case.batch):
+                    length = int(lengths[batch])
+                    keys = kv.float()[tables[batch].long()].reshape(-1, 576)
+                    for row in range(case.q_len):
+                        low = max(0, length - case.q_len - window + row)
+                        high = length - case.q_len + row + 1 if causal else length
+                        logits = q[batch, row].float() @ keys[low:high].T
+                        logits *= 192**-0.5
+                        expected[batch, row] = logits.softmax(-1) @ keys[low:high, :512]
+                        expected_lse[batch, row] = logits.logsumexp(-1) / torch.log(
+                            torch.tensor(2.0, device="cuda")
+                        )
+                        visible[batch, row] = high - low
+                kwargs = dict(
+                    query=q,
+                    kv_cache=kv,
+                    workspace_buffer=workspace,
+                    kv_lora_rank=512,
+                    qk_rope_head_dim=64,
+                    block_tables=tables,
+                    seq_lens=lengths,
+                    max_seq_len=case.kv_len,
+                    softmax_scale=192**-0.5,
+                    is_var_seq=True,
+                    causal_mask=causal,
+                    window_left=window,
+                    enable_pdl=True,
+                    return_lse=True,
+                )
+                for packed in (False, True):
+                    result, lse = tokenspeed_mla_decode(
+                        **kwargs, enable_packed_q=packed
+                    )
+                    _check_output(result, expected, dtype)
+                    lse_tol = 0.05 if dtype == "fp8" else 0.002
+                    torch.testing.assert_close(
+                        lse, expected_lse, atol=lse_tol, rtol=0.001
+                    )
+                # A uniform query makes each window's exact key count observable.
+                zero_kwargs = dict(kwargs, query=torch.zeros_like(q))
+                for packed in (False, True):
+                    _, lse = tokenspeed_mla_decode(
+                        **zero_kwargs, enable_packed_q=packed
+                    )
+                    torch.testing.assert_close(
+                        lse, visible.log2(), atol=2e-5, rtol=1e-5
+                    )
+                print(
+                    f"Window verified: dtype={dtype} window={window} causal={causal}",
+                    flush=True,
+                )
+
+    # Strided DCP keys use global positions for the causal upper boundary.
+    # Check against an explicit reference rather than only against the old kernel.
+    torch.manual_seed(19)
+    length, world, heads, queries = 515, 2, 96, 3
+    query = torch.randn(1, queries, heads, 576, device="cuda").to(torch.float8_e4m3fn)
+    keys = torch.randn(length, 576, device="cuda").to(torch.float8_e4m3fn)
+    for rank in range(world):
+        local = keys[rank::world]
+        pages = (local.shape[0] + 63) // 64
+        cache = torch.zeros(pages, 64, 576, dtype=keys.dtype, device="cuda")
+        cache.view(-1, 576)[: local.shape[0]] = local
+        table = torch.arange(pages, dtype=torch.int32, device="cuda")[None]
+        positions = torch.arange(rank, length, world, device="cuda")
+        expected = torch.empty(1, queries, heads, 512, device="cuda")
+        visible = torch.empty(1, queries, heads, device="cuda")
+        for row in range(queries):
+            count = int((positions < length - queries + row + 1).sum())
+            logits = query[0, row].float() @ local[:count].float().T
+            expected[0, row] = (logits * 192**-0.5).softmax(-1) @ local[
+                :count, :512
+            ].float()
+            visible[0, row] = count
+        kwargs = dict(
+            query=query,
+            kv_cache=cache,
+            workspace_buffer=workspace,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            block_tables=table,
+            seq_lens=torch.tensor([local.shape[0]], dtype=torch.int32, device="cuda"),
+            max_seq_len=local.shape[0],
+            softmax_scale=192**-0.5,
+            is_var_seq=False,
+            causal_mask=True,
+            window_left=-1,
+            cp_world=world,
+            cp_rank=rank,
+            causal_seqs=torch.tensor([length], dtype=torch.int32, device="cuda"),
+            return_lse=True,
+        )
+        for packed in (False, True):
+            output, _ = tokenspeed_mla_decode(**kwargs, enable_packed_q=packed)
+            _check_output(output, expected, "fp8")
+            _, lse = tokenspeed_mla_decode(
+                **dict(kwargs, query=torch.zeros_like(query)),
+                enable_packed_q=packed,
+            )
+            torch.testing.assert_close(lse, visible.log2(), atol=2e-5, rtol=1e-5)
+        print(f"DCP verified: rank={rank} world={world}", flush=True)
+
+
+def _check_reducer_variants():
+    import tokenspeed_mla.mla_decode as decode
+
+    torch.backends.cuda.matmul.allow_tf32 = False
+    original_compile = decode._get_compiled_mla_kernel
+    workspace = torch.zeros(256 * 1024**2, dtype=torch.int8, device="cuda")
+    for case, capacity in [(_Case(1, 8192, 12, 4), 64), (_Case(1, 8192, 96, 1), 32)]:
+        q, kv, tables, lengths = _make_inputs(case, "fp8", False, "cuda")
+        q.zero_()  # Uniform attention has a closed-form base-2 LSE.
+        expected_out = _reference_mla(q, kv, tables, lengths, [0])
+        visible = (
+            case.kv_len - case.q_len + torch.arange(1, case.q_len + 1, device="cuda")
+        )
+        expected_lse = (
+            visible.float().log2()[None, :, None].expand(1, case.q_len, case.heads)
+        )
+        for pdl in (False, True):
+            reference_out = reference_lse = None
+            for bands, max_splits in [
+                (1, 256),
+                (1, capacity),
+                (2, capacity),
+                (4, capacity),
+            ]:
+                # Exercise the original full-capacity reducer and all new
+                # topologies through the same wrapper/cache in one process.
+                def compile_variant(*args, **kwargs):
+                    kwargs.update(reducer_d_tiles=bands, reducer_max_splits=max_splits)
+                    return original_compile(*args, **kwargs)
+
+                decode._get_compiled_mla_kernel = compile_variant
+                output, lse = decode.tokenspeed_mla_decode(
+                    query=q,
+                    kv_cache=kv,
+                    workspace_buffer=workspace,
+                    kv_lora_rank=512,
+                    qk_rope_head_dim=64,
+                    block_tables=tables,
+                    seq_lens=lengths,
+                    max_seq_len=case.kv_len,
+                    softmax_scale=192**-0.5,
+                    return_lse=True,
+                    is_var_seq=False,
+                    enable_pdl=pdl,
+                )
+                torch.cuda.synchronize()
+                torch.testing.assert_close(lse, expected_lse, atol=2e-5, rtol=1e-5)
+                torch.testing.assert_close(
+                    output.float(), expected_out, atol=0.001, rtol=0.05
+                )
+                if reference_out is None:
+                    reference_out, reference_lse = output.clone(), lse.clone()
+                else:
+                    torch.testing.assert_close(output, reference_out, atol=0, rtol=0)
+                    torch.testing.assert_close(lse, reference_lse, atol=0, rtol=0)
+
+
+def _gpu_worker(check, arguments, send):
+    try:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        check(*arguments)
+        send.send(None)
+    except Exception:
+        send.send(traceback.format_exc())
+    finally:
+        send.close()
+
+
+def _run_gpu_check(check, arguments, timeout):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() not in (
+        (10, 0),
+        (10, 3),
+    ):
+        pytest.skip("Requires Blackwell SM100/SM103")
+    context = multiprocessing.get_context("spawn")
+    receive, send = context.Pipe(duplex=False)
+    process = context.Process(target=_gpu_worker, args=(check, arguments, send))
+    process.start()
+    send.close()
+    try:
+        assert receive.poll(timeout), f"{check.__name__} timed out after {timeout}s"
+        assert (error := receive.recv()) is None, error
+    finally:
+        receive.close()
+        process.join(timeout=1)
+        if process.is_alive():
+            process.kill()
+            process.join()
+
+
+class TestGPU:
+    @pytest.mark.parametrize(
+        "case,variable_kv",
+        [
+            (_Case(1, 1024, heads, q_len), False)
+            for heads, q_len in itertools.product((6, 12, 24, 48, 96, 128), (1, 4, 8))
+        ]
+        + [
+            (_Case(4, 1024, 12, 8), False),
+            (_Case(1, 1024, 128, 2), False),
+            (_Case(10, 385, 96, 8), True),
+            (_Case(128, 384, 96, 1), False),
+            # Exercise all reducer bands and both static capacities (32 and 64).
+            (_Case(1, 16384, 48, 1), False),
+            (_Case(1, 16384, 96, 1), False),
+            (_Case(1, 16512, 6, 1), False),
+            # Normalizing to one split must take the workspace-free kernel path.
+            (_Case(1, 128, 96, 1), False),
+        ],
+        ids=lambda value: value.name if isinstance(value, _Case) else None,
+    )
+    def test_fp8_decode_accuracy_and_cuda_graph(self, case, variable_kv):
+        _run_gpu_check(_check_fp8_gpu, (case, variable_kv), 180)
+
+    def test_packed_q_outputs_lse_tails_and_legacy_paths(self):
+        _run_gpu_check(_check_packed_gpu, (), 600)
+
+    def test_packed_q_preserves_sliding_window_and_dcp_masks(self):
+        _run_gpu_check(_check_packed_masks_gpu, (), 600)
+
+    def test_reducer_bands_preserve_output_lse_and_pdl(self):
+        _run_gpu_check(_check_reducer_variants, (), 240)


### PR DESCRIPTION
Pack contiguous query/head rows into M128 tiles, reducing H96/Sq4 from four query tiles to three without an additional packing kernel. Keep the existing layout as the default and preserve causal masking, sliding windows, DCP, output and LSE behavior.

Normalize FP8 split-KV partitions and optimize reducer capacity and parallelism. Consolidate regression coverage into one self-contained test module and document how to run CPU and GPU checks.

FP8 performance on SM100:
- Hq=96, Sq={4,8}, K={64K,128K}, Batch={1,4,16,64}
- Cold L2; median of 100 timing samples per case
- Packed path: 14.44%-21.17% lower latency than the baseline
- Legacy path: -0.13% to +0.88% latency change

Validation: 64 regression tests passed on SM100. All applicable pre-commit checks passed.

## Summary

<!-- What changed and why? -->

## Test Plan

<!-- How was this validated? -->
