### PR TITLE
Add SM120 DSpark bias argmax kernels and optional host launch

### DIFF
--- a/docs/design/bias-argmax-host-launch.md
+++ b/docs/design/bias-argmax-host-launch.md
@@ -1,0 +1,25 @@
+# SM120 bias argmax host launch contract
+
+The partial and final Triton GPU kernels remain unchanged. This experiment uses
+one CPU-built extension call to enqueue the same two kernels on the current
+stream after the original live Tensor, device, layout, stride, alias, dtype,
+offset and registry-selection checks. The cache retains executable handles and
+immutable launch metadata; it retains no input pointers, Tensors or streams.
+The two official runners remain alive in that same cache to own the executables.
+
+The native pair is bounded to the inspected tokenspeed-triton distribution
+3.8.10.post20260906 (its runtime version string is 3.8.10), one CTA per cluster,
+four warps, the verified pointer-only PTX signatures, and zero global/profile
+scratch. Both implicit scratch parameters are passed as null, as by the vendor
+launcher. Cooperative launch, PDL, GSan, debug/pre-run instrumentation, and live
+launch hooks preserve the official launcher path. Hook presence is checked at
+every warm call; it is never cached. CUDA errors propagate immediately.
+
+Eager and graph capture execute the identical dispatch. CUDA Graph records both
+driver launches; replay uses the already captured nodes. No timing-mode branch,
+new numerical kernel, changed output/work gate or new scheduler path is added.
+The CUDA package build compiles the host extension with the selected CUDA headers and current PyTorch. Its build record binds the binary hash, exact PyTorch version and Python major/minor. CUDA wheels carry CPython/platform tags. A missing or incompatible optional extension keeps the original bias-plus-argmax fallback, including CPU/ROCm source installations. No compilation occurs on import.
+
+C8 checks the pinned runtime HookChain call list live: an exactly typed empty chain is inactive; adding an enter/exit callback immediately restores official runner dispatch, and removal restores native dispatch. Arbitrary callables/subclasses keep the official path.
+
+C9 releases the Python GIL only around the two CUDA driver calls, after all Python/Tensor metadata has been read. The pinned vendor driver.c uses Py_BEGIN_ALLOW_THREADS around its launch at lines 1524-1528. This restores its thread-interleaving contract; tensor argument ownership and RAII keep lifetime/error translation safe. C8 held the GIL and regressed 7.67-8.23 percent in full Engine eager while graph improved. The final C9 complete Engine eager run remained 3.168–3.825 percent slower despite positive local-region results. Releasing the GIL preserves the vendor concurrency contract; it is not evidence of a complete-model speedup.

--- a/docs/performance/dspark-bias-argmax-sm120.md
+++ b/docs/performance/dspark-bias-argmax-sm120.md
@@ -1,0 +1,150 @@
+# SM120 DSpark bias-argmax candidate
+
+This experimental candidate fuses the per-step bias postprocessing used by the
+DSpark proposal consumer at TokenSpeed revision
+`7978c48b5c56445c600880f0ff275a611e584cef`. It does not change the Markov weights,
+proposal width, token semantics, verification, or scheduler. The completed C9 validation is summarized below. The proposal region improves,
+but complete Engine eager latency regresses, so this candidate remains a draft.
+
+## Consumer and numerical contract
+
+`DSpark._sample_block` already computes the block base-logit projection in one
+GEMM. Each subsequent position embeds the previous token, projects its Markov
+bias, and passes a positive-strided `next_tokens[:, position]` output view into
+`DFlash._greedy_argmax_vocab_parallel`. The candidate preserves these projections and
+their dependencies. It replaces the native bias cast, addition,
+maximum/index reduction, vocabulary offset, and output copy with two Triton
+launches: vocabulary-tile partials and a final strided-output reduction.
+
+For logits dtype `d`, the exact comparison scores are
+`round_d(logits + round_d(bias))`. Both rounding boundaries are explicit. NaNs
+win at the first index, equal maxima choose the smallest index, and signed
+zeros/infinities follow the original Torch result. The kernel uses int64
+address arithmetic and supports int32 or int64 outputs with checked global-ID
+bounds. It does not use the generic sampling argmax API, whose NaN policy is
+different.
+
+For example, fp16 logits `[1, 1]` and fp32 bias `[0.0003, 0.0004]` both round to
+score 1 and select index 0; omitting the result rounding selects index 1.
+Separately, logits `[-1, -1]` and bias `[1.0002, 1.0003]` select index 0 after
+bias conversion, while omitting that conversion leaves distinct small results
+after the addition rounding and selects index 1.
+
+## Scope and state lifetime
+
+The consumer enables this candidate only for SM120, TP1, a nonempty original
+vocabulary shard with no added-vocabulary section, no distributed argmax state,
+a Markov bias, and a supplied output. The current CUDA device must match the
+inputs. Vocabulary sizes 1 through 262144 are the experimental scope, not an
+upstream vocabulary limit. FP16, BF16, and FP32 logits and bias may use different
+dtypes and positive strides. The output may have any positive stride.
+
+Scratch is allocated in `wire_target`, after the real head has been bound and
+target wiring checks have succeeded, using the full input-buffer batch
+capacity and real vocabulary width. `_init_native_buffers` only initializes the
+empty workspace state because the target head is not yet bound there. All
+capture buckets reuse this storage sequentially. Different streams need separate
+workspaces or explicit ordering. The eager and CUDA Graph consumer use the same
+implementation.
+
+Unsupported metadata returns `False` before selection or writes. Checks cover
+workspace dtype/shape/contiguity, device, offsets, nonpositive strides, nested
+or sparse tensors, unresolved negative/conjugate views, and conservative byte
+span overlap between every write and all other read/write regions. Read/read
+aliasing is legal. Inputs must be ordinary strided Torch tensors, including
+parameters; custom Tensor subclasses that redefine storage/dispatch semantics
+are outside this experimental scope.
+
+The original collective probe stays before every rank-local branch. The bias
+closure executes once; a rejected candidate reuses that computed bias in the
+original fallback. `out=None` retains the original fresh-result behavior.
+Unsupported hardware, TP, added vocabulary, and distributed state use the
+existing path.
+
+## Launcher reuse
+
+The first call uses the normal Triton JIT. Later matching calls may reuse the
+official `CompiledKernel[grid]` runners, passing every current tensor and
+constant again. The cache retains code and grid, not input pointers or streams.
+Keys cover device, dtypes, full strides/constants, grids, kernel source, and
+all five tensor pointer residues modulo 16. Each alignment class first passes
+through normal JIT specialization, including unaligned output columns.
+
+Runtime launch hooks remain active through the official compiled interface.
+Debugging, stage inspection, instrumentation, or JIT pre-run hooks bypass the
+runner cache. Interpreter mode and an active `jit_cache_hook` reject the
+candidate before either launch: a hook may suppress compilation on a cold
+miss, so finalizing old partials would be incorrect. The original Torch consumer
+still provides the fallback in those modes.
+
+## Verification and timing harness
+
+Kernel tests cover all nine input dtype pairs, vocabulary tails and size
+bounds, NaNs/ties/infinities, both rounding witnesses, strided reads/writes,
+offset boundaries, malformed/alias metadata, pointer/alignment cache reuse,
+streams, changing graph inputs, shared capture-bucket scratch, and hooks.
+Consumer tests execute unchanged source methods with explicit dependency
+fixtures and fixed original source snapshots. The CPU configuration injects
+an unavailable-kernel dependency without importing GPU packages or fabricating
+capabilities; it only verifies host branches and workspace wiring.
+
+`tokenspeed-kernel/benchmarks/bench_dspark_bias_argmax_sm120.py` requires an
+explicit directory containing original `dflash.py`, `dspark.py`, `nvtx.py`, and
+`model_dspark.py` from the fixed baseline. Each complete file has a checked SHA.
+The support loader selects unchanged source methods through AST and preserves
+the original disabled NVTX wrapper. Heavy model construction and unrelated
+imports are replaced by declared boundary fixtures; this is not a model run.
+
+The benchmark has two independent timing regions:
+
+- `postprocess_precomputed_bias`: the complete actual DFlash method with the
+  same precomputed base logits and bias in both arms; neither projection GEMM
+  is in the timed region.
+- `proposal_walk`: the complete actual DSpark `_sample_block`, including anchor
+  copy, block base GEMM and layout, previous-token clamp/embedding, every Markov
+  GEMM and DFlash call, and final output clamp. `N` includes the anchor.
+
+Each shape/dtype/region runs eager and CUDA Graph separately, with independent
+but equal arm buffers/weights/graphs, warmup outside timing, profiler path
+checks outside timing, and random complete APPA/PAAP blocks. The primary
+latency reduction is `100 * (1 - exp(mean(block_log_ratio)))`, where each block
+ratio is `mean(log(P1), log(P2)) - mean(log(A1), log(A2))`. Keep runs and regions
+separate; these descriptive samples do not establish model throughput.
+
+Raw evidence files are created exclusively and never overwrite prior or
+partial runs. Failure appends `completion.success=false` with error details.
+Success requires full record counts, exact output equivalence, unchanged
+immutable inputs/parameters and source hashes, and the expected two-stage
+kernel path. Evidence includes GPU UUID, logical CUDA device/CVD, software
+versions, source paths/hashes, tensor hashes/shapes/strides/dtypes/pointers,
+and all block positions. Proposal base logits and bias are temporary results
+inside each actual method call; the precomputed group additionally hashes those
+persistent input buffers.
+
+The preregistered primary synthetic-weight geometry follows the released
+`deepseek-ai/dspark_qwen3_4b_block7` configuration (revision
+`3457dff1417cb84927f6098a5fcb7cee85c934b7`) paired with `Qwen/Qwen3-4B`
+(revision `1cfa9a7208912126459214e8b04321603b3df60c`): vocabulary 151936,
+hidden width 2560, Markov rank 256, BF16, and seven draft positions plus one
+anchor (`N=8`). Batch sizes are 1, 8, and 16. Primary timing uses eight
+APPA/PAAP blocks, 200 iterations per arm, and five capture warmup calls. All
+primary shapes, both regions, and both modes must be retained, including flat
+or slower results. Small/tail vocabulary shapes primarily test correctness.
+This geometry uses generated parameters and does not claim to load those
+checkpoint weights or to establish compatibility of a complete model run.
+
+## C9 validation and limitations
+
+The frozen GPU run passed 120 regression tests with zero skips, 324 numerical boundary rows, and all 384 timing arms across 12 paths. These are source-method/region measurements with generated weights, not complete-model speedups.
+
+| Batch | Postprocess eager reduction | Postprocess Graph reduction | Proposal walk eager reduction | Proposal walk Graph reduction |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 59.863% | 60.455% | 1.984% | 2.090% |
+| 8 | 59.526% | 64.919% | 3.708% | 3.658% |
+| 16 | 59.996% | 69.781% | 4.001% | 3.698% |
+
+The final complete Qwen3-4B target plus DSpark eager validation used four fresh processes in candidate/baseline/baseline/candidate order, batches 1/4/8, fixed 128-token outputs, two warmups, and seven measurements per process. Both arms include the same prerequisite runtime fixes. All ordered token IDs, text, finish reasons, and speculative-work counts matched exactly. Source, native-library, process-role and eager-path audits passed.
+
+Complete Engine eager latency increased **3.168% / 3.825% / 3.807%** for batches 1/4/8. These are descriptive ratios of geometric means of process medians; no confidence interval or general-model speedup is claimed. The two candidate processes varied. Earlier timings affected by shared-host overlap were rejected and are not included. No complete Engine Graph improvement is attributed to C9.
+
+C9 releases the GIL only during its two CUDA driver calls, retaining the vendor launcher's thread-interleaving contract and all live metadata/instrumentation checks. An absent or ABI-incompatible optional extension retains the original fallback. CUDA wheel packaging and broad hardware/runtime support require further validation. The limited route gains do not justify default promotion.

--- a/python/tokenspeed/runtime/execution/drafter/dflash.py
+++ b/python/tokenspeed/runtime/execution/drafter/dflash.py
@@ -22,6 +22,10 @@ from typing import TYPE_CHECKING
 
 import torch
 from tokenspeed_kernel.ops.kvcache.triton import mla_latent_norm_rope_scatter
+from tokenspeed_kernel.ops.sampling import (
+    create_bias_argmax_workspace,
+    try_bias_argmax,
+)
 from tokenspeed_kernel.ops.sampling.cute_dsl import distributed_argmax as _dist_argmax
 from tokenspeed_kernel.ops.sampling.cute_dsl import (
     supports_dist_argmax_shape as _supports_dist_argmax_shape,
@@ -238,6 +242,8 @@ class DFlash(BaseDrafter):
         )
         # None means probed-and-unavailable; unset means not probed yet.
         self._dist_argmax_state: object = _UNSET
+        # The target head is not bound until wire_target; allocate there.
+        self._bias_argmax_workspace = None
         self.draft_input_lengths_buf = torch.full(
             (max_bs,),
             self.draft_query_width,
@@ -291,6 +297,26 @@ class DFlash(BaseDrafter):
             )
         target_model.set_dflash_layers_to_capture(self.target_layer_ids)
         self._wire_aux_hidden_stream(target_model)
+        self._bias_argmax_workspace = None
+        # Only DSpark supplies Markov bias. Bind full-capacity scratch after
+        # the actual target head and all wiring checks, before graph capture.
+        if (
+            self.spec_algorithm == "DSPARK"
+            and hasattr(self.lm_head, "shard_indices")
+            and hasattr(self.lm_head, "weight")
+        ):
+            shard = self.lm_head.shard_indices
+            num_org = int(shard.num_org_elements)
+            if (
+                int(self.logits_processor.tp_size) == 1
+                and int(shard.num_added_elements) == 0
+                and num_org > 0
+            ):
+                self._bias_argmax_workspace = create_bias_argmax_workspace(
+                    max_rows=self.input_buffers.max_bs,
+                    vocab_size=num_org,
+                    device=self.lm_head.weight.device,
+                )
 
     def _wire_aux_hidden_stream(self, target_model) -> None:
         """Tell the target which residual stream the draft was trained on."""
@@ -439,9 +465,26 @@ class DFlash(BaseDrafter):
             if base_logits is None:
                 base_logits = torch.matmul(hidden_states, weight[:num_org].T)
             if bias_fn is not None:
-                base_logits = base_logits + bias_fn(org_vocab_start, num_org).to(
-                    base_logits.dtype
-                )
+                bias = bias_fn(org_vocab_start, num_org)
+                workspace = getattr(self, "_bias_argmax_workspace", None)
+                if (
+                    workspace is not None
+                    and out is not None
+                    and dist_state is None
+                    and num_added == 0
+                    and int(self.logits_processor.tp_size) == 1
+                    and try_bias_argmax(
+                        logits=base_logits,
+                        bias=bias,
+                        out=out,
+                        workspace=workspace,
+                        global_offset=org_vocab_start,
+                    )
+                ):
+                    return out
+                # A rejected candidate consumes the already-computed bias;
+                # never repeat the Markov projection on the fallback path.
+                base_logits = base_logits + bias.to(base_logits.dtype)
             if dist_state is not None:
                 # Without padding the rank-major index IS the global id.
                 _, idx = _dist_argmax(dist_state, base_logits)

--- a/test/runtime/test_dspark_bias_argmax_sm120.py
+++ b/test/runtime/test_dspark_bias_argmax_sm120.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Source-method consumer boundaries; dependency fixtures are not model E2E.
+
+Set TOKENSPEED_BIAS_ARGMAX_BASELINE_DIR to the SHA-verified original file
+snapshot used by the companion benchmark. CPU tests check host integration;
+GPU-marked cases additionally execute the registered candidate kernels.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tokenspeed-kernel/benchmarks"))
+from dspark_bias_argmax_support import (  # noqa: E402
+    copy_consumer_parameters,
+    load_consumers,
+    make_consumer,
+)
+
+GPU = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (12, 0),
+    reason="requires NVIDIA SM120",
+)
+
+
+@pytest.fixture(scope="module")
+def classes():
+    baseline_dir = os.environ.get("TOKENSPEED_BIAS_ARGMAX_BASELINE_DIR")
+    if baseline_dir is None:
+        pytest.skip("requires explicit original baseline snapshot directory")
+    if torch.cuda.is_available():
+        from tokenspeed_kernel.ops.sampling import (
+            create_bias_argmax_workspace,
+            try_bias_argmax,
+        )
+    else:
+        # CPU host-branch evidence: explicit unavailable-kernel dependency;
+        # no GPU package import or fabricated platform/capability.
+        def create_bias_argmax_workspace(*args, **kwargs):
+            return None
+
+        def try_bias_argmax(*args, **kwargs):
+            raise AssertionError("CPU boundary cannot execute GPU candidate")
+
+    result, provenance = load_consumers(
+        ROOT, baseline_dir, create_bias_argmax_workspace, try_bias_argmax
+    )
+    assert provenance["A"]["dflash"]["sha256"] != provenance["P"]["dflash"]["sha256"]
+    return result
+
+
+def _consumer(classes, arm, device):
+    return make_consumer(classes, arm, 2, 5, 4097, 16, 8, torch.float32, device)
+
+
+def test_bias_closure_is_once_when_candidate_rejects(classes):
+    consumer = _consumer(classes, "P", "cpu")
+    consumer._bias_argmax_workspace = object()
+    hidden = torch.zeros((2, 16))
+    logits = torch.randn((2, 4097))
+    bias = torch.randn_like(logits)
+    output = torch.full((2, 5), -37, dtype=torch.int32)
+    events = []
+    consumer._ensure_dist_argmax_state = lambda *args: events.append("probe")
+
+    def bias_fn(start, count):
+        events.append("bias")
+        assert (start, count) == (0, 4097)
+        return bias
+
+    def reject(**kwargs):
+        events.append("try")
+        return False
+
+    namespace = consumer._greedy_argmax_vocab_parallel.__func__.__globals__
+    with mock.patch.dict(namespace, try_bias_argmax=reject):
+        result = consumer._greedy_argmax_vocab_parallel(
+            hidden, out=output[:, 2], bias_fn=bias_fn, base_logits=logits
+        )
+    assert events == ["probe", "bias", "try"]
+    assert result.data_ptr() == output[:, 2].data_ptr()
+    torch.testing.assert_close(result, (logits + bias).argmax(-1).to(torch.int32))
+    assert torch.all(output[:, [0, 1, 3, 4]] == -37)
+
+
+def test_out_none_keeps_fresh_result_and_once_bias(classes):
+    consumer = _consumer(classes, "P", "cpu")
+    consumer._bias_argmax_workspace = object()
+    logits = torch.randn((2, 4097))
+    bias = torch.randn_like(logits)
+    hidden = torch.zeros((2, 16))
+    count = []
+
+    def bias_fn(start, width):
+        count.append((start, width))
+        return bias
+
+    namespace = consumer._greedy_argmax_vocab_parallel.__func__.__globals__
+    with mock.patch.dict(
+        namespace,
+        try_bias_argmax=mock.Mock(
+            side_effect=AssertionError("must not try without out")
+        ),
+    ):
+        first = consumer._greedy_argmax_vocab_parallel(
+            hidden, out=None, bias_fn=bias_fn, base_logits=logits
+        )
+        before = first.clone()
+        logits[:, 23] = 100
+        second = consumer._greedy_argmax_vocab_parallel(
+            hidden, out=None, bias_fn=bias_fn, base_logits=logits
+        )
+    assert count == [(0, 4097), (0, 4097)]
+    assert first.dtype == torch.int32 and first.data_ptr() != second.data_ptr()
+    torch.testing.assert_close(first, before)
+
+
+def test_collective_probe_precedes_empty_shard_branch(classes):
+    consumer = _consumer(classes, "P", "cpu")
+    consumer.lm_head.shard_indices.num_org_elements = 0
+    events = []
+    consumer._ensure_dist_argmax_state = lambda *args: events.append("probe")
+
+    def unused_bias(*args):
+        events.append("bias")
+        raise AssertionError("empty shard cannot call bias")
+
+    result = consumer._greedy_argmax_vocab_parallel(
+        torch.zeros((2, 16)), out=None, bias_fn=unused_bias, base_logits=None
+    )
+    assert events == ["probe"]
+    assert torch.equal(result, torch.zeros((2,), dtype=torch.int32))
+
+
+@pytest.mark.parametrize(
+    "guard", ["no_bias", "no_workspace", "added_vocab", "dist_state", "tp2"]
+)
+def test_unsupported_scope_never_calls_candidate(classes, guard):
+    consumer = _consumer(classes, "P", "cpu")
+    consumer._bias_argmax_workspace = None if guard == "no_workspace" else object()
+    if guard == "added_vocab":
+        consumer.lm_head.shard_indices.num_added_elements = 1
+        consumer.lm_head.weight = torch.cat(
+            (consumer.lm_head.weight, torch.zeros((1, 16)))
+        )
+    if guard == "tp2":
+        consumer.logits_processor.tp_size = 2
+        # Stop at the existing gather branch after the guarded candidate check.
+        consumer._ensure_greedy_gather_buffers = mock.Mock(
+            side_effect=RuntimeError("reached TP fallback")
+        )
+    if guard == "dist_state":
+        consumer._dist_argmax_state = object()
+    bias = torch.zeros((2, 4097))
+
+    def bias_fn(start, count):
+        return bias[:, :count]
+
+    namespace = consumer._greedy_argmax_vocab_parallel.__func__.__globals__
+    dist = lambda state, logits: (None, logits.argmax(-1))
+    with mock.patch.dict(
+        namespace,
+        try_bias_argmax=mock.Mock(side_effect=AssertionError("unsupported scope")),
+        _dist_argmax=dist,
+    ):
+        call = lambda: consumer._greedy_argmax_vocab_parallel(
+            torch.zeros((2, 16)),
+            out=torch.empty((2,), dtype=torch.int32),
+            bias_fn=None if guard == "no_bias" else bias_fn,
+            base_logits=torch.randn((2, 4097)),
+        )
+        if guard == "tp2":
+            with pytest.raises(RuntimeError, match="reached TP fallback"):
+                call()
+        else:
+            call()
+
+
+def test_wire_target_allocates_after_binding_and_checks(classes):
+    consumer = classes["P"][0]()
+    consumer.spec_algorithm = "DSPARK"
+    consumer.target_layer_ids = [2, 7]
+    consumer.input_buffers = SimpleNamespace(max_bs=16)
+    events = []
+    head = SimpleNamespace(
+        weight=torch.empty((4097, 16)),
+        shard_indices=SimpleNamespace(num_org_elements=4097, num_added_elements=0),
+    )
+    target = SimpleNamespace(
+        lm_head=head,
+        logits_processor=SimpleNamespace(tp_size=1),
+        get_input_embeddings=lambda: object(),
+        set_dflash_layers_to_capture=lambda layers: events.append(
+            ("capture_layers", layers)
+        ),
+    )
+    consumer._wire_aux_hidden_stream = lambda bound: events.append(
+        ("aux", bound is target)
+    )
+    marker = object()
+
+    def factory(**kwargs):
+        assert consumer.lm_head is head and consumer.target_model is target
+        events.append(("allocate", kwargs))
+        return marker
+
+    namespace = consumer.wire_target.__func__.__globals__
+    with mock.patch.dict(namespace, create_bias_argmax_workspace=factory):
+        consumer.wire_target(target)
+    assert [event[0] for event in events] == ["capture_layers", "aux", "allocate"]
+    assert events[-1][1] == {
+        "max_rows": 16,
+        "vocab_size": 4097,
+        "device": head.weight.device,
+    }
+    assert consumer._bias_argmax_workspace is marker
+
+
+@pytest.mark.parametrize("failure", ["missing_capture", "aux_failure"])
+def test_invalid_target_cannot_allocate_workspace(classes, failure):
+    consumer = classes["P"][0]()
+    consumer.spec_algorithm = "DSPARK"
+    consumer.target_layer_ids = [2]
+    consumer.input_buffers = SimpleNamespace(max_bs=16)
+    target = SimpleNamespace(
+        lm_head=object(),
+        logits_processor=SimpleNamespace(tp_size=1),
+        get_input_embeddings=lambda: object(),
+    )
+    if failure == "aux_failure":
+        target.set_dflash_layers_to_capture = lambda layers: None
+    consumer._wire_aux_hidden_stream = mock.Mock(
+        side_effect=ValueError("invalid aux stream")
+    )
+    namespace = consumer.wire_target.__func__.__globals__
+    factory = mock.Mock(side_effect=AssertionError("must validate first"))
+    with mock.patch.dict(namespace, create_bias_argmax_workspace=factory):
+        with pytest.raises(ValueError):
+            consumer.wire_target(target)
+    factory.assert_not_called()
+
+
+@GPU
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_actual_proposal_walk_matches_original_with_changing_anchors(classes, dtype):
+    consumers = {
+        arm: make_consumer(classes, arm, 2, 5, 4097, 32, 8, dtype, "cuda")
+        for arm in ("A", "P")
+    }
+    copy_consumer_parameters(consumers["A"], consumers["P"])
+    hidden = torch.randn((2, 4, 32), dtype=dtype, device="cuda")
+    block_ids = torch.zeros((2, 5), dtype=torch.int32, device="cuda")
+    outputs = {
+        arm: torch.full((2, 5), -37, dtype=torch.int32, device="cuda")
+        for arm in ("A", "P")
+    }
+    with torch.no_grad():
+        for anchor in (-3, 0, 173, 5000):
+            block_ids[:, 0] = anchor
+            for arm in ("A", "P"):
+                consumers[arm]._sample_block(hidden, block_ids, outputs[arm])
+            torch.testing.assert_close(outputs["A"], outputs["P"], rtol=0, atol=0)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        graphs = {}
+        with torch.cuda.stream(stream):
+            for arm in ("A", "P"):
+                graphs[arm] = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(graphs[arm], stream=stream):
+                    consumers[arm]._sample_block(hidden, block_ids, outputs[arm])
+        torch.cuda.current_stream().wait_stream(stream)
+        for anchor in (24, 89, 0):
+            block_ids[:, 0] = anchor
+            hidden.normal_()
+            for graph in graphs.values():
+                graph.replay()
+            torch.testing.assert_close(outputs["A"], outputs["P"], rtol=0, atol=0)

--- a/tokenspeed-kernel/benchmarks/bench_dspark_bias_argmax_sm120.py
+++ b/tokenspeed-kernel/benchmarks/bench_dspark_bias_argmax_sm120.py
@@ -1,0 +1,414 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Paired source-method DSpark consumer benchmark; this is not model E2E.
+
+Example shape syntax: B:N:V:H:R, where N includes the anchor. Both arms use
+independent equal buffers, weights and CUDA graphs. A comes from original
+fixed source files, not the candidate fallback. P must execute fused stages.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import subprocess
+import time
+import traceback
+from functools import partial
+from pathlib import Path
+
+import torch
+from dspark_bias_argmax_support import (
+    BASELINE_SHA,
+    copy_consumer_parameters,
+    digest,
+    load_consumers,
+    make_consumer,
+)
+from tokenspeed_kernel._triton import triton
+from tokenspeed_kernel.ops.sampling import bias_argmax as bias_ops
+from tokenspeed_kernel.ops.sampling import create_bias_argmax_workspace, try_bias_argmax
+from tokenspeed_kernel.ops.sampling.triton import bias_argmax as bias_kernels
+
+
+def capture(fn, warmup):
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(warmup):
+            fn()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            fn()
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+    return graph
+
+
+def measure(fn, iterations):
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000 / iterations
+
+
+def path_evidence(fn):
+    with torch.profiler.profile(
+        activities=[
+            torch.profiler.ProfilerActivity.CPU,
+            torch.profiler.ProfilerActivity.CUDA,
+        ]
+    ) as profile:
+        fn()
+        torch.cuda.synchronize()
+    return [
+        event.name for event in profile.events() if event.device_type.name == "CUDA"
+    ]
+
+
+def _constant_bias(bias, start, count):
+    assert start == 0 and count == bias.shape[1]
+    return bias
+
+
+def tensor_evidence(tensor):
+    # Hash logical bytes outside timing; dtype byte-view supports bf16 too.
+    byte_view = tensor.detach().contiguous().cpu().view(torch.uint8)
+    return {
+        "sha256": hashlib.sha256(memoryview(byte_view.numpy())).hexdigest(),
+        "shape": list(tensor.shape),
+        "stride": list(tensor.stride()),
+        "dtype": str(tensor.dtype),
+        "device": str(tensor.device),
+        "data_ptr": tensor.data_ptr(),
+    }
+
+
+def immutable_evidence(tensors):
+    return {
+        arm: {name: tensor_evidence(tensor) for name, tensor in named.items()}
+        for arm, named in tensors.items()
+    }
+
+
+def make_workload(classes, shape, dtype, group):
+    rows, steps, vocab, hidden, rank = map(int, shape.split(":"))
+    assert rows > 0 and steps >= 2 and 0 < vocab <= 262144 and hidden > 0 and rank > 0
+    consumers = {
+        arm: make_consumer(
+            classes, arm, rows, steps, vocab, hidden, rank, dtype, "cuda"
+        )
+        for arm in ("A", "P")
+    }
+    copy_consumer_parameters(consumers["A"], consumers["P"])
+    hidden_a = torch.randn((rows, steps - 1, hidden), dtype=dtype, device="cuda")
+    anchor_a = torch.randint(vocab, (rows, steps), dtype=torch.int32, device="cuda")
+    inputs = {arm: (hidden_a.clone(), anchor_a.clone()) for arm in ("A", "P")}
+    outputs = {
+        arm: torch.full((rows, steps), -37, dtype=torch.int32, device="cuda")
+        for arm in ("A", "P")
+    }
+    calls = {}
+    retained = [consumers, inputs, outputs]
+    if group == "proposal_walk":
+        for arm in ("A", "P"):
+            calls[arm] = partial(
+                consumers[arm]._sample_block,
+                inputs[arm][0],
+                inputs[arm][1],
+                outputs[arm],
+            )
+    else:
+        logits_a = consumers["A"]._block_base_logits(inputs["A"][0])[0]
+        bias_a = consumers["A"]._make_step_bias_fn(inputs["A"][1][:, 0])(0, vocab)
+        logits = {arm: logits_a.clone() for arm in ("A", "P")}
+        biases = {arm: bias_a.clone() for arm in ("A", "P")}
+        retained.extend([logits, biases])
+        for arm in ("A", "P"):
+            calls[arm] = partial(
+                consumers[arm]._greedy_argmax_vocab_parallel,
+                inputs[arm][0][:, 0],
+                out=outputs[arm][:, 1],
+                bias_fn=partial(_constant_bias, biases[arm]),
+                base_logits=logits[arm],
+            )
+    immutable = {
+        arm: {
+            "hidden": inputs[arm][0],
+            "anchor": inputs[arm][1],
+            "lm_head": consumers[arm].lm_head.weight,
+            "markov_w1": consumers[arm].markov_head.markov_w1.weight,
+            "markov_w2": consumers[arm].markov_head.markov_w2.weight,
+        }
+        for arm in ("A", "P")
+    }
+    if group == "postprocess_precomputed_bias":
+        for arm in ("A", "P"):
+            immutable[arm].update(base_logits=logits[arm], bias=biases[arm])
+    evidence = immutable_evidence(immutable)
+    for name in immutable["A"]:
+        assert evidence["A"][name]["sha256"] == evidence["P"][name]["sha256"]
+        assert evidence["A"][name]["data_ptr"] != evidence["P"][name]["data_ptr"]
+    for call in calls.values():
+        call()
+    torch.testing.assert_close(outputs["A"], outputs["P"], rtol=0, atol=0)
+    pointers = {
+        arm: {
+            "out": outputs[arm].data_ptr(),
+            "hidden": inputs[arm][0].data_ptr(),
+            "weight": consumers[arm].lm_head.weight.data_ptr(),
+            "markov_w1": consumers[arm].markov_head.markov_w1.weight.data_ptr(),
+            "markov_w2": consumers[arm].markov_head.markov_w2.weight.data_ptr(),
+        }
+        for arm in ("A", "P")
+    }
+    assert all(pointers["A"][key] != pointers["P"][key] for key in pointers["A"])
+    return calls, outputs, retained, pointers, immutable, evidence
+
+
+def run(args, record, counts):
+    assert args.blocks > 0 and args.iterations > 0 and args.warmup > 0
+    assert torch.cuda.get_device_capability() == (12, 0)
+    torch.set_grad_enabled(False)
+    torch.manual_seed(20260912)
+    rng = random.Random(20260912)
+    repository = Path(__file__).resolve().parents[2]
+    classes, provenance = load_consumers(
+        repository, args.baseline_dir, create_bias_argmax_workspace, try_bias_argmax
+    )
+    groups = ("postprocess_precomputed_bias", "proposal_walk")
+    expected_arms = (
+        len(args.shapes) * len(args.dtypes) * len(groups) * 2 * args.blocks * 4
+    )
+    expected_paths = len(args.shapes) * len(args.dtypes) * len(groups) * 2
+    sources = [
+        Path(__file__),
+        Path(__file__).with_name("dspark_bias_argmax_support.py"),
+        Path(bias_ops.__file__).with_name("__init__.py"),
+        Path(bias_ops.__file__),
+        Path(bias_kernels.__file__),
+    ]
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    selected_uuid = getattr(properties, "uuid", None)
+    assert selected_uuid is not None, "selected GPU UUID unavailable"
+    metadata = {
+        "kind": "metadata",
+        "pid": os.getpid(),
+        "started_at": time.time(),
+        "torch": torch.__version__,
+        "triton": triton.__version__,
+        "cuda": torch.version.cuda,
+        "gpu": torch.cuda.get_device_name(),
+        "selected_gpu_uuid": str(selected_uuid),
+        "current_device": torch.cuda.current_device(),
+        "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES"),
+        "capability": torch.cuda.get_device_capability(),
+        "driver": subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=driver_version", "--format=csv,noheader"],
+            text=True,
+        ).strip(),
+        "baseline_sha": BASELINE_SHA,
+        "consumer_sources": provenance,
+        "source_sha256": {str(path.resolve()): digest(path) for path in sources},
+        "arguments": {
+            key: str(value) if isinstance(value, Path) else value
+            for key, value in vars(args).items()
+        },
+        "expected_arm_records": expected_arms,
+        "expected_path_records": expected_paths,
+        "scope": "source-identical methods with TP1 head/comm/initialization fixtures; NVTX disabled via original wrapper; no model E2E",
+        "timed_regions": {
+            "postprocess_precomputed_bias": "actual DFlash method including metadata, once constant bias closure, native cast/add/max/offset/copy or fused selection and both launches; base and bias GEMMs excluded in both arms",
+            "proposal_walk": "actual DSpark _sample_block including anchor copy, complete block base GEMM/layout, prev-token clamp/embedding, each Markov GEMM and DFlash method, final clamp; N includes anchor",
+        },
+        "immutable_contract": "Each arm hashes hidden/anchor/LM head/Markov parameters before invocation and after timing; precomputed-bias group also hashes base_logits and bias. Proposal walk computes base_logits and bias as ephemeral in-region intermediates, not persistent input buffers. Only output/workspace are mutable persistent tensors.",
+        "statistics": "100*(1-exp(mean(block_log_ratio))); each block is mean(log P1,log P2)-mean(log A1,log A2); each run/shape/dtype/group/mode kept separate",
+    }
+    record(metadata)
+    for shape in args.shapes:
+        for dtype_name in args.dtypes:
+            for group in groups:
+                calls, outputs, retained, pointers, immutable, evidence = make_workload(
+                    classes, shape, getattr(torch, dtype_name), group
+                )
+                context = {"shape": shape, "dtype": dtype_name, "group": group}
+                record({"kind": "immutable_inputs", **context, "before": evidence})
+                for arm, fn in calls.items():
+                    kernels = path_evidence(fn)
+                    for stage in ("_bias_argmax_partials", "_bias_argmax_finalize"):
+                        hits = sum(stage in event for event in kernels)
+                        expected = (
+                            (
+                                int(shape.split(":")[1]) - 1
+                                if group == "proposal_walk"
+                                else 1
+                            )
+                            if arm == "P"
+                            else 0
+                        )
+                        assert hits == expected, (
+                            arm,
+                            stage,
+                            hits,
+                            expected,
+                            kernels,
+                        )
+                    record(
+                        {
+                            "kind": "path",
+                            **context,
+                            "arm": arm,
+                            "kernels": kernels,
+                            "pointers": pointers[arm],
+                        }
+                    )
+                graphs = {arm: capture(fn, args.warmup) for arm, fn in calls.items()}
+                for mode in ("eager", "cuda_graph"):
+                    timed = (
+                        calls
+                        if mode == "eager"
+                        else {arm: graph.replay for arm, graph in graphs.items()}
+                    )
+                    for fn in timed.values():
+                        measure(fn, args.iterations)
+                    for block in range(args.blocks):
+                        order = "APPA" if rng.randrange(2) == 0 else "PAAP"
+                        for position, arm in enumerate(order):
+                            latency = measure(timed[arm], args.iterations)
+                            record(
+                                {
+                                    "kind": "arm",
+                                    **context,
+                                    "mode": mode,
+                                    "block": block,
+                                    "position": position,
+                                    "arm": arm,
+                                    "latency_us": latency,
+                                    "iterations": args.iterations,
+                                }
+                            )
+                    torch.testing.assert_close(
+                        outputs["A"], outputs["P"], rtol=0, atol=0
+                    )
+                after = immutable_evidence(immutable)
+                unchanged = after == evidence
+                record(
+                    {
+                        "kind": "immutable_validation",
+                        **context,
+                        "after": after,
+                        "unchanged": unchanged,
+                    }
+                )
+                assert unchanged, "immutable input/weight changed during run"
+                del calls, outputs, retained, graphs, immutable
+    source_after = {str(path.resolve()): digest(path) for path in sources}
+    consumer_after = {
+        arm: {
+            name: {"path": entry["path"], "sha256": digest(entry["path"])}
+            for name, entry in entries.items()
+        }
+        for arm, entries in provenance.items()
+    }
+    sources_unchanged = (
+        source_after == metadata["source_sha256"] and consumer_after == provenance
+    )
+    record(
+        {
+            "kind": "source_validation",
+            "source_sha256": source_after,
+            "consumer_sources": consumer_after,
+            "unchanged": sources_unchanged,
+        }
+    )
+    assert sources_unchanged, "source changed during run"
+    assert counts == {"arm": expected_arms, "path": expected_paths}
+    record(
+        {
+            "kind": "completion",
+            "success": True,
+            "completed_at": time.time(),
+            "arm_records": counts["arm"],
+            "path_records": counts["path"],
+        }
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--blocks", type=int, required=True)
+    parser.add_argument("--iterations", type=int, required=True)
+    parser.add_argument("--warmup", type=int, required=True)
+    parser.add_argument("--shapes", nargs="+", required=True)
+    parser.add_argument(
+        "--dtypes", nargs="+", choices=["float16", "bfloat16", "float32"], required=True
+    )
+    args = parser.parse_args()
+    # Exclusive creation rejects previous/partial evidence before GPU work.
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x") as output:
+        counts = {"arm": 0, "path": 0}
+
+        def record(row):
+            if row["kind"] in counts:
+                counts[row["kind"]] += 1
+            line = json.dumps(row)
+            output.write(line + "\n")
+            output.flush()
+            print(line, flush=True)
+
+        record(
+            {
+                "kind": "run_start",
+                "pid": os.getpid(),
+                "started_at": time.time(),
+                "output": str(args.output),
+            }
+        )
+        try:
+            run(args, record, counts)
+        except BaseException as error:
+            record(
+                {
+                    "kind": "completion",
+                    "success": False,
+                    "completed_at": time.time(),
+                    "arm_records": counts["arm"],
+                    "path_records": counts["path"],
+                    "error_type": type(error).__name__,
+                    "error": str(error),
+                    "traceback": traceback.format_exc(),
+                }
+            )
+            raise
+
+
+if __name__ == "__main__":
+    main()

--- a/tokenspeed-kernel/benchmarks/dspark_bias_argmax_support.py
+++ b/tokenspeed-kernel/benchmarks/dspark_bias_argmax_support.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Execute source-identical DSpark methods with explicit boundary fixtures.
+
+The baseline is a verified snapshot of the original full files, never a
+candidate with its optimization disabled. AST selection removes unrelated
+model imports/initialization, but every selected method, including decorators,
+is compiled unchanged. This is a consumer-boundary replay, not model E2E.
+"""
+
+from __future__ import annotations
+
+import ast
+import functools
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+BASELINE_SHA = "7978c48b5c56445c600880f0ff275a611e584cef"
+BASELINE_DIGESTS = {
+    "dflash.py": "b026d3ca1ceea8f2d500e7f2f3ccf410e638722e77505080f61013d2d0f770fa",
+    "dspark.py": "a2f52f4d8dd815bbfbfacfcbba66e41a605c671fcd5e89ca8a1bf178c3483234",
+    "nvtx.py": "b8a257790b149053f1b0264987d8132120d58d4453b5c9abb8bed2d024644482",
+    "model_dspark.py": "aa6daae58b55846296740ff3deca2869c515f2efb32792e1ec481f85314041c2",
+}
+
+
+def digest(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _forbidden(*args, **kwargs):
+    raise AssertionError("fixture crossed its TP1 original-vocabulary boundary")
+
+
+def _compile_nodes(path, names, namespace, methods):
+    tree = ast.parse(Path(path).read_text(), filename=str(path))
+    selected = []
+    for node in tree.body:
+        if getattr(node, "name", None) not in names:
+            continue
+        if isinstance(node, ast.ClassDef) and node.name in methods:
+            keep = methods[node.name]
+            node.body = [
+                item for item in node.body if getattr(item, "name", None) in keep
+            ]
+            # Heavy base construction is outside this source-method replay.
+            node.bases = (
+                [ast.Name(id="DFlash", ctx=ast.Load())] if node.name == "DSpark" else []
+            )
+        selected.append(node)
+    assert {node.name for node in selected} == set(names)
+    module = ast.Module(
+        body=[
+            ast.ImportFrom(
+                module="__future__", names=[ast.alias(name="annotations")], level=0
+            ),
+            *selected,
+        ],
+        type_ignores=[],
+    )
+    exec(compile(ast.fix_missing_locations(module), str(path), "exec"), namespace)
+
+
+def load_consumers(repository, baseline_dir, create_workspace, try_argmax):
+    repository, baseline_dir = Path(repository), Path(baseline_dir)
+    for name, expected in BASELINE_DIGESTS.items():
+        assert digest(baseline_dir / name) == expected, f"baseline changed: {name}"
+    runtime = repository / "python/tokenspeed/runtime"
+    classes, provenance = {}, {}
+    for arm in ("A", "P"):
+        paths = {
+            "dflash": (
+                baseline_dir / "dflash.py"
+                if arm == "A"
+                else runtime / "execution/drafter/dflash.py"
+            ),
+            "dspark": (
+                baseline_dir / "dspark.py"
+                if arm == "A"
+                else runtime / "execution/drafter/dspark.py"
+            ),
+            "nvtx": (
+                baseline_dir / "nvtx.py" if arm == "A" else runtime / "utils/nvtx.py"
+            ),
+            "markov": (
+                baseline_dir / "model_dspark.py"
+                if arm == "A"
+                else runtime / "models/dspark.py"
+            ),
+        }
+        namespace = {
+            "__name__": f"_dspark_source_boundary_{arm}",
+            "torch": torch,
+            "nn": torch.nn,
+            "functools": functools,
+            "_enabled": False,
+            "_VALID_COLORS": frozenset({"blue", "purple"}),
+            "try_bias_argmax": try_argmax,
+            "create_bias_argmax_workspace": create_workspace,
+            "_UNSET": object(),
+            "_dist_argmax": _forbidden,
+            "all_gather_into_tensor": _forbidden,
+        }
+        _compile_nodes(paths["nvtx"], {"_Range", "nvtx_range"}, namespace, {})
+        _compile_nodes(
+            paths["dflash"],
+            {"DFlash"},
+            namespace,
+            {
+                "DFlash": {
+                    "_greedy_argmax_vocab_parallel",
+                    "_ensure_dist_argmax_state",
+                    "wire_target",
+                }
+            },
+        )
+        _compile_nodes(
+            paths["dspark"],
+            {"DSpark"},
+            namespace,
+            {
+                "DSpark": {
+                    "_sample_block",
+                    "_block_base_logits",
+                    "_make_step_bias_fn",
+                }
+            },
+        )
+        _compile_nodes(paths["markov"], {"VanillaMarkov"}, namespace, {})
+        classes[arm] = (namespace["DSpark"], namespace["VanillaMarkov"])
+        provenance[arm] = {
+            key: {"path": str(value.resolve()), "sha256": digest(value)}
+            for key, value in paths.items()
+        }
+    return classes, provenance
+
+
+def make_consumer(classes, arm, rows, steps, vocab, hidden, rank, dtype, device):
+    consumer_class, markov_class = classes[arm]
+    consumer = consumer_class()
+    consumer.spec_algorithm = "DSPARK"
+    consumer.spec_num_tokens = steps
+    consumer._dist_argmax_state = None
+    create_workspace = consumer._greedy_argmax_vocab_parallel.__func__.__globals__[
+        "create_bias_argmax_workspace"
+    ]
+    consumer._bias_argmax_workspace = (
+        create_workspace(rows, vocab, device) if arm == "P" else None
+    )
+    shard = SimpleNamespace(
+        num_org_elements=vocab,
+        num_org_elements_padded=vocab,
+        num_added_elements=0,
+        org_vocab_start_index=0,
+        added_vocab_start_index=vocab,
+    )
+    consumer.lm_head = SimpleNamespace(
+        weight=torch.randn((vocab, hidden), device=device, dtype=dtype) / hidden**0.5,
+        shard_indices=shard,
+    )
+    consumer.logits_processor = SimpleNamespace(tp_size=1)
+    consumer.markov_head = markov_class(vocab_size=vocab, markov_rank=rank).to(
+        device=device, dtype=dtype
+    )
+    consumer.markov_head.requires_grad_(False)
+    with torch.no_grad():
+        consumer.markov_head.markov_w1.weight.normal_(0, 1)
+        consumer.markov_head.markov_w2.weight.normal_(0, rank**-0.5)
+    return consumer
+
+
+def copy_consumer_parameters(source, target):
+    target.lm_head.weight.copy_(source.lm_head.weight)
+    target.markov_head.load_state_dict(source.markov_head.state_dict())

--- a/tokenspeed-kernel/python/MANIFEST.in
+++ b/tokenspeed-kernel/python/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include requirements *.txt
+include tokenspeed_kernel/thirdparty/cuda/csrc/sampling_metadata.cpp

--- a/tokenspeed-kernel/python/setup.py
+++ b/tokenspeed-kernel/python/setup.py
@@ -48,7 +48,9 @@ package installs as a pure-Python stub.
 """
 
 import ctypes
+import hashlib
 import importlib
+import json
 import os
 import shutil
 import site
@@ -58,7 +60,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 
-from setuptools import Command, find_packages, setup
+from setuptools import Command, Distribution, find_packages, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
@@ -874,6 +876,42 @@ class CudaKernelBuilder:
             subprocess.check_call(link_cmd)
 
 
+def _build_sampling_metadata(verbose):
+    """Build the host extension without executing a CUDA program."""
+    import torch
+    from torch.utils.cpp_extension import load
+
+    output_dir = CUDA_OBJS_DIR / "sampling_metadata"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    build_dir = ROOT / "build" / "sampling_metadata"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    module = load(
+        name="_sampling_metadata",
+        sources=[str(CUDA_CSRC_DIR / "sampling_metadata.cpp")],
+        build_directory=str(build_dir),
+        extra_cflags=["-O3", "-g0"],
+        extra_include_paths=[str(Path(CUDA_HOME) / "include")],
+        extra_ldflags=["-ldl"],
+        with_cuda=False,
+        verbose=verbose,
+    )
+    destination = output_dir / "_sampling_metadata.so"
+    shutil.copy2(module.__file__, destination)
+    record = {
+        "torch": torch.__version__,
+        "python": list(sys.version_info[:2]),
+        "sha256": hashlib.sha256(destination.read_bytes()).hexdigest(),
+    }
+    (output_dir / "build.json").write_text(json.dumps(record, sort_keys=True) + "\n")
+
+
+class KernelDistribution(Distribution):
+    """CUDA wheels include a CPython extension and require platform/ABI tags."""
+
+    def has_ext_modules(self):
+        return _selected_backend() == "cuda"
+
+
 class BuildKernels(build_ext):
     """Compile CUDA kernels into .so files for the CUDA backend."""
 
@@ -887,6 +925,7 @@ class BuildKernels(build_ext):
 
         _ensure_cuda_compiler()
         verbose = bool(getattr(self, "verbose", False))
+        _build_sampling_metadata(verbose)
         CudaKernelBuilder(KERNEL_GROUPS, verbose=verbose).run()
 
 
@@ -935,6 +974,7 @@ class BuildPyWithBuild(build_py):
 
 
 setup(
+    distclass=KernelDistribution,
     name="tokenspeed_kernel",
     version=_package_version(),
     install_requires=_selected_install_requires(),
@@ -942,7 +982,10 @@ setup(
     package_data={
         # Pre-swept flashinfer MoE tactic tables (see ops/tuning.py).
         "tokenspeed_kernel.ops.moe.flashinfer": ["tactics/*.json"],
-        "tokenspeed_kernel.thirdparty.cuda": ["objs/**/*.so"],
+        "tokenspeed_kernel.thirdparty.cuda": [
+            "objs/**/*.so",
+            "objs/sampling_metadata/build.json",
+        ],
         # Vendored MiniMax MSA CuTe sources: cute/ has no __init__.py (it is
         # loaded via the upstream sys.path bootstrap), so ship it as data.
         "tokenspeed_kernel.thirdparty.msa": [

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/__init__.py
@@ -23,11 +23,15 @@
 from __future__ import annotations
 
 import torch
+from tokenspeed_kernel.ops.sampling.bias_argmax import (
+    create_bias_argmax_workspace,
+    try_bias_argmax,
+)
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import dense_tensor_format, format_signature
 
-__all__ = ["argmax"]
+__all__ = ["argmax", "create_bias_argmax_workspace", "try_bias_argmax"]
 
 _SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
 _SUPPORTED_OUT_DTYPES = (torch.int32, torch.int64)
@@ -122,3 +126,4 @@ def argmax(
 # Backend registration (side-effect imports).
 import tokenspeed_kernel.ops.sampling.cute_dsl  # noqa: E402,F401
 import tokenspeed_kernel.ops.sampling.gluon  # noqa: E402,F401
+import tokenspeed_kernel.ops.sampling.triton.bias_argmax  # noqa: E402,F401

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/bias_argmax.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/bias_argmax.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Allocation-free, exact bias plus argmax for the SM120 proposal path."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+from tokenspeed_kernel._triton import triton
+from tokenspeed_kernel.platform import current_platform
+from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
+from tokenspeed_kernel.signature import dense_tensor_format, format_signature
+from tokenspeed_kernel.thirdparty.cuda.sampling_metadata import validate_metadata
+
+BIAS_ARGMAX_TILE = 4096
+BIAS_ARGMAX_MAX_VOCAB = 262144
+_FLOAT_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+_ELEMENT_BYTES = {
+    torch.float16: 2,
+    torch.bfloat16: 2,
+    torch.float32: 4,
+    torch.int32: 4,
+    torch.int64: 8,
+}
+_INDEX_MAX = {torch.int32: 2**31 - 1, torch.int64: 2**63 - 1}
+_SCALAR_DTYPES = {
+    3: torch.int32,
+    4: torch.int64,
+    5: torch.float16,
+    6: torch.float32,
+    15: torch.bfloat16,
+}
+_SIGNATURES = {
+    dtype: format_signature(logits=dense_tensor_format(dtype))
+    for dtype in _FLOAT_DTYPES
+}
+_SCALAR_SIGNATURES = {
+    code: _SIGNATURES[dtype]
+    for code, dtype in _SCALAR_DTYPES.items()
+    if dtype in _SIGNATURES
+}
+
+
+@dataclass(frozen=True)
+class BiasArgmaxWorkspace:
+    """Caller-owned partials, allocated before any graph captures.
+
+    The same workspace may be reused by sequential calls. Concurrent calls
+    on different streams require separate workspaces or explicit ordering.
+    """
+
+    values: torch.Tensor
+    indices: torch.Tensor
+    _device: torch.device | None = field(init=False, repr=False)
+    _capability: tuple[int, int] | None = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # A CUDA device's architecture is immutable for this process. Bind its
+        # identity when constructing the workspace, including direct callers
+        # and dataclasses.replace; no tensor descriptors or pointers are cached.
+        device = self.values.device if isinstance(self.values, torch.Tensor) else None
+        capability = (
+            torch.cuda.get_device_capability(device)
+            if device is not None
+            and device.type == "cuda"
+            and current_platform().is_nvidia
+            else None
+        )
+        object.__setattr__(self, "_device", device)
+        object.__setattr__(self, "_capability", capability)
+
+
+def create_bias_argmax_workspace(
+    max_rows: int, vocab_size: int, device: torch.device | str | None
+) -> BiasArgmaxWorkspace | None:
+    """Allocate stable partial buffers for a bounded SM120 bias argmax.
+
+    Args:
+        max_rows: Maximum number of proposal rows across capture buckets.
+        vocab_size: Maximum vocabulary width, in the range 1 through 262144.
+        device: Device owning the logits; None disables this candidate.
+
+    Returns:
+        Contiguous float32 values and int32 indices, or None for unsupported
+        hardware or sizes. The bound is this candidate's tested scope.
+    """
+    if device is None or max_rows <= 0 or not 0 < vocab_size <= BIAS_ARGMAX_MAX_VOCAB:
+        return None
+    device = torch.device(device)
+    if device.type != "cuda" or not current_platform().is_nvidia:
+        return None
+    if torch.cuda.get_device_capability(device) != (12, 0):
+        return None
+    tiles = (vocab_size + BIAS_ARGMAX_TILE - 1) // BIAS_ARGMAX_TILE
+    return BiasArgmaxWorkspace(
+        values=torch.empty((max_rows, tiles), dtype=torch.float32, device=device),
+        indices=torch.empty((max_rows, tiles), dtype=torch.int32, device=device),
+    )
+
+
+def _byte_span(tensor: torch.Tensor) -> tuple[int, int]:
+    """Conservative byte interval for a nonempty positive-strided view."""
+    start = tensor.data_ptr()
+    extent = 1 + sum(
+        (size - 1) * stride for size, stride in zip(tensor.shape, tensor.stride())
+    )
+    return start, start + extent * tensor.element_size()
+
+
+def try_bias_argmax(
+    logits: torch.Tensor,
+    bias: torch.Tensor,
+    out: torch.Tensor,
+    workspace: BiasArgmaxWorkspace | None,
+    global_offset: int,
+) -> bool:
+    """Write exact native-rounded bias argmax IDs without allocating tensors.
+
+    Args:
+        logits: Float16, bfloat16 or float32 matrix [M, V].
+        bias: Same-shaped matrix in any of those floating dtypes.
+        out: Int32 or int64 vector [M], including positive-strided column views.
+        workspace: Persistent partial buffers from the factory, sized for M,V.
+        global_offset: Nonnegative original-vocabulary start. Every possible
+            resulting ID must be representable by out.dtype.
+
+    Returns:
+        True when the registered SM120 kernel ran; False without any writes
+        for unsupported metadata. Scores are round_d(logits + round_d(bias)),
+        where d is logits.dtype. NaNs win at their first index, and equal
+        values (including signed zeros and infinities) choose the first index.
+        Inputs may alias each other; output and scratch must not overlap any
+        other read/write region. Overlapping byte spans are conservatively
+        rejected, even if an interleaved view's live elements do not overlap.
+    """
+    # An active cache hook may suppress a cold JIT compilation/launch. Reject
+    # before either stage: finalizing stale partials would change token IDs.
+    if (
+        triton.knobs.runtime.interpret
+        or triton.knobs.runtime.jit_cache_hook is not None
+    ):
+        return False
+    if not isinstance(workspace, BiasArgmaxWorkspace):
+        return False
+    if (
+        workspace._device is None
+        or workspace._device.type != "cuda"
+        or workspace._capability != (12, 0)
+    ):
+        return False
+    metadata = validate_metadata(
+        logits,
+        bias,
+        out,
+        workspace.values,
+        workspace.indices,
+        torch.cuda.current_device(),
+        workspace._device.index,
+        global_offset,
+    )
+    if metadata is None:
+        return False
+    # Native scalar tags already distinguish every launcher cache class.
+    # Pass the checked current tuple directly without rebuilding dtype fields.
+    signature = _SCALAR_SIGNATURES[metadata[3]]
+    try:
+        kernel = select_kernel(
+            "sampling", "bias_argmax", signature, solution="triton", override=None
+        )
+    except NoKernelFoundError:
+        return False
+    prepared = getattr(getattr(kernel, "impl", None), "_from_checked_metadata", None)
+    if prepared is None:
+        # Selection overrides keep their ordinary public five-argument call.
+        kernel(logits, bias, out, workspace, global_offset)
+    else:
+        prepared(logits, bias, out, workspace, global_offset, metadata)
+    return True

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/triton/bias_argmax.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/triton/bias_argmax.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Two-stage bias argmax, preserving both native dtype roundings."""
+
+from __future__ import annotations
+
+import importlib.metadata
+import re
+
+import torch
+from tokenspeed_kernel._triton import tl, triton
+from tokenspeed_kernel.ops.sampling.bias_argmax import (
+    BIAS_ARGMAX_TILE,
+    BiasArgmaxWorkspace,
+)
+from tokenspeed_kernel.platform import ArchVersion, CapabilityRequirement
+from tokenspeed_kernel.registry import Priority, register_kernel
+from tokenspeed_kernel.signature import format_signatures
+from tokenspeed_kernel.thirdparty.cuda.sampling_metadata import NativeLaunchPair
+
+
+@triton.jit
+def _bias_argmax_partials(
+    logits,
+    bias,
+    values,
+    indices,
+    VOCAB: tl.constexpr,
+    LOGIT_ROW_STRIDE: tl.constexpr,
+    LOGIT_COL_STRIDE: tl.constexpr,
+    BIAS_ROW_STRIDE: tl.constexpr,
+    BIAS_COL_STRIDE: tl.constexpr,
+    PARTIAL_STRIDE: tl.constexpr,
+    TILE: tl.constexpr,
+):
+    row, tile = tl.program_id(0), tl.program_id(1)
+    col = tile * TILE + tl.arange(0, TILE)
+    valid = col < VOCAB
+    dtype: tl.constexpr = logits.dtype.element_ty
+    x = tl.load(
+        logits
+        + row.to(tl.int64) * LOGIT_ROW_STRIDE
+        + col.to(tl.int64) * LOGIT_COL_STRIDE,
+        valid,
+        other=-float("inf"),
+    ).to(tl.float32)
+    b = (
+        tl.load(
+            bias
+            + row.to(tl.int64) * BIAS_ROW_STRIDE
+            + col.to(tl.int64) * BIAS_COL_STRIDE,
+            valid,
+            other=0,
+        )
+        .to(dtype)
+        .to(tl.float32)
+    )
+    # Native torch first casts bias to logits.dtype, then rounds the addition
+    # into a tensor of that dtype. Both boundaries can change the winning ID.
+    x = (x + b).to(dtype).to(tl.float32)
+    nan = (x != x) & valid
+    first_nan = tl.min(tl.where(nan, col, 2147483647), 0)
+    maximum = tl.max(tl.where(nan, -float("inf"), x), 0)
+    first_max = tl.min(tl.where(valid & (x == maximum), col, 2147483647), 0)
+    has_nan = first_nan != 2147483647
+    offset = row.to(tl.int64) * PARTIAL_STRIDE + tile
+    tl.store(values + offset, tl.where(has_nan, float("nan"), maximum))
+    tl.store(indices + offset, tl.where(has_nan, first_nan, first_max))
+
+
+@triton.jit
+def _bias_argmax_finalize(
+    values,
+    indices,
+    out,
+    TILES: tl.constexpr,
+    PARTIAL_STRIDE: tl.constexpr,
+    OUT_STRIDE: tl.constexpr,
+    GLOBAL_OFFSET: tl.constexpr,
+    BLOCK_TILES: tl.constexpr,
+):
+    row = tl.program_id(0)
+    tile = tl.arange(0, BLOCK_TILES)
+    valid = tile < TILES
+    offset = row.to(tl.int64) * PARTIAL_STRIDE + tile
+    x = tl.load(values + offset, valid, other=-float("inf"))
+    idx = tl.load(indices + offset, valid, other=2147483647)
+    nan = (x != x) & valid
+    first_nan = tl.min(tl.where(nan, idx, 2147483647), 0)
+    maximum = tl.max(tl.where(nan, -float("inf"), x), 0)
+    first_max = tl.min(tl.where(valid & (x == maximum), idx, 2147483647), 0)
+    target = tl.where(first_nan != 2147483647, first_nan, first_max)
+    global_id = target.to(tl.int64) + GLOBAL_OFFSET
+    tl.store(out + row.to(tl.int64) * OUT_STRIDE, global_id)
+
+
+# Official CompiledKernel[grid] runners retain code and grid, never tensors or
+# streams. All current arguments and constexpr slots are passed on each call.
+_LAUNCHERS = {}
+_MAX_LAUNCHERS = 128
+
+
+def _make_native_pair(partial, final):
+    # This direct driver ABI is bounded to the inspected pinned compiler. All
+    # instrumentation, nonstandard launches and scratch allocations retain the
+    # official CompiledKernel runner. No GPU algorithm differs between modes.
+    if (
+        NativeLaunchPair is None
+        or triton.__version__ != "3.8.10"
+        or importlib.metadata.version("tokenspeed-triton") != "3.8.10.post20260906"
+    ):
+        return None
+    for kernel, pointers in ((partial, 6), (final, 5)):
+        runner = kernel.run
+        if (
+            runner.global_scratch_size
+            or runner.profile_scratch_size
+            or runner.gsan_enabled
+            or runner.launch_cooperative_grid
+            or runner.launch_pdl
+            or kernel.metadata.num_ctas != 1
+            or kernel.metadata.num_warps != 4
+        ):
+            return None
+        declaration = kernel.asm["ptx"].split(".visible .entry", 1)[1].split(")", 1)[0]
+        parameters = re.findall(r"\.param\s+([^,\n]+)", declaration)
+        if len(parameters) != pointers or any(
+            not p.startswith(".u64 .ptr .global") for p in parameters
+        ):
+            return None
+    return NativeLaunchPair(
+        partial.function,
+        final.function,
+        partial.metadata.num_warps,
+        final.metadata.num_warps,
+        partial.metadata.shared,
+        final.metadata.shared,
+    )
+
+
+def _inactive_launch_hook(hook):
+    # The pinned vendor runtime uses an empty HookChain, not None, by default.
+    # Inspect its current calls on every launch; arbitrary callable replacements
+    # and HookChain subclasses always keep the official runner path.
+    return hook is None or (type(hook) is triton.knobs.HookChain and not hook.calls)
+
+
+def _can_reuse_launchers():
+    runtime = triton.knobs.runtime
+    compilation = triton.knobs.compilation
+    return not (
+        _bias_argmax_partials.pre_run_hooks
+        or _bias_argmax_finalize.pre_run_hooks
+        or _bias_argmax_partials.debug
+        or _bias_argmax_finalize.debug
+        or runtime.debug
+        or runtime.add_stages_inspection_hook is not None
+        or compilation.instrumentation_mode
+        or compilation.fpsan_homomorphic_casts
+    )
+
+
+@register_kernel(
+    "sampling",
+    "bias_argmax",
+    name="triton_bias_argmax_sm120",
+    solution="triton",
+    capability=CapabilityRequirement(
+        min_arch_version=ArchVersion(12, 0),
+        max_arch_version=ArchVersion(12, 0),
+        vendors=frozenset({"nvidia"}),
+    ),
+    signatures=format_signatures(
+        "logits", "dense", {torch.float16, torch.bfloat16, torch.float32}
+    ),
+    priority=Priority.SPECIALIZED,
+    tags={"latency", "determinism"},
+)
+def bias_argmax_sm120(
+    logits: torch.Tensor,
+    bias: torch.Tensor,
+    out: torch.Tensor,
+    workspace: BiasArgmaxWorkspace,
+    global_offset: int,
+) -> None:
+    """Run exact dtype-rounded partials followed by a strided-output merge."""
+    metadata = (
+        logits.shape[0],
+        logits.shape[1],
+        logits.device.index,
+        logits.dtype,
+        bias.dtype,
+        out.dtype,
+        logits.stride(),
+        bias.stride(),
+        out.stride(0),
+        workspace.values.stride(0),
+        tuple(
+            tensor.data_ptr() % 16
+            for tensor in (logits, bias, out, workspace.values, workspace.indices)
+        ),
+    )
+    _launch_from_metadata(logits, bias, out, workspace, global_offset, metadata)
+
+
+def _launch_from_metadata(logits, bias, out, workspace, global_offset, metadata):
+    """Use this invocation's checked scalars; retain no tensors or streams."""
+    (
+        rows,
+        vocab,
+        device_index,
+        logits_dtype,
+        bias_dtype,
+        out_dtype,
+        logit_strides,
+        bias_strides,
+        out_stride,
+        partial_stride,
+        alignments,
+    ) = metadata
+    values, indices = workspace.values, workspace.indices
+    tiles = triton.cdiv(vocab, BIAS_ARGMAX_TILE)
+    partial_constants = (
+        vocab,
+        logit_strides[0],
+        logit_strides[1],
+        bias_strides[0],
+        bias_strides[1],
+        partial_stride,
+        BIAS_ARGMAX_TILE,
+    )
+    final_constants = (
+        tiles,
+        partial_stride,
+        out_stride,
+        global_offset,
+        triton.next_power_of_2(tiles),
+    )
+    partial_args = (logits, bias, values, indices) + partial_constants
+    final_args = (values, indices, out) + final_constants
+    partial_grid, final_grid = (rows, tiles, 1), (rows, 1, 1)
+    cacheable = _can_reuse_launchers()
+    if cacheable:
+        key = (
+            device_index,
+            device_index,
+            logits_dtype,
+            bias_dtype,
+            out_dtype,
+            # JIT tensor specialization distinguishes 16-byte divisibility.
+            # Exact residues also separate every strided output column that
+            # can have weaker alignment; each class first uses normal JIT.
+            alignments,
+            partial_grid,
+            final_grid,
+            partial_constants,
+            final_constants,
+            _bias_argmax_partials.src,
+            _bias_argmax_finalize.src,
+        )
+        cached = _LAUNCHERS.get(key)
+        if cached is not None:
+            if (
+                cached[2] is not None
+                and _inactive_launch_hook(triton.knobs.runtime.launch_enter_hook)
+                and _inactive_launch_hook(triton.knobs.runtime.launch_exit_hook)
+            ):
+                stream = triton.runtime.driver.active.get_current_stream(device_index)
+                cached[2].run(logits, bias, out, values, indices, rows, tiles, stream)
+            else:
+                cached[0](*partial_args)
+                cached[1](*final_args)
+            return
+    partial = _bias_argmax_partials[partial_grid](*partial_args, num_warps=4)
+    final = _bias_argmax_finalize[final_grid](*final_args, num_warps=4)
+    if cacheable and partial is not None and final is not None:
+        if len(_LAUNCHERS) >= _MAX_LAUNCHERS:
+            _LAUNCHERS.clear()
+        _LAUNCHERS[key] = (
+            partial[partial_grid],
+            final[final_grid],
+            _make_native_pair(partial, final),
+        )
+
+
+# Only this selected implementation opts into the checked-descriptor handoff.
+bias_argmax_sm120._from_checked_metadata = _launch_from_metadata

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/sampling_metadata.cpp
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/sampling_metadata.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 LightSeek Foundation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <torch/csrc/autograd/python_variable.h>
+#include <pybind11/pybind11.h>
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <cuda.h>
+#include <dlfcn.h>
+#include <stdexcept>
+
+namespace py = pybind11;
+
+static bool floating(at::ScalarType dtype) {
+  return dtype == at::kHalf || dtype == at::kBFloat16 || dtype == at::kFloat;
+}
+
+class MetadataValidator {
+  using Key = std::array<int64_t, 17>;
+  std::map<Key, py::tuple> tuples_;
+ public:
+py::object validate_metadata(py::handle logits, py::handle bias, py::handle out,
+                            py::handle values, py::handle indices,
+                            int current_device, int bound_device,
+                            py::handle global_offset) {
+  const std::array<py::handle, 5> objects = {logits, bias, out, values, indices};
+  std::array<const at::Tensor*, 5> tensors;
+  for (int i = 0; i < 5; ++i) {
+    if (!THPVariable_Check(objects[i].ptr())) return py::none();
+    const auto& tensor = THPVariable_Unpack(objects[i].ptr());
+    if (tensor.is_nested() || tensor.layout() != at::kStrided || tensor.is_neg() || tensor.is_conj())
+      return py::none();
+    tensors[i] = &tensor;
+  }
+  const auto& x = *tensors[0]; const auto& b = *tensors[1];
+  const auto& o = *tensors[2]; const auto& v = *tensors[3]; const auto& ix = *tensors[4];
+  if (x.dim() != 2 || b.sizes() != x.sizes()) return py::none();
+  const int64_t rows = x.size(0), vocab = x.size(1), tiles = (vocab + 4095) / 4096;
+  if (rows <= 0 || vocab <= 0 || vocab > 262144 || !floating(x.scalar_type()) || !floating(b.scalar_type())
+      || (o.scalar_type() != at::kInt && o.scalar_type() != at::kLong)
+      || o.dim() != 1 || o.size(0) != rows || !x.is_cuda()
+      || x.get_device() != current_device || x.get_device() != bound_device
+      || v.dim() != 2 || ix.sizes() != v.sizes() || v.size(0) < rows || v.size(1) < tiles
+      || v.scalar_type() != at::kFloat || ix.scalar_type() != at::kInt
+      || !v.is_contiguous() || !ix.is_contiguous()
+      || x.stride(0) <= 0 || x.stride(1) <= 0 || b.stride(0) <= 0 || b.stride(1) <= 0 || o.stride(0) <= 0
+      || !PyLong_CheckExact(global_offset.ptr())) return py::none();
+  for (int i = 1; i < 5; ++i) if (tensors[i]->device() != x.device()) return py::none();
+  int overflow = 0;
+  const int64_t offset = PyLong_AsLongLongAndOverflow(global_offset.ptr(), &overflow);
+  if (PyErr_Occurred()) { PyErr_Clear(); return py::none(); }
+  const int64_t max_id = o.scalar_type() == at::kInt ? std::numeric_limits<int32_t>::max() : std::numeric_limits<int64_t>::max();
+  if (overflow || offset < 0 || offset > max_id - (vocab - 1)) return py::none();
+  // Use wider intermediates so conservative byte intervals retain Python's
+  // non-wrapping arithmetic even for unusual positive-strided descriptors.
+  std::array<__int128, 5> starts, ends;
+  for (int i = 0; i < 5; ++i) {
+    const auto& t = *tensors[i];
+    starts[i] = reinterpret_cast<uintptr_t>(t.const_data_ptr());
+    __int128 elements = 1;
+    for (int dim = 0; dim < t.dim(); ++dim) elements += static_cast<__int128>(t.size(dim) - 1) * t.stride(dim);
+    ends[i] = starts[i] + elements * t.element_size();
+  }
+  for (int write = 2; write < 5; ++write)
+    for (int read = 0; read < write; ++read)
+      if (starts[write] < ends[read] && starts[read] < ends[write]) return py::none();
+  // Cache only immutable scalar tuples after every live eligibility/alias
+  // check above has passed. Never retain full addresses or Tensor objects.
+  Key key = {rows, vocab, x.get_device(), static_cast<int>(x.scalar_type()),
+             static_cast<int>(b.scalar_type()), static_cast<int>(o.scalar_type()),
+             x.stride(0), x.stride(1), b.stride(0), b.stride(1), o.stride(0), v.stride(0),
+             static_cast<int64_t>(starts[0] % 16), static_cast<int64_t>(starts[1] % 16),
+             static_cast<int64_t>(starts[2] % 16), static_cast<int64_t>(starts[3] % 16),
+             static_cast<int64_t>(starts[4] % 16)};
+  auto found = tuples_.find(key);
+  if (found != tuples_.end()) return found->second;
+  py::tuple alignments(5);
+  for (int i = 0; i < 5; ++i) alignments[i] = py::int_(key[12 + i]);
+  auto result = py::make_tuple(rows, vocab, x.get_device(), key[3], key[4], key[5],
+                              py::make_tuple(x.stride(0), x.stride(1)), py::make_tuple(b.stride(0), b.stride(1)),
+                              o.stride(0), v.stride(0), alignments);
+  if (tuples_.size() >= 128) tuples_.clear();
+  tuples_.emplace(key, result);
+  return result;
+}
+};
+
+// Keep only executable handles and immutable launch dimensions. The Python
+// cache owns both original CompiledKernel runners, keeping these handles live.
+// Every call receives the current tensors and current stream. Two trailing
+// null pointers preserve Triton 3.8.10's zero-sized scratch ABI.
+class NativeLaunchPair {
+  using Launch = CUresult (*)(CUfunction, unsigned, unsigned, unsigned,
+                              unsigned, unsigned, unsigned, unsigned,
+                              CUstream, void**, void**);
+  Launch launch_;
+  CUfunction partial_, final_;
+  unsigned partial_threads_, final_threads_, partial_shared_, final_shared_;
+  static Launch resolve_launch() {
+    static void* library = dlopen("libcuda.so.1", RTLD_NOW | RTLD_LOCAL);
+    if (!library) throw std::runtime_error("CUDA driver is unavailable for native launch");
+    static auto function = reinterpret_cast<Launch>(dlsym(library, "cuLaunchKernel"));
+    if (!function) throw std::runtime_error("CUDA driver lacks cuLaunchKernel");
+    return function;
+  }
+  static void check(CUresult result) {
+    if (result != CUDA_SUCCESS)
+      throw std::runtime_error("Native bias-argmax CUDA launch failed with code " + std::to_string(result));
+  }
+ public:
+  NativeLaunchPair(uintptr_t partial, uintptr_t final,
+                   unsigned partial_warps, unsigned final_warps,
+                   unsigned partial_shared, unsigned final_shared)
+      : launch_(resolve_launch()), partial_(reinterpret_cast<CUfunction>(partial)),
+        final_(reinterpret_cast<CUfunction>(final)), partial_threads_(partial_warps * 32),
+        final_threads_(final_warps * 32), partial_shared_(partial_shared), final_shared_(final_shared) {
+    if (!partial_ || !final_ || partial_warps != 4 || final_warps != 4)
+      throw std::runtime_error("Unexpected bias-argmax executable geometry");
+  }
+  void run(py::handle logits, py::handle bias, py::handle out,
+           py::handle values, py::handle indices, unsigned rows, unsigned tiles,
+           uintptr_t stream) const {
+    if (!rows || !tiles) throw std::runtime_error("Empty native launch geometry");
+    std::array<py::handle, 5> objects = {logits, bias, out, values, indices};
+    std::array<void*, 5> addresses;
+    for (int i = 0; i < 5; ++i) {
+      if (!THPVariable_Check(objects[i].ptr())) throw py::type_error("Expected a current Tensor");
+      const auto& tensor = THPVariable_Unpack(objects[i].ptr());
+      if (!tensor.is_cuda()) throw py::type_error("Expected a current CUDA Tensor");
+      addresses[i] = const_cast<void*>(tensor.const_data_ptr());
+    }
+    void* scratch = nullptr;
+    void* partial_args[] = {&addresses[0], &addresses[1], &addresses[3], &addresses[4], &scratch, &scratch};
+    void* final_args[] = {&addresses[3], &addresses[4], &addresses[2], &scratch, &scratch};
+    auto current_stream = reinterpret_cast<CUstream>(stream);
+    // Match the vendor launcher's GIL contract. All Python/Tensor metadata
+    // has been read above; only driver calls and C++ error checks run here.
+    // The argument tuple keeps tensors alive, and RAII reacquires the GIL
+    // before pybind11 returns or translates a CUDA failure to Python.
+    {
+      py::gil_scoped_release release;
+      check(launch_(partial_, rows, tiles, 1, partial_threads_, 1, 1,
+                    partial_shared_, current_stream, partial_args, nullptr));
+      check(launch_(final_, rows, 1, 1, final_threads_, 1, 1,
+                    final_shared_, current_stream, final_args, nullptr));
+    }
+  }
+};
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
+  py::class_<MetadataValidator>(module, "MetadataValidator")
+      .def(py::init<>())
+      .def("validate_metadata", &MetadataValidator::validate_metadata,
+           "Check all current tensors before reusing an immutable scalar tuple");
+  py::class_<NativeLaunchPair>(module, "NativeLaunchPair")
+      .def(py::init<uintptr_t, uintptr_t, unsigned, unsigned, unsigned, unsigned>())
+      .def("run", &NativeLaunchPair::run,
+           "Launch the unchanged checked two-stage kernels on this invocation's current stream");
+}

--- a/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/sampling_metadata.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/sampling_metadata.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Load the optional metadata extension only with its matching build ABI."""
+
+import hashlib
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import torch
+
+
+def _load_extension():
+    directory = Path(__file__).resolve().parent / "objs/sampling_metadata"
+    path = directory / "_sampling_metadata.so"
+    try:
+        record = json.loads((directory / "build.json").read_text())
+        if (
+            not isinstance(record, dict)
+            or record.get("torch") != torch.__version__
+            or record.get("python") != list(sys.version_info[:2])
+            or record.get("sha256") != hashlib.sha256(path.read_bytes()).hexdigest()
+        ):
+            return None
+        spec = importlib.util.spec_from_file_location("_sampling_metadata", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except (OSError, ImportError, ValueError):
+        # CPU/ROCm source installations and incompatible optional binaries
+        # retain the caller's original bias-plus-argmax implementation.
+        return None
+
+
+def _unavailable_metadata(
+    logits, bias, out, values, indices, current_device, bound_device, global_offset
+):
+    return None
+
+
+_module = _load_extension()
+if _module is None:
+    validate_metadata = _unavailable_metadata
+    NativeLaunchPair = None
+else:
+    _validator = _module.MetadataValidator()
+    validate_metadata = _validator.validate_metadata
+    NativeLaunchPair = _module.NativeLaunchPair

--- a/tokenspeed-kernel/test/ops/test_bias_argmax_metadata_sm120.py
+++ b/tokenspeed-kernel/test/ops/test_bias_argmax_metadata_sm120.py
@@ -1,0 +1,321 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""GPU checks for current descriptor handoff and selection override compatibility."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+from tokenspeed_kernel.ops.sampling import bias_argmax as ops
+from tokenspeed_kernel.ops.sampling.triton import bias_argmax as kernels
+from tokenspeed_kernel.selection import SelectedKernel
+
+
+def test_native_pair_warm_launch_and_dynamic_hooks(monkeypatch):
+    monkeypatch.setattr(kernels, "_LAUNCHERS", {})
+    original = kernels.NativeLaunchPair
+    calls = []
+
+    class ObservedPair:
+        def __init__(self, *args):
+            self.pair = original(*args)
+
+        def run(self, *args):
+            calls.append(args[-1])
+            return self.pair.run(*args)
+
+    monkeypatch.setattr(kernels, "NativeLaunchPair", ObservedPair)
+    logits, bias, out, workspace = inputs(30)
+    assert ops.try_bias_argmax(logits, bias, out, workspace, 11)
+    assert not calls
+    assert any(value[2] is not None for value in kernels._LAUNCHERS.values())
+    assert ops.try_bias_argmax(logits, bias, out, workspace, 11)
+    assert len(calls) == 1
+    torch.testing.assert_close(
+        out, (logits + bias).max(-1).indices + 11, rtol=0, atol=0
+    )
+    hooks = []
+    monkeypatch.setattr(
+        kernels.triton.knobs.runtime,
+        "launch_enter_hook",
+        lambda metadata: hooks.append(metadata),
+    )
+    assert ops.try_bias_argmax(logits, bias, out, workspace, 11)
+    assert len(calls) == 1 and len(hooks) == 2
+    torch.testing.assert_close(
+        out, (logits + bias).max(-1).indices + 11, rtol=0, atol=0
+    )
+
+
+def test_native_pair_rejects_unreviewed_scratch_launches_and_ptx_abi():
+    def kernel(pointer_count):
+        return SimpleNamespace(
+            run=SimpleNamespace(
+                global_scratch_size=0,
+                profile_scratch_size=0,
+                gsan_enabled=False,
+                launch_cooperative_grid=False,
+                launch_pdl=False,
+            ),
+            metadata=SimpleNamespace(num_ctas=1, num_warps=4),
+            asm={
+                "ptx": ".visible .entry fake("
+                + ",\n".join(
+                    ".param .u64 .ptr .global a" + str(i) for i in range(pointer_count)
+                )
+                + ")"
+            },
+        )
+
+    partial, final = kernel(6), kernel(5)
+    for flag in (
+        "global_scratch_size",
+        "profile_scratch_size",
+        "gsan_enabled",
+        "launch_cooperative_grid",
+        "launch_pdl",
+    ):
+        with mock.patch.object(partial.run, flag, 1):
+            assert kernels._make_native_pair(partial, final) is None
+    assert kernels._make_native_pair(kernel(5), final) is None
+    assert kernels._make_native_pair(partial, kernel(4)) is None
+
+
+def inputs(seed):
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    logits = torch.randn(
+        (3, 8197), dtype=torch.bfloat16, device="cuda", generator=generator
+    )
+    bias = torch.randn_like(logits)
+    out = torch.empty((3, 5), dtype=torch.int64, device="cuda")[:, 2]
+    workspace = ops.create_bias_argmax_workspace(3, 8197, "cuda")
+    return logits, bias, out, workspace
+
+
+def test_live_hook_chains_add_remove_and_restore_native_path(monkeypatch):
+    monkeypatch.setattr(kernels, "_LAUNCHERS", {})
+    enter = kernels.triton.knobs.HookChain()
+    leave = kernels.triton.knobs.HookChain(reversed=True)
+    monkeypatch.setattr(kernels.triton.knobs.runtime, "launch_enter_hook", enter)
+    monkeypatch.setattr(kernels.triton.knobs.runtime, "launch_exit_hook", leave)
+    original = kernels.NativeLaunchPair
+    native_calls = []
+
+    class ObservedPair:
+        def __init__(self, *args):
+            self.pair = original(*args)
+
+        def run(self, *args):
+            native_calls.append(1)
+            return self.pair.run(*args)
+
+    monkeypatch.setattr(kernels, "NativeLaunchPair", ObservedPair)
+    logits, bias, out, workspace = inputs(31)
+
+    def invoke():
+        assert ops.try_bias_argmax(logits, bias, out, workspace, 13)
+        torch.testing.assert_close(
+            out, (logits + bias).max(-1).indices + 13, rtol=0, atol=0
+        )
+
+    invoke()
+    invoke()
+    assert len(native_calls) == 1
+    observed = []
+    callback = lambda metadata: observed.append(metadata)
+    for chain in (enter, leave):
+        previous = len(native_calls)
+        chain.add(callback)
+        invoke()
+        assert len(native_calls) == previous and len(observed) == 2
+        chain.remove(callback)
+        invoke()
+        assert len(native_calls) == previous + 1
+        observed.clear()
+
+
+def test_current_metadata_handoff_and_fresh_storage(monkeypatch):
+    original = kernels.bias_argmax_sm120._from_checked_metadata
+    seen = []
+
+    def record(logits, bias, out, workspace, offset, metadata):
+        codes = {dtype: code for code, dtype in ops._SCALAR_DTYPES.items()}
+        assert metadata[:6] == (
+            3,
+            8197,
+            logits.device.index,
+            codes[logits.dtype],
+            codes[bias.dtype],
+            codes[out.dtype],
+        )
+        assert metadata[6:10] == (
+            logits.stride(),
+            bias.stride(),
+            out.stride(0),
+            workspace.values.stride(0),
+        )
+        assert metadata[10] == tuple(
+            t.data_ptr() % 16
+            for t in (logits, bias, out, workspace.values, workspace.indices)
+        )
+        seen.append((logits.data_ptr(), bias.data_ptr(), out.data_ptr()))
+        return original(logits, bias, out, workspace, offset, metadata)
+
+    monkeypatch.setattr(kernels.bias_argmax_sm120, "_from_checked_metadata", record)
+    keep_alive = []
+    for seed in (13, 14):
+        tensors = inputs(seed)
+        keep_alive.append(tensors)
+        logits, bias, out, workspace = tensors
+        assert ops.try_bias_argmax(logits, bias, out, workspace, 29)
+        expected = (logits + bias.to(logits.dtype)).max(-1).indices + 29
+        torch.testing.assert_close(out, expected, rtol=0, atol=0)
+    assert len(seen) == 2 and all(a != b for a, b in zip(seen[0], seen[1]))
+
+
+def test_selected_override_keeps_original_five_argument_protocol():
+    logits, bias, out, workspace = inputs(15)
+    calls = []
+
+    def alternate(a, b, output, scratch, offset):
+        calls.append(
+            (a is logits, b is bias, output is out, scratch is workspace, offset)
+        )
+        output.copy_((a + b.to(a.dtype)).max(-1).indices + offset)
+
+    with mock.patch.object(
+        ops, "select_kernel", return_value=SelectedKernel("alternate", alternate)
+    ):
+        assert ops.try_bias_argmax(logits, bias, out, workspace, 31)
+    assert calls == [(True, True, True, True, 31)]
+    torch.testing.assert_close(
+        out, (logits + bias).max(-1).indices + 31, rtol=0, atol=0
+    )
+
+
+def test_workspace_live_resize_is_rejected_before_prepared_launch(monkeypatch):
+    logits, bias, out, workspace = inputs(16)
+    workspace.values.resize_(1, 1)
+    out.fill_(-7)
+    called = mock.Mock()
+    monkeypatch.setattr(kernels.bias_argmax_sm120, "_from_checked_metadata", called)
+    assert not ops.try_bias_argmax(logits, bias, out, workspace, 0)
+    called.assert_not_called()
+    assert torch.equal(out, torch.full_like(out, -7))
+
+
+def test_workspace_architecture_is_bound_once_but_live_inputs_change():
+    logits, bias, out, workspace = inputs(17)
+    assert workspace._device == logits.device
+    assert workspace._capability == (12, 0)
+    assert ops.try_bias_argmax(logits, bias, out, workspace, 0)
+    with mock.patch.object(
+        torch.cuda,
+        "get_device_capability",
+        side_effect=AssertionError("unexpected per-call architecture query"),
+    ):
+        for value in (0.0, 3.0):
+            logits.fill_(value)
+            bias.zero_()
+            bias[:, 37] = 10
+            assert ops.try_bias_argmax(logits, bias, out, workspace, 9)
+            torch.testing.assert_close(out, torch.full_like(out, 46), rtol=0, atol=0)
+
+
+def test_workspace_replacement_rebinds_hardware_and_rejects_unsupported():
+    logits, bias, out, workspace = inputs(18)
+    out.fill_(-19)
+    cpu = replace(workspace, values=workspace.values.cpu())
+    assert cpu._device.type == "cpu" and cpu._capability is None
+    assert not ops.try_bias_argmax(logits, bias, out, cpu, 0)
+    with mock.patch.object(torch.cuda, "get_device_capability", return_value=(9, 0)):
+        unsupported = replace(workspace)
+    assert unsupported._capability == (9, 0)
+    assert not ops.try_bias_argmax(logits, bias, out, unsupported, 0)
+    assert torch.equal(out, torch.full_like(out, -19))
+    restored = replace(cpu, values=workspace.values)
+    assert restored._capability == (12, 0)
+    assert ops.try_bias_argmax(logits, bias, out, restored, 0)
+    torch.testing.assert_close(out, (logits + bias).max(-1).indices, rtol=0, atol=0)
+
+
+def test_bound_device_does_not_bypass_current_device_or_tensor_validation():
+    logits, bias, out, workspace = inputs(19)
+    out.fill_(-23)
+    with mock.patch.object(
+        torch.cuda, "current_device", return_value=logits.device.index + 1
+    ):
+        assert not ops.try_bias_argmax(logits, bias, out, workspace, 0)
+    invalid = ops.BiasArgmaxWorkspace(values=None, indices=workspace.indices)
+    assert invalid._device is None and invalid._capability is None
+    assert not ops.try_bias_argmax(logits, bias, out, invalid, 0)
+    assert torch.equal(out, torch.full_like(out, -23))
+
+
+def test_native_metadata_preserves_exact_python_integer_bounds():
+    logits, bias, out, workspace = inputs(20)
+    out.fill_(-17)
+    for offset in (True, 3.0, -(2**100), 2**100):
+        assert not ops.try_bias_argmax(logits, bias, out, workspace, offset)
+        assert torch.equal(out, torch.full_like(out, -17))
+    offset = 2**63 - 1 - (logits.shape[1] - 1)
+    assert ops.try_bias_argmax(logits, bias, out, workspace, offset)
+    torch.testing.assert_close(
+        out, (logits + bias).max(-1).indices + offset, rtol=0, atol=0
+    )
+
+
+def test_native_validator_rejects_non_tensor_operands_without_raising():
+    logits, bias, out, workspace = inputs(21)
+    for slot in range(5):
+        args = [logits, bias, out, workspace.values, workspace.indices]
+        args[slot] = None
+        assert (
+            ops.validate_metadata(*args, logits.device.index, logits.device.index, 0)
+            is None
+        )
+
+
+def test_native_tuple_reuse_never_reuses_eligibility_or_input_pointers():
+    first = inputs(22)
+    second = inputs(23)
+
+    def metadata(tensors, offset):
+        x, b, o, w = tensors
+        return ops.validate_metadata(
+            x, b, o, w.values, w.indices, x.device.index, x.device.index, offset
+        )
+
+    a = metadata(first, 0)
+    b = metadata(second, 0)
+    assert a is b
+    assert all(not isinstance(value, torch.Tensor) for value in a)
+    for tensors, value, index in ((first, 1.0, 37), (second, 2.0, 42)):
+        x, bias, out, workspace = tensors
+        x.fill_(value)
+        bias.zero_()
+        bias[:, index] = 10
+        assert ops.try_bias_argmax(x, bias, out, workspace, 0)
+        torch.testing.assert_close(out, torch.full_like(out, index), rtol=0, atol=0)
+    assert metadata(second, 2**100) is None
+    second[3].values.resize_(1, 1)
+    assert metadata(second, 0) is None

--- a/tokenspeed-kernel/test/ops/test_bias_argmax_sm120.py
+++ b/tokenspeed-kernel/test/ops/test_bias_argmax_sm120.py
@@ -1,0 +1,457 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Exact native-rounded IDs, metadata rejection, stream and cache contracts."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest import mock
+
+import pytest
+import torch
+from tokenspeed_kernel._triton import triton
+from tokenspeed_kernel.ops.sampling import bias_argmax as ops
+from tokenspeed_kernel.ops.sampling import create_bias_argmax_workspace, try_bias_argmax
+from tokenspeed_kernel.ops.sampling.triton import bias_argmax as kernels
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() != (12, 0),
+    reason="requires NVIDIA SM120",
+)
+DTYPES = [torch.float16, torch.bfloat16, torch.float32]
+
+
+def _expected(logits, bias, offset):
+    return (logits + bias.to(logits.dtype)).max(dim=-1).indices + offset
+
+
+def _check(logits, bias, workspace, output_dtype, offset, column):
+    storage = torch.full((logits.shape[0], 5), -91, dtype=output_dtype, device="cuda")
+    out = storage[:, column]
+    before_logits, before_bias = logits.clone(), bias.clone()
+    expected = _expected(logits, bias, offset).to(output_dtype)
+    assert try_bias_argmax(logits, bias, out, workspace, offset)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+    for other in range(5):
+        if other != column:
+            assert torch.all(storage[:, other] == -91)
+    torch.testing.assert_close(logits, before_logits, rtol=0, atol=0, equal_nan=True)
+    torch.testing.assert_close(bias, before_bias, rtol=0, atol=0, equal_nan=True)
+    return storage
+
+
+@pytest.mark.parametrize("logits_dtype", DTYPES)
+@pytest.mark.parametrize("bias_dtype", DTYPES)
+@pytest.mark.parametrize("rows,vocab", [(1, 1), (2, 4097), (8, 32771), (16, 262144)])
+def test_native_dtype_matrix(logits_dtype, bias_dtype, rows, vocab):
+    torch.manual_seed(42)
+    logits = torch.randn((rows * 2, vocab * 2), dtype=logits_dtype, device="cuda")[
+        ::2, ::2
+    ]
+    bias = torch.randn((vocab * 2, rows * 2), dtype=bias_dtype, device="cuda")[
+        ::2, ::2
+    ].T
+    workspace = create_bias_argmax_workspace(rows, vocab, "cuda")
+    _check(logits, bias, workspace, torch.int32, 123, 1)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_nan_ties_infinities_tail_and_signed_zero(dtype):
+    logits = torch.full((9, 8197), -float("inf"), dtype=dtype, device="cuda")
+    bias = torch.zeros_like(logits)
+    logits[1, 4] = logits[1, 7001] = 8
+    logits[2, 3] = logits[2, 6123] = float("inf")
+    logits[3, 5001] = float("nan")
+    logits[4, 2] = logits[4, 5001] = float("nan")
+    logits[5, :] = float("nan")
+    logits[6, 8196] = 6
+    logits[7, :] = 0
+    logits[7, 0] = -0.0
+    logits[8, 3] = float("inf")
+    bias[8, 3] = -float("inf")
+    workspace = create_bias_argmax_workspace(9, 8197, "cuda")
+    _check(logits, bias, workspace, torch.int64, 2**40, 3)
+
+
+@pytest.mark.parametrize(
+    "dtype,correction",
+    [(torch.float16, [0.0003, 0.0004]), (torch.bfloat16, [0.003, 0.0031])],
+)
+def test_add_rounding_changes_winner(dtype, correction):
+    logits = torch.ones((1, 2), dtype=dtype, device="cuda")
+    bias = torch.tensor([correction], dtype=torch.float32, device="cuda")
+    assert _expected(logits, bias, 0).item() == 0
+    assert (logits.float() + bias.to(dtype).float()).argmax().item() == 1
+    _check(logits, bias, create_bias_argmax_workspace(1, 2, "cuda"), torch.int32, 0, 1)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_bias_cast_rounding_changes_winner(dtype):
+    logits = torch.full((1, 2), -1.0, dtype=dtype, device="cuda")
+    # Bias conversion ties at 1; omitting it preserves two distinct small
+    # results even if the subsequent addition still rounds to logits.dtype.
+    bias = torch.tensor([[1.0002, 1.0003]], dtype=torch.float32, device="cuda")
+    assert (logits.float() + bias).to(dtype).argmax().item() == 1
+    assert _expected(logits, bias, 0).item() == 0
+    _check(logits, bias, create_bias_argmax_workspace(1, 2, "cuda"), torch.int32, 0, 2)
+
+
+@pytest.mark.parametrize("dtype", [torch.int32, torch.int64])
+def test_maximum_representable_offset(dtype):
+    logits = torch.zeros((2, 4097), device="cuda")
+    logits[:, -1] = 5
+    bias = torch.zeros_like(logits)
+    offset = torch.iinfo(dtype).max - 4096
+    _check(
+        logits, bias, create_bias_argmax_workspace(2, 4097, "cuda"), dtype, offset, 1
+    )
+
+
+@pytest.mark.parametrize("field", ["values", "indices"])
+@pytest.mark.parametrize("malformation", ["rank", "dtype", "stride", "shape", "device"])
+def test_malformed_workspace_without_writes(field, malformation):
+    rows, vocab = 2, 8197
+    logits = torch.randn((rows, vocab), device="cuda")
+    bias = torch.zeros_like(logits)
+    out = torch.full((rows,), -37, dtype=torch.int32, device="cuda")
+    workspace = create_bias_argmax_workspace(rows, vocab, "cuda")
+    tensor = getattr(workspace, field)
+    if malformation == "rank":
+        changed = tensor.flatten()
+    elif malformation == "dtype":
+        changed = tensor.to(torch.float16)
+    elif malformation == "stride":
+        changed = torch.empty(
+            (rows, tensor.shape[1] * 2), dtype=tensor.dtype, device="cuda"
+        )[:, ::2]
+    elif malformation == "shape":
+        changed = tensor[:1]
+    else:
+        changed = tensor.cpu()
+    workspace = replace(workspace, **{field: changed})
+    for scratch in (workspace.values, workspace.indices):
+        scratch.fill_(123)
+    before = [tensor.clone() for tensor in (out, workspace.values, workspace.indices)]
+    with mock.patch.object(ops, "select_kernel") as selection:
+        assert not try_bias_argmax(logits, bias, out, workspace, 0)
+        selection.assert_not_called()
+    for actual, expected in zip((out, workspace.values, workspace.indices), before):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "out_logits",
+        "out_bias",
+        "values_logits",
+        "indices_bias",
+        "scratch_overlap",
+        "out_values",
+        "out_indices",
+    ],
+)
+def test_read_write_aliases_reject_without_writes(case):
+    logits = torch.randn((2, 8197), device="cuda")
+    bias = torch.zeros_like(logits)
+    out = torch.full((2,), -91, dtype=torch.int32, device="cuda")
+    workspace = create_bias_argmax_workspace(2, 8197, "cuda")
+    if case == "out_logits":
+        out = logits.view(torch.int32).flatten()[:2]
+    elif case == "out_bias":
+        out = bias.view(torch.int32).flatten()[:2]
+    elif case == "values_logits":
+        workspace = replace(workspace, values=logits.flatten()[:6].view(2, 3))
+    elif case == "indices_bias":
+        workspace = replace(
+            workspace, indices=bias.view(torch.int32).flatten()[:6].view(2, 3)
+        )
+    elif case == "scratch_overlap":
+        workspace = replace(workspace, indices=workspace.values.view(torch.int32))
+    elif case == "out_values":
+        out = workspace.values.view(torch.int32).flatten()[:2]
+    else:
+        out = workspace.indices.flatten()[:2]
+    tensors = (logits, bias, out, workspace.values, workspace.indices)
+    # Bytewise comparison also handles uninitialized scratch NaN payloads.
+    before = [tensor.contiguous().view(torch.uint8).clone() for tensor in tensors]
+    with mock.patch.object(ops, "select_kernel") as selection:
+        assert not try_bias_argmax(logits, bias, out, workspace, 0)
+        selection.assert_not_called()
+    for actual, expected in zip(tensors, before):
+        assert torch.equal(actual.contiguous().view(torch.uint8), expected)
+
+
+def test_read_read_alias_is_legal():
+    logits = torch.randn((2, 4097), device="cuda")
+    _check(
+        logits, logits, create_bias_argmax_workspace(2, 4097, "cuda"), torch.int64, 0, 0
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "overflow",
+        "negative_offset",
+        "bool_offset",
+        "zero_stride",
+        "wrong_device",
+        "none_workspace",
+        "none_out",
+        "wrong_out_dtype",
+        "wrong_bias_shape",
+    ],
+)
+def test_invalid_metadata_without_launch(case, monkeypatch):
+    logits = torch.randn((2, 4097), device="cuda")
+    bias = torch.zeros_like(logits)
+    out = torch.full((2,), -91, dtype=torch.int32, device="cuda")
+    workspace = create_bias_argmax_workspace(2, 4097, "cuda")
+    offset = 0
+    if case == "overflow":
+        offset = torch.iinfo(torch.int32).max - 4095
+    elif case == "negative_offset":
+        offset = -1
+    elif case == "bool_offset":
+        offset = True
+    elif case == "zero_stride":
+        bias = bias[:1].expand(2, -1)
+    elif case == "wrong_device":
+        monkeypatch.setattr(
+            torch.cuda, "current_device", lambda: logits.device.index + 1
+        )
+    elif case == "none_workspace":
+        workspace = None
+    elif case == "none_out":
+        out = None
+    elif case == "wrong_out_dtype":
+        out = out.float()
+    else:
+        bias = bias[:, :-1]
+    before = None if out is None else out.clone()
+    with mock.patch.object(ops, "select_kernel") as selection:
+        assert not try_bias_argmax(logits, bias, out, workspace, offset)
+        selection.assert_not_called()
+    if out is not None:
+        torch.testing.assert_close(out, before, rtol=0, atol=0)
+
+
+def test_cached_launchers_new_pointers_all_column_alignments(monkeypatch):
+    monkeypatch.setattr(kernels, "_LAUNCHERS", {})
+    workspace = create_bias_argmax_workspace(2, 8197, "cuda")
+    alive = []
+    for repeat in range(2):
+        for column in range(4):
+            logits = torch.full((2, 8197), -3.0, device="cuda")
+            logits[:, 17 + repeat * 4 + column] = 8
+            bias = torch.zeros_like(logits)
+            storage = _check(logits, bias, workspace, torch.int32, 0, column)
+            assert len(kernels._LAUNCHERS) == (column + 1 if repeat == 0 else 4)
+            assert all(logits.data_ptr() != item[0].data_ptr() for item in alive)
+            alive.append((logits, bias, storage))
+    for case, (logits, bias, storage) in enumerate(alive):
+        assert torch.all(storage[:, case % 4] == 17 + case)
+
+
+def test_cached_launchers_follow_streams_graph_contents_and_buckets(monkeypatch):
+    monkeypatch.setattr(kernels, "_LAUNCHERS", {})
+    workspace = create_bias_argmax_workspace(16, 32771, "cuda")
+    pointers = (workspace.values.data_ptr(), workspace.indices.data_ptr())
+    captures = []
+    for rows in (1, 16, 2, 8):
+        logits = torch.zeros((rows, 32771), device="cuda")
+        bias = torch.zeros_like(logits)
+        storage = torch.full((rows, 5), -91, dtype=torch.int32, device="cuda")
+        out = storage[:, 1]
+        assert try_bias_argmax(logits, bias, out, workspace, 123)
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            logits[:, 17] = 8
+            assert try_bias_argmax(logits, bias, out, workspace, 123)
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph, stream=stream):
+                assert try_bias_argmax(logits, bias, out, workspace, 123)
+        torch.cuda.current_stream().wait_stream(stream)
+        assert torch.all(out == 140)
+        captures.append((graph, logits, bias, out))
+    for step, bucket in enumerate((0, 2, 1, 3, 0, 1, 2, 3)):
+        graph, logits, bias, out = captures[bucket]
+        logits.normal_()
+        bias.normal_()
+        if step % 2:
+            bias[:, 4099] = float("nan")
+        expected = _expected(logits, bias, 123).to(out.dtype)
+        graph.replay()
+        torch.testing.assert_close(out, expected, rtol=0, atol=0)
+        assert pointers == (workspace.values.data_ptr(), workspace.indices.data_ptr())
+
+
+def test_cache_keeps_dynamic_launch_hooks(monkeypatch):
+    monkeypatch.setattr(kernels, "_LAUNCHERS", {})
+    logits = torch.randn((2, 8197), device="cuda")
+    bias = torch.zeros_like(logits)
+    workspace = create_bias_argmax_workspace(2, 8197, "cuda")
+    _check(logits, bias, workspace, torch.int32, 0, 1)
+    seen = []
+
+    def record(metadata):
+        seen.append(metadata.get()["name"])
+
+    monkeypatch.setattr(triton.knobs.runtime, "launch_enter_hook", record)
+    _check(logits, bias, workspace, torch.int32, 0, 1)
+    assert seen == ["_bias_argmax_partials", "_bias_argmax_finalize"]
+
+
+def test_jit_pre_run_hooks_bypass_cache(monkeypatch):
+    monkeypatch.setattr(kernels, "_LAUNCHERS", {})
+    logits = torch.randn((2, 8197), device="cuda")
+    bias = torch.zeros_like(logits)
+    workspace = create_bias_argmax_workspace(2, 8197, "cuda")
+    _check(logits, bias, workspace, torch.int32, 0, 1)
+    seen = []
+
+    def before(*args, **kwargs):
+        seen.append(len(args))
+
+    monkeypatch.setattr(kernels._bias_argmax_partials, "pre_run_hooks", [before])
+    monkeypatch.setattr(kernels._bias_argmax_finalize, "pre_run_hooks", [before])
+    _check(logits, bias, workspace, torch.int32, 0, 1)
+    assert len(seen) == 2
+
+
+@pytest.mark.parametrize(
+    "group,setting,value",
+    [
+        ("runtime", "debug", True),
+        ("runtime", "add_stages_inspection_hook", object()),
+        ("compilation", "instrumentation_mode", "test-only-no-launch"),
+        ("compilation", "fpsan_homomorphic_casts", True),
+    ],
+)
+def test_instrumentation_bypasses_cache(group, setting, value, monkeypatch):
+    monkeypatch.setattr(getattr(triton.knobs, group), setting, value)
+    assert not kernels._can_reuse_launchers()
+
+
+@pytest.mark.parametrize("field", ["logits", "bias", "out", "values", "indices"])
+@pytest.mark.parametrize("transform", ["negative_view", "sparse_layout"])
+def test_unresolved_views_and_sparse_layout_reject_without_selection(field, transform):
+    logits = torch.randn((2, 4097), device="cuda")
+    bias = torch.zeros_like(logits)
+    out = torch.full((2,), -91, dtype=torch.int32, device="cuda")
+    workspace = create_bias_argmax_workspace(2, 4097, "cuda")
+    workspace.values.fill_(17)
+    workspace.indices.fill_(23)
+    named = {
+        "logits": logits,
+        "bias": bias,
+        "out": out,
+        "values": workspace.values,
+        "indices": workspace.indices,
+    }
+    original = named[field]
+    named[field] = (
+        torch._neg_view(original)
+        if transform == "negative_view"
+        else original.to_sparse()
+    )
+    workspace = replace(workspace, values=named["values"], indices=named["indices"])
+    before = {name: tensor.to_dense().clone() for name, tensor in named.items()}
+    with mock.patch.object(ops, "select_kernel") as selection:
+        assert not try_bias_argmax(
+            named["logits"], named["bias"], named["out"], workspace, 0
+        )
+        selection.assert_not_called()
+    for name, tensor in named.items():
+        torch.testing.assert_close(tensor.to_dense(), before[name], rtol=0, atol=0)
+
+
+def test_bias_cast_overflow_creates_first_nan():
+    logits = torch.tensor([[-float("inf"), 0.0]], dtype=torch.float16, device="cuda")
+    bias = torch.tensor([[100000.0, 1.0]], dtype=torch.float32, device="cuda")
+    assert _expected(logits, bias, 0).item() == 0
+    assert (logits.float() + bias).to(logits.dtype).argmax().item() == 1
+    _check(logits, bias, create_bias_argmax_workspace(1, 2, "cuda"), torch.int32, 0, 1)
+
+
+def test_active_jit_cache_hook_rejects_before_selection_without_writes(monkeypatch):
+    logits = torch.randn((2, 4097), device="cuda")
+    bias = torch.zeros_like(logits)
+    out = torch.full((2,), -91, dtype=torch.int32, device="cuda")
+    workspace = create_bias_argmax_workspace(2, 4097, "cuda")
+    workspace.values.fill_(17)
+    workspace.indices.fill_(23)
+    tensors = (logits, bias, out, workspace.values, workspace.indices)
+    before = [tensor.clone() for tensor in tensors]
+    seen = []
+
+    def suppress(**kwargs):
+        seen.append(True)
+        return True
+
+    monkeypatch.setattr(triton.knobs.runtime, "jit_cache_hook", suppress)
+    with mock.patch.object(ops, "select_kernel") as selection:
+        assert not try_bias_argmax(logits, bias, out, workspace, 0)
+        selection.assert_not_called()
+    assert not seen
+    for actual, expected in zip(tensors, before):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_interpreter_mode_rejects_before_selection_without_writes(monkeypatch):
+    logits = torch.randn((2, 4097), device="cuda")
+    bias = torch.zeros_like(logits)
+    out = torch.full((2,), -91, dtype=torch.int32, device="cuda")
+    workspace = create_bias_argmax_workspace(2, 4097, "cuda")
+    workspace.values.fill_(17)
+    workspace.indices.fill_(23)
+    tensors = (logits, bias, out, workspace.values, workspace.indices)
+    before = [tensor.clone() for tensor in tensors]
+    monkeypatch.setattr(triton.knobs.runtime, "interpret", True)
+    with mock.patch.object(ops, "select_kernel") as selection:
+        assert not try_bias_argmax(logits, bias, out, workspace, 0)
+        selection.assert_not_called()
+    for actual, expected in zip(tensors, before):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+def test_nested_logits_reject_before_shape_or_selection():
+    logits = torch.nested.nested_tensor(
+        [torch.randn(4097, device="cuda"), torch.randn(4096, device="cuda")]
+    )
+    bias = torch.zeros((2, 4097), device="cuda")
+    out = torch.full((2,), -91, dtype=torch.int32, device="cuda")
+    workspace = create_bias_argmax_workspace(2, 4097, "cuda")
+    workspace.values.fill_(17)
+    workspace.indices.fill_(23)
+    logits_before = logits.to_padded_tensor(0).clone()
+    tensors = (bias, out, workspace.values, workspace.indices)
+    before = [tensor.clone() for tensor in tensors]
+    with mock.patch.object(ops, "select_kernel") as selection:
+        assert not try_bias_argmax(logits, bias, out, workspace, 0)
+        selection.assert_not_called()
+    torch.testing.assert_close(
+        logits.to_padded_tensor(0), logits_before, rtol=0, atol=0
+    )
+    for actual, expected in zip(tensors, before):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tokenspeed-kernel/test/test_sampling_metadata_packaging.py
+++ b/tokenspeed-kernel/test/test_sampling_metadata_packaging.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026 LightSeek Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""CPU tests for optional extension compatibility and package build metadata."""
+
+import ast
+import hashlib
+import json
+import runpy
+import shutil
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from setuptools import Distribution
+
+ROOT = Path(__file__).resolve().parents[1] / "python"
+LOADER = ROOT / "tokenspeed_kernel/thirdparty/cuda/sampling_metadata.py"
+
+
+class MetadataPackagingTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.loader = self.directory / "sampling_metadata.py"
+        shutil.copy2(LOADER, self.loader)
+        self.output = self.directory / "objs/sampling_metadata"
+        self.output.mkdir(parents=True)
+        self.torch = types.ModuleType("torch")
+        self.torch.__version__ = "2.13.0+cu130"
+
+    def load(self, spec):
+        with patch.dict(sys.modules, {"torch": self.torch}), patch(
+            "importlib.util.spec_from_file_location", spec
+        ):
+            return runpy.run_path(str(self.loader))
+
+    def record(self):
+        binary = self.output / "_sampling_metadata.so"
+        binary.write_bytes(b"binary fixture; never executed")
+        record = {
+            "torch": self.torch.__version__,
+            "python": list(sys.version_info[:2]),
+            "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+        }
+        (self.output / "build.json").write_text(json.dumps(record))
+        return record
+
+    def unavailable(self):
+        def forbidden(*args, **kwargs):
+            raise AssertionError("incompatible binary must not be loaded")
+
+        module = self.load(forbidden)
+        self.assertIsNone(module["NativeLaunchPair"])
+        self.assertIsNone(module["validate_metadata"](*([None] * 8)))
+
+    def test_source_install_without_native_binary_retains_fallback(self):
+        self.unavailable()
+
+    def test_build_abi_and_integrity_mismatch_never_loads_binary(self):
+        for field, value in (
+            ("torch", "different"),
+            ("python", [1, 2]),
+            ("sha256", "invalid"),
+        ):
+            with self.subTest(field=field):
+                record = self.record()
+                record[field] = value
+                (self.output / "build.json").write_text(json.dumps(record))
+                self.unavailable()
+        for value in ("[]", "not-json"):
+            with self.subTest(record=value):
+                (self.output / "build.json").write_text(value)
+                self.unavailable()
+
+    def test_compatible_binary_preserves_native_bound_method(self):
+        self.record()
+        marker = object()
+
+        class Validator:
+            def validate_metadata(self, *args):
+                return marker
+
+        native = types.ModuleType("_sampling_metadata")
+        native.MetadataValidator = Validator
+        native.NativeLaunchPair = object()
+
+        class Loader:
+            def exec_module(self, module):
+                self.module = module
+
+        loader = Loader()
+        spec = types.SimpleNamespace(loader=loader)
+        with patch("importlib.util.module_from_spec", return_value=native):
+            module = self.load(lambda *args: spec)
+        self.assertIs(module["NativeLaunchPair"], native.NativeLaunchPair)
+        self.assertIs(module["validate_metadata"](*([None] * 8)), marker)
+        self.assertIs(loader.module, native)
+
+    def test_dynamic_loader_failure_preserves_fallback(self):
+        self.record()
+
+        def broken(*args, **kwargs):
+            raise ImportError("incompatible optional shared object")
+
+        module = self.load(broken)
+        self.assertIsNone(module["validate_metadata"](*([None] * 8)))
+
+    def test_build_records_actual_binary_abi_and_avoids_gpu_compilation(self):
+        tree = ast.parse((ROOT / "setup.py").read_text())
+        fn = next(
+            n
+            for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name == "_build_sampling_metadata"
+        )
+        compiled = self.directory / "compiled.so"
+        compiled.write_bytes(b"compiler fixture output")
+        calls = []
+
+        def compile_host(**kwargs):
+            calls.append(kwargs)
+            return types.SimpleNamespace(__file__=str(compiled))
+
+        utils = types.ModuleType("torch.utils")
+        cpp = types.ModuleType("torch.utils.cpp_extension")
+        cpp.load = compile_host
+        namespace = {
+            "ROOT": self.directory,
+            "CUDA_OBJS_DIR": self.directory / "objects",
+            "CUDA_CSRC_DIR": self.directory / "csrc",
+            "CUDA_HOME": "/selected/cuda",
+            "Path": Path,
+            "shutil": shutil,
+            "json": json,
+            "hashlib": hashlib,
+            "sys": sys,
+        }
+        exec(
+            compile(ast.Module(body=[fn], type_ignores=[]), "setup.py", "exec"),
+            namespace,
+        )
+        with patch.dict(
+            sys.modules,
+            {
+                "torch": self.torch,
+                "torch.utils": utils,
+                "torch.utils.cpp_extension": cpp,
+            },
+        ):
+            namespace["_build_sampling_metadata"](False)
+        record = json.loads(
+            (self.directory / "objects/sampling_metadata/build.json").read_text()
+        )
+        self.assertEqual(
+            record["sha256"], hashlib.sha256(compiled.read_bytes()).hexdigest()
+        )
+        self.assertEqual(record["torch"], self.torch.__version__)
+        self.assertEqual(record["python"], list(sys.version_info[:2]))
+        self.assertEqual(len(calls), 1)
+        self.assertFalse(calls[0]["with_cuda"])
+        self.assertEqual(calls[0]["extra_include_paths"], ["/selected/cuda/include"])
+        self.assertEqual(calls[0]["extra_ldflags"], ["-ldl"])
+        self.assertFalse(
+            Path(calls[0]["build_directory"]).is_relative_to(self.directory / "objects")
+        )
+
+    def test_only_cuda_wheel_requires_cpython_platform_tag(self):
+        tree = ast.parse((ROOT / "setup.py").read_text())
+        cls = next(
+            n
+            for n in tree.body
+            if isinstance(n, ast.ClassDef) and n.name == "KernelDistribution"
+        )
+        for backend, expected in (("cuda", True), ("rocm", False)):
+            with self.subTest(backend=backend):
+                namespace = {
+                    "Distribution": Distribution,
+                    "_selected_backend": lambda: backend,
+                }
+                exec(
+                    compile(
+                        ast.Module(body=[cls], type_ignores=[]), "setup.py", "exec"
+                    ),
+                    namespace,
+                )
+                self.assertEqual(
+                    namespace["KernelDistribution"]().has_ext_modules(), expected
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add the C9 SM120 TP1 DSpark Markov-bias argmax path, preserving the original bias cast, score rounding, first-index tie/NaN behavior, vocabulary offset, and strided output. Two kernels replace bias postprocessing only; the proposal projections, Markov weights, verifier, and scheduler remain unchanged.

An optional ABI-checked host extension validates live metadata and can enqueue the same two kernels while releasing the GIL around driver calls. Cached entries retain executable owners and immutable launch metadata, never caller tensor addresses or streams. Live instrumentation hooks and unsupported layouts/devices use the original dispatch. Add packaging, metadata, kernel, consumer, and benchmark coverage, with the final results documented in `docs/performance/dspark-bias-argmax-sm120.md`.

This is a **draft** because positive region results have not translated to complete Engine eager improvement.

## Measured scope

Frozen baseline: `7978c48b5c56445c600880f0ff275a611e584cef`; NVIDIA RTX PRO 4000 Blackwell, SM120. The 384-arm paired matrix covers batches 1/8/16, BF16, vocabulary 151936, hidden width 2560, Markov rank 256, and eight proposal positions including the anchor.

| Measurement | Eager latency reduction | Graph latency reduction |
| --- | ---: | ---: |
| Precomputed-bias postprocess | 59.53–60.00% | 60.45–69.78% |
| Complete source-method proposal walk | 1.98–4.00% | 2.09–3.70% |

All 12 paths improved descriptively. These boundaries use generated parameters and are not model E2E; their percentages must not be added.

The final complete Qwen3-4B + DSpark eager cohort used four fresh processes in PAAP order, batches 1/4/8, two warmups, seven measurements, and fixed 128-token output workloads. Both arms included the same prerequisite runtime fixes. Complete Engine latency **increased 3.168% / 3.825% / 3.807%**. Ordered token IDs, text, finish reasons, and speculative-work counts matched exactly. Earlier runs affected by shared-host overlap were excluded. C8 Graph results are not attributed to C9.

## Validation

Archived frozen C9 validation: **120 GPU regressions, zero skips**, **324 numerical boundary rows**, and all **384 timing arms / 12 paths** passed. Source, native-library, process-role, output, and workload audits passed. No complete Engine Graph or distributable CUDA-wheel claim is made from the final eager cohort.

Publication checks: the full `pre-commit run --all-files` passed after applying its formatting changes. Python function/class ASTs remain unchanged from the validated implementation. Fresh publication checks passed: **17 CPU tests and seven subtests; three CUDA tests skipped**. These consumer and optional-extension packaging checks do not execute CUDA. No new GPU test is claimed during publication.

CUDA regressions require the pinned TokenSpeed/Triton environment and an SM120 device. The checked-in benchmark requires the original baseline source snapshot and validates its hashes before comparing the two consumer boundaries. Broad hardware/runtime coverage, wheel acceptance, and the complete-model regression remain open before promotion.
