### PR TITLE
refactor(kernel): remove dead imports

### DIFF
--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/dsa/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/dsa/__init__.py
@@ -21,19 +21,11 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
 from tokenspeed_kernel.platform import pdl_enabled
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/dsv4/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/dsv4/__init__.py
@@ -21,19 +21,12 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
 from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.registry import KernelRegistry
+from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gdn/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/gdn/__init__.py
@@ -21,19 +21,12 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 
 import torch
-from tokenspeed_kernel.platform import current_platform, pdl_enabled
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.selection import NoKernelFoundError, select_kernel
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/kda/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/kda/__init__.py
@@ -21,14 +21,11 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
 from dataclasses import dataclass
-from enum import Enum
 
 import torch
 from tokenspeed_kernel.platform import current_platform
-from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
+from tokenspeed_kernel.registry import KernelRegistry
 from tokenspeed_kernel.selection import (
     NoKernelFoundError,
     select_kernel,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/kpool/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/kpool/__init__.py
@@ -21,18 +21,10 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/mha/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/mha/__init__.py
@@ -21,19 +21,12 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
 from tokenspeed_kernel.platform import current_platform, pdl_enabled
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.selection import select_kernel, spec_matches_traits
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/mla/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/mla/__init__.py
@@ -21,14 +21,11 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
-from tokenspeed_kernel.platform import current_platform, pdl_enabled
+from tokenspeed_kernel.platform import current_platform
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
+from tokenspeed_kernel.registry import KernelRegistry
 from tokenspeed_kernel.selection import (
     NoKernelFoundError,
     select_kernel,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/msa/__init__.py
@@ -22,18 +22,11 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
-from tokenspeed_kernel.platform import current_platform, pdl_enabled
+from tokenspeed_kernel.platform import pdl_enabled
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/qsa/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/qsa/__init__.py
@@ -21,18 +21,9 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
-from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
-from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.selection import select_kernel
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/rmha/__init__.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/rmha/__init__.py
@@ -21,19 +21,12 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass
-from enum import Enum
 
 import torch
 from tokenspeed_kernel.platform import current_platform, pdl_enabled
 from tokenspeed_kernel.profiling import ShapeCapture, kernel_scope
 from tokenspeed_kernel.registry import KernelRegistry, Priority
-from tokenspeed_kernel.selection import (
-    NoKernelFoundError,
-    select_kernel,
-    spec_matches_traits,
-)
+from tokenspeed_kernel.selection import select_kernel, spec_matches_traits
 from tokenspeed_kernel.signature import (
     MXFP8_BLOCK_SCALE,
     dense_tensor_format,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/rmha/_cute_dsl/flash_fwd_sm100_bias.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/rmha/_cute_dsl/flash_fwd_sm100_bias.py
@@ -23,7 +23,7 @@ import math
 import time
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Literal, Optional, Tuple, Type
+from typing import Callable, Literal, Optional, Tuple
 
 import cuda.bindings.driver as cuda
 import cutlass

--- a/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/ops/sampling/cute_dsl.py
@@ -150,7 +150,7 @@ if _ARCH_SUPPORTED and _has_cluster_launch_support():
         import cutlass.cute as cute
         from cutlass._mlir.dialects import llvm
         from cutlass.cute.runtime import from_dlpack
-        from cutlass.cute.typing import Float32, Int32
+        from cutlass.cute.typing import Int32
         from cutlass.cutlass_dsl import T, dsl_user_op
         from tokenspeed_kernel.thirdparty.cute_dsl.argmax import (
             ArgmaxKernel,

--- a/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
+++ b/tokenspeed-kernel/python/tokenspeed_kernel/platform.py
@@ -21,22 +21,14 @@
 from __future__ import annotations
 
 import ctypes
-import json
 import logging
 import math
 import os
-import pickle
-import subprocess
-import sys
-import tempfile
 from dataclasses import dataclass
 from functools import lru_cache
-from itertools import product
 from pathlib import Path
 
 import torch
-import torch.distributed as dist
-import torch.multiprocessing as mp
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Drop imports that nothing in the repository consumes, neither locally nor as a re-export:

* platform.py: json, pickle, subprocess, sys, tempfile, itertools.product, torch.distributed, torch.multiprocessing.
* attention family __init__.py (dsa, dsv4, gdn, kda, kpool, mha, mla, msa, qsa, rmha): the copy-pasted preamble of Sequence, dataclass, Enum, KernelRegistry, Priority, NoKernelFoundError, spec_matches_traits, current_platform, pdl_enabled, ShapeCapture and kernel_scope where the module never references them.
* sampling/cute_dsl.py: Float32 from the optional cute probe import.
* rmha/_cute_dsl/flash_fwd_sm100_bias.py: typing.Type.

Re-export hubs whose "unused" imports are consumed elsewhere (gdn/triton.py, kda/triton.py, dsa/triton.py, kpool/triton.py, rmha/triton.py and rmha/_cute_dsl/fmha_bias_helper.py) are left untouched.